### PR TITLE
Make overlay browser windows focusable so OpenKneeboard can capture them

### DIFF
--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -63,7 +63,7 @@ export class OverlayManager {
       title: `iRacing Dashies - ${title}`,
       transparent: true,
       frame: false,
-      focusable: false,
+      focusable: true, //for OpenKneeeboard/VR
       resizable: false,
       movable: false,
       roundedCorners: false,


### PR DESCRIPTION
If focusable is set to false on these windows, OpenKneeboard fails to capture them and can´t show them in VR.
I havent see any obvious ill effects when running them normally in 2D like this, but I might have missed something.
If so, I guess it should be made an option, would look into it if necessary