### PR TITLE
Updated relative and standings to focus on the currently spectated driver

### DIFF
--- a/src/frontend/context/shared/useFocusCarIdx.ts
+++ b/src/frontend/context/shared/useFocusCarIdx.ts
@@ -1,4 +1,4 @@
-import { useDriverCarIdx, useSessionDrivers } from '../SessionStore/SessionStore';
+import { useDriverCarIdx } from '../SessionStore/SessionStore';
 import { useTelemetryValue } from '../TelemetryStore/TelemetryStore';
 
 /**


### PR DESCRIPTION
Removed filter to only update when the isSpectator flag is true.
Now any change to the camera car should update the relative and standings.