### PR TITLE
Fix parsing of YAML values with leading commas

### DIFF
--- a/src/app/irsdk/node/irsdk-node.ts
+++ b/src/app/irsdk/node/irsdk-node.ts
@@ -165,8 +165,11 @@ export class IRacingSDK {
 
     try {
       const seshString = this._sdk?.getSessionData();
-      // Remove leading and trailing commas
-      const fixedYaml = seshString?.replace(/(\w+):\s*,?((\w+,)*\w+)?,?\s*\n/g, '$1: $2 \n');
+      // Handle leading commas in YAML values. 
+      // First regex will drop the comma if no values follow (e.g. 'field: ,' => 'field: ')
+      // Second regex will put value in quotes, if leading comma is followed by values (e.g. 'field: ,data' => 'field: ",data"')
+      const fixedYaml = seshString?.replace(/(\w+: ) *, *\n/g, '$1 \n')
+                                   .replace(/(\w+: )(,.*)/g, '$1"$2" \n');
       this._sessionData = yaml.load(fixedYaml, { json: true }) as SessionData;
       return this._sessionData;
     } catch (err) {


### PR DESCRIPTION
A previous fix to solve YAML parser errors due to leading commas did
actually lead to errors in races with the Super Formula (Light) cars,
as the value 'DownforceToDrag' contains a colon (e.g. '3.634:1'). This
did match the new regex, and introduced a space behind the colon,
invalidating the YAML data.

Now we use the same regex as in Kutu's SDK implementation, which is used
in Kapps, so we can consider it stable. It is also much simpler than
the previous regex.
https://github.com/kutu/pyirsdk/blob/master/irsdk.py#L633

Additionally, we also have to handle the case where there is no data
behind the leading comma. In that case, we want to drop the value completely.