### PR TITLE
fix: gap/int label

### DIFF
--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -268,7 +268,7 @@ export const DriverInfoRow = memo(
               key="gap"
               hidden={hidden}
               delta={gap}
-              showForUndefined="gap"
+              showForUndefined={position === 1 ? "gap" : undefined}
             />
           ),
         },
@@ -285,7 +285,7 @@ export const DriverInfoRow = memo(
               key="interval"
               hidden={hidden}
               delta={interval}
-              showForUndefined="int"
+              showForUndefined={position === 1 ? "int" : undefined}
             />
           ),
         },


### PR DESCRIPTION
if there isn't a valid gap/int because times aren't set, the gap/int labels would repeat for every driver row. Updated to only show gap/int label word if driver is first in the list.
