### PR TITLE
fix: hide ui wrapper style fixes

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -42,21 +42,21 @@ const AppRoutes = () => {
 
 const App = () => {
   return (
-    <HideUIWrapper>
-      <DashboardProvider bridge={window.dashboardBridge}>
-        <RunningStateProvider bridge={window.irsdkBridge}>
-          <SessionProvider bridge={window.irsdkBridge} />
-          <TelemetryProvider bridge={window.irsdkBridge} />
-          <HashRouter>
+    <DashboardProvider bridge={window.dashboardBridge}>
+      <RunningStateProvider bridge={window.irsdkBridge}>
+        <SessionProvider bridge={window.irsdkBridge} />
+        <TelemetryProvider bridge={window.irsdkBridge} />
+        <HashRouter>
+          <HideUIWrapper>
             <EditMode>
               <ThemeManager>
                 <AppRoutes />
               </ThemeManager>
             </EditMode>
-          </HashRouter>
-        </RunningStateProvider>
-      </DashboardProvider>
-    </HideUIWrapper>
+          </HideUIWrapper>
+        </HashRouter>
+      </RunningStateProvider>
+    </DashboardProvider>
   );
 };
 

--- a/src/frontend/components/HideUIWrapper.tsx
+++ b/src/frontend/components/HideUIWrapper.tsx
@@ -22,5 +22,9 @@ export const HideUIWrapper = ({ children }: HideUIWrapperProps) => {
     return () => unsub();
   }, []);
 
-  return <div className={hideUI ? 'opacity-0 pointer-events-none transition-opacity duration-100 ease-linear' : ''}>{children}</div>;
+  if (hideUI) {
+    return <></>;
+  }
+
+  return children;
 };


### PR DESCRIPTION
Currently the styles causing issues with the children components specifically with the track map (and flag map).

This change moves the HideUI wrapper component deeper so it doesn't reset the providers
Makes it render children or not instead of applying styles to avoid issues.