### PR TITLE
fix: reset all stores when user exits iRacing session

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -9,6 +9,7 @@ import {
   useRunningState,
   SessionProvider,
   PitLaneProvider,
+  useResetOnDisconnect,
 } from '@irdashies/context';
 import { Settings } from './components/Settings/Settings';
 import { EditMode } from './components/EditMode/EditMode';
@@ -19,6 +20,7 @@ import { HideUIWrapper } from './components/HideUIWrapper/HideUIWrapper';
 const AppRoutes = () => {
   const { currentDashboard } = useDashboard();
   const { running } = useRunningState();
+  useResetOnDisconnect(running);
 
   return (
     <Routes>

--- a/src/frontend/components/Standings/hooks/useDriverRelatives.spec.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverRelatives.spec.tsx
@@ -181,6 +181,7 @@ describe('useDriverRelatives', () => {
           CarSetup: {} as any,
         },
         setSession: vi.fn(),
+        resetSession: vi.fn(),
       })
     );
   });

--- a/src/frontend/context/CarSpeedStore/CarSpeedsStore.tsx
+++ b/src/frontend/context/CarSpeedStore/CarSpeedsStore.tsx
@@ -12,6 +12,7 @@ interface CarSpeedsState {
   lastSpeedUpdate: number;
   carSpeeds: number[];
   updateCarSpeeds: (telemetry: Telemetry | null, trackLength: number) => void;
+  resetCarSpeeds: () => void;
 }
 
 const SPEED_AVG_WINDOW = 5;
@@ -65,6 +66,13 @@ export const useCarSpeedsStore = create<CarSpeedsState>((set, get) => ({
       },
       lastSpeedUpdate: sessionTime,
       carSpeeds: avgSpeeds,
+    });
+  },
+  resetCarSpeeds: () => {
+    set({
+      carSpeedBuffer: null,
+      lastSpeedUpdate: 0,
+      carSpeeds: [],
     });
   },
 }));

--- a/src/frontend/context/PitLapStore/PitLapStore.tsx
+++ b/src/frontend/context/PitLapStore/PitLapStore.tsx
@@ -23,6 +23,7 @@ interface PitLapState {
     carIdxTrackSurface: number[],
     sessionState: number
   ) => void;
+  reset: () => void;
 }
 
 export const usePitLapStore = create<PitLapState>((set, get) => ({
@@ -119,6 +120,21 @@ export const usePitLapStore = create<PitLapState>((set, get) => ({
       sessionTime: currentSessionTime,
       sessionState: sessionState,
       sessionUniqId: currentSessionUniqId
+    });
+  },
+  reset: () => {
+    set({
+      sessionUniqId: 0,
+      sessionTime: 0,
+      sessionState: 0,
+      pitLaps: [],
+      carLaps: [],
+      prevCarTrackSurface: [],
+      actualCarTrackSurface: [],
+      pitEntryTime: [],
+      pitExitTime: [],
+      prevOnPitRoad: [],
+      entryLap: [],
     });
   },
 }));

--- a/src/frontend/context/SessionStore/SessionStore.tsx
+++ b/src/frontend/context/SessionStore/SessionStore.tsx
@@ -7,11 +7,13 @@ import { shallow } from 'zustand/shallow';
 interface SessionState {
   session: Session | null;
   setSession: (session: Session) => void;
+  resetSession: () => void;
 }
 
 export const useSessionStore = create<SessionState>((set) => ({
   session: null as Session | null,
   setSession: (session: Session) => set({ session }),
+  resetSession: () => set({ session: null }),
 }));
 
 export const useSessionDrivers = () =>

--- a/src/frontend/context/TelemetryStore/TelemetryStore.tsx
+++ b/src/frontend/context/TelemetryStore/TelemetryStore.tsx
@@ -7,11 +7,13 @@ import { arrayCompare, telemetryCompare } from './telemetryCompare';
 interface TelemetryState {
   telemetry: Telemetry | null;
   setTelemetry: (telemetry: Telemetry | null) => void;
+  resetTelemetry: () => void;
 }
 
 export const useTelemetryStore = create<TelemetryState>((set) => ({
   telemetry: null,
   setTelemetry: (telemetry: Telemetry | null) => set({ telemetry }),
+  resetTelemetry: () => set({ telemetry: null }),
 }));
 
 export const useTelemetry = <T extends number[] | boolean[] = number[]>(

--- a/src/frontend/context/shared/index.ts
+++ b/src/frontend/context/shared/index.ts
@@ -3,4 +3,5 @@ export * from './useCarIdxAverageLapTime';
 export * from './useCurrentSessionType';
 export * from './useDrivingState';
 export * from './useFocusCarIdx';
+export * from './useResetOnDisconnect';
 export * from './useSessionVisibility';

--- a/src/frontend/context/shared/useCarIdxSpeed.spec.tsx
+++ b/src/frontend/context/shared/useCarIdxSpeed.spec.tsx
@@ -31,6 +31,7 @@ const mockCarSpeedsState = {
   lastSpeedUpdate: 0,
   carSpeeds: [],
   updateCarSpeeds: vi.fn(),
+  resetCarSpeeds: vi.fn(),
 };
 
 describe('useCarIdxSpeed', () => {

--- a/src/frontend/context/shared/useResetOnDisconnect.ts
+++ b/src/frontend/context/shared/useResetOnDisconnect.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+import { useSessionStore } from '../SessionStore/SessionStore';
+import { useTelemetryStore } from '../TelemetryStore/TelemetryStore';
+import { useCarSpeedsStore } from '../CarSpeedStore/CarSpeedsStore';
+import { useLapTimesStore } from '../LapTimesStore/LapTimesStore';
+import { usePitLapStore } from '../PitLapStore/PitLapStore';
+import { useFuelStore } from '../../components/FuelCalculator/FuelStore';
+
+/**
+ * Resets all session-related stores when the iRacing sim disconnects.
+ * Watches for the running state to transition from true to false,
+ * then clears stale data so overlays start fresh on the next session.
+ */
+export const useResetOnDisconnect = (running: boolean) => {
+  const prevRunning = useRef(running);
+
+  useEffect(() => {
+    if (prevRunning.current && !running) {
+      console.log(
+        '[useResetOnDisconnect] Sim disconnected, resetting all stores'
+      );
+      useSessionStore.getState().resetSession();
+      useTelemetryStore.getState().resetTelemetry();
+      useCarSpeedsStore.getState().resetCarSpeeds();
+      useLapTimesStore.getState().reset();
+      usePitLapStore.getState().reset();
+      useFuelStore.getState().clearAllData();
+    }
+    prevRunning.current = running;
+  }, [running]);
+};


### PR DESCRIPTION
## Summary
- Adds reset actions to SessionStore, TelemetryStore, CarSpeedsStore, and PitLapStore
- Introduces `useResetOnDisconnect` hook that watches the `running` state and clears all stores on `true → false` transition (sim disconnect)
- Ensures overlays start fresh when loading into a new session

Closes https://github.com/tariknz/irdashies/issues/97

## Test plan
- [ ] Run `npm run lint` and `npm run test`
- [ ] Connect to iRacing session, verify overlays populate normally
- [ ] Exit session, verify overlays clear (stores reset to initial state)
- [ ] Load into a new session, verify fresh data populates without stale data from previous session
