### PR TITLE
fix: trackmap text shadow

### DIFF
--- a/src/frontend/components/TrackMap/trackDrawingUtils.ts
+++ b/src/frontend/components/TrackMap/trackDrawingUtils.ts
@@ -13,9 +13,9 @@ export const setupCanvasContext = (
 
   // Apply shadow
   ctx.shadowColor = 'black';
-  ctx.shadowBlur = 2;
-  ctx.shadowOffsetX = 1;
-  ctx.shadowOffsetY = 1;
+  ctx.shadowBlur = 4;
+  ctx.shadowOffsetX = 0;
+  ctx.shadowOffsetY = 0;
 };
 
 export const drawTrack = (
@@ -129,7 +129,7 @@ export const drawDrivers = (
         ctx.fillStyle = color.text;
         ctx.font = `${fontSize}px sans-serif`;
 
-        // Use contrasting shadow color: white shadow for black text, black for white text
+        // White shadow for black text, black shadow for white text
         const originalShadowColor = ctx.shadowColor;
         ctx.shadowColor = color.text === 'black' ? 'white' : 'black';
 


### PR DESCRIPTION
## Description

When the constrasting text was introduced it created a slightly blurry text because the shadow was black so black text with black shadow looks a little blurry.

- Changes default shadows to a glow effect
- When contrasting text flip the shadow colour, e.g. black text has white glow and white text has black glow

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before

<img width="904" height="585" alt="image" src="https://github.com/user-attachments/assets/669d0975-0b90-4726-9f41-fd825880e647" />

### After

<img width="940" height="582" alt="image" src="https://github.com/user-attachments/assets/b71bddee-f068-4dc0-9c01-86bf45d9e870" />

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
