### PR TITLE
Loading index.html updates the title of every browser window

### DIFF
--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -72,6 +72,9 @@ export class OverlayManager {
       },
     });
 
+    browserWindow.on('page-title-updated', (evt) => {
+      evt.preventDefault();
+    });
     browserWindow.setIgnoreMouseEvents(true);
     browserWindow.setVisibleOnAllWorkspaces(true, {
       visibleOnFullScreen: true,


### PR DESCRIPTION
…  from the one we set up, unless prevented. This is undesirable if we want to capture these windows from another application.
Note that this still lets the settings window have the title from the index.html, as that one isn't created in this loop