### PR TITLE
fix: always use same format for rpm text

### DIFF
--- a/src/frontend/components/Input/InputTachometer/InputTachometer.tsx
+++ b/src/frontend/components/Input/InputTachometer/InputTachometer.tsx
@@ -283,7 +283,7 @@ export const Tachometer = ({
           >
             {showRpmText && (
               <>
-                {Math.round(clampedRpm).toLocaleString()}
+                {Math.round(clampedRpm).toLocaleString('en-US')}
                 <span className="text-xs text-gray-300 ml-1">RPM</span>
                 {shouldShowCustomShift && <span className="text-xs ml-2 font-bold">SHIFT</span>}
               </>


### PR DESCRIPTION
I apologize to my european friends