### PR TITLE
fix: ignore faster cars from behind when in pit road

### DIFF
--- a/src/frontend/components/FasterCarsFromBehind/hooks/useCarBehind.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/hooks/useCarBehind.tsx
@@ -27,7 +27,8 @@ export const useCarBehind = ({
 
   if (
     carBehind?.carClass?.relativeSpeed <= myCar?.carClass?.relativeSpeed ||
-    carBehind?.delta < threshold
+    carBehind?.delta < threshold ||
+    carBehind?.onPitRoad
   ) {
     return { name: undefined, distance: 0, classColor: undefined, percent: 0 };
   }


### PR DESCRIPTION
## Summary
- Suppresses the "faster car from behind" warning when the approaching car is on pit road
- Adds `carBehind?.onPitRoad` check to the existing filter in `useCarBehind` hook

## Test plan
- [ ] Enter a session with faster class cars
- [ ] Verify warning still appears when a faster car approaches from behind on track
- [ ] Verify warning does NOT appear when the faster car is in pit lane or on pit road
