### PR TITLE
feat: allow adjust line width for input traces

### DIFF
--- a/src/app/storage/defaultDashboard.ts
+++ b/src/app/storage/defaultDashboard.ts
@@ -157,7 +157,8 @@ export const defaultDashboard: DashboardLayout = {
           "includeThrottle": true,
           "includeBrake": true,
           "includeAbs": true,
-          "includeSteer": true
+          "includeSteer": true,
+          "strokeWidth": 3
         },
         "bar": {
           "enabled": true,

--- a/src/frontend/components/Input/InputTrace/InputTrace.stories.tsx
+++ b/src/frontend/components/Input/InputTrace/InputTrace.stories.tsx
@@ -68,3 +68,50 @@ export const OutsideRange: StoryObj<typeof InputTrace> = {
     },
   },
 };
+
+const ConfigurableStrokeWidthComponent = ({ strokeWidth }: { strokeWidth: number }) => {
+  const [throttle, setThrottle] = useState(0);
+  const [brake, setBrake] = useState(0);
+  const [brakeAbsActive, setBrakeAbsActive] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setThrottle((value) =>
+        Math.max(0, Math.min(1, value + Math.random() * 0.1 - 0.05))
+      );
+
+      setBrake((value) =>
+        Math.max(0, Math.min(1, value + Math.random() * 0.1 - 0.05))
+      );
+
+      setBrakeAbsActive((value) => Math.random() > 0.7 ? !value : value);
+    }, 1000 / 60);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return (
+    <InputTrace
+      input={{ brake, throttle, brakeAbsActive }}
+      settings={{
+        includeBrake: true,
+        includeThrottle: true,
+        includeAbs: true,
+        strokeWidth,
+      }}
+    />
+  );
+};
+
+export const ConfigurableStrokeWidth: StoryObj<typeof ConfigurableStrokeWidthComponent> = {
+  render: (args) => <ConfigurableStrokeWidthComponent strokeWidth={args.strokeWidth} />,
+  args: {
+    strokeWidth: 3,
+  },
+  argTypes: {
+    strokeWidth: {
+      control: { type: 'range', min: 1, max: 10, step: 1 },
+      description: 'Stroke width for throttle, brake, and ABS traces',
+    },
+  },
+};

--- a/src/frontend/components/Settings/sections/InputSettings.tsx
+++ b/src/frontend/components/Settings/sections/InputSettings.tsx
@@ -29,6 +29,7 @@ const defaultConfig: InputWidgetSettings['config'] = {
     includeBrake: true,
     includeAbs: true,
     includeSteer: true,
+    strokeWidth: 3,
   },
   bar: {
     enabled: true,
@@ -81,6 +82,9 @@ const migrateConfig = (savedConfig: unknown): InputWidgetSettings['config'] => {
       includeSteer:
         (config.trace as { includeSteer?: boolean })?.includeSteer ??
         defaultConfig.trace.includeSteer,
+      strokeWidth:
+        (config.trace as { strokeWidth?: number })?.strokeWidth ??
+        defaultConfig.trace.strokeWidth,
     },
     bar: {
       enabled:
@@ -318,6 +322,26 @@ export const InputSettings = () => {
                     />
                     <span className="text-sm text-slate-200">Show Steering Trace</span>
                   </label>
+                  <div className="flex items-center justify-between pt-2">
+                    <span className="text-sm text-slate-200">Stroke Width</span>
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="range"
+                        min="1"
+                        max="10"
+                        value={config.trace.strokeWidth ?? 3}
+                        onChange={(e) =>
+                          handleConfigChange({
+                            trace: { ...config.trace, strokeWidth: parseInt(e.target.value) },
+                          })
+                        }
+                        className="w-20 h-2 bg-slate-600 rounded-lg appearance-none cursor-pointer"
+                      />
+                      <span className="text-xs text-slate-400 w-8">
+                        {config.trace.strokeWidth ?? 3}
+                      </span>
+                    </div>
+                  </div>
                 </div>
               )}
             </div>

--- a/src/frontend/components/Settings/types.ts
+++ b/src/frontend/components/Settings/types.ts
@@ -136,6 +136,7 @@ export interface InputWidgetSettings extends BaseWidgetSettings {
       includeBrake: boolean;
       includeAbs: boolean;
       includeSteer?: boolean;
+      strokeWidth?: number;
     };
     bar: {
       enabled: boolean;


### PR DESCRIPTION
1. Adjust input trace width via setting
2. ABS will be still slightly thicker at a multiplier of 1.67

https://github.com/user-attachments/assets/047048f2-95d0-4237-a54c-bcbb44f68f80

