### PR TITLE
fix: rejoin indicator shows in spectate mode

### DIFF
--- a/src/frontend/components/RejoinIndicator/RejoinIndicator.tsx
+++ b/src/frontend/components/RejoinIndicator/RejoinIndicator.tsx
@@ -75,9 +75,9 @@ export const RejoinIndicator = () => {
   // Decide visibility when there is no valid on-track car behind
   const isHiddenByNoCarBehind = !Number.isFinite(gap);
 
-  // Hide during standing start: session state 2 (WarmUp) or session time < 3 seconds during racing
+  // Hide during standing start: pre-race session states (< 4) or session time < 3 seconds during racing
   // SessionState 2 = WarmUp/ParadeLaps (pre-race), 3 = GetInCar (unlikely), 4 = Racing
-  const isHiddenBySessionStart = sessionState !== 4 || (sessionState === 4 && sessionTime < 3);
+  const isHiddenBySessionStart = sessionState < 4 || (sessionState === 4 && sessionTime < 3);
 
   if (isHiddenBySpeed) return null;
   if (isHiddenByLocation) return null;


### PR DESCRIPTION
### Overview
- Fixed bug where the indicator would show in replays. Now just check the player is actually driving so removed the isInGarage check since its no longer needed
- Fixed unintended showing on formation/parade lap and standing starts

### Testing
- tested using a local replay that was streaming data back. tested before changes to make sure i could replicate then after changes to validate fix
- tested standing start in AI session