### PR TITLE
Show the last track rubbered state that isn´t 'carry over' instead of the one from the first session

### DIFF
--- a/src/frontend/components/Weather/hooks/useTrackRubberedState.tsx
+++ b/src/frontend/components/Weather/hooks/useTrackRubberedState.tsx
@@ -6,7 +6,7 @@ export const useTrackRubberedState = () => {
     useSessionStore,
     (state) =>
       state.session?.SessionInfo?.Sessions?.findLast(
-        (session) => session.SessionTrackRubberState != 'carry over'
+        (session) => session.SessionTrackRubberState !== 'carry over'
       )?.SessionTrackRubberState
   );
 };

--- a/src/frontend/components/Weather/hooks/useTrackRubberedState.tsx
+++ b/src/frontend/components/Weather/hooks/useTrackRubberedState.tsx
@@ -5,8 +5,8 @@ export const useTrackRubberedState = () => {
   return useStore(
     useSessionStore,
     (state) =>
-      state.session?.SessionInfo?.Sessions?.find(
-        (session) => session.SessionNum === 0
+      state.session?.SessionInfo?.Sessions?.findLast(
+        (session) => session.SessionTrackRubberState != 'carry over'
       )?.SessionTrackRubberState
   );
 };


### PR DESCRIPTION
I think this is fine now, as it should show the latest meaningful known track state.
Maybe we could add an indicator of the state shown being carried over when it is, instead of new for the session, but it might just confuse users.