### PR TITLE
Fix the regex to sanitize YAML input

### DIFF
--- a/src/app/irsdk/node/irsdk-node.ts
+++ b/src/app/irsdk/node/irsdk-node.ts
@@ -165,8 +165,8 @@ export class IRacingSDK {
 
     try {
       const seshString = this._sdk?.getSessionData();
-      // Remove trailing commas
-      const fixedYaml = seshString?.replace(/(\w+):\s*,\s*\n/g, '$1: \n');
+      // Remove leading and trailing commas
+      const fixedYaml = seshString?.replace(/(\w+):\s*,?((\w+,)*\w+)?,?\s*\n/g, '$1: $2 \n');
       this._sessionData = yaml.load(fixedYaml, { json: true }) as SessionData;
       return this._sessionData;
     } catch (err) {


### PR DESCRIPTION
The regex was supposed to fix trailing commas, which it didn't actually
do.
Additionaly, iRacing telemetry can also publish lists with leading commas,
which will cause an error in the YAML parser.

The regex was updated to remove leading AND trailing regexes.

Validated with test-data on https://regex101.com/r/d6I24n/1