### PR TITLE
Pit lap formatting

### DIFF
--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/PitStatusCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/PitStatusCell.tsx
@@ -83,7 +83,7 @@ export const PitStatusCell = memo(
         )}
         {lastPit && (
           <div>
-            <span className="text-white text-xs border-yellow-500 border text-center text-nowrap px-2 m-0 leading-tight">
+            <span className="text-white text-xs border-yellow-500 border-2 rounded-md text-center text-nowrap px-2 m-0 leading-tight">
               L {lastPitLap}
             </span>
           </div>


### PR DESCRIPTION
The L## badge after pitting that shows the lap of the pit stop needs consistent formatting to the rest of the badges.