### PR TITLE
feat: add earliest pit lap and fuel-to-add mode to fuel calculator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -178,7 +178,6 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -539,7 +538,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -583,7 +581,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1376,7 +1373,6 @@
       "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -2647,7 +2643,6 @@
       "version": "6.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^3.0.1",
         "@inquirer/confirm": "^4.0.1",
@@ -3039,7 +3034,6 @@
       "version": "5.2.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -4188,7 +4182,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4579,7 +4574,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4590,7 +4584,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4702,7 +4695,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -5343,7 +5335,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5883,7 +5874,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -6771,7 +6761,6 @@
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7118,7 +7107,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.2.3",
@@ -7657,7 +7647,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7718,7 +7707,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10318,6 +10306,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11540,6 +11529,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11555,6 +11545,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11682,7 +11673,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11737,7 +11727,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -11750,7 +11739,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -12151,7 +12141,6 @@
       "version": "4.46.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12334,7 +12323,6 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12730,7 +12718,6 @@
       "integrity": "sha512-oK0t0jEogiKKfv5Z1ao4Of99+xWw1TMUGuGRYDQS4kp2yyBsJQEgu7NI7OLYsCDI6gzt5p3RPtl1lqdeVLUi8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.0",
@@ -13535,7 +13522,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13700,7 +13686,6 @@
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -13737,7 +13722,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -13813,7 +13797,6 @@
       "integrity": "sha512-n1RxDp8UJm6N0IbJLQo+yzLZ2sQCDyl1o0LeugbPWf8+8Fttp29GghsQBjYJVmWq3gBFfe9Hs1spR44vovn2wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.15",
         "@vitest/mocker": "4.0.15",
@@ -14548,7 +14531,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -123,8 +123,12 @@ export const NormalRaceSimulation: Story = {
     show10LapAvg: true,
     showMax: true,
     showPitWindow: true,
+    showEnduranceStrategy: true,
     showFuelScenarios: true,
     showFuelRequired: true,
+    fuelRequiredMode: 'toAdd',
+    showConsumptionGraph: true,
+    consumptionGraphType: 'histogram',
     safetyMargin: 0.05,
     background: { opacity: 85 },
   },
@@ -150,7 +154,9 @@ export const HorizontalLayout: Story = {
     showMax: true,
     showPitWindow: true,
     showEnduranceStrategy: true,
+    showFuelScenarios: true,
     showFuelRequired: true,
+    fuelRequiredMode: 'toAdd',
     showConsumptionGraph: true,
     consumptionGraphType: 'histogram',
     safetyMargin: 0.05,
@@ -173,9 +179,9 @@ const MockFuelDataProvider = ({ children }: { children: React.ReactNode }) => {
       // Create varied fuel usage with some above and below average (avg ~2.1)
       const baseUsage = 2.1;
       const variation = [
-        -0.3, 0, 0.05, -0.02, 0.02, -0.05, 0.08, 0, 0.01, -0.06,
-        0.15, -0.1, 0.03, -0.02, 0.05, -0.08, 0.1, -0.03, 0.02, -0.05,
-        0.12, -0.07, 0.04, -0.01, 0.06, -0.04, 0.09, -0.02, 0.03, -0.06
+        -0.3, 0, 0.05, -0.02, 0.02, -0.05, 0.08, 0, 0.01, -0.06, 0.15, -0.1,
+        0.03, -0.02, 0.05, -0.08, 0.1, -0.03, 0.02, -0.05, 0.12, -0.07, 0.04,
+        -0.01, 0.06, -0.04, 0.09, -0.02, 0.03, -0.06,
       ][i];
       return {
         lapNumber: i + 1,
@@ -188,7 +194,7 @@ const MockFuelDataProvider = ({ children }: { children: React.ReactNode }) => {
       };
     });
 
-    mockLaps.forEach(lap => addLapData(lap));
+    mockLaps.forEach((lap) => addLapData(lap));
 
     // Set current lap crossing state
     updateLapCrossing(0.1, 35.5, 2700, 31, false);
@@ -216,7 +222,9 @@ export const WithMockLapData: Story = {
     show10LapAvg: true,
     showMax: true,
     showPitWindow: true,
+    showEnduranceStrategy: true,
     showFuelRequired: true,
+    fuelRequiredMode: 'toAdd',
     showConsumptionGraph: true,
     consumptionGraphType: 'histogram',
     safetyMargin: 0.05,
@@ -292,8 +300,10 @@ export const FuelScenariosShowcase: Story = {
     show10LapAvg: true,
     showMax: true,
     showPitWindow: true,
+    showEnduranceStrategy: true,
     showFuelScenarios: true,
-    showFuelRequired: false,
+    showFuelRequired: true,
+    fuelRequiredMode: 'toFinish',
     showConsumptionGraph: true,
     consumptionGraphType: 'histogram',
     safetyMargin: 0.05,
@@ -315,7 +325,8 @@ export const FuelScenariosHorizontal: Story = {
     showPitWindow: true,
     showEnduranceStrategy: true,
     showFuelScenarios: true,
-    showFuelRequired: false,
+    showFuelRequired: true,
+    fuelRequiredMode: 'toFinish',
     showConsumptionGraph: true,
     consumptionGraphType: 'histogram',
     safetyMargin: 0.05,

--- a/src/frontend/components/FuelCalculator/types.ts
+++ b/src/frontend/components/FuelCalculator/types.ts
@@ -78,6 +78,10 @@ export interface FuelCalculation {
     fuelPerLap: number;        // Required L/lap to achieve this (e.g., 2.63)
     isCurrentTarget: boolean;  // True for the middle/current value
   }[];
+  /** Earliest lap to pit while still being able to finish (for safety car strategy) */
+  earliestPitLap?: number;
+  /** Fuel tank capacity in liters (respecting session limits) */
+  fuelTankCapacity?: number;
 }
 
 /**
@@ -116,4 +120,6 @@ export interface FuelCalculatorSettings {
   safetyMargin: number;
   /** Background opacity (0-100) */
   background: { opacity: number };
+  /** Display mode for fuel required column: 'toFinish' shows total fuel needed, 'toAdd' shows fuel to add at stop */
+  fuelRequiredMode?: 'toFinish' | 'toAdd';
 }

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -500,6 +500,34 @@ export function useFuelCalculation(
       }
     }
 
+    // ========================================================================
+    // Calculate Earliest Pit Lap (for safety car strategy)
+    // ========================================================================
+    let earliestPitLap: number | undefined;
+
+    if (stopsRemaining !== undefined && stopsRemaining > 0 && lapsPerStint !== undefined && lapsPerStint > 0) {
+      // Maximum laps coverable with all remaining stops (each fills full tank)
+      const maxLapsWithAllStops = lapsPerStint * stopsRemaining;
+
+      // Excess capacity = how much more we can cover than needed
+      const excessCapacity = maxLapsWithAllStops - lapsRemaining;
+
+      if (excessCapacity >= 0) {
+        // Can pit immediately on next lap
+        earliestPitLap = lap + 1;
+      } else {
+        // Must drive some laps first before we can pit
+        // Each lap we delay reduces how many laps we need to cover after pitting
+        const minLapsBeforePit = Math.ceil(-excessCapacity);
+        earliestPitLap = lap + Math.max(1, minLapsBeforePit);
+      }
+
+      // Ensure earliest pit doesn't exceed pit window close
+      if (earliestPitLap > pitWindowClose) {
+        earliestPitLap = Math.floor(pitWindowClose);
+      }
+    }
+
     const result: FuelCalculation = {
       fuelLevel,
       lastLapUsage,
@@ -525,6 +553,8 @@ export function useFuelCalculation(
       stopsRemaining,
       lapsPerStint,
       targetScenarios,
+      earliestPitLap,
+      fuelTankCapacity,
     };
 
     // Only log when lap changes to avoid spam

--- a/src/frontend/components/Settings/sections/FuelSettings.tsx
+++ b/src/frontend/components/Settings/sections/FuelSettings.tsx
@@ -22,6 +22,7 @@ const defaultConfig: FuelWidgetSettings['config'] = {
   consumptionGraphType: 'histogram',
   safetyMargin: 0.05,
   background: { opacity: 85 },
+  fuelRequiredMode: 'toFinish',
 };
 
 const migrateConfig = (
@@ -49,6 +50,7 @@ const migrateConfig = (
       opacity:
         (config.background as { opacity?: number })?.opacity ?? 85,
     },
+    fuelRequiredMode: (config.fuelRequiredMode as 'toFinish' | 'toAdd') ?? 'toFinish',
   };
 };
 
@@ -225,6 +227,30 @@ export const FuelSettings = () => {
                   className="w-4 h-4 bg-slate-700 rounded"
                 />
               </div>
+              {settings.config.showFuelRequired && (
+                <div className="ml-4 mt-2 border-l-2 border-slate-600 pl-4">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-slate-400">
+                      Display Mode
+                      <span className="block text-[10px] text-slate-500">
+                        To Finish: Total fuel needed | To Add: Fuel to add at stop
+                      </span>
+                    </span>
+                    <select
+                      value={settings.config.fuelRequiredMode}
+                      onChange={(e) =>
+                        handleConfigChange({
+                          fuelRequiredMode: e.target.value as 'toFinish' | 'toAdd',
+                        })
+                      }
+                      className="px-3 py-1 bg-slate-700 text-slate-200 rounded text-sm"
+                    >
+                      <option value="toFinish">To Finish</option>
+                      <option value="toAdd">Fuel to Add</option>
+                    </select>
+                  </div>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/frontend/components/Settings/types.ts
+++ b/src/frontend/components/Settings/types.ts
@@ -205,6 +205,7 @@ export interface FuelWidgetSettings extends BaseWidgetSettings {
     consumptionGraphType: 'line' | 'histogram';
     safetyMargin: number;
     background: { opacity: number };
+    fuelRequiredMode: 'toFinish' | 'toAdd';
   };
 }
 


### PR DESCRIPTION
- Add earliestPitLap calculation for safety car pit strategy
- Add fuelRequiredMode setting to toggle between "To Finish" and "Fuel to Add" display
- Implement context-aware fuel-to-add: shows fill tank if >1 stop remains, exact fuel on last stop
- Display earliest pit lap in horizontal layout endurance strategy and vertical layout pit window
- Update Storybook stories to showcase new features
- Consolidate footer by removing redundant "To Finish" value (already in consumption table)