### PR TITLE
fix: dont force settings to always on top

### DIFF
--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -459,12 +459,6 @@ export class OverlayManager {
     // Track window movement and resizing to save bounds
     trackSettingsWindowMovement(browserWindow);
 
-    // Set settings window to screen-saver level so it appears above the overlay
-    // Use relative level 2 (higher than overlay's 1) so it's always clickable
-    if (this.overlayAlwaysOnTop) {
-      browserWindow.setAlwaysOnTop(true, 'screen-saver', 2);
-    }
-
     // and load the index.html of the app.
     if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
       browserWindow.loadURL(`${MAIN_WINDOW_VITE_DEV_SERVER_URL}#/settings`);


### PR DESCRIPTION
## Description

Don't force settings to stay on top 
## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

### After
<!-- Screenshot or description of the new behaviour -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run lint` and fixed any issues
- [ ] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
