### PR TITLE
fix: debris flag orientation

### DIFF
--- a/src/frontend/components/Flag/hooks/getLedColor.tsx
+++ b/src/frontend/components/Flag/hooks/getLedColor.tsx
@@ -67,7 +67,7 @@ export const getLedColor = (
       return BLUE;
     }
     if (flagType === 'DEBRIS') {
-      return (row % 2 === 0) ? RED : YELLOW;
+      return (col % 2 === 0) ? RED : YELLOW;
     }
     if (flagType === 'DISQUALIFIED') {
       const diag1 = row - col;


### PR DESCRIPTION
## Description

Fixed orientation of red and yellow stripes in the debris flag

## Screenshots

### Before
<img width="367" height="400" alt="Screenshot 2026-02-06 153200" src="https://github.com/user-attachments/assets/a3b31eb9-ce29-4e23-a98f-42a165490db6" />


### After
<img width="369" height="408" alt="Screenshot 2026-02-06 153214" src="https://github.com/user-attachments/assets/0890df0d-fe75-4171-a627-f9675f76903f" />

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
