### PR TITLE
Add settings to standings + ability to reset configs

### DIFF
--- a/.storybook/mockDashboardBridge.ts
+++ b/.storybook/mockDashboardBridge.ts
@@ -8,6 +8,10 @@ export const mockDashboardBridge: DashboardBridge = {
   saveDashboard: () => {
     // noop
   },
+  resetDashboard: async () => {
+    // For mock, just return the default dashboard
+    return defaultDashboard;
+  },
   dashboardUpdated: (callback) => {
     callback(defaultDashboard);
     return () => {

--- a/src/app/bridge/dashboard/dashboardBridge.ts
+++ b/src/app/bridge/dashboard/dashboardBridge.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron';
 import { onDashboardUpdated } from '../../storage/dashboardEvents';
-import { getDashboard, saveDashboard } from '../../storage/dashboards';
+import { getDashboard, saveDashboard, resetDashboard } from '../../storage/dashboards';
 import { OverlayManager } from 'src/app/overlayManager';
 
 export async function publishDashboardUpdates(overlayManager: OverlayManager) {
@@ -16,6 +16,10 @@ export async function publishDashboardUpdates(overlayManager: OverlayManager) {
     if (!dashboard) return;
     overlayManager.closeOrCreateWindows(dashboard);
     overlayManager.publishMessage('dashboardUpdated', dashboard);
+  });
+
+  ipcMain.handle('resetDashboard', (_, resetEverything: boolean) => {
+    return resetDashboard(resetEverything, 'default');
   });
 
   ipcMain.handle('toggleLockOverlays', () => {

--- a/src/app/bridge/rendererExposeBridge.ts
+++ b/src/app/bridge/rendererExposeBridge.ts
@@ -45,6 +45,9 @@ export function exposeBridge() {
     saveDashboard: (value: DashboardLayout) => {
       ipcRenderer.send('saveDashboard', value);
     },
+    resetDashboard: (resetEverything: boolean) => {
+      return ipcRenderer.invoke('resetDashboard', resetEverything);
+    },
     toggleLockOverlays: () => {
       return ipcRenderer.invoke('toggleLockOverlays');
     },

--- a/src/app/storage/dashboards.ts
+++ b/src/app/storage/dashboards.ts
@@ -115,3 +115,34 @@ export const saveDashboard = (
     emitDashboardUpdated(mergedDashboard);
   }
 };
+
+export const resetDashboard = (resetEverything = false, dashboardId = 'default') => {
+  const dashboard = getDashboard(dashboardId);
+  if (!dashboard) {
+    throw new Error('Dashboard not found');
+  }
+
+  if (resetEverything) {
+    // Completely reset to default dashboard
+    saveDashboard(dashboardId, defaultDashboard);
+    return defaultDashboard;
+  } else {
+    // Reset only widget configurations while preserving positions and enabled states
+    const resetDashboard: DashboardLayout = {
+      ...dashboard,
+      widgets: dashboard.widgets.map((widget) => {
+        const defaultWidget = defaultDashboard.widgets.find((w) => w.id === widget.id);
+        return {
+          ...widget,
+          config: defaultWidget?.config || widget.config,
+        };
+      }),
+      generalSettings: {
+        ...defaultDashboard.generalSettings,
+      },
+    };
+
+    saveDashboard(dashboardId, resetDashboard);
+    return resetDashboard;
+  }
+};

--- a/src/app/storage/defaultDashboard.ts
+++ b/src/app/storage/defaultDashboard.ts
@@ -12,11 +12,11 @@ export const defaultDashboard: DashboardLayout = {
         height: 600,
       },
       config: {
-        showIRatingChange: true,
-        showBadge: true,
-        showDelta: true,
-        showLastTime: true,
-        showFastestTime: true,
+        iRatingChange: { enabled: true },
+        badge: { enabled: true },
+        delta: { enabled: true },
+        lastTime: { enabled: true },
+        fastestTime: { enabled: true },
       },
     },
     {

--- a/src/app/storage/defaultDashboard.ts
+++ b/src/app/storage/defaultDashboard.ts
@@ -11,6 +11,13 @@ export const defaultDashboard: DashboardLayout = {
         width: 400,
         height: 600,
       },
+      config: {
+        showIRatingChange: true,
+        showBadge: true,
+        showDelta: true,
+        showLastTime: true,
+        showFastestTime: true,
+      },
     },
     {
       id: 'input',

--- a/src/frontend/components/Settings/sections/AdvancedSettings.tsx
+++ b/src/frontend/components/Settings/sections/AdvancedSettings.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useDashboard } from '@irdashies/context';
 
 export const AdvancedSettings = () => {
-  const { currentDashboard, onDashboardUpdated } = useDashboard();
+  const { currentDashboard, onDashboardUpdated, resetDashboard } = useDashboard();
   const [dashboardInput, setDashboardInput] = useState<string | undefined>(
     JSON.stringify(currentDashboard, undefined, 2)
   );
@@ -29,11 +29,56 @@ export const AdvancedSettings = () => {
     }
   };
 
+  const handleResetConfigs = async () => {
+    if (!confirm('Reset all widget configurations to defaults? This will preserve widget positions and enabled states.')) {
+      return;
+    }
+
+    try {
+      const result = await resetDashboard(false);
+      setDashboardInput(JSON.stringify(result, undefined, 2));
+    } catch (e) {
+      console.error('Failed to reset configurations:', e);
+      alert('Failed to reset configurations');
+    }
+  };
+
+  const handleResetCompletely = async () => {
+    if (!confirm('Reset everything to defaults? This will reset all widget positions, enabled states, and configurations.')) {
+      return;
+    }
+
+    try {
+      const result = await resetDashboard(true);
+      setDashboardInput(JSON.stringify(result, undefined, 2));
+    } catch (e) {
+      console.error('Failed to reset dashboard:', e);
+      alert('Failed to reset dashboard');
+    }
+  };
+
   return (
     <div className="flex flex-col h-full space-y-4">
       <div>
         <h2 className="text-xl mb-4">Advanced Settings</h2>
         <p className="text-slate-400 mb-4">Configure advanced system settings and preferences.</p>
+      </div>
+      
+      <div className="flex space-x-2">
+        <button
+          type="button"
+          onClick={handleResetConfigs}
+          className="flex-1 bg-amber-700 hover:bg-amber-600 rounded px-4 py-2 transition-colors cursor-pointer"
+        >
+          Reset Configurations
+        </button>
+        <button
+          type="button"
+          onClick={handleResetCompletely}
+          className="flex-1 bg-red-700 hover:bg-red-600 rounded px-4 py-2 transition-colors cursor-pointer"
+        >
+          Reset Everything
+        </button>
       </div>
       
       <textarea

--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -7,18 +7,35 @@ import { ToggleSwitch } from '../components/ToggleSwitch';
 const SETTING_ID = 'standings';
 
 const defaultConfig: StandingsWidgetSettings['config'] = {
-  showIRatingChange: true,
-  showBadge: true,
-  showDelta: true,
-  showLastTime: true,
-  showFastestTime: true,
+  iRatingChange: { enabled: true },
+  badge: { enabled: true },
+  delta: { enabled: true },
+  lastTime: { enabled: true },
+  fastestTime: { enabled: true },
+};
+
+// Migration function to handle missing properties in the new config format
+const migrateConfig = (savedConfig: unknown): StandingsWidgetSettings['config'] => {
+  if (!savedConfig || typeof savedConfig !== 'object') return defaultConfig;
+
+  const config = savedConfig as Record<string, unknown>;
+
+  // Handle new format with missing properties
+  return {
+    iRatingChange: { enabled: (config.iRatingChange as { enabled?: boolean })?.enabled ?? true },
+    badge: { enabled: (config.badge as { enabled?: boolean })?.enabled ?? true },
+    delta: { enabled: (config.delta as { enabled?: boolean })?.enabled ?? true },
+    lastTime: { enabled: (config.lastTime as { enabled?: boolean })?.enabled ?? true },
+    fastestTime: { enabled: (config.fastestTime as { enabled?: boolean })?.enabled ?? true },
+  };
 };
 
 export const StandingsSettings = () => {
   const { currentDashboard } = useDashboard();
+  const savedSettings = currentDashboard?.widgets.find(w => w.id === SETTING_ID) as StandingsWidgetSettings | undefined;
   const [settings, setSettings] = useState<StandingsWidgetSettings>({
-    enabled: currentDashboard?.widgets.find(w => w.id === SETTING_ID)?.enabled ?? false,
-    config: currentDashboard?.widgets.find(w => w.id === SETTING_ID)?.config as StandingsWidgetSettings['config'] ?? defaultConfig,
+    enabled: savedSettings?.enabled ?? false,
+    config: migrateConfig(savedSettings?.config),
   });
 
   if (!currentDashboard) {
@@ -44,45 +61,45 @@ export const StandingsSettings = () => {
               <div className="flex items-center justify-between">
                 <span className="text-sm text-slate-300">Show iRating Changes</span>
                 <ToggleSwitch
-                  enabled={settings.config.showIRatingChange}
+                  enabled={settings.config.iRatingChange.enabled}
                   onToggle={(enabled) =>
-                    handleConfigChange({ showIRatingChange: enabled })
+                    handleConfigChange({ iRatingChange: { enabled } })
                   }
                 />
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-sm text-slate-300">Show Driver Badge</span>
                 <ToggleSwitch
-                  enabled={settings.config.showBadge}
+                  enabled={settings.config.badge.enabled}
                   onToggle={(enabled) =>
-                    handleConfigChange({ showBadge: enabled })
+                    handleConfigChange({ badge: { enabled } })
                   }
                 />
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-sm text-slate-300">Show Delta</span>
                 <ToggleSwitch
-                  enabled={settings.config.showDelta}
+                  enabled={settings.config.delta.enabled}
                   onToggle={(enabled) =>
-                    handleConfigChange({ showDelta: enabled })
+                    handleConfigChange({ delta: { enabled } })
                   }
                 />
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-sm text-slate-300">Show Last Time</span>
                 <ToggleSwitch
-                  enabled={settings.config.showLastTime}
+                  enabled={settings.config.lastTime.enabled}
                   onToggle={(enabled) =>
-                    handleConfigChange({ showLastTime: enabled })
+                    handleConfigChange({ lastTime: { enabled } })
                   }
                 />
               </div>
               <div className="flex items-center justify-between">
                 <span className="text-sm text-slate-300">Show Fastest Time</span>
                 <ToggleSwitch
-                  enabled={settings.config.showFastestTime}
+                  enabled={settings.config.fastestTime.enabled}
                   onToggle={(enabled) =>
-                    handleConfigChange({ showFastestTime: enabled })
+                    handleConfigChange({ fastestTime: { enabled } })
                   }
                 />
               </div>

--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -2,12 +2,23 @@ import { useState } from 'react';
 import { BaseSettingsSection } from '../components/BaseSettingsSection';
 import { StandingsWidgetSettings } from '../types';
 import { useDashboard } from '@irdashies/context';
+import { ToggleSwitch } from '../components/ToggleSwitch';
+
+const SETTING_ID = 'standings';
+
+const defaultConfig: StandingsWidgetSettings['config'] = {
+  showIRatingChange: true,
+  showBadge: true,
+  showDelta: true,
+  showLastTime: true,
+  showFastestTime: true,
+};
 
 export const StandingsSettings = () => {
   const { currentDashboard } = useDashboard();
   const [settings, setSettings] = useState<StandingsWidgetSettings>({
-    enabled: currentDashboard?.widgets.find(w => w.id === 'standings')?.enabled ?? false,
-    config: currentDashboard?.widgets.find(w => w.id === 'standings')?.config ?? {},
+    enabled: currentDashboard?.widgets.find(w => w.id === SETTING_ID)?.enabled ?? false,
+    config: currentDashboard?.widgets.find(w => w.id === SETTING_ID)?.config as StandingsWidgetSettings['config'] ?? defaultConfig,
   });
 
   if (!currentDashboard) {
@@ -20,12 +31,65 @@ export const StandingsSettings = () => {
       description="Configure how the standings widget appears and behaves."
       settings={settings}
       onSettingsChange={setSettings}
-      widgetId="standings"
+      widgetId={SETTING_ID}
     >
-      {/* Add specific settings controls here */}
-      <div className="text-slate-300">
-        Additional settings will appear here
-      </div>
+      {(handleConfigChange) => (
+        <div className="space-y-8">
+          {/* Display Settings */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-medium text-slate-200">Display Settings</h3>
+            </div>
+            <div className="space-y-3 pl-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-300">Show iRating Changes</span>
+                <ToggleSwitch
+                  enabled={settings.config.showIRatingChange}
+                  onToggle={(enabled) =>
+                    handleConfigChange({ showIRatingChange: enabled })
+                  }
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-300">Show Driver Badge</span>
+                <ToggleSwitch
+                  enabled={settings.config.showBadge}
+                  onToggle={(enabled) =>
+                    handleConfigChange({ showBadge: enabled })
+                  }
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-300">Show Delta</span>
+                <ToggleSwitch
+                  enabled={settings.config.showDelta}
+                  onToggle={(enabled) =>
+                    handleConfigChange({ showDelta: enabled })
+                  }
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-300">Show Last Time</span>
+                <ToggleSwitch
+                  enabled={settings.config.showLastTime}
+                  onToggle={(enabled) =>
+                    handleConfigChange({ showLastTime: enabled })
+                  }
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-300">Show Fastest Time</span>
+                <ToggleSwitch
+                  enabled={settings.config.showFastestTime}
+                  onToggle={(enabled) =>
+                    handleConfigChange({ showFastestTime: enabled })
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </BaseSettingsSection>
   );
 }; 

--- a/src/frontend/components/Settings/types.ts
+++ b/src/frontend/components/Settings/types.ts
@@ -7,7 +7,13 @@ export interface BaseWidgetSettings<T = Record<string, unknown>> {
 }
 
 export interface StandingsWidgetSettings extends BaseWidgetSettings {
-  // Add specific standings settings here
+  config: {
+    showIRatingChange: boolean;
+    showBadge: boolean;
+    showDelta: boolean;
+    showLastTime: boolean;
+    showFastestTime: boolean;
+  };
 }
 
 export interface RelativeWidgetSettings extends BaseWidgetSettings {

--- a/src/frontend/components/Settings/types.ts
+++ b/src/frontend/components/Settings/types.ts
@@ -8,11 +8,11 @@ export interface BaseWidgetSettings<T = Record<string, unknown>> {
 
 export interface StandingsWidgetSettings extends BaseWidgetSettings {
   config: {
-    showIRatingChange: boolean;
-    showBadge: boolean;
-    showDelta: boolean;
-    showLastTime: boolean;
-    showFastestTime: boolean;
+    iRatingChange: { enabled: boolean };
+    badge: { enabled: boolean };
+    delta: { enabled: boolean };
+    lastTime: { enabled: boolean };
+    fastestTime: { enabled: boolean };
   };
 }
 

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -37,15 +37,15 @@ export const Standings = () => {
                   name={result.driver?.name || ''}
                   isPlayer={result.isPlayer}
                   hasFastestTime={result.hasFastestTime}
-                  delta={settings?.showDelta ? result.delta : undefined}
+                  delta={settings?.delta?.enabled ? result.delta : undefined}
                   position={result.classPosition}
-                  iratingChange={settings?.showIRatingChange ? <RatingChange value={result.iratingChange} /> : undefined}
-                  lastTime={settings?.showLastTime ? result.lastTime : undefined}
-                  fastestTime={settings?.showFastestTime ? result.fastestTime : undefined}
+                  iratingChange={settings?.iRatingChange?.enabled ? <RatingChange value={result.iratingChange} /> : undefined}
+                  lastTime={settings?.lastTime?.enabled ? result.lastTime : undefined}
+                  fastestTime={settings?.fastestTime?.enabled ? result.fastestTime : undefined}
                   onPitRoad={result.onPitRoad}
                   onTrack={result.onTrack}
                   radioActive={result.radioActive}
-                  badge={settings?.showBadge ? (
+                  badge={settings?.badge?.enabled ? (
                     <DriverRatingBadge
                       license={result.driver?.license}
                       rating={result.driver?.rating}

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -6,16 +6,13 @@ import { DriverRatingBadge } from './components/DriverRatingBadge/DriverRatingBa
 import { RatingChange } from './components/RatingChange/RatingChange';
 import { SessionBar } from './components/SessionBar/SessionBar';
 import { SessionFooter } from './components/SessionFooter/SessionFooter';
-import { useCarClassStats, useDriverStandings } from './hooks';
-import { useDashboard } from '@irdashies/context';
-import { StandingsWidgetSettings } from '../Settings/types';
+import { useCarClassStats, useDriverStandings, useStandingsSettings } from './hooks';
 
 export const Standings = () => {
   const [parent] = useAutoAnimate();
   const standings = useDriverStandings({ buffer: 3 });
   const classStats = useCarClassStats();
-  const { currentDashboard } = useDashboard();
-  const settings = currentDashboard?.widgets.find(w => w.id === 'standings')?.config as StandingsWidgetSettings['config'];
+  const settings = useStandingsSettings();
 
   return (
     <div className="w-full h-full">

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -7,11 +7,15 @@ import { RatingChange } from './components/RatingChange/RatingChange';
 import { SessionBar } from './components/SessionBar/SessionBar';
 import { SessionFooter } from './components/SessionFooter/SessionFooter';
 import { useCarClassStats, useDriverStandings } from './hooks';
+import { useDashboard } from '@irdashies/context';
+import { StandingsWidgetSettings } from '../Settings/types';
 
 export const Standings = () => {
   const [parent] = useAutoAnimate();
   const standings = useDriverStandings({ buffer: 3 });
   const classStats = useCarClassStats();
+  const { currentDashboard } = useDashboard();
+  const settings = currentDashboard?.widgets.find(w => w.id === 'standings')?.config as StandingsWidgetSettings['config'];
 
   return (
     <div className="w-full h-full">
@@ -36,20 +40,20 @@ export const Standings = () => {
                   name={result.driver?.name || ''}
                   isPlayer={result.isPlayer}
                   hasFastestTime={result.hasFastestTime}
-                  delta={result.delta}
+                  delta={settings?.showDelta ? result.delta : undefined}
                   position={result.classPosition}
-                  iratingChange={<RatingChange value={result.iratingChange} />}
-                  lastTime={result.lastTime}
-                  fastestTime={result.fastestTime}
+                  iratingChange={settings?.showIRatingChange ? <RatingChange value={result.iratingChange} /> : undefined}
+                  lastTime={settings?.showLastTime ? result.lastTime : undefined}
+                  fastestTime={settings?.showFastestTime ? result.fastestTime : undefined}
                   onPitRoad={result.onPitRoad}
                   onTrack={result.onTrack}
                   radioActive={result.radioActive}
-                  badge={
+                  badge={settings?.showBadge ? (
                     <DriverRatingBadge
                       license={result.driver?.license}
                       rating={result.driver?.rating}
                     />
-                  }
+                  ) : undefined}
                 />
               ))}
             </Fragment>

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -13,7 +13,7 @@ interface DriverRowInfoProps {
   hasFastestTime: boolean;
   delta?: number;
   position: number;
-  badge: React.ReactNode;
+  badge?: React.ReactNode;
   iratingChange?: React.ReactNode;
   lastTime?: number;
   fastestTime?: number;
@@ -52,14 +52,14 @@ export const DriverInfoRow = ({
       key={carIdx}
       className={[
         `odd:bg-slate-800/70 even:bg-slate-900/70 text-sm`,
-        !onTrack ? 'text-white/60' : '',
+        !onTrack || onPitRoad ? 'text-white/60' : '',
         isPlayer ? 'text-amber-300' : '',
         !isPlayer && isLapped ? 'text-blue-400' : '',
         !isPlayer && isLappingAhead ? 'text-red-400' : '',
       ].join(' ')}
     >
       <td
-        className={`text-center  text-white px-2 ${isPlayer ? `${getTailwindStyle(classColor).classHeader}` : ''}`}
+        className={`text-center text-white px-2 ${isPlayer ? `${getTailwindStyle(classColor).classHeader}` : ''}`}
       >
         {position}
       </td>
@@ -85,27 +85,33 @@ export const DriverInfoRow = ({
           )}
         </div>
       </td>
-      <td>{badge}</td>
-      {iratingChange !== undefined && (
+      {badge && <td>{badge}</td>}
+      {iratingChange && (
         <td className="px-2 text-left">
           {iratingChange}
         </td>
       )}
-      <td className={`px-2`}>{delta?.toFixed(1)}</td>
-      <td className={`px-2 ${hasFastestTime ? 'text-purple-400' : ''}`}>
-        {fastestTimeString}
-      </td>
-      <td
-        className={`px-2 ${
-          lastTimeString === fastestTimeString
-            ? hasFastestTime
-              ? 'text-purple-400'
-              : 'text-green-400'
-            : ''
-        }`}
-      >
-        {lastTimeString}
-      </td>
+      {delta !== undefined && (
+        <td className="px-2">{delta.toFixed(1)}</td>
+      )}
+      {fastestTime !== undefined && (
+        <td className={`px-2 ${hasFastestTime ? 'text-purple-400' : ''}`}>
+          {fastestTimeString}
+        </td>
+      )}
+      {lastTime !== undefined && (
+        <td
+          className={`px-2 ${
+            lastTimeString === fastestTimeString
+              ? hasFastestTime
+                ? 'text-purple-400'
+                : 'text-green-400'
+              : ''
+          }`}
+        >
+          {lastTimeString}
+        </td>
+      )}
     </tr>
   );
 };

--- a/src/frontend/components/Standings/hooks/index.ts
+++ b/src/frontend/components/Standings/hooks/index.ts
@@ -2,3 +2,4 @@ export * from './useCarClassStats';
 export * from './useDriverIncidents';
 export * from './useDriverStandings';
 export * from './useSessionLapCount';
+export * from './useStandingsSettings';

--- a/src/frontend/components/Standings/hooks/useStandingsSettings.tsx
+++ b/src/frontend/components/Standings/hooks/useStandingsSettings.tsx
@@ -1,0 +1,11 @@
+import { useDashboard } from '@irdashies/context';
+import { StandingsWidgetSettings } from '../sections/StandingsSettings';
+
+export const useStandingsSettings = () => {
+  const { currentDashboard } = useDashboard();
+  const settings = currentDashboard?.widgets.find((w) => w.id === 'standings')?.config as StandingsWidgetSettings['config'];
+
+  return {
+    showIRatingChange: settings?.showIRatingChange ?? true,
+  };
+}; 

--- a/src/frontend/components/Standings/hooks/useStandingsSettings.tsx
+++ b/src/frontend/components/Standings/hooks/useStandingsSettings.tsx
@@ -1,11 +1,12 @@
 import { useDashboard } from '@irdashies/context';
-import { StandingsWidgetSettings } from '../sections/StandingsSettings';
+import { StandingsWidgetSettings } from '../../Settings/types';
 
 export const useStandingsSettings = () => {
   const { currentDashboard } = useDashboard();
-  const settings = currentDashboard?.widgets.find((w) => w.id === 'standings')?.config as StandingsWidgetSettings['config'];
 
-  return {
-    showIRatingChange: settings?.showIRatingChange ?? true,
-  };
+  const standingsSettings = currentDashboard?.widgets.find(
+    (widget) => widget.id === 'standings',
+  )?.config;
+  
+  return standingsSettings as StandingsWidgetSettings['config'];
 }; 

--- a/src/frontend/context/CarSpeedStore/CarSpeedsStore.tsx
+++ b/src/frontend/context/CarSpeedStore/CarSpeedsStore.tsx
@@ -15,7 +15,7 @@ interface CarSpeedsState {
 }
 
 const SPEED_AVG_WINDOW = 5;
-export const SPEED_UPDATE_INTERVAL = 0.1; // Update interval in seconds
+const SPEED_UPDATE_INTERVAL = 0.1; // Update interval in seconds
 
 export const useCarSpeedsStore = create<CarSpeedsState>((set, get) => ({
   carSpeedBuffer: null,

--- a/src/frontend/context/DashboardContext/DashboardContext.tsx
+++ b/src/frontend/context/DashboardContext/DashboardContext.tsx
@@ -11,6 +11,7 @@ interface DashboardContextProps {
   editMode: boolean;
   currentDashboard: DashboardLayout | undefined;
   onDashboardUpdated?: (dashboard: DashboardLayout) => void;
+  resetDashboard: (resetEverything: boolean) => Promise<DashboardLayout>;
   bridge: DashboardBridge;
   version: string;
   isDemoMode: boolean;
@@ -41,6 +42,12 @@ export const DashboardProvider: React.FC<{
     bridge.saveDashboard(dashboard);
   };
 
+  const resetDashboard = async (resetEverything: boolean) => {
+    const result = await bridge.resetDashboard(resetEverything);
+    setDashboard(result);
+    return result;
+  };
+
   const toggleDemoMode = () => {
     const newDemoMode = !isDemoMode;
     setIsDemoMode(newDemoMode);
@@ -54,6 +61,7 @@ export const DashboardProvider: React.FC<{
         editMode: editMode,
         currentDashboard: dashboard,
         onDashboardUpdated: saveDashboard,
+        resetDashboard,
         bridge,
         version,
         isDemoMode,

--- a/src/frontend/context/shared/useCarIdxAverageLapTime.ts
+++ b/src/frontend/context/shared/useCarIdxAverageLapTime.ts
@@ -4,8 +4,7 @@ import { useLapTimes, useLapTimesStore } from '../LapTimesStore/LapTimesStore';
 import { useCarIdxClassEstLapTime } from '../SessionStore/SessionStore';
 
 /**
- * Custom hook to update lap times using telemetry state.
- * @returns An array of average lap times for each car in the session by index. Time value in seconds. -1 if not known.
+ * @returns An array of average lap times in seconds for each car in the session by index. Uses estimated class lap time if lap time is not known.
  */
 export function useCarIdxAverageLapTime() {
   const telemetry = useTelemetryStore(state => state.telemetry);

--- a/src/types/dashboardBridge.ts
+++ b/src/types/dashboardBridge.ts
@@ -5,6 +5,7 @@ export interface DashboardBridge {
   dashboardUpdated: (callback: (value: DashboardLayout) => void) => void;
   reloadDashboard: () => void;
   saveDashboard: (dashboard: DashboardLayout) => void;
+  resetDashboard: (resetEverything: boolean) => Promise<DashboardLayout>;
   toggleLockOverlays: () => Promise<boolean>;
   getAppVersion: () => Promise<string>;
   toggleDemoMode?: (value: boolean) => void;


### PR DESCRIPTION
Adds settings for the standings overlay:

<img width="799" alt="image" src="https://github.com/user-attachments/assets/daeda989-3764-4746-a447-a687790c341e" />

Reset configs:

<img width="801" alt="image" src="https://github.com/user-attachments/assets/b5155d07-f07e-4845-99be-9dc15da63a47" />

