### PR TITLE
Fix multi class highlight color

### DIFF
--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { DriverInfoRow } from './components/DriverInfoRow/DriverInfoRow';
 import { useDrivingState } from '@irdashies/context';
-import { useRelativeSettings, useDriverRelatives, useDriverStandings, useHighlightColor } from './hooks';
+import { useRelativeSettings, useDriverRelatives, useHighlightColor } from './hooks';
 import { DriverRatingBadge } from './components/DriverRatingBadge/DriverRatingBadge';
 import { RatingChange } from './components/RatingChange/RatingChange';
 import { SessionBar } from './components/SessionBar/SessionBar';
@@ -10,6 +10,7 @@ import { SessionFooter } from './components/SessionFooter/SessionFooter';
 import { TitleBar } from './components/TitleBar/TitleBar';
 import { usePitLabStoreUpdater } from '../../context/PitLapStore/PitLapStoreUpdater';
 import { useRelativeGapStoreUpdater } from '@irdashies/context';
+import { useWeekendInfoNumCarClasses } from '@irdashies/context';
 
 export const Relative = () => {
   const settings = useRelativeSettings();
@@ -17,13 +18,9 @@ export const Relative = () => {
   const { isDriving } = useDrivingState();
   const standings = useDriverRelatives({ buffer });
   const [parent] = useAutoAnimate();
-  const activeDrivers = useDriverStandings();
   const highlightColor = useHighlightColor();
-  const isMultiClass = useMemo(() => {
-    const uniqueClasses = new Set(activeDrivers.flatMap(([, drivers]) => drivers.map(d => d.carClass.id)));
-    return uniqueClasses.size > 1;
-  }, [activeDrivers]);
-
+  const numCarClasses = useWeekendInfoNumCarClasses();
+  const isMultiClass = (numCarClasses ?? 0) > 1;
 
   // Update relative gap store with telemetry data
   useRelativeGapStoreUpdater();

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -15,7 +15,7 @@ import {
 } from './hooks';
 import { useLapTimesStoreUpdater } from '../../context/LapTimesStore/LapTimesStoreUpdater';
 import { usePitLabStoreUpdater } from '../../context/PitLapStore/PitLapStoreUpdater';
-import { useDrivingState } from '@irdashies/context';
+import { useDrivingState, useWeekendInfoNumCarClasses } from '@irdashies/context';
 
 export const Standings = () => {
   const [parent] = useAutoAnimate();
@@ -30,7 +30,8 @@ export const Standings = () => {
 
   const standings = useDriverStandings(settings);
   const classStats = useCarClassStats();
-  const isMultiClass = standings.length > 1;
+  const numCarClasses = useWeekendInfoNumCarClasses();
+  const isMultiClass = (numCarClasses ?? 0) > 1;
   const highlightColor = useHighlightColor();
 
   // Show only when on track setting

--- a/src/frontend/context/SessionStore/SessionStore.tsx
+++ b/src/frontend/context/SessionStore/SessionStore.tsx
@@ -77,6 +77,12 @@ export const useWeekendInfoEventType = () =>
     (state) => state.session?.WeekendInfo?.EventType
   );
 
+export const useWeekendInfoNumCarClasses = () =>
+  useStore(
+    useSessionStore,
+    (state) => state.session?.WeekendInfo?.NumCarClasses
+  );
+
 export const useDriverCarIdx = () =>
   useStore(useSessionStore, (state) => state.session?.DriverInfo?.DriverCarIdx);
 


### PR DESCRIPTION
updated fix (last one was incorrect) on how to define a multi class race. Now using iracing session data, so driver number boxes in standings/relatives get colored correctly in multi class and not use the highlight color when in multi class races.