### PR TITLE
FasterCarsFromBehind: Always show one decimal place for distance

### DIFF
--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
@@ -85,7 +85,7 @@ export const FasterCarsFromBehindDisplay = ({
           )}
         </div>
         {settings?.showDistance && (
-          <div className="rounded-sm bg-gray-700 p-1">{distance}</div>
+          <div className="rounded-sm bg-gray-700 p-1">{distance?.toFixed(1)}</div>
         )}
       </div>
 


### PR DESCRIPTION
## Before
<img width="504" height="261" alt="grafik" src="https://github.com/user-attachments/assets/5985590b-7493-4a25-96e2-ba48ebf515a1" />

## After:
<img width="480" height="196" alt="grafik" src="https://github.com/user-attachments/assets/108b9f47-a26e-4b8e-9169-f26a6ef71c70" />
