### PR TITLE
fix: carId to always be provided to standings/relative

### DIFF
--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -125,7 +125,7 @@ export const Relative = () => {
           fastestTime={settings?.fastestTime?.enabled ? result.fastestTime : undefined}
           lastTimeState={settings?.lastTime?.enabled ? result.lastTimeState : undefined}
           tireCompound={settings?.compound?.enabled ? result.tireCompound : undefined}
-          carId={settings?.carManufacturer?.enabled ?? true ? result.carId : undefined}
+          carId={result.carId}
           isMultiClass={isMultiClass}
           badge={
             settings?.badge?.enabled ? (

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -81,7 +81,7 @@ export const Standings = () => {
                   isMultiClass={isMultiClass}
                   flairId={settings?.countryFlags?.enabled ?? true ? result.driver?.flairId : undefined}
                   tireCompound={settings?.compound?.enabled ?? true ? result.tireCompound : undefined}
-                  carId={settings?.carManufacturer?.enabled ?? true ? result.carId : undefined}
+                  carId={result.carId}
                   badge={
                     settings?.badge?.enabled ? (
                       <DriverRatingBadge


### PR DESCRIPTION
Was causing tire compounds to disappear when car manufacturer is turned off