### PR TITLE
Show track rubbered state in the Weather overlay

### DIFF
--- a/src/frontend/components/Weather/Weather.tsx
+++ b/src/frontend/components/Weather/Weather.tsx
@@ -3,7 +3,9 @@ import { useTrackTemperature } from './hooks/useTrackTemperature';
 import { useTrackWeather } from './hooks/useTrackWeather';
 import { WeatherTemp } from './WeatherTemp/WeatherTemp';
 import { WeatherTrackWetness } from './WeatherTrackWetness/WeatherTrackWetness';
+import { WeatherTrackRubbered } from './WeatherTrackRubbered/WeatherTrackRubbered';
 import { WindDirection } from './WindDirection/WindDirection';
+import { useTrackRubberedState } from './hooks/useTrackRubberedState';
 
 export const Weather = () => {
   const [parent] = useAutoAnimate();
@@ -11,6 +13,7 @@ export const Weather = () => {
   const trackTemp = useTrackTemperature();
   const windSpeed = weather.windVelocity;
   const relativeWindDirection =  (weather.windDirection ?? 0) - (weather.windYaw ?? 0);
+  const trackRubbered = useTrackRubberedState();
 
   return (
     <div
@@ -22,6 +25,7 @@ export const Weather = () => {
         <WeatherTemp title="Air" value={trackTemp.airTemp} />
         <WindDirection speedMs={windSpeed} direction={relativeWindDirection} />
         <WeatherTrackWetness trackMoisture={weather.trackMoisture} />
+        <WeatherTrackRubbered trackRubbered={trackRubbered} />
       </div>
     </div>
   );

--- a/src/frontend/components/Weather/WeatherTrackRubbered/WeatherTrackRubbered.tsx
+++ b/src/frontend/components/Weather/WeatherTrackRubbered/WeatherTrackRubbered.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Path } from '@phosphor-icons/react';
+interface Props {
+  trackRubbered: string | undefined;
+}
+
+export const WeatherTrackRubbered: React.FC<Props> = ({ trackRubbered }) => {
+  return (
+    <div className="bg-slate-800/70 p-2 rounded-sm">
+    <div className="flex flex-row items-center gap-6">
+      <span className="text-m text-gray-400 mr-1"><Path /></span>
+      <span className="text-sm">{trackRubbered ?? 'N/A'}</span>
+    </div>
+    </div>
+  );
+};

--- a/src/frontend/components/Weather/hooks/useTrackRubberedState.tsx
+++ b/src/frontend/components/Weather/hooks/useTrackRubberedState.tsx
@@ -1,0 +1,12 @@
+import { useSessionStore } from '@irdashies/context';
+import { useStore } from 'zustand';
+
+export const useTrackRubberedState = () => {
+  return useStore(
+    useSessionStore,
+    (state) =>
+      state.session?.SessionInfo?.Sessions?.find(
+        (session) => session.SessionNum === 0
+      )?.SessionTrackRubberState
+  );
+};


### PR DESCRIPTION
I think this is nice to have, can confirm feelings of "slow track" on entering the session.
Could be elsewhere, and this is not strictly weather, but it´s "conditions"
I chose the icon to indicate "slipperyness", maybe there's a better one
I'm not sure about the formatting, those spans look sus to me, but CSS stumps me
Again this might be a toggle in the options, but can´t see anyone not wanting it