### PR TITLE
feat: remove sign from number value

### DIFF
--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/LapTimeDeltasCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/LapTimeDeltasCell.tsx
@@ -17,7 +17,7 @@ export const LapTimeDeltasCell = memo(({ hidden, lapTimeDeltas, emptyLapDeltaPla
             data-column="lapTimeDelta"
             className={`w-auto px-1 text-center whitespace-nowrap ${deltaValue > 0 ? 'text-green-400' : 'text-red-400'}`}
           >
-            {hidden ? '' : (deltaValue > 0 ? '+' : '') + deltaValue.toFixed(1)}
+            {hidden ? '' : Math.abs(deltaValue).toFixed(1)}
           </td>
         ))}
       </Fragment>


### PR DESCRIPTION
since lap time deltas are color coded, we don't need the sign in front of the value. removed the sign to save space/minimize.