### PR TITLE
feat: add settings for standings for displaying number of drivers

### DIFF
--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -13,22 +13,55 @@ const defaultConfig: StandingsWidgetSettings['config'] = {
   lastTime: { enabled: true },
   fastestTime: { enabled: true },
   background: { opacity: 0 },
+  driverStandings: {
+    buffer: 3,
+    numNonClassDrivers: 3,
+    minPlayerClassDrivers: 10,
+    numTopDrivers: 3,
+  },
 };
 
 // Migration function to handle missing properties in the new config format
-const migrateConfig = (savedConfig: unknown): StandingsWidgetSettings['config'] => {
+const migrateConfig = (
+  savedConfig: unknown
+): StandingsWidgetSettings['config'] => {
   if (!savedConfig || typeof savedConfig !== 'object') return defaultConfig;
 
   const config = savedConfig as Record<string, unknown>;
 
   // Handle new format with missing properties
   return {
-    iRatingChange: { enabled: (config.iRatingChange as { enabled?: boolean })?.enabled ?? true },
+    iRatingChange: {
+      enabled:
+        (config.iRatingChange as { enabled?: boolean })?.enabled ?? true,
+    },
     badge: { enabled: (config.badge as { enabled?: boolean })?.enabled ?? true },
     delta: { enabled: (config.delta as { enabled?: boolean })?.enabled ?? true },
-    lastTime: { enabled: (config.lastTime as { enabled?: boolean })?.enabled ?? true },
-    fastestTime: { enabled: (config.fastestTime as { enabled?: boolean })?.enabled ?? true },
-    background: { opacity: (config.background as { opacity?: number })?.opacity ?? 0 },
+    lastTime: {
+      enabled: (config.lastTime as { enabled?: boolean })?.enabled ?? true,
+    },
+    fastestTime: {
+      enabled: (config.fastestTime as { enabled?: boolean })?.enabled ?? true,
+    },
+    background: {
+      opacity: (config.background as { opacity?: number })?.opacity ?? 0,
+    },
+    driverStandings: {
+      buffer:
+        (config.driverStandings as { buffer?: number })?.buffer ??
+        defaultConfig.driverStandings.buffer,
+      numNonClassDrivers:
+        (config.driverStandings as { numNonClassDrivers?: number })
+          ?.numNonClassDrivers ??
+        defaultConfig.driverStandings.numNonClassDrivers,
+      minPlayerClassDrivers:
+        (config.driverStandings as { minPlayerClassDrivers?: number })
+          ?.minPlayerClassDrivers ??
+        defaultConfig.driverStandings.minPlayerClassDrivers,
+      numTopDrivers:
+        (config.driverStandings as { numTopDrivers?: number })?.numTopDrivers ??
+        defaultConfig.driverStandings.numTopDrivers,
+    },
   };
 };
 
@@ -105,8 +138,103 @@ export const StandingsSettings = () => {
                   }
                 />
               </div>
+            </div>
+          </div>
+          {/* Driver Standings Settings */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-medium text-slate-200">
+                Driver Standings
+              </h3>
+            </div>
+            <div className="space-y-3 pl-4">
               <div className="flex items-center justify-between">
-                <span className="text-sm text-slate-300">Background Opacity</span>
+                <span className="text-sm text-slate-300">
+                  Drivers to show around player
+                </span>
+                <input
+                  type="number"
+                  value={settings.config.driverStandings.buffer}
+                  onChange={(e) =>
+                    handleConfigChange({
+                      driverStandings: {
+                        ...settings.config.driverStandings,
+                        buffer: parseInt(e.target.value),
+                      },
+                    })
+                  }
+                  className="w-20 bg-slate-700 text-white rounded-md px-2 py-1"
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-300">
+                  Drivers to show in other classes
+                </span>
+                <input
+                  type="number"
+                  value={settings.config.driverStandings.numNonClassDrivers}
+                  onChange={(e) =>
+                    handleConfigChange({
+                      driverStandings: {
+                        ...settings.config.driverStandings,
+                        numNonClassDrivers: parseInt(e.target.value),
+                      },
+                    })
+                  }
+                  className="w-20 bg-slate-700 text-white rounded-md px-2 py-1"
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-300">
+                  Minimum drivers in player&apos;s class
+                </span>
+                <input
+                  type="number"
+                  value={settings.config.driverStandings.minPlayerClassDrivers}
+                  onChange={(e) =>
+                    handleConfigChange({
+                      driverStandings: {
+                        ...settings.config.driverStandings,
+                        minPlayerClassDrivers: parseInt(e.target.value),
+                      },
+                    })
+                  }
+                  className="w-20 bg-slate-700 text-white rounded-md px-2 py-1"
+                />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-300">
+                  Top drivers to always show in player&apos;s class
+                </span>
+                <input
+                  type="number"
+                  value={settings.config.driverStandings.numTopDrivers}
+                  onChange={(e) =>
+                    handleConfigChange({
+                      driverStandings: {
+                        ...settings.config.driverStandings,
+                        numTopDrivers: parseInt(e.target.value),
+                      },
+                    })
+                  }
+                  className="w-20 bg-slate-700 text-white rounded-md px-2 py-1"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Background Settings */}
+          <div className="space-y-4">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-medium text-slate-200">
+                Background
+              </h3>
+            </div>
+            <div className="space-y-3 pl-4">
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-slate-300">
+                  Background Opacity
+                </span>
                 <div className="flex items-center gap-2">
                   <input
                     type="range"
@@ -114,7 +242,9 @@ export const StandingsSettings = () => {
                     max="100"
                     value={settings.config.background.opacity}
                     onChange={(e) =>
-                      handleConfigChange({ background: { opacity: parseInt(e.target.value) } })
+                      handleConfigChange({
+                        background: { opacity: parseInt(e.target.value) },
+                      })
                     }
                     className="w-20 h-2 bg-slate-600 rounded-lg appearance-none cursor-pointer"
                   />

--- a/src/frontend/components/Settings/types.ts
+++ b/src/frontend/components/Settings/types.ts
@@ -14,6 +14,12 @@ export interface StandingsWidgetSettings extends BaseWidgetSettings {
     lastTime: { enabled: boolean };
     fastestTime: { enabled: boolean };
     background: { opacity: number };
+    driverStandings: {
+      buffer: number;
+      numNonClassDrivers: number;
+      minPlayerClassDrivers: number;
+      numTopDrivers: number;
+    };
   };
 }
 

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -14,9 +14,9 @@ import {
 
 export const Standings = () => {
   const [parent] = useAutoAnimate();
-  const standings = useDriverStandings({ buffer: 3 });
-  const classStats = useCarClassStats();
   const settings = useStandingsSettings();
+  const standings = useDriverStandings(settings?.driverStandings);
+  const classStats = useCarClassStats();
   return (
     <div
       className={`w-full bg-slate-800/[var(--bg-opacity)] rounded-sm p-2 text-white overflow-hidden`}

--- a/src/frontend/components/Standings/createStandings.spec.ts
+++ b/src/frontend/components/Standings/createStandings.spec.ts
@@ -315,6 +315,8 @@ describe('createStandings', () => {
 
       const filteredDrivers = sliceRelevantDrivers(results, 'GT3');
 
+      expect(filteredDrivers[0][1]).toHaveLength(10);
+
       expect(filteredDrivers).toEqual([
         [
           'GT3',
@@ -326,9 +328,87 @@ describe('createStandings', () => {
             { name: '5. David' },
             { name: '6. Sebastian' },
             { name: '7. Nico' },
+            { name: '8. Eve' },
+            { name: '9. Frank' },
+            { name: '10. Max' },
           ],
         ],
       ]);
+    });
+
+    it('should return at least 10 drivers if available', () => {
+      const results: [string, DummyStanding[]][] = [
+        [
+          'GT3',
+          [
+            { name: '1. Bob' },
+            { name: '2. Alice' },
+            { name: '3. Charlie' },
+            { name: '4. David' },
+            { name: '5. Eve' },
+            { name: '6. Frank' },
+            { name: '7. Player', isPlayer: true },
+            { name: '8. Hannah' },
+            { name: '9. Irene' },
+            { name: '10. Jack' },
+            { name: '11. Kevin' },
+          ],
+        ],
+      ];
+      const filteredDrivers = sliceRelevantDrivers(results, 'GT3');
+      expect(filteredDrivers[0][1].length).toBe(10);
+    });
+
+    it('should allow minPlayerClassDrivers to be configured', () => {
+      const results: [string, DummyStanding[]][] = [
+        [
+          'GT3',
+          [
+            { name: '1. Bob' },
+            { name: '2. Alice' },
+            { name: '3. Charlie' },
+            { name: '4. David' },
+            { name: '5. Eve' },
+            { name: '6. Frank' },
+            { name: '7. Player', isPlayer: true },
+            { name: '8. Hannah' },
+            { name: '9. Irene' },
+            { name: '10. Jack' },
+            { name: '11. Kevin' },
+          ],
+        ],
+      ];
+      const filteredDrivers = sliceRelevantDrivers(results, 'GT3', {
+        minPlayerClassDrivers: 5,
+      });
+      expect(filteredDrivers[0][1].length).toBe(10);
+    });
+
+    it('should allow numTopDrivers to be configured', () => {
+      const results: [string, DummyStanding[]][] = [
+        [
+          'GT3',
+          [
+            { name: '1. Bob' },
+            { name: '2. Alice' },
+            { name: '3. Charlie' },
+            { name: '4. David' },
+            { name: '5. Eve' },
+            { name: '6. Frank' },
+            { name: '7. Player', isPlayer: true },
+            { name: '8. Hannah' },
+            { name: '9. Irene' },
+            { name: '10. Jack' },
+            { name: '11. Kevin' },
+          ],
+        ],
+      ];
+      const filteredDrivers = sliceRelevantDrivers(results, 'GT3', {
+        numTopDrivers: 1,
+      });
+      expect(filteredDrivers[0][1].length).toBe(9);
+      expect(filteredDrivers[0][1][0].name).toBe('1. Bob');
+      expect(filteredDrivers[0][1][1].name).toBe('4. David');
     });
   });
 });
@@ -347,6 +427,8 @@ function createStandings(
   options?: {
     buffer?: number;
     numNonClassDrivers?: number;
+    minPlayerClassDrivers?: number;
+    numTopDrivers?: number;
   }
 ) {
   const standings = createDriverStandings(

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -202,50 +202,69 @@ export const augmentStandingsWithIRating = (
  * @param driverClass - The class of the player
  * @param options.buffer - The number of drivers to include before and after the player
  * @param options.numNonClassDrivers - The number of drivers to include in classes outside of the player's class
+ * @param options.minPlayerClassDrivers - The minimum number of drivers to include in the player's class
+ * @param options.numTopDrivers - The number of top drivers to always include in the player's class
  * @returns The sliced standings
  */
 export const sliceRelevantDrivers = <T extends { isPlayer?: boolean }>(
   groupedStandings: [string, T[]][],
   driverClass: string | number | undefined,
-  { buffer = 3, numNonClassDrivers = 3 } = {}
+  {
+    buffer = 3,
+    numNonClassDrivers = 3,
+    minPlayerClassDrivers = 10,
+    numTopDrivers = 3,
+  } = {}
 ): [string, T[]][] => {
-  // this is honestly a bit too complicated to maintain so after some testing will
-  // probably simplify it so its a bit more readable
   return groupedStandings.map(([classIdx, standings]) => {
     const playerIndex = standings.findIndex((driver) => driver.isPlayer);
     if (String(driverClass) !== classIdx) {
-      // if player is not in this class, return only top 3 drivers in that class
+      // if player is not in this class, return only top N drivers in that class
       return [classIdx, standings.slice(0, numNonClassDrivers)];
     }
 
-    // if there are less than 10 drivers, return all
-    if (standings.length <= 10) return [classIdx, standings];
-
-    // take the player and a buffer of drivers before and after the player
-    const start = Math.max(playerIndex - buffer, 0);
-    let end = Math.min(playerIndex + buffer + 1, standings.length);
-
-    if (playerIndex <= 3) {
-      // if player is in top 3, include more drivers at the end
-      end = Math.min(
-        playerIndex + buffer + 3 - playerIndex + 1,
-        standings.length
-      );
+    // if there are less than minPlayerClassDrivers drivers, return all of them
+    if (standings.length <= minPlayerClassDrivers) {
+      return [classIdx, standings];
     }
 
-    const sliced = standings.slice(start, end);
-
-    if (playerIndex > 3) {
-      // add back top 3 but don't include overlapping indexes
-      // reverse to add in correct order when doing array unshift
-      standings
-        .slice(0, 3)
-        .reverse()
-        .forEach((driver) => {
-          if (!sliced.includes(driver)) sliced.unshift(driver);
-        });
+    // when no player is found, just return the top `minPlayerClassDrivers`
+    if (playerIndex === -1) {
+      return [classIdx, standings.slice(0, minPlayerClassDrivers)];
     }
 
-    return [classIdx, sliced];
+    const relevantDrivers = new Set<T>();
+
+    // Add top drivers
+    for (let i = 0; i < numTopDrivers; i++) {
+      if (standings[i]) {
+        relevantDrivers.add(standings[i]);
+      }
+    }
+
+    // Add drivers around the player
+    const start = Math.max(0, playerIndex - buffer);
+    const end = Math.min(standings.length, playerIndex + buffer + 1);
+    for (let i = start; i < end; i++) {
+      if (standings[i]) {
+        relevantDrivers.add(standings[i]);
+      }
+    }
+
+    // Ensure we have at least `minPlayerClassDrivers`
+    let lastIndex = end;
+    while (
+      relevantDrivers.size < minPlayerClassDrivers &&
+      lastIndex < standings.length
+    ) {
+      relevantDrivers.add(standings[lastIndex]);
+      lastIndex++;
+    }
+
+    const sortedDrivers = [...relevantDrivers].sort(
+      (a, b) => standings.indexOf(a) - standings.indexOf(b)
+    );
+
+    return [classIdx, sortedDrivers];
   });
 };

--- a/src/frontend/components/Standings/hooks/useDriverStandings.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverStandings.tsx
@@ -17,7 +17,17 @@ import {
   augmentStandingsWithIRating,
 } from '../createStandings';
 
-export const useDriverStandings = ({ buffer }: { buffer: number }) => {
+export const useDriverStandings = ({
+  buffer,
+  numNonClassDrivers,
+  minPlayerClassDrivers,
+  numTopDrivers,
+}: {
+  buffer?: number;
+  numNonClassDrivers?: number;
+  minPlayerClassDrivers?: number;
+  numTopDrivers?: number;
+} = {}) => {
   const sessionDrivers = useSessionDrivers();
   const driverCarIdx = useDriverCarIdx();
   const qualifyingResults = useSessionQualifyingResults();
@@ -61,7 +71,12 @@ export const useDriverStandings = ({ buffer }: { buffer: number }) => {
         ? augmentStandingsWithIRating(groupedByClass)
         : groupedByClass;
 
-    return sliceRelevantDrivers(augmentedGroupedByClass, driverClass, { buffer });
+    return sliceRelevantDrivers(augmentedGroupedByClass, driverClass, {
+      buffer,
+      numNonClassDrivers,
+      minPlayerClassDrivers,
+      numTopDrivers,
+    });
   }, [
     driverCarIdx,
     sessionDrivers,
@@ -75,6 +90,9 @@ export const useDriverStandings = ({ buffer }: { buffer: number }) => {
     sessionType,
     isOfficial,
     buffer,
+    numNonClassDrivers,
+    minPlayerClassDrivers,
+    numTopDrivers,
   ]);
 
   return standingsWithGain;


### PR DESCRIPTION
1. Drivers to show around player
2. Drivers to show in other classes
3. Minimum drivers in player's class
4. Top drivers to always show in player's class

<img width="1600" height="1402" alt="image" src="https://github.com/user-attachments/assets/68e000a4-9295-4372-b6cf-0b3b2eaa297a" />
