### PR TITLE
feat: implement global toggle for UI overlays

### DIFF
--- a/src/app/rendererExpose.ts
+++ b/src/app/rendererExpose.ts
@@ -1,0 +1,11 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+export function exposeInMainWorld() {
+contextBridge.exposeInMainWorld('globalKey', {
+  onToggle: (cb: (hide: boolean) => void) => {
+    const listener = (_: Electron.IpcRendererEvent, hide: boolean) => cb(hide);
+    ipcRenderer.on('global-toggle-hide', listener);
+    return () => ipcRenderer.removeListener('global-toggle-hide', listener);
+  }
+});
+}

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+// App.tsx
 import { createRoot } from 'react-dom/client';
 import { HashRouter, Route, Routes } from 'react-router-dom';
 import {
@@ -13,6 +13,7 @@ import { Settings } from './components/Settings/Settings';
 import { EditMode } from './components/EditMode/EditMode';
 import { ThemeManager } from './components/ThemeManager/ThemeManager';
 import { WIDGET_MAP } from './WidgetIndex';
+import { HideUIWrapper } from './components/HideUIWrapper';
 
 const AppRoutes = () => {
   const { currentDashboard } = useDashboard();
@@ -30,13 +31,7 @@ const AppRoutes = () => {
           <Route
             key={widget.id}
             path={`/${widget.id}`}
-            element={
-              running ? (
-                <WidgetComponent {...widget.config} />
-              ) : (
-                <></>
-              )
-            }
+            element={running ? <WidgetComponent {...widget.config} /> : <></>}
           />
         );
       })}
@@ -45,26 +40,9 @@ const AppRoutes = () => {
   );
 };
 
-declare global {
-  interface Window {
-    globalKey?: {
-      onToggle: (cb: (hide: boolean) => void) => () => void;
-    };
-  }
-}
-
 const App = () => {
-  const [hideUI, setHideUI] = useState(false);
-
-  useEffect(() => {
-    if (window.globalKey?.onToggle) {
-      const unsub = window.globalKey.onToggle((hide) => setHideUI(hide));
-      return () => unsub();
-    }
-  }, []);
-
   return (
-    <div className={hideUI ? 'hidden-ui' : ''}>
+    <HideUIWrapper>
       <DashboardProvider bridge={window.dashboardBridge}>
         <RunningStateProvider bridge={window.irsdkBridge}>
           <SessionProvider bridge={window.irsdkBridge} />
@@ -78,7 +56,7 @@ const App = () => {
           </HashRouter>
         </RunningStateProvider>
       </DashboardProvider>
-    </div>
+    </HideUIWrapper>
   );
 };
 

--- a/src/frontend/components/HideUIWrapper.tsx
+++ b/src/frontend/components/HideUIWrapper.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState, type ReactNode } from 'react';
+
+declare global {
+  interface Window {
+    globalKey?: {
+      onToggle: (cb: (hide: boolean) => void) => () => void;
+    };
+  }
+}
+
+interface HideUIWrapperProps {
+  children: ReactNode;
+}
+
+export const HideUIWrapper = ({ children }: HideUIWrapperProps) => {
+  const [hideUI, setHideUI] = useState(false);
+
+  useEffect(() => {
+    if (!window.globalKey?.onToggle) return;
+
+    const unsub = window.globalKey.onToggle((hide) => setHideUI(hide));
+    return () => unsub();
+  }, []);
+
+  return <div className={hideUI ? 'opacity-0 pointer-events-none transition-opacity duration-100 ease-linear' : ''}>{children}</div>;
+};

--- a/src/frontend/index.css
+++ b/src/frontend/index.css
@@ -8,9 +8,3 @@ html,body,#app {
   width: 100%;
   height: 100%;
 }
-
-.hidden-ui {
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 120ms linear;
-}

--- a/src/frontend/utils/globalShortcuts.ts
+++ b/src/frontend/utils/globalShortcuts.ts
@@ -1,0 +1,28 @@
+import { app, globalShortcut } from 'electron';
+import { OverlayManager } from 'src/app/overlayManager';
+
+
+export function registerHideUiShortcut(overlayManager: OverlayManager) {
+  let hideState = false;
+  const accel = 'Alt+H';
+
+  app.whenReady().then(() => {
+    const registered = globalShortcut.register(accel, () => {
+      // Toggle internal state and notify all overlay windows
+      hideState = !hideState;
+      overlayManager.getOverlays().forEach(({ window }) => {
+        window.webContents.send('global-toggle-hide', hideState);
+      });
+    });
+
+    if (!registered) {
+      console.error(`Failed to register global shortcut: ${accel}`);
+    }
+  });
+
+  // Cleanup when the app is quitting
+  app.on('will-quit', () => {
+    globalShortcut.unregister(accel);
+    globalShortcut.unregisterAll();
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, globalShortcut } from 'electron';
+import { app } from 'electron';
 import { iRacingSDKSetup, getCurrentBridge } from './app/bridge/iracingSdk/setup';
 import { getOrCreateDefaultDashboard } from './app/storage/dashboards';
 import { setupTaskbar } from './app';
@@ -10,6 +10,7 @@ import { updateElectronApp } from 'update-electron-app';
 // @ts-expect-error no types for squirrel
 import started from 'electron-squirrel-startup';
 import { Analytics } from './app/analytics';
+import { registerHideUiShortcut } from './frontend/utils/globalShortcuts';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) app.quit();
@@ -43,32 +44,9 @@ app.on('ready', async () => {
   publishDashboardUpdates(overlayManager, analytics);
   
   await analytics.init(overlayManager.getVersion(), dashboard);
-});
 
-let hideState = false;
-
-app.whenReady().then(() => {
-
-  // Register a global accelerator. Recommended: use a modifier to avoid conflicts.
-  // Examples: 'Alt+H', 'CommandOrControl+R', 'Ctrl+Alt+H'
-  const accel = 'Alt+H';
-
-  const registered = globalShortcut.register(accel, () => {
-    // Toggle internal state and notify renderer
-    hideState = !hideState;
-    overlayManager.getOverlays().forEach(({ window }) => {
-    window.webContents.send('global-toggle-hide', hideState);
-  });
-  });
-
-  if (!registered) {
-    console.error(`Failed to register global shortcut: ${accel}`);
-  }
-});
-
-app.on('will-quit', () => {
-  globalShortcut.unregister('Alt+H');
-  globalShortcut.unregisterAll();
+  // 🔽 Register the global hide UI shortcut once everything is set up
+  registerHideUiShortcut(overlayManager);
 });
 
 app.on('window-all-closed', () => app.quit());

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -1,14 +1,7 @@
 // See the Electron documentation for details on how to use preload scripts:
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 import { exposeBridge } from './app/bridge/rendererExposeBridge';
-import { contextBridge, ipcRenderer } from 'electron';
+import { exposeInMainWorld } from './app/rendererExpose';
 
 exposeBridge();
-
-contextBridge.exposeInMainWorld('globalKey', {
-  onToggle: (cb: (hide: boolean) => void) => {
-    const listener = (_: Electron.IpcRendererEvent, hide: boolean) => cb(hide);
-    ipcRenderer.on('global-toggle-hide', listener);
-    return () => ipcRenderer.removeListener('global-toggle-hide', listener);
-  }
-});
+exposeInMainWorld();


### PR DESCRIPTION
This is a initial implementation of a "hide overlay" mechanism. It's a global hide-all-overlays hardcoded to Alt+H. In the future I'd like to make this configurable per overlay, allowing user to set shortcuts to hide each overlay.