### PR TITLE
feat: add fuel scenarios to fuel calculator

### DIFF
--- a/src/app/storage/defaultDashboard.ts
+++ b/src/app/storage/defaultDashboard.ts
@@ -394,7 +394,7 @@ export const defaultDashboard: DashboardLayout = {
         "showMax": true,
         "showPitWindow": true,
         "showEnduranceStrategy": false,
-        "showFuelSave": true,
+        "showFuelScenarios": true,
         "showFuelRequired": false,
         "showConsumptionGraph": true,
         "consumptionGraphType": "histogram",

--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -87,10 +87,10 @@ export const WithoutPitWindow: Story = {
   },
 };
 
-export const WithoutFuelSave: Story = {
+export const WithoutFuelScenarios: Story = {
   decorators: [TelemetryDecorator()],
   args: {
-    showFuelSave: false,
+    showFuelScenarios: false,
   },
 };
 
@@ -106,7 +106,7 @@ export const MinimalView: Story = {
   args: {
     showConsumption: true,
     showPitWindow: true,
-    showFuelSave: true,
+    showFuelScenarios: true,
     show10LapAvg: true,
   },
 };
@@ -123,7 +123,7 @@ export const NormalRaceSimulation: Story = {
     show10LapAvg: true,
     showMax: true,
     showPitWindow: true,
-    showFuelSave: true,
+    showFuelScenarios: true,
     showFuelRequired: true,
     safetyMargin: 0.05,
     background: { opacity: 85 },
@@ -277,5 +277,48 @@ export const WithoutConsumptionGraph: Story = {
   ],
   args: {
     showConsumptionGraph: false,
+  },
+};
+
+export const FuelScenariosShowcase: Story = {
+  decorators: [TelemetryDecorator('/test-data/mock-fuel/normal')],
+  args: {
+    fuelUnits: 'L',
+    layout: 'vertical',
+    showConsumption: true,
+    showMin: true,
+    showLastLap: true,
+    show3LapAvg: true,
+    show10LapAvg: true,
+    showMax: true,
+    showPitWindow: true,
+    showFuelScenarios: true,
+    showFuelRequired: false,
+    showConsumptionGraph: true,
+    consumptionGraphType: 'histogram',
+    safetyMargin: 0.05,
+    background: { opacity: 85 },
+  },
+};
+
+export const FuelScenariosHorizontal: Story = {
+  decorators: [TelemetryDecorator('/test-data/mock-fuel/normal')],
+  args: {
+    fuelUnits: 'L',
+    layout: 'horizontal',
+    showConsumption: true,
+    showMin: true,
+    showLastLap: true,
+    show3LapAvg: true,
+    show10LapAvg: true,
+    showMax: true,
+    showPitWindow: true,
+    showEnduranceStrategy: true,
+    showFuelScenarios: true,
+    showFuelRequired: false,
+    showConsumptionGraph: true,
+    consumptionGraphType: 'histogram',
+    safetyMargin: 0.05,
+    background: { opacity: 85 },
   },
 };

--- a/src/frontend/components/FuelCalculator/types.ts
+++ b/src/frontend/components/FuelCalculator/types.ts
@@ -72,6 +72,12 @@ export interface FuelCalculation {
   stopsRemaining?: number;
   /** Estimated laps per fuel stint (on a full tank) */
   lapsPerStint?: number;
+  /** Target scenarios for making current fuel last different lap counts */
+  targetScenarios?: {
+    laps: number;              // Target lap count (e.g., 19, 20, 21)
+    fuelPerLap: number;        // Required L/lap to achieve this (e.g., 2.63)
+    isCurrentTarget: boolean;  // True for the middle/current value
+  }[];
 }
 
 /**
@@ -98,8 +104,8 @@ export interface FuelCalculatorSettings {
   showPitWindow: boolean;
   /** Show endurance strategy (total pit stops for entire session) */
   showEnduranceStrategy?: boolean;
-  /** Show fuel save indicator */
-  showFuelSave: boolean;
+  /** Show fuel scenarios (target consumption for different lap counts) */
+  showFuelScenarios: boolean;
   /** Show fuel required for min/avg/max consumption */
   showFuelRequired?: boolean;
   /** Show consumption history graph */

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -470,6 +470,36 @@ export function useFuelCalculation(
       );
     }
 
+    // ========================================================================
+    // Calculate Target Consumption Scenarios
+    // ========================================================================
+    const targetScenarios: FuelCalculation['targetScenarios'] = [];
+
+    // Only show scenarios if we have meaningful fuel data
+    if (lapsWithFuel >= 0.5) {
+      const currentLapTarget = Math.round(lapsWithFuel);
+
+      // Determine which scenarios to show based on lapsWithFuel
+      const scenarios: number[] = [];
+
+      if (currentLapTarget > 1) {
+        scenarios.push(currentLapTarget - 1); // -1 lap
+      }
+      scenarios.push(currentLapTarget);        // current
+      scenarios.push(currentLapTarget + 1);    // +1 lap
+
+      // Calculate fuel per lap for each scenario
+      for (const lapCount of scenarios) {
+        if (lapCount > 0) {
+          targetScenarios.push({
+            laps: lapCount,
+            fuelPerLap: fuelLevel / lapCount,
+            isCurrentTarget: lapCount === currentLapTarget,
+          });
+        }
+      }
+    }
+
     const result: FuelCalculation = {
       fuelLevel,
       lastLapUsage,
@@ -494,6 +524,7 @@ export function useFuelCalculation(
       sessionTimeTotal,
       stopsRemaining,
       lapsPerStint,
+      targetScenarios,
     };
 
     // Only log when lap changes to avoid spam

--- a/src/frontend/components/Settings/sections/FuelSettings.tsx
+++ b/src/frontend/components/Settings/sections/FuelSettings.tsx
@@ -16,7 +16,7 @@ const defaultConfig: FuelWidgetSettings['config'] = {
   showMax: true,
   showPitWindow: true,
   showEnduranceStrategy: false,
-  showFuelSave: true,
+  showFuelScenarios: true,
   showFuelRequired: false,
   showConsumptionGraph: true,
   consumptionGraphType: 'histogram',
@@ -40,7 +40,7 @@ const migrateConfig = (
     showMax: (config.showMax as boolean) ?? true,
     showPitWindow: (config.showPitWindow as boolean) ?? true,
     showEnduranceStrategy: (config.showEnduranceStrategy as boolean) ?? false,
-    showFuelSave: (config.showFuelSave as boolean) ?? true,
+    showFuelScenarios: (config.showFuelScenarios as boolean) ?? (config.showFuelSave as boolean) ?? true,
     showFuelRequired: (config.showFuelRequired as boolean) ?? false,
     showConsumptionGraph: (config.showConsumptionGraph as boolean) ?? true,
     consumptionGraphType: (config.consumptionGraphType as 'line' | 'histogram') ?? 'histogram',
@@ -259,21 +259,20 @@ export const FuelSettings = () => {
             />
           </div>
 
-          {/* Show Fuel Save Indicator - Commented out while feature is disabled
+          {/* Show Fuel Scenarios */}
           <div className="flex items-center justify-between">
             <span className="text-sm text-slate-300">
-              Show Fuel Save Indicator
+              Show Fuel Scenarios
             </span>
             <input
               type="checkbox"
-              checked={settings.config.showFuelSave}
+              checked={settings.config.showFuelScenarios}
               onChange={(e) =>
-                handleConfigChange({ showFuelSave: e.target.checked })
+                handleConfigChange({ showFuelScenarios: e.target.checked })
               }
               className="w-4 h-4 bg-slate-700 rounded"
             />
           </div>
-          */}
 
           {/* Show Consumption Graph */}
           <div className="flex items-center justify-between">

--- a/src/frontend/components/Settings/types.ts
+++ b/src/frontend/components/Settings/types.ts
@@ -190,7 +190,7 @@ export interface FuelWidgetSettings extends BaseWidgetSettings {
     showMax: boolean;
     showPitWindow: boolean;
     showEnduranceStrategy: boolean;
-    showFuelSave: boolean;
+    showFuelScenarios: boolean;
     showFuelRequired: boolean;
     showConsumptionGraph: boolean;
     consumptionGraphType: 'line' | 'histogram';


### PR DESCRIPTION
Add a new Target Consumption section that shows what fuel consumption rate is required to make current fuel last different lap counts (±1 from current).

Features:
- Calculates target consumption for lapsWithFuel -1, current, and +1
- Highlights current target in blue for easy identification
- Shows in both vertical and horizontal layouts
- Dynamically adjusts based on current fuel level
- Only displays when lapsWithFuel >= 0.5 (meaningful fuel data)

Implementation:
- Added targetScenarios calculation in useFuelCalculation hook
- Added UI sections for both vertical and horizontal layouts
- Renamed showFuelSave to showFuelScenarios setting with backward compatibility
- Added Storybook stories to showcase the feature
- Preserves targetScenarios when fuel level changes in garage

Example:
If current fuel = 55L with 2.5 L/lap average (22 laps of fuel):
- 21 Laps: 2.62 L/lap
- 22 Laps: 2.50 L/lap (highlighted)
- 23 Laps: 2.39 L/lap