### PR TITLE
Settings: show overlays only when on track

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -7,6 +7,7 @@ import {
   RunningStateProvider,
   useRunningState,
   SessionProvider,
+  useDrivingState,
 } from '@irdashies/context';
 import { Settings } from './components/Settings/Settings';
 import { EditMode } from './components/EditMode/EditMode';
@@ -16,6 +17,11 @@ import { WIDGET_MAP } from './WidgetIndex';
 const AppRoutes = () => {
   const { currentDashboard } = useDashboard();
   const { running } = useRunningState();
+  const { isDriving } = useDrivingState();
+
+  const shouldShowOverlays =
+    currentDashboard?.generalSettings?.showOnlyWhenOnTrack === false ||
+    isDriving;
 
   return (
     <Routes>
@@ -29,7 +35,13 @@ const AppRoutes = () => {
           <Route
             key={widget.id}
             path={`/${widget.id}`}
-            element={running ? <WidgetComponent {...widget.config} /> : <></>}
+            element={
+              running && shouldShowOverlays ? (
+                <WidgetComponent {...widget.config} />
+              ) : (
+                <></>
+              )
+            }
           />
         );
       })}

--- a/src/frontend/components/Settings/sections/GeneralSettings.tsx
+++ b/src/frontend/components/Settings/sections/GeneralSettings.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useDashboard } from '@irdashies/context';
 import { GeneralSettingsType } from '@irdashies/types';
+import { ToggleSwitch } from '../components/ToggleSwitch';
 
 const FONT_SIZE_PRESETS = {
   xs: 'Extra Small',
@@ -19,6 +20,8 @@ export const GeneralSettings = () => {
   const [settings, setSettings] = useState<GeneralSettingsType>({
     fontSize: currentDashboard?.generalSettings?.fontSize ?? 'sm',
     colorPalette: currentDashboard?.generalSettings?.colorPalette ?? 'default',
+    showOnlyWhenOnTrack:
+      currentDashboard?.generalSettings?.showOnlyWhenOnTrack ?? false,
   });
 
   if (!currentDashboard || !onDashboardUpdated) {
@@ -41,6 +44,12 @@ export const GeneralSettings = () => {
 
   const handleColorThemeChange = (newTheme: 'default' | 'black') => {
     const newSettings = { ...settings, colorPalette: newTheme };
+    setSettings(newSettings);
+    updateDashboard(newSettings);
+  };
+
+  const handleShowOnlyWhenOnTrackChange = (checked: boolean) => {
+    const newSettings = { ...settings, showOnlyWhenOnTrack: checked };
     setSettings(newSettings);
     updateDashboard(newSettings);
   };
@@ -127,6 +136,22 @@ export const GeneralSettings = () => {
           </select>
         </div>
       </div>
+
+      {/* Show Only When On Track Settings */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h4 className="text-md font-medium text-slate-300">
+            Show Only When On Track
+          </h4>
+          <p className="text-sm text-slate-400">
+            If enabled, overlays will only be shown when you are driving.
+          </p>
+        </div>
+        <ToggleSwitch
+          enabled={settings.showOnlyWhenOnTrack ?? false}
+          onToggle={handleShowOnlyWhenOnTrackChange}
+        />
+      </div>
     </div>
   );
-}; 
+};

--- a/src/frontend/context/shared/index.ts
+++ b/src/frontend/context/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './useCarIdxSpeed';
 export * from './useCarIdxAverageLapTime';
 export * from './useCurrentSessionType';
+export * from './useDrivingState';

--- a/src/frontend/context/shared/useDrivingState.spec.ts
+++ b/src/frontend/context/shared/useDrivingState.spec.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDrivingState } from './useDrivingState';
+import { useTelemetryValue } from '../TelemetryStore/TelemetryStore';
+
+// Mock the telemetry store
+vi.mock('../TelemetryStore/TelemetryStore', () => ({
+  useTelemetryValue: vi.fn(),
+}));
+
+describe('useDrivingState', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('actively driving scenarios', () => {
+    it('should return true when on track and not in replay', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return true;
+            case 'PlayerCarInPitStall': return false;
+            case 'CarIdxOnPitRoad': return false;
+            case 'IsInGarage': return false;
+            case 'IsReplayPlaying': return false;
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(true);
+      expect(useTelemetryValue).toHaveBeenCalledWith('IsOnTrack');
+      expect(useTelemetryValue).toHaveBeenCalledWith('PlayerCarInPitStall');
+      expect(useTelemetryValue).toHaveBeenCalledWith('CarIdxOnPitRoad');
+      expect(useTelemetryValue).toHaveBeenCalledWith('IsInGarage');
+      expect(useTelemetryValue).toHaveBeenCalledWith('IsReplayPlaying');
+    });
+
+    it('should return true when in pit stall and not in garage/replay', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return false;
+            case 'PlayerCarInPitStall': return true;
+            case 'CarIdxOnPitRoad': return false;
+            case 'IsInGarage': return false;
+            case 'IsReplayPlaying': return false;
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(true);
+    });
+
+    it('should return true when on pit road and not in garage/replay', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return false;
+            case 'PlayerCarInPitStall': return false;
+            case 'CarIdxOnPitRoad': return true;
+            case 'IsInGarage': return false;
+            case 'IsReplayPlaying': return false;
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(true);
+    });
+
+    it('should return true when on track and in pit stall simultaneously', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return true;
+            case 'PlayerCarInPitStall': return true;
+            case 'CarIdxOnPitRoad': return false;
+            case 'IsInGarage': return false;
+            case 'IsReplayPlaying': return false;
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(true);
+    });
+  });
+
+  describe('non-driving scenarios', () => {
+    it('should return false when in garage', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return true;
+            case 'PlayerCarInPitStall': return false;
+            case 'CarIdxOnPitRoad': return false;
+            case 'IsInGarage': return true; // In garage
+            case 'IsReplayPlaying': return false;
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(false);
+    });
+
+    it('should return false when watching replay', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return true;
+            case 'PlayerCarInPitStall': return false;
+            case 'CarIdxOnPitRoad': return false;
+            case 'IsInGarage': return false;
+            case 'IsReplayPlaying': return true; // Watching replay
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(false);
+    });
+
+    it('should return false when not on track, not in pit, not on pit road', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return false;
+            case 'PlayerCarInPitStall': return false;
+            case 'CarIdxOnPitRoad': return false;
+            case 'IsInGarage': return false;
+            case 'IsReplayPlaying': return false;
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(false);
+    });
+
+    it('should return false when all telemetry values are undefined', () => {
+      vi.mocked(useTelemetryValue).mockReturnValue(undefined);
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return false when in garage even if also in pit stall', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return false;
+            case 'PlayerCarInPitStall': return true;
+            case 'CarIdxOnPitRoad': return false;
+            case 'IsInGarage': return true; // In garage overrides pit stall
+            case 'IsReplayPlaying': return false;
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(false);
+    });
+
+    it('should return false when watching replay even if on track', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return true;
+            case 'PlayerCarInPitStall': return false;
+            case 'CarIdxOnPitRoad': return false;
+            case 'IsInGarage': return false;
+            case 'IsReplayPlaying': return true; // Replay overrides on track
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(false);
+    });
+
+    it('should handle mixed boolean and undefined values correctly', () => {
+      vi.mocked(useTelemetryValue)
+        .mockImplementation((key: string) => {
+          switch (key) {
+            case 'IsOnTrack': return undefined;
+            case 'PlayerCarInPitStall': return true;
+            case 'CarIdxOnPitRoad': return undefined;
+            case 'IsInGarage': return false;
+            case 'IsReplayPlaying': return false;
+            default: return undefined;
+          }
+        });
+
+      const { result } = renderHook(() => useDrivingState());
+
+      expect(result.current.isDriving).toBe(true);
+    });
+  });
+
+  describe('telemetry calls', () => {
+    it('should call useTelemetryValue with correct keys', () => {
+      vi.mocked(useTelemetryValue).mockReturnValue(false);
+
+      renderHook(() => useDrivingState());
+
+      expect(useTelemetryValue).toHaveBeenCalledWith('IsOnTrack');
+      expect(useTelemetryValue).toHaveBeenCalledWith('PlayerCarInPitStall');
+      expect(useTelemetryValue).toHaveBeenCalledWith('CarIdxOnPitRoad');
+      expect(useTelemetryValue).toHaveBeenCalledWith('IsInGarage');
+      expect(useTelemetryValue).toHaveBeenCalledWith('IsReplayPlaying');
+      expect(useTelemetryValue).toHaveBeenCalledTimes(5);
+    });
+  });
+});

--- a/src/frontend/context/shared/useDrivingState.ts
+++ b/src/frontend/context/shared/useDrivingState.ts
@@ -1,11 +1,11 @@
 import { useTelemetryValue } from '@irdashies/context';
 
 export const useDrivingState = () => {
-  const isOnTrack = useTelemetryValue<boolean>('IsOnTrack');
-  const inPitStall = useTelemetryValue<boolean>('PlayerCarInPitStall');
-  const onPitRoad = useTelemetryValue<boolean>('CarIdxOnPitRoad');
-  const isInGarage = useTelemetryValue<boolean>('IsInGarage');
-  const isReplayPlaying = useTelemetryValue<boolean>('IsReplayPlaying');
+  const isOnTrack = useTelemetryValue<boolean>('IsOnTrack') ?? false;
+  const inPitStall = useTelemetryValue<boolean>('PlayerCarInPitStall') ?? false;
+  const onPitRoad = useTelemetryValue<boolean>('CarIdxOnPitRoad') ?? false;
+  const isInGarage = useTelemetryValue<boolean>('IsInGarage') ?? false;
+  const isReplayPlaying = useTelemetryValue<boolean>('IsReplayPlaying') ?? false;
 
   const isDriving =
     (isOnTrack || inPitStall || onPitRoad) && !isInGarage && !isReplayPlaying;

--- a/src/frontend/context/shared/useDrivingState.ts
+++ b/src/frontend/context/shared/useDrivingState.ts
@@ -1,0 +1,16 @@
+import { useTelemetryValue } from '@irdashies/context';
+
+export const useDrivingState = () => {
+  const isOnTrack = useTelemetryValue<boolean>('IsOnTrack');
+  const inPitStall = useTelemetryValue<boolean>('PlayerCarInPitStall');
+  const onPitRoad = useTelemetryValue<boolean>('CarIdxOnPitRoad');
+  const isInGarage = useTelemetryValue<boolean>('IsInGarage');
+  const isReplayPlaying = useTelemetryValue<boolean>('IsReplayPlaying');
+
+  const isDriving =
+    (isOnTrack || inPitStall || onPitRoad) && !isInGarage && !isReplayPlaying;
+
+  return {
+    isDriving,
+  };
+};

--- a/src/types/dashboardLayout.ts
+++ b/src/types/dashboardLayout.ts
@@ -26,6 +26,7 @@ export interface DashboardWidget {
 export interface GeneralSettingsType {
   fontSize?: 'xs' | 'sm' | 'lg' | 'xl';
   colorPalette?: 'default' | string;
+  showOnlyWhenOnTrack?: boolean;
 }
 
 export interface DashboardLayout {


### PR DESCRIPTION
<img width="798" height="698" alt="SCR-20250828-spau" src="https://github.com/user-attachments/assets/983fb5ff-bc45-434f-a4f0-b701d83e2c66" />

With this setting enabled, overlays will be rendered only when the car is on the track or in the pit stall. Benefits:

- prevent overlays from showing up when iRacing is still being loaded
- rendering them when in the menus may cover important info on the screen
- no more need to close the app if recording the replay as a video