### PR TITLE
fix: use contrasting text color for track map car numbers

### DIFF
--- a/src/frontend/components/TrackMap/FlatTrackMapCanvas.tsx
+++ b/src/frontend/components/TrackMap/FlatTrackMapCanvas.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { TrackDriver, TrackDrawing } from './TrackCanvas';
-import { getColor, getTailwindStyle } from '@irdashies/utils/colors';
+import { getColor, getContrastingTextColor, getTailwindStyle } from '@irdashies/utils/colors';
 import { useDriverOffTrack } from './hooks/useDriverOffTrack';
 
 export interface FlatTrackMapCanvasProps {
@@ -45,13 +45,14 @@ export const FlatTrackMapCanvas = ({
       if (isPlayer) {
         if (highlightColor) {
           const highlightColorHex = `#${highlightColor.toString(16).padStart(6, '0')}`;
-          colors[driver.CarIdx] = { fill: highlightColorHex, text: 'white' };
+          colors[driver.CarIdx] = { fill: highlightColorHex, text: getContrastingTextColor(highlightColorHex) };
         } else {
-          colors[driver.CarIdx] = { fill: getColor('amber'), text: 'white' };
+          const amberColor = getColor('amber');
+          colors[driver.CarIdx] = { fill: amberColor, text: getContrastingTextColor(amberColor) };
         }
       } else {
         const style = getTailwindStyle(driver.CarClassColor, undefined, isMultiClass);
-        colors[driver.CarIdx] = { fill: style.canvasFill, text: 'white' };
+        colors[driver.CarIdx] = { fill: style.canvasFill, text: getContrastingTextColor(style.canvasFill) };
       }
     });
     return colors;

--- a/src/frontend/components/TrackMap/TrackCanvas.tsx
+++ b/src/frontend/components/TrackMap/TrackCanvas.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Driver } from '@irdashies/types';
 import tracks from './tracks/tracks.json';
-import { getColor, getTailwindStyle } from '@irdashies/utils/colors';
+import { getColor, getContrastingTextColor, getTailwindStyle } from '@irdashies/utils/colors';
 import { shouldShowTrack } from './tracks/brokenTracks';
 import { TrackDebug } from './TrackDebug';
 import { useStartFinishLine } from './hooks/useStartFinishLine';
@@ -110,14 +110,15 @@ export const TrackCanvas = ({
         if (highlightColor) {
           // Convert highlight color number to hex string for canvas
           const highlightColorHex = `#${highlightColor.toString(16).padStart(6, '0')}`;
-          colors[driver.CarIdx] = { fill: highlightColorHex, text: 'white' };
+          colors[driver.CarIdx] = { fill: highlightColorHex, text: getContrastingTextColor(highlightColorHex) };
         } else {
           // Default to amber when highlightColor is undefined
-          colors[driver.CarIdx] = { fill: getColor('amber'), text: 'white' };
+          const amberColor = getColor('amber');
+          colors[driver.CarIdx] = { fill: amberColor, text: getContrastingTextColor(amberColor) };
         }
       } else {
         const style = getTailwindStyle(driver.CarClassColor, undefined, isMultiClass);
-        colors[driver.CarIdx] = { fill: style.canvasFill, text: 'white' };
+        colors[driver.CarIdx] = { fill: style.canvasFill, text: getContrastingTextColor(style.canvasFill) };
       }
     });
 


### PR DESCRIPTION
## Summary
- Car number text on track map dots was always white, making it hard to read on light-colored dots (yellow, amber, lime, etc.)
- Dynamically picks black or white text based on the background dot color luminance
- Applies to both curved and flat track map variants

## Test plan
- [ ] Verify car numbers are readable on light-colored dots (yellow, amber, lime)
- [ ] Verify car numbers remain white on dark-colored dots (blue, indigo, purple)
- [ ] Check both curved track map and flat track map
- [ ] Confirm player highlight color also gets correct contrasting text