### PR TITLE
hide multi class header with 0 drivers

### DIFF
--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -50,75 +50,77 @@ export const Standings = () => {
       <table className="w-full table-auto text-sm border-separate border-spacing-y-0.5 mb-3">
         <tbody ref={parent}>
           {standings.map(([classId, classStandings]) => (
-            <Fragment key={classId}>
-              <DriverClassHeader
-                key={classId}
-                className={classStats?.[classId]?.shortName}
-                classColor={isMultiClass ? classStats?.[classId]?.color : highlightColor}
-                totalDrivers={classStats?.[classId]?.total}
-                sof={classStats?.[classId]?.sof}
-                highlightColor={highlightColor}
-                isMultiClass={isMultiClass}
-                colSpan={12}
-              />
-              {classStandings.map((result) => (
-                <DriverInfoRow
-                  key={result.carIdx}
-                  carIdx={result.carIdx}
-                  classColor={result.carClass.color}
-                  carNumber={settings?.carNumber?.enabled ?? true ? result.driver?.carNum || '' : undefined}
-                  name={result.driver?.name || ''}
-                  isPlayer={result.isPlayer}
-                  hasFastestTime={result.hasFastestTime}
-                  delta={settings?.delta?.enabled ? result.delta : undefined}
-                  gap={settings?.gap?.enabled ? result.gap : undefined}
-                  interval={settings?.interval?.enabled ? result.interval : undefined}
-                  position={result.classPosition}
-                  iratingChange={
-                    settings?.iratingChange?.enabled ? (
-                      <RatingChange value={result.iratingChange} />
-                    ) : undefined
-                  }
-                  lastTime={
-                    settings?.lastTime?.enabled ? result.lastTime : undefined
-                  }
-                  fastestTime={
-                    settings?.fastestTime?.enabled
-                      ? result.fastestTime
-                      : undefined
-                  }
-                  lastTimeState={
-                    settings?.lastTime?.enabled ? result.lastTimeState : undefined
-                  }
-                  onPitRoad={result.onPitRoad}
-                  onTrack={result.onTrack}
-                  radioActive={result.radioActive}
-                  isMultiClass={isMultiClass}
-                  flairId={settings?.countryFlags?.enabled ?? true ? result.driver?.flairId : undefined}
-                  tireCompound={settings?.compound?.enabled ?? true ? result.tireCompound : undefined}
-                  carId={result.carId}
-                  lastPitLap={result.lastPitLap}
-                  lastLap={result.lastLap}
-                  carTrackSurface={result.carTrackSurface}
-                  prevCarTrackSurface={result.prevCarTrackSurface}
-                  badge={
-                    settings?.badge?.enabled ? (
-                      <DriverRatingBadge
-                        license={result.driver?.license}
-                        rating={result.driver?.rating}
-                        format={settings.badge.badgeFormat}
-                      />
-                    ) : undefined
-                  }
-                  lapTimeDeltas={settings?.lapTimeDeltas?.enabled ? result.lapTimeDeltas : undefined}
-                  numLapDeltasToShow={settings?.lapTimeDeltas?.enabled ? settings.lapTimeDeltas.numLaps : undefined}
-                  displayOrder={settings?.displayOrder}
-                  currentSessionType={result.currentSessionType}
-                  config={settings}
+            classStandings.length > 0 ? (
+              <Fragment key={classId}>
+                <DriverClassHeader
+                  key={classId}
+                  className={classStats?.[classId]?.shortName}
+                  classColor={isMultiClass ? classStats?.[classId]?.color : highlightColor}
+                  totalDrivers={classStats?.[classId]?.total}
+                  sof={classStats?.[classId]?.sof}
                   highlightColor={highlightColor}
+                  isMultiClass={isMultiClass}
+                  colSpan={12}
                 />
-              ))}
-            </Fragment>
+                {classStandings.map((result) => (
+                  <DriverInfoRow
+                    key={result.carIdx}
+                    carIdx={result.carIdx}
+                    classColor={result.carClass.color}
+                    carNumber={settings?.carNumber?.enabled ?? true ? result.driver?.carNum || '' : undefined}
+                    name={result.driver?.name || ''}
+                    isPlayer={result.isPlayer}
+                    hasFastestTime={result.hasFastestTime}
+                    delta={settings?.delta?.enabled ? result.delta : undefined}
+                    gap={settings?.gap?.enabled ? result.gap : undefined}
+                    interval={settings?.interval?.enabled ? result.interval : undefined}
+                    position={result.classPosition}
+                    iratingChange={
+                      settings?.iratingChange?.enabled ? (
+                        <RatingChange value={result.iratingChange} />
+                      ) : undefined
+                    }
+                    lastTime={
+                      settings?.lastTime?.enabled ? result.lastTime : undefined
+                    }
+                    fastestTime={
+                      settings?.fastestTime?.enabled
+                        ? result.fastestTime
+                        : undefined
+                    }
+                    lastTimeState={
+                      settings?.lastTime?.enabled ? result.lastTimeState : undefined
+                    }
+                    onPitRoad={result.onPitRoad}
+                    onTrack={result.onTrack}
+                    radioActive={result.radioActive}
+                    isMultiClass={isMultiClass}
+                    flairId={settings?.countryFlags?.enabled ?? true ? result.driver?.flairId : undefined}
+                    tireCompound={settings?.compound?.enabled ?? true ? result.tireCompound : undefined}
+                    carId={result.carId}
+                    lastPitLap={result.lastPitLap}
+                    lastLap={result.lastLap}
+                    carTrackSurface={result.carTrackSurface}
+                    prevCarTrackSurface={result.prevCarTrackSurface}
+                    badge={
+                      settings?.badge?.enabled ? (
+                        <DriverRatingBadge
+                          license={result.driver?.license}
+                          rating={result.driver?.rating}
+                          format={settings.badge.badgeFormat}
+                        />
+                      ) : undefined
+                    }
+                    lapTimeDeltas={settings?.lapTimeDeltas?.enabled ? result.lapTimeDeltas : undefined}
+                    numLapDeltasToShow={settings?.lapTimeDeltas?.enabled ? settings.lapTimeDeltas.numLaps : undefined}
+                    displayOrder={settings?.displayOrder}
+                    currentSessionType={result.currentSessionType}
+                    config={settings}
+                    highlightColor={highlightColor}
+                  />
+                ))}
+              </Fragment>
+            ) : null
           ))}
         </tbody>
       </table>


### PR DESCRIPTION
when 0 is selected for standings settings for number of drivers to show in other classes, the class header shouldn't be displayed. This fix hides the class header whenever 0 drivers are available for a given class.