### PR TITLE
fix: dual flag behaviour when label is off

### DIFF
--- a/src/frontend/components/Flag/Flag.tsx
+++ b/src/frontend/components/Flag/Flag.tsx
@@ -49,7 +49,7 @@ export const Flag = () => {
   // Double flag
   return (
     <div className="flex h-full w-full justify-between items-stretch">
-      <div className="h-full aspect-square flex-none">
+      <div className="h-full aspect-square">
         <FlagDisplay
           label={visibleLabel}
           showLabel={settings.showLabel ?? true}
@@ -64,7 +64,7 @@ export const Flag = () => {
         />
       </div>
 
-      <div className="h-full aspect-square flex-none">
+      <div className="h-full aspect-square">
         <FlagDisplay
           label={visibleLabel}
           showLabel={settings.showLabel ?? true}
@@ -143,7 +143,7 @@ export const FlagDisplay = ({
 
   const outerClass = fullBleed
     ? 'flex flex-col items-stretch gap-0 bg-slate-900 border-4 border-slate-800 shadow-2xl w-full h-full box-border m-0 p-0'
-    : 'flex flex-col items-center gap-2 p-4 bg-slate-900 rounded-2xl border-4 border-slate-800 shadow-2xl w-full h-full';
+    : 'flex flex-col items-center gap-[3%] p-[4%] bg-slate-900 rounded-2xl border-4 border-slate-800 shadow-2xl w-full h-full';
 
   return (
     <div className={outerClass}>
@@ -200,15 +200,15 @@ export const FlagDisplay = ({
           })}
         </div>
       </div>
-      <div className="w-full h-6 flex items-center justify-center shrink-0">
-        {showLabel && (
+      {showLabel && (
+        <div className="w-full h-6 flex items-center justify-center shrink-0">
           <span
             className={`text-sm font-black px-3 py-1 uppercase rounded-md bg-black ${textColorClass} ${shortLabel === 'NO' ? 'opacity-0' : ''}`}
           >
             {shortLabel === 'NO' ? 'NO' : shortLabel}
           </span>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Description

Fixed a bug that occurred when the dual flag was used without labels


### Before
Please see discord, videos too large https://discord.com/channels/1339669873386586152/1471247209956900874

### After
Please see discord, videos too large https://discord.com/channels/1339669873386586152/1471247209956900874

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [x] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
