### PR TITLE
feat: Driver name format options

### DIFF
--- a/src/frontend/components/Settings/components/DriverNamePreview.tsx
+++ b/src/frontend/components/Settings/components/DriverNamePreview.tsx
@@ -1,0 +1,42 @@
+export const DriverNamePreview = ({
+  format,
+  selected,
+  onClick
+}: {
+  format: string;
+  selected: boolean;
+  onClick: () => void;
+}) => {
+  const renderPreview = () => {
+    switch (format) {
+      case 'name-middlename-surname':
+        return <div> Max Emilian Verstappen </div>;
+      case 'name-m.-surname':
+        return <div> Max E. Verstappen </div>;
+      case 'name-surname':
+        return <div> Max Verstappen </div>;
+      case 'n.-surname':
+        return <div> M. Verstappen </div>;
+      case 'surname-n.':
+        return <div> Verstappen M. </div>;
+      case 'surname':
+        return <div> Verstappen </div>;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1 rounded cursor-pointer transition-colors inline-flex items-center justify-center ${
+        selected
+          ? 'border border-blue-500 bg-blue-500/10'
+          : 'hover:bg-slate-800'
+      }`}
+    >
+      {renderPreview()}
+    </button>
+  );
+};

--- a/src/frontend/components/Settings/sections/RelativeSettings.tsx
+++ b/src/frontend/components/Settings/sections/RelativeSettings.tsx
@@ -9,6 +9,7 @@ import { BadgeFormatPreview } from '../components/BadgeFormatPreview';
 import { VALID_SESSION_BAR_ITEM_KEYS, SESSION_BAR_ITEM_LABELS, DEFAULT_SESSION_BAR_DISPLAY_ORDER } from '../sessionBarConstants';
 import { mergeDisplayOrder } from '../../../utils/displayOrder';
 import { SessionVisibility } from '../components/SessionVisibility';
+import { DriverNamePreview } from '../components/DriverNamePreview';
 
 const SETTING_ID = 'relative';
 
@@ -41,7 +42,7 @@ const defaultConfig: RelativeWidgetSettings['config'] = {
   position: { enabled: true },
   carNumber: { enabled: true },
   countryFlags: { enabled: true },
-  driverName: { enabled: true, showStatusBadges: true },
+  driverName: { enabled: true, showStatusBadges: true, nameFormat: 'name-surname' },
   teamName: { enabled: false },
   pitStatus: { enabled: true, showPitTime: false },
   carManufacturer: { enabled: true, hideIfSingleMake: false },
@@ -104,6 +105,7 @@ const migrateConfig = (savedConfig: unknown): RelativeWidgetSettings['config'] =
       showStatusBadges:
         (config.driverName as { showStatusBadges?: boolean })?.showStatusBadges ??
         true,
+      nameFormat: ((config.driverName as { nameFormat?: 'name-middlename-surname' | 'name-m.-surname' | 'name-surname' | 'n.-surname' | 'surname-n.' | 'surname' })?.nameFormat) ?? 'name-middlename-surname',
     },
     teamName: { enabled: (config.teamName as { enabled?: boolean })?.enabled ?? false },
     pitStatus: {
@@ -246,6 +248,25 @@ const DisplaySettingsList = ({ itemsOrder, onReorder, settings, handleConfigChan
                         const cv = settings.config[setting.configKey] as { enabled: boolean; badgeFormat: string;[key: string]: unknown };
                         handleConfigChange({
                           [setting.configKey]: { ...cv, badgeFormat: format },
+                        });
+                      }}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+            {setting.configKey === 'driverName' && (configValue as { enabled: boolean }).enabled && (
+              <div className="mt-3">
+                <div className="flex flex-wrap gap-3 justify-end">
+                  {(['name-middlename-surname', 'name-m.-surname', 'name-surname', 'n.-surname', 'surname-n.', 'surname'] as const).map((format) => (
+                    <DriverNamePreview
+                      key={format}
+                      format={format}
+                      selected={(configValue as { enabled: boolean; nameFormat: string }).nameFormat === format}
+                      onClick={() => {
+                        const cv = settings.config[setting.configKey] as { enabled: boolean; nameFormat: string; [key: string]: unknown };
+                        handleConfigChange({
+                          [setting.configKey]: { ...cv, nameFormat: format },
                         });
                       }}
                     />

--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -6,6 +6,7 @@ import { ToggleSwitch } from '../components/ToggleSwitch';
 import { useSortableList } from '../../SortableList';
 import { DotsSixVerticalIcon } from '@phosphor-icons/react';
 import { BadgeFormatPreview } from '../components/BadgeFormatPreview';
+import { DriverNamePreview } from '../components/DriverNamePreview';
 import { VALID_SESSION_BAR_ITEM_KEYS, SESSION_BAR_ITEM_LABELS, DEFAULT_SESSION_BAR_DISPLAY_ORDER } from '../sessionBarConstants';
 import { mergeDisplayOrder } from '../../../utils/displayOrder';
 import { SessionVisibility } from '../components/SessionVisibility';
@@ -91,7 +92,7 @@ const defaultConfig: StandingsWidgetSettings['config'] = {
   useLivePosition: false,
   lapTimeDeltas: { enabled: false, numLaps: 3 },
   position: { enabled: true },
-  driverName: { enabled: true, showStatusBadges: true },
+  driverName: { enabled: true, showStatusBadges: true, nameFormat: 'name-surname' },
   teamName: { enabled: false },
   pitStatus: { enabled: true, showPitTime: false },
   displayOrder: sortableSettings.map(s => s.id),
@@ -224,6 +225,7 @@ const migrateConfig = (
       showStatusBadges:
         (config.driverName as { showStatusBadges?: boolean })?.showStatusBadges ??
         true,
+      nameFormat: ((config.driverName as { nameFormat?: 'name-middlename-surname' | 'name-m.-surname' | 'name-surname' | 'n.-surname' | 'surname-n.' | 'surname' })?.nameFormat) ?? 'name-middlename-surname',
     },
     teamName: { enabled: (config.teamName as { enabled?: boolean })?.enabled ?? false },
     pitStatus: {
@@ -361,6 +363,25 @@ const DisplaySettingsList = ({ itemsOrder, onReorder, settings, handleConfigChan
                         const cv = settings.config[setting.configKey] as { enabled: boolean; badgeFormat: string; [key: string]: unknown };
                         handleConfigChange({
                           [setting.configKey]: { ...cv, badgeFormat: format },
+                        });
+                      }}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+            {setting.configKey === 'driverName' && (configValue as { enabled: boolean }).enabled && (
+              <div className="mt-3">
+                <div className="flex flex-wrap gap-3 justify-end">
+                  {(['name-middlename-surname', 'name-m.-surname', 'name-surname', 'n.-surname', 'surname-n.', 'surname'] as const).map((format) => (
+                    <DriverNamePreview
+                      key={format}
+                      format={format}
+                      selected={(configValue as { enabled: boolean; nameFormat: string }).nameFormat === format}
+                      onClick={() => {
+                        const cv = settings.config[setting.configKey] as { enabled: boolean; nameFormat: string; [key: string]: unknown };
+                        handleConfigChange({
+                          [setting.configKey]: { ...cv, nameFormat: format },
                         });
                       }}
                     />

--- a/src/frontend/components/Settings/types.ts
+++ b/src/frontend/components/Settings/types.ts
@@ -84,7 +84,7 @@ export interface StandingsWidgetSettings extends BaseWidgetSettings {
     showOnlyWhenOnTrack: boolean;
     useLivePosition: boolean;
     position: { enabled: boolean };
-    driverName: { enabled: boolean; showStatusBadges: boolean };
+    driverName: { enabled: boolean; showStatusBadges: boolean; nameFormat: 'name-middlename-surname' | 'name-m.-surname' | 'name-surname' | 'n.-surname' | 'surname-n.' | 'surname' };
     teamName: { enabled: boolean };
     pitStatus: { enabled: boolean; showPitTime?: boolean };
     displayOrder: string[];
@@ -159,7 +159,7 @@ export interface RelativeWidgetSettings extends BaseWidgetSettings {
       precision: number;
     };
     position: { enabled: boolean };
-    driverName: { enabled: boolean; showStatusBadges: boolean };
+    driverName: { enabled: boolean; showStatusBadges: boolean; nameFormat: 'name-middlename-surname' | 'name-m.-surname' | 'name-surname' | 'n.-surname' | 'surname-n.' | 'surname' };
     teamName: { enabled: boolean };
     pitStatus: { enabled: boolean; showPitTime?: boolean };
     displayOrder: string[];

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.ReorderableConfig.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.ReorderableConfig.stories.tsx
@@ -305,7 +305,7 @@ const RelativeWithReorderableConfig = () => {
       position: { enabled: true },
       carNumber: { enabled: true },
       countryFlags: { enabled: true },
-      driverName: { enabled: true, showStatusBadges: true },
+      driverName: { enabled: true, showStatusBadges: true, nameFormat: 'name-surname'},
       teamName: { enabled: true },
       pitStatus: { enabled: true },
       carManufacturer: { enabled: true },

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -194,13 +194,14 @@ export const DriverInfoRow = memo(
           component: (
             <DriverNameCell
               key="driverName"
-              hidden={hidden}
-              name={name}
               radioActive={radioActive}
               repair={repair}
               penalty={penalty}
               slowdown={slowdown}
               showStatusBadges={config?.driverName?.showStatusBadges ?? true}
+              hidden={hidden}
+              fullName={name}
+              nameFormat={config?.driverName?.nameFormat}
             />
           ),
         },

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverNameCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverNameCell.tsx
@@ -1,10 +1,17 @@
 import { memo } from 'react';
 import { SpeakerHighIcon } from '@phosphor-icons/react';
 import { DriverStatusBadges } from './DriverStatusBadges';
+import {
+  DriverName as formatDriverName,
+  extractDriverName,
+  type DriverNameFormat,
+} from '../../DriverName/DriverName';
 
 interface DriverNameCellProps {
   hidden?: boolean;
-  name: string;
+  name?: string;
+  fullName?: string;
+  nameFormat?: DriverNameFormat;
   radioActive?: boolean;
   repair?: boolean;
   penalty?: boolean;
@@ -16,26 +23,38 @@ export const DriverNameCell = memo(
   ({
     hidden,
     name,
+    fullName,
+    nameFormat,
     radioActive,
     repair,
     penalty,
     slowdown,
     showStatusBadges = true,
   }: DriverNameCellProps) => {
+    const displayName = hidden
+      ? ''
+      : fullName
+      ? formatDriverName(
+          extractDriverName(fullName),
+          nameFormat ?? 'name-middlename-surname'
+        )
+      : name ?? '';
+
     return (
-      <td 
-        data-column="driverName" 
-        className="w-full max-w-0 px-1 py-0.5"
-      >
+      <td data-column="driverName" className="w-full max-w-0 px-1 py-0.5">
         <div className="flex items-center overflow-hidden">
           <span
-            className={`animate-pulse transition-[width] duration-300 ${radioActive ? 'w-4 mr-1' : 'w-0 overflow-hidden'}`}
+            className={`animate-pulse transition-[width] duration-300 ${
+              radioActive ? 'w-4 mr-1' : 'w-0 overflow-hidden'
+            }`}
           >
             <SpeakerHighIcon className="mt-px" size={16} />
           </span>
+
           <div className="flex-1 min-w-0 overflow-hidden mask-[linear-gradient(90deg,#000_90%,transparent)]">
-            <span className="block truncate">{hidden ? '' : name}</span>
+            <span className="block truncate">{displayName}</span>
           </div>
+
           {showStatusBadges && (
             <DriverStatusBadges
               hidden={hidden}

--- a/src/frontend/components/Standings/components/DriverName/DriverName.spec.tsx
+++ b/src/frontend/components/Standings/components/DriverName/DriverName.spec.tsx
@@ -1,0 +1,143 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { DriverNameView } from './DriverNameView';
+
+describe('DriverNameView', () => {
+  it('renders name-surname format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Charles Marc Hervé Perceval Leclerc"
+        format="name-surname"
+      />
+    );
+
+    expect(container.textContent).toBe('Charles Leclerc');
+  });
+
+  it('renders name-middlename-surname format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Charles Marc Hervé Perceval Leclerc"
+        format="name-middlename-surname"
+      />
+    );
+
+    expect(container.textContent).toBe(
+      'Charles Marc Hervé Perceval Leclerc'
+    );
+  });
+
+  it('renders name-m.-surname format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Charles Marc Hervé Perceval Leclerc"
+        format="name-m.-surname"
+      />
+    );
+
+    expect(container.textContent).toBe('Charles M. Leclerc');
+  });
+
+  it('renders n.-surname format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Charles Marc Hervé Perceval Leclerc"
+        format="n.-surname"
+      />
+    );
+
+    expect(container.textContent).toBe('C. Leclerc');
+  });
+
+  it('renders surname only', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Charles Marc Hervé Perceval Leclerc"
+        format="surname"
+      />
+    );
+
+    expect(container.textContent).toBe('Leclerc');
+  });
+
+// every driver should have a name but you never know. Delete it if you think it's useless
+
+  it('handles empty fullName', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName=""
+        format="name-surname"
+      />
+    );
+
+    expect(container.textContent).toBe('');
+  });
+
+// tests for drivers with single name
+
+  it('renders single name, name-surname format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Max"
+        format="name-surname"
+      />
+    );
+
+    expect(container.textContent).toBe('Max');
+  });
+
+  it('renders single name, name-middlename-surname format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Max"
+        format="name-middlename-surname"
+      />
+    );
+
+    expect(container.textContent).toBe('Max');
+  });
+
+ it('renders single name, name-m.-surname format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Max"
+        format="name-m.-surname"
+      />
+    );
+
+    expect(container.textContent).toBe('Max');
+  });
+
+  it('renders single name, n.-surname format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Max"
+        format="n.-surname"
+      />
+    );
+
+    expect(container.textContent).toBe('Max');
+  });
+
+ it('renders single name, surname-n. format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Max"
+        format="surname-n."
+      />
+    );
+
+    expect(container.textContent).toBe('Max');
+  });
+
+ it('renders single name, surname format', () => {
+    const { container } = render(
+      <DriverNameView
+        fullName="Max"
+        format="surname"
+      />
+    );
+
+    expect(container.textContent).toBe('Max');
+  });
+});

--- a/src/frontend/components/Standings/components/DriverName/DriverName.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverName/DriverName.stories.tsx
@@ -1,0 +1,74 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { DriverNameView, DriverNameViewProps } from './DriverNameView';
+
+export default {
+  component: DriverNameView,
+  title: 'widgets/Standings/components/DriverNameView',
+} as Meta;
+
+type Story = StoryObj<DriverNameViewProps>;
+
+export const Primary: Story = {
+  args: {
+    fullName: 'Charles Marc Hervé Perceval Leclerc',
+    format: 'name-surname',
+  },
+};
+
+export const WithMiddleName: Story = {
+  args: {
+    fullName: 'Charles Marc Hervé Perceval Leclerc',
+    format: 'name-middlename-surname',
+  },
+};
+
+export const WithMiddleInitial: Story = {
+  args: {
+    fullName: 'Charles Marc Hervé Perceval Leclerc',
+    format: 'name-m.-surname',
+  },
+};
+
+export const FirstInitialSurname: Story = {
+  args: {
+    fullName: 'Charles Marc Hervé Perceval Leclerc',
+    format: 'n.-surname',
+  },
+};
+
+export const SurnameOnly: Story = {
+  args: {
+    fullName: 'Charles Marc Hervé Perceval Leclerc',
+    format: 'surname',
+  },
+};
+
+export const NameOnly_SingleName: Story = {
+  args: {
+    fullName: 'Charles',
+    format: 'name-surname',
+  },
+};
+
+export const SurnameOnly_SingleName: Story = {
+  args: {
+    fullName: 'Charles',
+    format: 'surname',
+  },
+};
+
+export const AllFormats: Story = {
+  args: {
+    fullName: 'Charles Marc Hervé Perceval Leclerc',
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      <DriverNameView {...args} format="name-surname" />
+      <DriverNameView {...args} format="name-middlename-surname" />
+      <DriverNameView {...args} format="name-m.-surname" />
+      <DriverNameView {...args} format="n.-surname" />
+      <DriverNameView {...args} format="surname-n." />
+      <DriverNameView {...args} format="surname" />
+    </div>
+  ),
+};

--- a/src/frontend/components/Standings/components/DriverName/DriverName.tsx
+++ b/src/frontend/components/Standings/components/DriverName/DriverName.tsx
@@ -1,0 +1,84 @@
+export interface DriverNameParts {
+  firstName: string;
+  middleName: string | null;
+  surname: string;
+};
+
+// Utility: capitalize the first letter of each word (some people use lower case for the fist letter of their name for strange reasons)
+const capitalizeWords = (str: string) =>
+  str
+    .split(' ')
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
+
+export const extractDriverName = (
+  fullName = ''
+): DriverNameParts => {
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+
+  if (parts.length === 0) {
+    return { firstName: '', middleName: null, surname: '' };
+  }
+
+  if (parts.length === 1) {
+    return {
+      firstName: capitalizeWords(parts[0]),
+      middleName: null,
+      surname: '',
+    };
+  }
+
+  return {
+    firstName: capitalizeWords(parts[0]),
+    middleName:
+      parts.length > 2
+        ? capitalizeWords(parts.slice(1, -1).join(' '))
+        : null,
+    surname: capitalizeWords(parts[parts.length - 1]),
+  };
+};
+
+export type DriverNameFormat =
+  | 'name-middlename-surname'
+  | 'name-m.-surname'
+  | 'name-surname'
+  | 'n.-surname'
+  | 'surname-n.'
+  | 'surname';
+
+export const DriverName = (
+  name: DriverNameParts,
+  format: DriverNameFormat
+): string => {
+  const { firstName, middleName, surname } = name;
+  const middleInitial = middleName?.charAt(0);
+
+  // needed to display the name in case the driver has no surname i.e fullname is 'Charles'
+  if (!surname) {
+    return firstName;
+  }
+
+  switch (format) {
+    case 'name-middlename-surname':
+      return [firstName, middleName, surname].filter(Boolean).join(' ');
+
+    case 'name-m.-surname':
+      return [firstName, middleInitial && `${middleInitial}.`, surname].filter(Boolean).join(' ');
+
+    case 'name-surname':
+      return [firstName, surname].filter(Boolean).join(' ');
+
+    case 'n.-surname':
+      return `${firstName.charAt(0)}. ${surname}`;
+
+    case 'surname-n.':
+      return `${surname} ${firstName.charAt(0)}.`;
+
+    case 'surname':
+      return surname;
+
+    default:
+      return `${firstName} ${surname}`;
+  }
+};

--- a/src/frontend/components/Standings/components/DriverName/DriverNameView.tsx
+++ b/src/frontend/components/Standings/components/DriverName/DriverNameView.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { extractDriverName, DriverName, DriverNameFormat } from './DriverName';
+
+export interface DriverNameViewProps {
+  fullName?: string;
+  format: DriverNameFormat;
+}
+
+// This component lets us render DriverName in JSX / Storybook
+export const DriverNameView: React.FC<DriverNameViewProps> = ({
+  fullName = '',
+  format,
+}) => {
+  const parts = extractDriverName(fullName);
+  const formatted = DriverName(parts, format);
+
+  return <span>{formatted}</span>;
+};


### PR DESCRIPTION
Sorry for another PR, fucked up the other one. 
Anyways, this feature includes the possibility to change the format of driver's name for both standings and relative.
<img width="1069" height="107" alt="Screenshot 2026-01-19 224854" src="https://github.com/user-attachments/assets/ef52f22c-79bd-4508-9c1e-8475d4f79a30" />

Lint and test run successfully.
- Fixed typo in DriverName.tsx
- With respect to last PR, I modified the algorithim so that when a driver with only one name is in the session, his name is displayed indipendently of the format selected
- Modified DriverName.spec.tsx to test all the format options with a single name driver
