### PR TITLE
fix: don't use car number as a fallback for position

### DIFF
--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -12,7 +12,7 @@ interface DriverRowInfoProps {
   isPlayer: boolean;
   hasFastestTime: boolean;
   delta?: number;
-  position: number;
+  position?: number;
   badge?: React.ReactNode;
   iratingChange?: React.ReactNode;
   lastTime?: number;

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -14,7 +14,7 @@ import {
 export interface Standings {
   carIdx: number;
   position?: number;
-  classPosition: number;
+  classPosition?: number;
   lap?: number;
   lappedState?: 'ahead' | 'behind' | 'same';
   delta?: number;
@@ -171,14 +171,16 @@ export const augmentStandingsWithIRating = (
   groupedStandings: [string, Standings[]][]
 ): [string, Standings[]][] => {
   return groupedStandings.map(([classId, classStandings]) => {
-    const raceResultsInput: RaceResult<number>[] = classStandings.map(
-      (driverStanding) => ({
-        driver: driverStanding.carIdx,
-        finishRank: driverStanding.classPosition,
-        startIRating: driverStanding.driver.rating,
-        started: true, // This is a critical assumption.
-      })
-    );
+    const raceResultsInput: RaceResult<number>[] = classStandings
+      .filter(s => !!s.classPosition)  // Only include drivers with a class position, should not happen in races
+      .map(
+        (driverStanding) => ({
+          driver: driverStanding.carIdx,
+          finishRank: driverStanding.classPosition ?? 0,
+          startIRating: driverStanding.driver.rating,
+          started: true, // This is a critical assumption.
+        })
+      );
 
     if (raceResultsInput.length === 0) {
       return [classId, classStandings];

--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -96,15 +96,12 @@ export const useDriverStandings = () => {
       }
 
       // If the driver is not in the standings, use the qualifying position
-      // else fallback to the car number, shitty workaround for now
-      let classPosition = driverPos.classPosition;
+      let classPosition: number | undefined = driverPos.classPosition;
       if (classPosition <= 0) {
         const qualifyingPosition = qualifyingPositions?.find(
           (q) => q.CarIdx === driver.carIdx
         );
-        classPosition = qualifyingPosition
-          ? qualifyingPosition.Position + 1
-          : driver.carNumRaw;
+        classPosition = qualifyingPosition ? qualifyingPosition.Position + 1 : undefined;
       }
 
       return {


### PR DESCRIPTION
Removes the workaround that uses a car number when no position is identified, usually in practice.

<img width="471" alt="image" src="https://github.com/user-attachments/assets/4fd6f7eb-3e46-4be8-b752-c3ef4b5a8e1b" />
