### PR TITLE
Session bar time format

### DIFF
--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -1,5 +1,5 @@
 import { useSessionName, useTelemetryValue } from '@irdashies/context';
-import { formatTimeElapsedHMS, formatTimeRemainingHours } from '@irdashies/utils/time';
+import { formatTimeElapsedHMS, formatTimeRemaining } from '@irdashies/utils/time';
 import { useDriverIncidents, useSessionLapCount, useBrakeBias, useRelativeSettings } from '../../hooks';
 
 export const SessionBar = () => {
@@ -24,8 +24,8 @@ export const SessionBar = () => {
         <div className="flex flex-1 grow justify-center">
           {(() => {
             const elapsed = formatTimeElapsedHMS(timeElapsed);
-            const remaining = formatTimeRemainingHours(timeRemaining);
-            return elapsed ? `${elapsed} / ${remaining} H` : (remaining ? `${remaining} H` : '');
+            const remaining = formatTimeRemaining(timeRemaining);
+            return elapsed ? `${elapsed} / ${remaining}` : (remaining ? `${remaining}` : '');
           })()}
         </div>
       )}

--- a/src/frontend/utils/time.ts
+++ b/src/frontend/utils/time.ts
@@ -40,15 +40,33 @@ export const formatTimeElapsedHMS = (seconds?: number): string => {
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const secs = totalSeconds % 60;
 
-  return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  } else {
+    return `${minutes}:${String(secs).padStart(2, '0')}`;
+  }
 };
 
-export const formatTimeRemainingHours = (seconds?: number): string => {
+export const formatTimeRemaining = (seconds?: number): string => {
   if (!seconds) return '';
   if (seconds < 0) return '';
 
   const totalSeconds = Math.floor(seconds);
-  const hours = Math.round(totalSeconds / 3600); // Round to nearest hour
+  const totalMinutes = Math.floor(totalSeconds / 60);
 
-  return `${hours}`;
+  if (totalMinutes >= 60) {
+    const hours = Math.round(totalSeconds / 3600);
+    return `${hours} hr`;
+  } else if (totalMinutes > 0) {
+    const remainingMinutes = totalMinutes;
+    const remainingSeconds = totalSeconds % 60;
+    if (remainingSeconds === 0) {
+      return `${remainingMinutes} min`;
+    } else {
+      return `${remainingMinutes}:${String(remainingSeconds).padStart(2, '0')} min`;
+    }
+  } else if (totalSeconds > 0) {
+    return `${totalSeconds} sec`;
+  }
+  return '';
 };


### PR DESCRIPTION
Session bar time was showing in minutes only. Added formatting.

Before
1282:41 / 1440 m
30:12 / 35 m

After
21:22:41 / 24 hr
30:12 / 35 min
