### PR TITLE
fix: round humidity value to ensure its always a intiger

### DIFF
--- a/src/frontend/components/Weather/WeatherHumidity/WeatherHumidity.tsx
+++ b/src/frontend/components/Weather/WeatherHumidity/WeatherHumidity.tsx
@@ -15,7 +15,7 @@ export const WeatherHumidity: React.FC<Props> = ({ humidity }) => {
             <div className="flex flex-row gap-x-2 items-center text-sm">
                 {hasHumidity && (humidityPercent <= 50 ? <DropIcon /> : <DropHalfIcon />)}
         <span className="grow">Humidity</span>
-        <div className="text-center">{hasHumidity ? `${humidityPercent}%` : '- %'}</div>
+        <div className="text-center">{hasHumidity ? `${Math.round(humidityPercent)}%` : '- %'}</div>
       </div>
     </div>
     );


### PR DESCRIPTION
Speculative fix for a edge case where the humidity value could be a large float instead of a intiger
<img width="276" height="369" alt="image" src="https://github.com/user-attachments/assets/63e2d746-6d55-448f-85b4-ec349210199c" />

Wasnt able to replicate locally, but rounding the value should fix regardless. tested in a practice session and looks okay
<img width="506" height="788" alt="image" src="https://github.com/user-attachments/assets/1912f34e-a494-420a-92da-811ebec0cdb4" />
