### PR TITLE
fix: pit status OUT visibility

### DIFF
--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -1,7 +1,17 @@
 import { useMemo } from 'react';
 import { DriverInfoRow } from './components/DriverInfoRow/DriverInfoRow';
-import { useDrivingState, useWeekendInfoNumCarClasses, useWeekendInfoTeamRacing, useSessionVisibility, useGeneralSettings } from '@irdashies/context';
-import { useRelativeSettings, useDriverRelatives, useHighlightColor } from './hooks';
+import {
+  useDrivingState,
+  useWeekendInfoNumCarClasses,
+  useWeekendInfoTeamRacing,
+  useSessionVisibility,
+  useGeneralSettings,
+} from '@irdashies/context';
+import {
+  useRelativeSettings,
+  useDriverRelatives,
+  useHighlightColor,
+} from './hooks';
 import { SessionBar } from './components/SessionBar/SessionBar';
 
 import { TitleBar } from './components/TitleBar/TitleBar';
@@ -22,13 +32,17 @@ export const Relative = () => {
   usePitLapStoreUpdater();
 
   const isSingleMake = useIsSingleMake();
-  const hideCarManufacturer = !!(settings?.carManufacturer?.hideIfSingleMake && isSingleMake);
+  const hideCarManufacturer = !!(
+    settings?.carManufacturer?.hideIfSingleMake && isSingleMake
+  );
 
   // Check if this is a team racing session
   const isTeamRacing = useWeekendInfoTeamRacing();
 
   // Determine table border spacing based on compact mode
-  const tableBorderSpacing = generalSettings?.compactMode ? 'border-spacing-y-0' : 'border-spacing-y-0.5';
+  const tableBorderSpacing = generalSettings?.compactMode
+    ? 'border-spacing-y-0'
+    : 'border-spacing-y-0.5';
 
   // Always render 2 * buffer + 1 rows (buffer above + player + buffer below)
   const totalRows = 2 * buffer + 1;
@@ -49,21 +63,23 @@ export const Relative = () => {
           carIdx={0}
           classColor={0}
           name="Franz Hermann"
-          teamName={settings?.teamName?.enabled && isTeamRacing ? '' : undefined}
+          teamName={
+            settings?.teamName?.enabled && isTeamRacing ? '' : undefined
+          }
           isPlayer={false}
           hasFastestTime={false}
           hidden={true}
           isMultiClass={false}
           displayOrder={settings?.displayOrder}
           config={settings}
-          carNumber={settings?.carNumber?.enabled ?? true ? '' : undefined}
-          flairId={settings?.countryFlags?.enabled ?? true ? 0 : undefined}
-          carId={settings?.carManufacturer?.enabled ?? true ? 0 : undefined}
+          carNumber={(settings?.carNumber?.enabled ?? true) ? '' : undefined}
+          flairId={(settings?.countryFlags?.enabled ?? true) ? 0 : undefined}
+          carId={(settings?.carManufacturer?.enabled ?? true) ? 0 : undefined}
           license={undefined}
           rating={undefined}
           currentSessionType=""
           iratingChangeValue={undefined}
-          delta={settings?.delta?.enabled ?? true ? 0 : undefined}
+          delta={(settings?.delta?.enabled ?? true) ? 0 : undefined}
           fastestTime={settings?.fastestTime?.enabled ? undefined : undefined}
           lastTime={settings?.lastTime?.enabled ? undefined : undefined}
           lastTimeState={settings?.lastTime?.enabled ? undefined : undefined}
@@ -98,21 +114,23 @@ export const Relative = () => {
             carIdx={0}
             classColor={0}
             name="Franz Hermann"
-            teamName={settings?.teamName?.enabled && isTeamRacing ? '' : undefined}
+            teamName={
+              settings?.teamName?.enabled && isTeamRacing ? '' : undefined
+            }
             isPlayer={false}
             hasFastestTime={false}
             hidden={true}
             isMultiClass={false}
             displayOrder={settings?.displayOrder}
             config={settings}
-            carNumber={settings?.carNumber?.enabled ?? true ? '' : undefined}
-            flairId={settings?.countryFlags?.enabled ?? true ? 0 : undefined}
-            carId={settings?.carManufacturer?.enabled ?? true ? 0 : undefined}
+            carNumber={(settings?.carNumber?.enabled ?? true) ? '' : undefined}
+            flairId={(settings?.countryFlags?.enabled ?? true) ? 0 : undefined}
+            carId={(settings?.carManufacturer?.enabled ?? true) ? 0 : undefined}
             license={undefined}
             rating={undefined}
             currentSessionType=""
             iratingChangeValue={undefined}
-            delta={settings?.delta?.enabled ?? true ? 0 : undefined}
+            delta={(settings?.delta?.enabled ?? true) ? 0 : undefined}
             fastestTime={settings?.fastestTime?.enabled ? undefined : undefined}
             lastTime={settings?.lastTime?.enabled ? undefined : undefined}
             lastTimeState={settings?.lastTime?.enabled ? undefined : undefined}
@@ -138,23 +156,41 @@ export const Relative = () => {
           key={result.carIdx}
           carIdx={result.carIdx}
           classColor={result.carClass.color}
-          carNumber={settings?.carNumber?.enabled ?? true ? result.driver?.carNum || '' : undefined}
+          carNumber={
+            (settings?.carNumber?.enabled ?? true)
+              ? result.driver?.carNum || ''
+              : undefined
+          }
           name={result.driver?.name || ''}
-          teamName={settings?.teamName?.enabled && isTeamRacing ? result.driver?.teamName || '' : undefined}
+          teamName={
+            settings?.teamName?.enabled && isTeamRacing
+              ? result.driver?.teamName || ''
+              : undefined
+          }
           isPlayer={result.isPlayer}
           hasFastestTime={result.hasFastestTime}
           position={result.classPosition}
-          lap={result.lap}
+          lap={result.lastLap}
           onPitRoad={result.onPitRoad}
           onTrack={result.onTrack}
           radioActive={result.radioActive}
           isLapped={result.lappedState === 'behind'}
           isLappingAhead={result.lappedState === 'ahead'}
-          flairId={settings?.countryFlags?.enabled ?? true ? result.driver?.flairId : undefined}
+          flairId={
+            (settings?.countryFlags?.enabled ?? true)
+              ? result.driver?.flairId
+              : undefined
+          }
           lastTime={settings?.lastTime?.enabled ? result.lastTime : undefined}
-          fastestTime={settings?.fastestTime?.enabled ? result.fastestTime : undefined}
-          lastTimeState={settings?.lastTime?.enabled ? result.lastTimeState : undefined}
-          tireCompound={settings?.compound?.enabled ? result.tireCompound : undefined}
+          fastestTime={
+            settings?.fastestTime?.enabled ? result.fastestTime : undefined
+          }
+          lastTimeState={
+            settings?.lastTime?.enabled ? result.lastTimeState : undefined
+          }
+          tireCompound={
+            settings?.compound?.enabled ? result.tireCompound : undefined
+          }
           carId={result.carId}
           lastPitLap={result.lastPitLap}
           lastLap={result.lastLap}
@@ -165,7 +201,7 @@ export const Relative = () => {
           license={result.driver?.license}
           rating={result.driver?.rating}
           iratingChangeValue={result.iratingChange}
-          delta={settings?.delta?.enabled ?? true ? result.delta : undefined}
+          delta={(settings?.delta?.enabled ?? true) ? result.delta : undefined}
           displayOrder={settings?.displayOrder}
           config={settings}
           highlightColor={highlightColor}
@@ -175,13 +211,23 @@ export const Relative = () => {
           slowdown={result.slowdown}
           deltaDecimalPlaces={settings?.delta?.precision}
           hideCarManufacturer={hideCarManufacturer}
+          carIdxLapDistPct={result.carIdxLapDistPct}
         />
       );
     });
-  }, [standings, playerIndex, totalRows, settings, isMultiClass, highlightColor, hideCarManufacturer, isTeamRacing]);
+  }, [
+    standings,
+    playerIndex,
+    totalRows,
+    settings,
+    isMultiClass,
+    highlightColor,
+    hideCarManufacturer,
+    isTeamRacing,
+  ]);
 
   if (!isSessionVisible) return <></>;
-  
+
   // Show only when on track setting
   if (settings?.showOnlyWhenOnTrack && !isDriving) {
     return <></>;
@@ -192,11 +238,17 @@ export const Relative = () => {
     return (
       <div className="w-full h-full">
         <TitleBar titleBarSettings={settings?.titleBar} />
-        {(settings?.headerBar?.enabled ?? false) && <SessionBar position="header" variant="relative" />}
-        <table className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}>
+        {(settings?.headerBar?.enabled ?? false) && (
+          <SessionBar position="header" variant="relative" />
+        )}
+        <table
+          className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
+        >
           <tbody>{rows}</tbody>
         </table>
-        {(settings?.footerBar?.enabled ?? true) && <SessionBar position="footer" variant="relative" />}
+        {(settings?.footerBar?.enabled ?? true) && (
+          <SessionBar position="footer" variant="relative" />
+        )}
       </div>
     );
   }
@@ -209,11 +261,17 @@ export const Relative = () => {
       }}
     >
       <TitleBar titleBarSettings={settings?.titleBar} />
-      {(settings?.headerBar?.enabled ?? false) && <SessionBar position="header" variant="relative" />}
-      <table className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}>
+      {(settings?.headerBar?.enabled ?? false) && (
+        <SessionBar position="header" variant="relative" />
+      )}
+      <table
+        className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
+      >
         <tbody>{rows}</tbody>
       </table>
-      {(settings?.footerBar?.enabled ?? true) && <SessionBar position="footer" variant="relative" />}
+      {(settings?.footerBar?.enabled ?? true) && (
+        <SessionBar position="footer" variant="relative" />
+      )}
     </div>
   );
 };

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -49,7 +49,9 @@ export const Standings = () => {
   const isTeamRacing = useWeekendInfoTeamRacing();
 
   // Determine table border spacing based on compact mode
-  const tableBorderSpacing = generalSettings?.compactMode ? 'border-spacing-y-0' : 'border-spacing-y-0.5';
+  const tableBorderSpacing = generalSettings?.compactMode
+    ? 'border-spacing-y-0'
+    : 'border-spacing-y-0.5';
 
   if (!isSessionVisible) return <></>;
 
@@ -69,7 +71,9 @@ export const Standings = () => {
       {(settings?.headerBar?.enabled ?? true) && (
         <SessionBar position="header" variant="standings" />
       )}
-      <table className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}>
+      <table
+        className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
+      >
         <tbody>
           {standings.map(([classId, classStandings], index) =>
             classStandings.length > 0 ? (
@@ -165,13 +169,15 @@ export const Standings = () => {
                     penalty={result.penalty}
                     slowdown={result.slowdown}
                     hideCarManufacturer={hideCarManufacturer}
+                    carIdxLapDistPct={result.carIdxLapDistPct}
                   />
                 ))}
-                {index < standings.length - 1 && !generalSettings?.compactMode && (
-                  <tr>
-                    <td colSpan={12} className="h-2"></td>
-                  </tr>
-                )}
+                {index < standings.length - 1 &&
+                  !generalSettings?.compactMode && (
+                    <tr>
+                      <td colSpan={12} className="h-2"></td>
+                    </tr>
+                  )}
               </Fragment>
             ) : null
           )}

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -68,6 +68,7 @@ interface DriverRowInfoProps {
   slowdown: boolean;
   deltaDecimalPlaces?: number;
   hideCarManufacturer?: boolean;
+  carIdxLapDistPct?: number;
 }
 
 // Helper function to provide dummy data for hidden rows
@@ -78,7 +79,7 @@ const getDummyData = () => ({
   teamName: 'Team Name',
   delta: 0,
   fastestTime: 60000, // 1:00.000
-  lastTime: 60000,    // 1:00.000
+  lastTime: 60000, // 1:00.000
   tireCompound: 0,
   license: 'A 4.99',
   rating: 4999,
@@ -98,9 +99,9 @@ const getDummyData = () => ({
 // Helper function to transform props for hidden rows
 const getDisplayProps = (props: DriverRowInfoProps) => {
   if (!props.hidden) return props;
-  
+
   const dummyData = getDummyData();
-  
+
   return {
     ...props,
     // Override with dummy data for hidden rows
@@ -128,395 +129,380 @@ const getDisplayProps = (props: DriverRowInfoProps) => {
   };
 };
 
-export const DriverInfoRow = memo(
-  (props: DriverRowInfoProps) => {
-    // Transform props for hidden rows
-    const displayProps = getDisplayProps(props);
-    
-    const {
-      carIdx,
-      carNumber,
-      classColor,
-      name,
-      teamName,
-      isPlayer,
-      hasFastestTime,
-      delta,
-      gap,
-      interval,
-      position,
-      lap,
-      license,
-      rating,
-      iratingChangeValue,
-      lastTime,
-      fastestTime,
-      lastTimeState,
-      onPitRoad,
-      onTrack,
-      radioActive,
-      isLapped,
-      isLappingAhead,
-      hidden,
-      flairId,
-      tireCompound,
-      carId,
-      lapTimeDeltas,
-      numLapDeltasToShow,
-      isMultiClass,
-      displayOrder,
-      config,
-      lastPitLap,
-      lastLap,
-      prevCarTrackSurface,
-      carTrackSurface,
-      currentSessionType,
-      highlightColor = 960745,
-      dnf,
-      repair,
-      penalty,
-      slowdown,
-      deltaDecimalPlaces,
-      pitStopDuration: pitStopDurationProp,
-      hideCarManufacturer,
-    } = displayProps;
-    const pitStopDurations = usePitStopDuration();
-    const pitStopDuration =
-      pitStopDurationProp ?? pitStopDurations[carIdx] ?? null;
+export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
+  // Transform props for hidden rows
+  const displayProps = getDisplayProps(props);
 
-    const lastTimeString = useMemo(() => {
-      const format = config?.lastTime?.timeFormat ?? 'full';
-      return formatTime(lastTime, format as TimeFormat);
-    }, [lastTime, config?.lastTime?.timeFormat]);
+  const {
+    carIdx,
+    carNumber,
+    classColor,
+    name,
+    teamName,
+    isPlayer,
+    hasFastestTime,
+    delta,
+    gap,
+    interval,
+    position,
+    lap,
+    license,
+    rating,
+    iratingChangeValue,
+    lastTime,
+    fastestTime,
+    lastTimeState,
+    onPitRoad,
+    onTrack,
+    radioActive,
+    isLapped,
+    isLappingAhead,
+    hidden,
+    flairId,
+    tireCompound,
+    carId,
+    lapTimeDeltas,
+    numLapDeltasToShow,
+    isMultiClass,
+    displayOrder,
+    config,
+    lastPitLap,
+    lastLap,
+    prevCarTrackSurface,
+    carTrackSurface,
+    currentSessionType,
+    highlightColor = 960745,
+    dnf,
+    repair,
+    penalty,
+    slowdown,
+    deltaDecimalPlaces,
+    pitStopDuration: pitStopDurationProp,
+    hideCarManufacturer,
+    carIdxLapDistPct,
+  } = displayProps;
+  const pitStopDurations = usePitStopDuration();
+  const pitStopDuration =
+    pitStopDurationProp ?? pitStopDurations[carIdx] ?? null;
 
-    const fastestTimeString = useMemo(() => {
-      const format = config?.fastestTime?.timeFormat ?? 'full';
-      return formatTime(fastestTime, format as TimeFormat);
-    }, [fastestTime, config?.fastestTime?.timeFormat]);
+  const lastTimeString = useMemo(() => {
+    const format = config?.lastTime?.timeFormat ?? 'full';
+    return formatTime(lastTime, format as TimeFormat);
+  }, [lastTime, config?.lastTime?.timeFormat]);
 
-    const offTrack = carTrackSurface === 0 ? true : false;
+  const fastestTimeString = useMemo(() => {
+    const format = config?.fastestTime?.timeFormat ?? 'full';
+    return formatTime(fastestTime, format as TimeFormat);
+  }, [fastestTime, config?.fastestTime?.timeFormat]);
 
-    const tailwindStyles = useMemo(() => {
-      return getTailwindStyle(classColor, highlightColor, isMultiClass);
-    }, [classColor, highlightColor, isMultiClass]);
+  const offTrack = carTrackSurface === 0 ? true : false;
 
-    const emptyLapDeltaPlaceholders = useMemo(() => {
-      if (!numLapDeltasToShow) return null;
-      return Array.from({ length: numLapDeltasToShow }, (_, index) => index);
-    }, [numLapDeltasToShow]);
-    
-    const columnDefinitions = useMemo(() => {
-      const columns = [
-        {
-          id: 'position',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('position') : true) &&
-            (config?.position?.enabled ?? true),
-          component: (
-            <PositionCell
-              key="position"
-              position={position}
-              isPlayer={isPlayer}
-              offTrack={offTrack}
-              tailwindStyles={tailwindStyles}
-            />
-          ),
-        },
-        {
-          id: 'carNumber',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('carNumber') : true) &&
-            (config?.carNumber?.enabled ?? true),
-          component: (
-            <CarNumberCell
-              key="carNumber"
-              carNumber={carNumber}
-              tailwindStyles={tailwindStyles}
-            />
-          ),
-        },
-        {
-          id: 'countryFlags',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('countryFlags') : true) &&
-            (config?.countryFlags?.enabled ?? true),
-          component: (
-            <CountryFlagsCell
-              key="countryFlags"
-              flairId={flairId}
-            />
-          ),
-        },
-        {
-          id: 'driverName',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('driverName') : true) &&
-            (config?.driverName?.enabled ?? true),
-          component: (
-            <DriverNameCell
-              key="driverName"
-              radioActive={radioActive}
-              repair={repair}
-              penalty={penalty}
-              slowdown={slowdown}
-              showStatusBadges={config?.driverName?.showStatusBadges ?? true}
-              fullName={name}
-              nameFormat={config?.driverName?.nameFormat}
-            />
-          ),
-        },
-        {
-          id: 'teamName',
-          shouldRender:
-            teamName !== undefined &&
-            (displayOrder ? displayOrder.includes('teamName') : false) &&
-            (config?.teamName?.enabled ?? false),
-          component: (
-            <TeamNameCell 
-              key="teamName" 
-              teamName={teamName} />
-          ),
-        },
-        {
-          id: 'pitStatus',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('pitStatus') : true) &&
-            (config?.pitStatus?.enabled ?? true),
-          component: (
-            <PitStatusCell
-              key="pitStatus"
-              onPitRoad={onPitRoad}
-              carTrackSurface={carTrackSurface}
-              prevCarTrackSurface={prevCarTrackSurface}
-              lap={lap}
-              lastPitLap={lastPitLap}
-              lastLap={lastLap}
-              currentSessionType={currentSessionType}
-              dnf={dnf}
-              pitStopDuration={pitStopDuration}
-              showPitTime={config?.pitStatus?.showPitTime ?? false}
-              pitLapDisplayMode={config?.pitStatus?.pitLapDisplayMode}
-            />
-          ),
-        },
-        {
-          id: 'carManufacturer',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('carManufacturer') : true) &&
-            (config?.carManufacturer?.enabled ?? true) &&
-            !hideCarManufacturer,
-          component: (
-            <CarManufacturerCell
-              key="carManufacturer"
-              carId={carId}
-            />
-          ),
-        },
-        {
-          id: 'badge',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('badge') : true) &&
-            (config?.badge?.enabled ?? true),
-          component: (
-            <BadgeCell
-              key="badge"
-              license={license}
-              rating={rating}
-              badgeFormat={config?.badge?.badgeFormat}
-            />
-          ),
-        },
-        {
-          id: 'iratingChange',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('iratingChange') : true) &&
-            (config?.iratingChange?.enabled ?? false),
-          component: (
-            <IratingChangeCell
-              key="iratingChange"
-              iratingChangeValue={iratingChangeValue}
-            />
-          ),
-        },
-        {
-          id: 'delta',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('delta') : true) &&
-            (config?.delta?.enabled ?? true) &&
-            !(config && 'gap' in config),
-          component: (
-            <DeltaCell
-              key="delta"
-              delta={delta}
-              decimalPlaces={deltaDecimalPlaces}
-            />
-          ),
-        },
-        {
-          id: 'gap',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('gap') : true) &&
-            (config && 'gap' in config ? config.gap.enabled : false) &&
-            currentSessionType?.toLowerCase() === 'race',
-          component: (
-            <DeltaCell
-              key="gap"
-              delta={gap}
-              showForUndefined={position === 1 ? 'gap' : undefined}
-              decimalPlaces={deltaDecimalPlaces}
-            />
-          ),
-        },
-        {
-          id: 'interval',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('interval') : true) &&
-            (config && 'interval' in config
-              ? config.interval.enabled
-              : false) &&
-            currentSessionType?.toLowerCase() === 'race',
-          component: (
-            <DeltaCell
-              key="interval"
-              delta={interval}
-              showForUndefined={position === 1 ? 'int' : undefined}
-              decimalPlaces={deltaDecimalPlaces}
-            />
-          ),
-        },
-        {
-          id: 'fastestTime',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('fastestTime') : true) &&
-            (config?.fastestTime?.enabled ?? false),
-          component: (
-            <FastestTimeCell
-              key="fastestTime"
-              fastestTimeString={fastestTimeString}
-              hasFastestTime={hasFastestTime}
-            />
-          ),
-        },
-        {
-          id: 'lastTime',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('lastTime') : true) &&
-            (config?.lastTime?.enabled ?? false),
-          component: (
-            <LastTimeCell
-              key="lastTime"
-              lastTimeString={lastTimeString}
-              lastTimeState={lastTimeState}
-            />
-          ),
-        },
-        {
-          id: 'compound',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('compound') : true) &&
-            (config?.compound?.enabled ?? false),
-          component: (
-            <CompoundCell
-              key="compound"
-              tireCompound={tireCompound}
-              carId={carId}
-            />
-          ),
-        },
-        {
-          id: 'lapTimeDeltas',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('lapTimeDeltas') : false) &&
-            (config && 'lapTimeDeltas' in config
-              ? config.lapTimeDeltas.enabled
-              : false),
-          component: (
-            <LapTimeDeltasCell
-              key="lapTimeDeltas"
-              lapTimeDeltas={lapTimeDeltas}
-              emptyLapDeltaPlaceholders={emptyLapDeltaPlaceholders}
-              isPlayer={isPlayer}
-            />
-          ),
-        },
-      ];
+  const tailwindStyles = useMemo(() => {
+    return getTailwindStyle(classColor, highlightColor, isMultiClass);
+  }, [classColor, highlightColor, isMultiClass]);
 
-      if (displayOrder) {
-        const orderedColumns = displayOrder
-          .map((orderId) => columns.find((col) => col.id === orderId))
-          .filter(
-            (col): col is NonNullable<typeof col> =>
-              col !== undefined && col.shouldRender
-          );
+  const emptyLapDeltaPlaceholders = useMemo(() => {
+    if (!numLapDeltasToShow) return null;
+    return Array.from({ length: numLapDeltasToShow }, (_, index) => index);
+  }, [numLapDeltasToShow]);
 
-        const remainingColumns = columns.filter(
-          (col) => col.shouldRender && !displayOrder.includes(col.id)
+  const columnDefinitions = useMemo(() => {
+    const columns = [
+      {
+        id: 'position',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('position') : true) &&
+          (config?.position?.enabled ?? true),
+        component: (
+          <PositionCell
+            key="position"
+            position={position}
+            isPlayer={isPlayer}
+            offTrack={offTrack}
+            tailwindStyles={tailwindStyles}
+          />
+        ),
+      },
+      {
+        id: 'carNumber',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('carNumber') : true) &&
+          (config?.carNumber?.enabled ?? true),
+        component: (
+          <CarNumberCell
+            key="carNumber"
+            carNumber={carNumber}
+            tailwindStyles={tailwindStyles}
+          />
+        ),
+      },
+      {
+        id: 'countryFlags',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('countryFlags') : true) &&
+          (config?.countryFlags?.enabled ?? true),
+        component: <CountryFlagsCell key="countryFlags" flairId={flairId} />,
+      },
+      {
+        id: 'driverName',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('driverName') : true) &&
+          (config?.driverName?.enabled ?? true),
+        component: (
+          <DriverNameCell
+            key="driverName"
+            radioActive={radioActive}
+            repair={repair}
+            penalty={penalty}
+            slowdown={slowdown}
+            showStatusBadges={config?.driverName?.showStatusBadges ?? true}
+            fullName={name}
+            nameFormat={config?.driverName?.nameFormat}
+          />
+        ),
+      },
+      {
+        id: 'teamName',
+        shouldRender:
+          teamName !== undefined &&
+          (displayOrder ? displayOrder.includes('teamName') : false) &&
+          (config?.teamName?.enabled ?? false),
+        component: <TeamNameCell key="teamName" teamName={teamName} />,
+      },
+      {
+        id: 'pitStatus',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('pitStatus') : true) &&
+          (config?.pitStatus?.enabled ?? true),
+        component: (
+          <PitStatusCell
+            key="pitStatus"
+            onPitRoad={onPitRoad}
+            carTrackSurface={carTrackSurface}
+            prevCarTrackSurface={prevCarTrackSurface}
+            lap={lap}
+            lastPitLap={lastPitLap}
+            lastLap={lastLap}
+            currentSessionType={currentSessionType}
+            dnf={dnf}
+            pitStopDuration={pitStopDuration}
+            showPitTime={config?.pitStatus?.showPitTime ?? false}
+            pitLapDisplayMode={config?.pitStatus?.pitLapDisplayMode}
+            carIdxLapDistPct={carIdxLapDistPct}
+          />
+        ),
+      },
+      {
+        id: 'carManufacturer',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('carManufacturer') : true) &&
+          (config?.carManufacturer?.enabled ?? true) &&
+          !hideCarManufacturer,
+        component: <CarManufacturerCell key="carManufacturer" carId={carId} />,
+      },
+      {
+        id: 'badge',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('badge') : true) &&
+          (config?.badge?.enabled ?? true),
+        component: (
+          <BadgeCell
+            key="badge"
+            license={license}
+            rating={rating}
+            badgeFormat={config?.badge?.badgeFormat}
+          />
+        ),
+      },
+      {
+        id: 'iratingChange',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('iratingChange') : true) &&
+          (config?.iratingChange?.enabled ?? false),
+        component: (
+          <IratingChangeCell
+            key="iratingChange"
+            iratingChangeValue={iratingChangeValue}
+          />
+        ),
+      },
+      {
+        id: 'delta',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('delta') : true) &&
+          (config?.delta?.enabled ?? true) &&
+          !(config && 'gap' in config),
+        component: (
+          <DeltaCell
+            key="delta"
+            delta={delta}
+            decimalPlaces={deltaDecimalPlaces}
+          />
+        ),
+      },
+      {
+        id: 'gap',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('gap') : true) &&
+          (config && 'gap' in config ? config.gap.enabled : false) &&
+          currentSessionType?.toLowerCase() === 'race',
+        component: (
+          <DeltaCell
+            key="gap"
+            delta={gap}
+            showForUndefined={position === 1 ? 'gap' : undefined}
+            decimalPlaces={deltaDecimalPlaces}
+          />
+        ),
+      },
+      {
+        id: 'interval',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('interval') : true) &&
+          (config && 'interval' in config ? config.interval.enabled : false) &&
+          currentSessionType?.toLowerCase() === 'race',
+        component: (
+          <DeltaCell
+            key="interval"
+            delta={interval}
+            showForUndefined={position === 1 ? 'int' : undefined}
+            decimalPlaces={deltaDecimalPlaces}
+          />
+        ),
+      },
+      {
+        id: 'fastestTime',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('fastestTime') : true) &&
+          (config?.fastestTime?.enabled ?? false),
+        component: (
+          <FastestTimeCell
+            key="fastestTime"
+            fastestTimeString={fastestTimeString}
+            hasFastestTime={hasFastestTime}
+          />
+        ),
+      },
+      {
+        id: 'lastTime',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('lastTime') : true) &&
+          (config?.lastTime?.enabled ?? false),
+        component: (
+          <LastTimeCell
+            key="lastTime"
+            lastTimeString={lastTimeString}
+            lastTimeState={lastTimeState}
+          />
+        ),
+      },
+      {
+        id: 'compound',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('compound') : true) &&
+          (config?.compound?.enabled ?? false),
+        component: (
+          <CompoundCell
+            key="compound"
+            tireCompound={tireCompound}
+            carId={carId}
+          />
+        ),
+      },
+      {
+        id: 'lapTimeDeltas',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('lapTimeDeltas') : false) &&
+          (config && 'lapTimeDeltas' in config
+            ? config.lapTimeDeltas.enabled
+            : false),
+        component: (
+          <LapTimeDeltasCell
+            key="lapTimeDeltas"
+            lapTimeDeltas={lapTimeDeltas}
+            emptyLapDeltaPlaceholders={emptyLapDeltaPlaceholders}
+            isPlayer={isPlayer}
+          />
+        ),
+      },
+    ];
+
+    if (displayOrder) {
+      const orderedColumns = displayOrder
+        .map((orderId) => columns.find((col) => col.id === orderId))
+        .filter(
+          (col): col is NonNullable<typeof col> =>
+            col !== undefined && col.shouldRender
         );
 
-        return [...orderedColumns, ...remainingColumns];
-      }
+      const remainingColumns = columns.filter(
+        (col) => col.shouldRender && !displayOrder.includes(col.id)
+      );
 
-      return columns.filter((col) => col.shouldRender);
-    }, [
-      displayOrder,
-      config,
-      position,
-      lap,
-      isPlayer,
-      offTrack,
-      tailwindStyles,
-      carNumber,
-      flairId,
-      name,
-      teamName,
-      radioActive,
-      onPitRoad,
-      carTrackSurface,
-      prevCarTrackSurface,
-      lastPitLap,
-      lastLap,
-      currentSessionType,
-      dnf,
-      repair,
-      penalty,
-      slowdown,
-      pitStopDuration,
-      carId,
-      license,
-      rating,
-      iratingChangeValue,
-      delta,
-      deltaDecimalPlaces,
-      gap,
-      interval,
-      fastestTimeString,
-      hasFastestTime,
-      lastTimeString,
-      lastTimeState,
-      tireCompound,
-      lapTimeDeltas,
-      emptyLapDeltaPlaceholders,
-      hideCarManufacturer,
-    ]);
+      return [...orderedColumns, ...remainingColumns];
+    }
 
-    return (
-      <tr
-        key={carIdx}
-        className={[
-          !onTrack || onPitRoad ? 'text-white/60' : '',
-          isPlayer ? 'text-amber-300' : '',
-          isPlayer
-            ? 'bg-yellow-500/20'
-            : 'odd:bg-slate-800/70 even:bg-slate-900/70 text-sm',
-          !isPlayer && isLapped ? 'text-blue-400' : '',
-          !isPlayer && isLappingAhead ? 'text-red-400' : '',
-          hidden ? 'invisible' : '',
-        ].join(' ')}
-      >
-        {columnDefinitions.map((column) => column.component)}
-      </tr>
-    );
-  }
-);
+    return columns.filter((col) => col.shouldRender);
+  }, [
+    displayOrder,
+    config,
+    position,
+    lap,
+    isPlayer,
+    offTrack,
+    tailwindStyles,
+    carNumber,
+    flairId,
+    name,
+    teamName,
+    radioActive,
+    onPitRoad,
+    carTrackSurface,
+    prevCarTrackSurface,
+    lastPitLap,
+    lastLap,
+    currentSessionType,
+    dnf,
+    repair,
+    penalty,
+    slowdown,
+    pitStopDuration,
+    carId,
+    license,
+    rating,
+    iratingChangeValue,
+    delta,
+    deltaDecimalPlaces,
+    gap,
+    interval,
+    fastestTimeString,
+    hasFastestTime,
+    lastTimeString,
+    lastTimeState,
+    tireCompound,
+    lapTimeDeltas,
+    emptyLapDeltaPlaceholders,
+    hideCarManufacturer,
+    carIdxLapDistPct,
+  ]);
+
+  return (
+    <tr
+      key={carIdx}
+      className={[
+        !onTrack || onPitRoad ? 'text-white/60' : '',
+        isPlayer ? 'text-amber-300' : '',
+        isPlayer
+          ? 'bg-yellow-500/20'
+          : 'odd:bg-slate-800/70 even:bg-slate-900/70 text-sm',
+        !isPlayer && isLapped ? 'text-blue-400' : '',
+        !isPlayer && isLappingAhead ? 'text-red-400' : '',
+        hidden ? 'invisible' : '',
+      ].join(' ')}
+    >
+      {columnDefinitions.map((column) => column.component)}
+    </tr>
+  );
+});
 
 DriverInfoRow.displayName = 'DriverInfoRow';

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/PitStatusCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/PitStatusCell.tsx
@@ -1,5 +1,34 @@
-import { memo } from 'react';
+import { memo, useRef, useEffect, useReducer } from 'react';
 import { DriverStatusBadges } from './DriverStatusBadges';
+
+interface PitExitState {
+  exitLap: number | undefined;
+  outCleared: boolean;
+  lastPitLap: number | undefined;
+}
+
+type PitExitAction =
+  | { type: 'reset'; lastPitLap: number | undefined }
+  | { type: 'capture_exit'; exitLap: number | undefined }
+  | { type: 'clear_out' };
+
+function pitExitReducer(
+  state: PitExitState,
+  action: PitExitAction
+): PitExitState {
+  switch (action.type) {
+    case 'reset':
+      return {
+        exitLap: undefined,
+        outCleared: false,
+        lastPitLap: action.lastPitLap,
+      };
+    case 'capture_exit':
+      return { ...state, exitLap: action.exitLap };
+    case 'clear_out':
+      return { ...state, outCleared: true };
+  }
+}
 
 interface PitStatusCellProps {
   onPitRoad?: boolean;
@@ -13,6 +42,7 @@ interface PitStatusCellProps {
   pitStopDuration?: number | null;
   showPitTime?: boolean;
   pitLapDisplayMode?: string;
+  carIdxLapDistPct?: number;
 }
 
 export const PitStatusCell = memo(
@@ -27,7 +57,8 @@ export const PitStatusCell = memo(
     dnf,
     pitStopDuration,
     showPitTime = false,
-    pitLapDisplayMode
+    pitLapDisplayMode,
+    carIdxLapDistPct,
   }: PitStatusCellProps) => {
     const widthClass = showPitTime ? 'w-[7rem]' : 'w-[4.5rem]';
     const tow =
@@ -42,16 +73,80 @@ export const PitStatusCell = memo(
         (carTrackSurface === 1 && prevCarTrackSurface == 2) ||
         prevCarTrackSurface == undefined ||
         currentSessionType != 'Race');
+    // Only show L# badge for mid-race pit stops (lastPitLap > 0 means pitted after session start).
+    // Cars that started from pits at session start (lastPitLap === 0) only show OUT, never L#.
     const lastPit =
-      !onPitRoad &&
-      !!lastPitLap &&
-      lastPitLap > 1 &&
-      carTrackSurface != -1;
+      !onPitRoad && !!lastPitLap && lastPitLap > 0 && carTrackSurface != -1;
+
+    // exitPctRef: lap dist pct captured at pit exit (only needed inside effect, not for render)
+    const exitPctRef = useRef<number | undefined>(undefined);
+
+    // Reducer holds state needed during render: exitLap and outCleared
+    const [pitExit, dispatch] = useReducer(pitExitReducer, {
+      exitLap: undefined,
+      outCleared: false,
+      lastPitLap: undefined,
+    });
+
+    useEffect(() => {
+      // Reset for a new pit stop (or on initial mount when pitExit.lastPitLap is undefined).
+      if (lastPitLap !== pitExit.lastPitLap) {
+        exitPctRef.current = undefined;
+        dispatch({ type: 'reset', lastPitLap });
+        return;
+      }
+
+      // Capture exit position and lap once per pit stop.
+      // carTrackSurface === 3 means the car is on track (out of pit road/box).
+      // Guard with prevCarTrackSurface === 1|2 so we only capture on a genuine pit exit.
+      if (
+        carTrackSurface === 3 &&
+        (prevCarTrackSurface === 1 || prevCarTrackSurface === 2) &&
+        carIdxLapDistPct !== undefined &&
+        exitPctRef.current === undefined &&
+        !pitExit.outCleared
+      ) {
+        exitPctRef.current = carIdxLapDistPct;
+        dispatch({ type: 'capture_exit', exitLap: lap });
+      }
+
+      // Latch outCleared once 85% traveled — prevents re-triggering after the next S/F crossing
+      const exitPct = exitPctRef.current;
+      if (
+        !pitExit.outCleared &&
+        exitPct !== undefined &&
+        carIdxLapDistPct !== undefined
+      ) {
+        const distanceTraveled =
+          carIdxLapDistPct >= exitPct
+            ? carIdxLapDistPct - exitPct
+            : 1.0 - exitPct + carIdxLapDistPct;
+        if (distanceTraveled >= 0.85) {
+          dispatch({ type: 'clear_out' });
+        }
+      }
+    }, [
+      onPitRoad,
+      carTrackSurface,
+      prevCarTrackSurface,
+      carIdxLapDistPct,
+      lastPitLap,
+      lap,
+      pitExit.lastPitLap,
+      pitExit.outCleared,
+    ]);
+
+    // OUT is active from pit exit until outCleared latches (85% traveled).
+    // lastPitLap can be 0 at session start (lap 0), so check !== undefined rather than truthy.
     const out =
       !onPitRoad &&
-      !!lastPitLap &&
-      lastPitLap == lastLap &&
+      lastPitLap !== undefined &&
+      !pitExit.outCleared &&
       carTrackSurface != -1;
+
+    // Use exitLap as the base for lapsSinceLastPit so that S/F crossings
+    // that happen between pit exit and exitPct capture don't throw the count off
+    const lapBaseLap = pitExit.exitLap ?? lastPitLap;
 
     return (
       <td
@@ -65,7 +160,7 @@ export const PitStatusCell = memo(
           out={out}
           lap={lap}
           lastPit={lastPit}
-          lastPitLap={lastPitLap}
+          lastPitLap={lapBaseLap}
           pitStopDuration={pitStopDuration}
           showPitTime={showPitTime}
           pitLapDisplayMode={pitLapDisplayMode}

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -59,6 +59,7 @@ export interface Standings {
   penalty: boolean;
   slowdown: boolean;
   relativePct: number;
+  carIdxLapDistPct?: number;
 }
 
 const calculateDelta = (
@@ -118,6 +119,7 @@ export const createDriverStandings = (
     carIdxTireCompoundValue?: number[];
     isOnTrack?: boolean;
     carIdxSessionFlags?: number[];
+    carIdxLapDistPctValue?: number[];
   },
   currentSession: {
     resultsPositions?: SessionResults[];
@@ -224,6 +226,8 @@ export const createDriverStandings = (
           GlobalFlags.Furled
         ),
         relativePct: 0,
+        carIdxLapDistPct:
+          telemetry?.carIdxLapDistPctValue?.[result.CarIdx] ?? undefined,
       };
     })
     .filter((s) => !!s);

--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -287,6 +287,7 @@ export const useDriverStandings = () => {
         penalty: carState?.penalty ?? false,
         slowdown: carState?.slowdown ?? false,
         relativePct: 0,
+        carIdxLapDistPct: driverPos.lapDstPct,
       };
     });
 


### PR DESCRIPTION
## Description

Fixes incorrect OUT and L# pit status badge behaviour for drivers in the standings and relative overlays, particularly on tracks where the start/finish line is immediately after pit exit (e.g. Watkins Glen, Sebring).

**Root cause of the old `out` logic:** `out` was gated on `lastPitLap == lastLap`, meaning OUT only showed for a single telemetry tick when the car's pit lap matched its current lap — unreliable and frequently missed entirely.

**New `out` logic:** `PitStatusCell` now captures the car's track position (`carIdxLapDistPct`) at the moment of pit exit and latches `outCleared` once the car has traveled 85% of a lap from that position. OUT shows from pit exit until that threshold, then clears cleanly regardless of S/F line crossings.

**L# suppression for session-start pits:** Cars that start from pit lane at session start (`lastPitLap === 0`) no longer show a L# badge after OUT clears — OUT transitions to nothing. Only mid-race pit stops (`lastPitLap > 0`) progress to the L# badge.

## Screenshots

_Before: OUT either never appeared or flashed for a single frame on pit exit._

_After: OUT shows from pit exit and clears ~85% of a lap later, then shows L# for mid-race pit stops only._

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
