### PR TITLE
fix: pit OUT status

### DIFF
--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react';
 import { getTailwindStyle } from '@irdashies/utils/colors';
 import { formatTime, type TimeFormat } from '@irdashies/utils/time';
-import { usePitStopDuration } from '@irdashies/context';
+import { usePitStopDuration, usePitLaneStore } from '@irdashies/context';
 import type { Gap, LastTimeState } from '../../createStandings';
 import type {
   RelativeWidgetSettings,
@@ -78,7 +78,7 @@ const getDummyData = () => ({
   teamName: 'Team Name',
   delta: 0,
   fastestTime: 60000, // 1:00.000
-  lastTime: 60000,    // 1:00.000
+  lastTime: 60000, // 1:00.000
   tireCompound: 0,
   license: 'A 4.99',
   rating: 4999,
@@ -98,9 +98,9 @@ const getDummyData = () => ({
 // Helper function to transform props for hidden rows
 const getDisplayProps = (props: DriverRowInfoProps) => {
   if (!props.hidden) return props;
-  
+
   const dummyData = getDummyData();
-  
+
   return {
     ...props,
     // Override with dummy data for hidden rows
@@ -128,395 +128,384 @@ const getDisplayProps = (props: DriverRowInfoProps) => {
   };
 };
 
-export const DriverInfoRow = memo(
-  (props: DriverRowInfoProps) => {
-    // Transform props for hidden rows
-    const displayProps = getDisplayProps(props);
-    
-    const {
-      carIdx,
-      carNumber,
-      classColor,
-      name,
-      teamName,
-      isPlayer,
-      hasFastestTime,
-      delta,
-      gap,
-      interval,
-      position,
-      lap,
-      license,
-      rating,
-      iratingChangeValue,
-      lastTime,
-      fastestTime,
-      lastTimeState,
-      onPitRoad,
-      onTrack,
-      radioActive,
-      isLapped,
-      isLappingAhead,
-      hidden,
-      flairId,
-      tireCompound,
-      carId,
-      lapTimeDeltas,
-      numLapDeltasToShow,
-      isMultiClass,
-      displayOrder,
-      config,
-      lastPitLap,
-      lastLap,
-      prevCarTrackSurface,
-      carTrackSurface,
-      currentSessionType,
-      highlightColor = 960745,
-      dnf,
-      repair,
-      penalty,
-      slowdown,
-      deltaDecimalPlaces,
-      pitStopDuration: pitStopDurationProp,
-      hideCarManufacturer,
-    } = displayProps;
-    const pitStopDurations = usePitStopDuration();
-    const pitStopDuration =
-      pitStopDurationProp ?? pitStopDurations[carIdx] ?? null;
+export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
+  // Transform props for hidden rows
+  const displayProps = getDisplayProps(props);
 
-    const lastTimeString = useMemo(() => {
-      const format = config?.lastTime?.timeFormat ?? 'full';
-      return formatTime(lastTime, format as TimeFormat);
-    }, [lastTime, config?.lastTime?.timeFormat]);
+  const {
+    carIdx,
+    carNumber,
+    classColor,
+    name,
+    teamName,
+    isPlayer,
+    hasFastestTime,
+    delta,
+    gap,
+    interval,
+    position,
+    lap,
+    license,
+    rating,
+    iratingChangeValue,
+    lastTime,
+    fastestTime,
+    lastTimeState,
+    onPitRoad,
+    onTrack,
+    radioActive,
+    isLapped,
+    isLappingAhead,
+    hidden,
+    flairId,
+    tireCompound,
+    carId,
+    lapTimeDeltas,
+    numLapDeltasToShow,
+    isMultiClass,
+    displayOrder,
+    config,
+    lastPitLap,
+    lastLap,
+    prevCarTrackSurface,
+    carTrackSurface,
+    currentSessionType,
+    highlightColor = 960745,
+    dnf,
+    repair,
+    penalty,
+    slowdown,
+    deltaDecimalPlaces,
+    pitStopDuration: pitStopDurationProp,
+    hideCarManufacturer,
+  } = displayProps;
+  const pitStopDurations = usePitStopDuration();
+  const pitStopDuration =
+    pitStopDurationProp ?? pitStopDurations[carIdx] ?? null;
 
-    const fastestTimeString = useMemo(() => {
-      const format = config?.fastestTime?.timeFormat ?? 'full';
-      return formatTime(fastestTime, format as TimeFormat);
-    }, [fastestTime, config?.fastestTime?.timeFormat]);
+  const pitExitPct = usePitLaneStore((s) => s.pitExitPct);
+  // When pit exit is in the last 15% of the lap, the S/F line is reached
+  // very shortly after exiting pits. OUT must persist for one extra lap count.
+  const pitExitAfterSF = pitExitPct !== null && pitExitPct > 0.85;
 
-    const offTrack = carTrackSurface === 0 ? true : false;
+  const lastTimeString = useMemo(() => {
+    const format = config?.lastTime?.timeFormat ?? 'full';
+    return formatTime(lastTime, format as TimeFormat);
+  }, [lastTime, config?.lastTime?.timeFormat]);
 
-    const tailwindStyles = useMemo(() => {
-      return getTailwindStyle(classColor, highlightColor, isMultiClass);
-    }, [classColor, highlightColor, isMultiClass]);
+  const fastestTimeString = useMemo(() => {
+    const format = config?.fastestTime?.timeFormat ?? 'full';
+    return formatTime(fastestTime, format as TimeFormat);
+  }, [fastestTime, config?.fastestTime?.timeFormat]);
 
-    const emptyLapDeltaPlaceholders = useMemo(() => {
-      if (!numLapDeltasToShow) return null;
-      return Array.from({ length: numLapDeltasToShow }, (_, index) => index);
-    }, [numLapDeltasToShow]);
-    
-    const columnDefinitions = useMemo(() => {
-      const columns = [
-        {
-          id: 'position',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('position') : true) &&
-            (config?.position?.enabled ?? true),
-          component: (
-            <PositionCell
-              key="position"
-              position={position}
-              isPlayer={isPlayer}
-              offTrack={offTrack}
-              tailwindStyles={tailwindStyles}
-            />
-          ),
-        },
-        {
-          id: 'carNumber',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('carNumber') : true) &&
-            (config?.carNumber?.enabled ?? true),
-          component: (
-            <CarNumberCell
-              key="carNumber"
-              carNumber={carNumber}
-              tailwindStyles={tailwindStyles}
-            />
-          ),
-        },
-        {
-          id: 'countryFlags',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('countryFlags') : true) &&
-            (config?.countryFlags?.enabled ?? true),
-          component: (
-            <CountryFlagsCell
-              key="countryFlags"
-              flairId={flairId}
-            />
-          ),
-        },
-        {
-          id: 'driverName',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('driverName') : true) &&
-            (config?.driverName?.enabled ?? true),
-          component: (
-            <DriverNameCell
-              key="driverName"
-              radioActive={radioActive}
-              repair={repair}
-              penalty={penalty}
-              slowdown={slowdown}
-              showStatusBadges={config?.driverName?.showStatusBadges ?? true}
-              fullName={name}
-              nameFormat={config?.driverName?.nameFormat}
-            />
-          ),
-        },
-        {
-          id: 'teamName',
-          shouldRender:
-            teamName !== undefined &&
-            (displayOrder ? displayOrder.includes('teamName') : false) &&
-            (config?.teamName?.enabled ?? false),
-          component: (
-            <TeamNameCell 
-              key="teamName" 
-              teamName={teamName} />
-          ),
-        },
-        {
-          id: 'pitStatus',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('pitStatus') : true) &&
-            (config?.pitStatus?.enabled ?? true),
-          component: (
-            <PitStatusCell
-              key="pitStatus"
-              onPitRoad={onPitRoad}
-              carTrackSurface={carTrackSurface}
-              prevCarTrackSurface={prevCarTrackSurface}
-              lap={lap}
-              lastPitLap={lastPitLap}
-              lastLap={lastLap}
-              currentSessionType={currentSessionType}
-              dnf={dnf}
-              pitStopDuration={pitStopDuration}
-              showPitTime={config?.pitStatus?.showPitTime ?? false}
-              pitLapDisplayMode={config?.pitStatus?.pitLapDisplayMode}
-            />
-          ),
-        },
-        {
-          id: 'carManufacturer',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('carManufacturer') : true) &&
-            (config?.carManufacturer?.enabled ?? true) &&
-            !hideCarManufacturer,
-          component: (
-            <CarManufacturerCell
-              key="carManufacturer"
-              carId={carId}
-            />
-          ),
-        },
-        {
-          id: 'badge',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('badge') : true) &&
-            (config?.badge?.enabled ?? true),
-          component: (
-            <BadgeCell
-              key="badge"
-              license={license}
-              rating={rating}
-              badgeFormat={config?.badge?.badgeFormat}
-            />
-          ),
-        },
-        {
-          id: 'iratingChange',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('iratingChange') : true) &&
-            (config?.iratingChange?.enabled ?? false),
-          component: (
-            <IratingChangeCell
-              key="iratingChange"
-              iratingChangeValue={iratingChangeValue}
-            />
-          ),
-        },
-        {
-          id: 'delta',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('delta') : true) &&
-            (config?.delta?.enabled ?? true) &&
-            !(config && 'gap' in config),
-          component: (
-            <DeltaCell
-              key="delta"
-              delta={delta}
-              decimalPlaces={deltaDecimalPlaces}
-            />
-          ),
-        },
-        {
-          id: 'gap',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('gap') : true) &&
-            (config && 'gap' in config ? config.gap.enabled : false) &&
-            currentSessionType?.toLowerCase() === 'race',
-          component: (
-            <DeltaCell
-              key="gap"
-              delta={gap}
-              showForUndefined={position === 1 ? 'gap' : undefined}
-              decimalPlaces={deltaDecimalPlaces}
-            />
-          ),
-        },
-        {
-          id: 'interval',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('interval') : true) &&
-            (config && 'interval' in config
-              ? config.interval.enabled
-              : false) &&
-            currentSessionType?.toLowerCase() === 'race',
-          component: (
-            <DeltaCell
-              key="interval"
-              delta={interval}
-              showForUndefined={position === 1 ? 'int' : undefined}
-              decimalPlaces={deltaDecimalPlaces}
-            />
-          ),
-        },
-        {
-          id: 'fastestTime',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('fastestTime') : true) &&
-            (config?.fastestTime?.enabled ?? false),
-          component: (
-            <FastestTimeCell
-              key="fastestTime"
-              fastestTimeString={fastestTimeString}
-              hasFastestTime={hasFastestTime}
-            />
-          ),
-        },
-        {
-          id: 'lastTime',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('lastTime') : true) &&
-            (config?.lastTime?.enabled ?? false),
-          component: (
-            <LastTimeCell
-              key="lastTime"
-              lastTimeString={lastTimeString}
-              lastTimeState={lastTimeState}
-            />
-          ),
-        },
-        {
-          id: 'compound',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('compound') : true) &&
-            (config?.compound?.enabled ?? false),
-          component: (
-            <CompoundCell
-              key="compound"
-              tireCompound={tireCompound}
-              carId={carId}
-            />
-          ),
-        },
-        {
-          id: 'lapTimeDeltas',
-          shouldRender:
-            (displayOrder ? displayOrder.includes('lapTimeDeltas') : false) &&
-            (config && 'lapTimeDeltas' in config
-              ? config.lapTimeDeltas.enabled
-              : false),
-          component: (
-            <LapTimeDeltasCell
-              key="lapTimeDeltas"
-              lapTimeDeltas={lapTimeDeltas}
-              emptyLapDeltaPlaceholders={emptyLapDeltaPlaceholders}
-              isPlayer={isPlayer}
-            />
-          ),
-        },
-      ];
+  const offTrack = carTrackSurface === 0 ? true : false;
 
-      if (displayOrder) {
-        const orderedColumns = displayOrder
-          .map((orderId) => columns.find((col) => col.id === orderId))
-          .filter(
-            (col): col is NonNullable<typeof col> =>
-              col !== undefined && col.shouldRender
-          );
+  const tailwindStyles = useMemo(() => {
+    return getTailwindStyle(classColor, highlightColor, isMultiClass);
+  }, [classColor, highlightColor, isMultiClass]);
 
-        const remainingColumns = columns.filter(
-          (col) => col.shouldRender && !displayOrder.includes(col.id)
+  const emptyLapDeltaPlaceholders = useMemo(() => {
+    if (!numLapDeltasToShow) return null;
+    return Array.from({ length: numLapDeltasToShow }, (_, index) => index);
+  }, [numLapDeltasToShow]);
+
+  const columnDefinitions = useMemo(() => {
+    const columns = [
+      {
+        id: 'position',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('position') : true) &&
+          (config?.position?.enabled ?? true),
+        component: (
+          <PositionCell
+            key="position"
+            position={position}
+            isPlayer={isPlayer}
+            offTrack={offTrack}
+            tailwindStyles={tailwindStyles}
+          />
+        ),
+      },
+      {
+        id: 'carNumber',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('carNumber') : true) &&
+          (config?.carNumber?.enabled ?? true),
+        component: (
+          <CarNumberCell
+            key="carNumber"
+            carNumber={carNumber}
+            tailwindStyles={tailwindStyles}
+          />
+        ),
+      },
+      {
+        id: 'countryFlags',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('countryFlags') : true) &&
+          (config?.countryFlags?.enabled ?? true),
+        component: <CountryFlagsCell key="countryFlags" flairId={flairId} />,
+      },
+      {
+        id: 'driverName',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('driverName') : true) &&
+          (config?.driverName?.enabled ?? true),
+        component: (
+          <DriverNameCell
+            key="driverName"
+            radioActive={radioActive}
+            repair={repair}
+            penalty={penalty}
+            slowdown={slowdown}
+            showStatusBadges={config?.driverName?.showStatusBadges ?? true}
+            fullName={name}
+            nameFormat={config?.driverName?.nameFormat}
+          />
+        ),
+      },
+      {
+        id: 'teamName',
+        shouldRender:
+          teamName !== undefined &&
+          (displayOrder ? displayOrder.includes('teamName') : false) &&
+          (config?.teamName?.enabled ?? false),
+        component: <TeamNameCell key="teamName" teamName={teamName} />,
+      },
+      {
+        id: 'pitStatus',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('pitStatus') : true) &&
+          (config?.pitStatus?.enabled ?? true),
+        component: (
+          <PitStatusCell
+            key="pitStatus"
+            onPitRoad={onPitRoad}
+            carTrackSurface={carTrackSurface}
+            prevCarTrackSurface={prevCarTrackSurface}
+            lap={lap}
+            lastPitLap={lastPitLap}
+            lastLap={lastLap}
+            currentSessionType={currentSessionType}
+            dnf={dnf}
+            pitStopDuration={pitStopDuration}
+            showPitTime={config?.pitStatus?.showPitTime ?? false}
+            pitLapDisplayMode={config?.pitStatus?.pitLapDisplayMode}
+            pitExitAfterSF={pitExitAfterSF}
+          />
+        ),
+      },
+      {
+        id: 'carManufacturer',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('carManufacturer') : true) &&
+          (config?.carManufacturer?.enabled ?? true) &&
+          !hideCarManufacturer,
+        component: <CarManufacturerCell key="carManufacturer" carId={carId} />,
+      },
+      {
+        id: 'badge',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('badge') : true) &&
+          (config?.badge?.enabled ?? true),
+        component: (
+          <BadgeCell
+            key="badge"
+            license={license}
+            rating={rating}
+            badgeFormat={config?.badge?.badgeFormat}
+          />
+        ),
+      },
+      {
+        id: 'iratingChange',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('iratingChange') : true) &&
+          (config?.iratingChange?.enabled ?? false),
+        component: (
+          <IratingChangeCell
+            key="iratingChange"
+            iratingChangeValue={iratingChangeValue}
+          />
+        ),
+      },
+      {
+        id: 'delta',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('delta') : true) &&
+          (config?.delta?.enabled ?? true) &&
+          !(config && 'gap' in config),
+        component: (
+          <DeltaCell
+            key="delta"
+            delta={delta}
+            decimalPlaces={deltaDecimalPlaces}
+          />
+        ),
+      },
+      {
+        id: 'gap',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('gap') : true) &&
+          (config && 'gap' in config ? config.gap.enabled : false) &&
+          currentSessionType?.toLowerCase() === 'race',
+        component: (
+          <DeltaCell
+            key="gap"
+            delta={gap}
+            showForUndefined={position === 1 ? 'gap' : undefined}
+            decimalPlaces={deltaDecimalPlaces}
+          />
+        ),
+      },
+      {
+        id: 'interval',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('interval') : true) &&
+          (config && 'interval' in config ? config.interval.enabled : false) &&
+          currentSessionType?.toLowerCase() === 'race',
+        component: (
+          <DeltaCell
+            key="interval"
+            delta={interval}
+            showForUndefined={position === 1 ? 'int' : undefined}
+            decimalPlaces={deltaDecimalPlaces}
+          />
+        ),
+      },
+      {
+        id: 'fastestTime',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('fastestTime') : true) &&
+          (config?.fastestTime?.enabled ?? false),
+        component: (
+          <FastestTimeCell
+            key="fastestTime"
+            fastestTimeString={fastestTimeString}
+            hasFastestTime={hasFastestTime}
+          />
+        ),
+      },
+      {
+        id: 'lastTime',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('lastTime') : true) &&
+          (config?.lastTime?.enabled ?? false),
+        component: (
+          <LastTimeCell
+            key="lastTime"
+            lastTimeString={lastTimeString}
+            lastTimeState={lastTimeState}
+          />
+        ),
+      },
+      {
+        id: 'compound',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('compound') : true) &&
+          (config?.compound?.enabled ?? false),
+        component: (
+          <CompoundCell
+            key="compound"
+            tireCompound={tireCompound}
+            carId={carId}
+          />
+        ),
+      },
+      {
+        id: 'lapTimeDeltas',
+        shouldRender:
+          (displayOrder ? displayOrder.includes('lapTimeDeltas') : false) &&
+          (config && 'lapTimeDeltas' in config
+            ? config.lapTimeDeltas.enabled
+            : false),
+        component: (
+          <LapTimeDeltasCell
+            key="lapTimeDeltas"
+            lapTimeDeltas={lapTimeDeltas}
+            emptyLapDeltaPlaceholders={emptyLapDeltaPlaceholders}
+            isPlayer={isPlayer}
+          />
+        ),
+      },
+    ];
+
+    if (displayOrder) {
+      const orderedColumns = displayOrder
+        .map((orderId) => columns.find((col) => col.id === orderId))
+        .filter(
+          (col): col is NonNullable<typeof col> =>
+            col !== undefined && col.shouldRender
         );
 
-        return [...orderedColumns, ...remainingColumns];
-      }
+      const remainingColumns = columns.filter(
+        (col) => col.shouldRender && !displayOrder.includes(col.id)
+      );
 
-      return columns.filter((col) => col.shouldRender);
-    }, [
-      displayOrder,
-      config,
-      position,
-      lap,
-      isPlayer,
-      offTrack,
-      tailwindStyles,
-      carNumber,
-      flairId,
-      name,
-      teamName,
-      radioActive,
-      onPitRoad,
-      carTrackSurface,
-      prevCarTrackSurface,
-      lastPitLap,
-      lastLap,
-      currentSessionType,
-      dnf,
-      repair,
-      penalty,
-      slowdown,
-      pitStopDuration,
-      carId,
-      license,
-      rating,
-      iratingChangeValue,
-      delta,
-      deltaDecimalPlaces,
-      gap,
-      interval,
-      fastestTimeString,
-      hasFastestTime,
-      lastTimeString,
-      lastTimeState,
-      tireCompound,
-      lapTimeDeltas,
-      emptyLapDeltaPlaceholders,
-      hideCarManufacturer,
-    ]);
+      return [...orderedColumns, ...remainingColumns];
+    }
 
-    return (
-      <tr
-        key={carIdx}
-        className={[
-          !onTrack || onPitRoad ? 'text-white/60' : '',
-          isPlayer ? 'text-amber-300' : '',
-          isPlayer
-            ? 'bg-yellow-500/20'
-            : 'odd:bg-slate-800/70 even:bg-slate-900/70 text-sm',
-          !isPlayer && isLapped ? 'text-blue-400' : '',
-          !isPlayer && isLappingAhead ? 'text-red-400' : '',
-          hidden ? 'invisible' : '',
-        ].join(' ')}
-      >
-        {columnDefinitions.map((column) => column.component)}
-      </tr>
-    );
-  }
-);
+    return columns.filter((col) => col.shouldRender);
+  }, [
+    displayOrder,
+    config,
+    position,
+    lap,
+    isPlayer,
+    offTrack,
+    tailwindStyles,
+    carNumber,
+    flairId,
+    name,
+    teamName,
+    radioActive,
+    onPitRoad,
+    carTrackSurface,
+    prevCarTrackSurface,
+    lastPitLap,
+    lastLap,
+    currentSessionType,
+    dnf,
+    repair,
+    penalty,
+    slowdown,
+    pitStopDuration,
+    carId,
+    license,
+    rating,
+    iratingChangeValue,
+    delta,
+    deltaDecimalPlaces,
+    gap,
+    interval,
+    fastestTimeString,
+    hasFastestTime,
+    lastTimeString,
+    lastTimeState,
+    tireCompound,
+    lapTimeDeltas,
+    emptyLapDeltaPlaceholders,
+    hideCarManufacturer,
+    pitExitAfterSF,
+  ]);
+
+  return (
+    <tr
+      key={carIdx}
+      className={[
+        !onTrack || onPitRoad ? 'text-white/60' : '',
+        isPlayer ? 'text-amber-300' : '',
+        isPlayer
+          ? 'bg-yellow-500/20'
+          : 'odd:bg-slate-800/70 even:bg-slate-900/70 text-sm',
+        !isPlayer && isLapped ? 'text-blue-400' : '',
+        !isPlayer && isLappingAhead ? 'text-red-400' : '',
+        hidden ? 'invisible' : '',
+      ].join(' ')}
+    >
+      {columnDefinitions.map((column) => column.component)}
+    </tr>
+  );
+});
 
 DriverInfoRow.displayName = 'DriverInfoRow';

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverStatusBadges.spec.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverStatusBadges.spec.tsx
@@ -72,4 +72,51 @@ describe('DriverStatusBadges', () => {
 
     expect(container.querySelectorAll('span.border-gray-500')).toHaveLength(3);
   });
+
+  describe('lapsSinceLastPit with pitExitAfterSF', () => {
+    it('shows L2 on 2nd lap out when pitExitAfterSF is true (not L3)', () => {
+      // pitted lap 5, now lap 7 — without fix this would show L3
+      const { container } = render(
+        <DriverStatusBadges
+          lastPit
+          lastPitLap={5}
+          lap={7}
+          pitLapDisplayMode="lapsSinceLastPit"
+          pitExitAfterSF={true}
+        />
+      );
+
+      expect(container.textContent).toContain('L 2');
+      expect(container.textContent).not.toContain('L 3');
+    });
+
+    it('shows L3 on 3rd lap out when pitExitAfterSF is true', () => {
+      const { container } = render(
+        <DriverStatusBadges
+          lastPit
+          lastPitLap={5}
+          lap={8}
+          pitLapDisplayMode="lapsSinceLastPit"
+          pitExitAfterSF={true}
+        />
+      );
+
+      expect(container.textContent).toContain('L 3');
+    });
+
+    it('uses normal lapsSinceLastPit formula when pitExitAfterSF is false', () => {
+      // pitted lap 5, now lap 7 — normal track shows L3
+      const { container } = render(
+        <DriverStatusBadges
+          lastPit
+          lastPitLap={5}
+          lap={7}
+          pitLapDisplayMode="lapsSinceLastPit"
+          pitExitAfterSF={false}
+        />
+      );
+
+      expect(container.textContent).toContain('L 3');
+    });
+  });
 });

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverStatusBadges.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverStatusBadges.tsx
@@ -36,7 +36,7 @@ interface DriverStatusBadgesProps {
   dnf?: boolean;
   tow?: boolean;
   out?: boolean;
-  lap?:number;
+  lap?: number;
   pit?: boolean;
   lastPit?: boolean;
   lastPitLap?: number;
@@ -44,6 +44,7 @@ interface DriverStatusBadgesProps {
   showPitTime?: boolean;
   className?: string;
   pitLapDisplayMode?: string;
+  pitExitAfterSF?: boolean;
 }
 
 export const DriverStatusBadges = memo(
@@ -61,48 +62,71 @@ export const DriverStatusBadges = memo(
     pitStopDuration,
     showPitTime = false,
     className = '',
-    pitLapDisplayMode
+    pitLapDisplayMode,
+    pitExitAfterSF,
   }: DriverStatusBadgesProps) => {
     const hasStatus =
-      (penalty || slowdown || repair || dnf || tow || out || pit || lastPit);
+      penalty || slowdown || repair || dnf || tow || out || pit || lastPit;
 
     if (!hasStatus) {
       return null;
     }
 
-    const pitDuration = <>{showPitTime && lastPitLap && lastPitLap > 1 && pitStopDuration && <span className="text-yellow-500">{formatTime(pitStopDuration, 'duration')}</span>}</>;
+    const pitDuration = (
+      <>
+        {showPitTime && lastPitLap && lastPitLap > 1 && pitStopDuration && (
+          <span className="text-yellow-500">
+            {formatTime(pitStopDuration, 'duration')}
+          </span>
+        )}
+      </>
+    );
     let pitLap = lastPitLap;
 
-    if (pitLapDisplayMode == 'lapsSinceLastPit')
-    {
-      if (lap && lastPitLap)
-      {
-        pitLap = lap - lastPitLap + 1;
+    if (pitLapDisplayMode == 'lapsSinceLastPit') {
+      if (lap && lastPitLap) {
+        // On tracks where pit exit is before the S/F line (pitExitAfterSF), the
+        // driver crosses S/F before completing a full out-lap. The +1 offset that
+        // normally accounts for the current in-progress lap would count that tiny
+        // partial lap as a full one, so we omit it in that case.
+        pitLap = pitExitAfterSF ? lap - lastPitLap : lap - lastPitLap + 1;
       }
     }
 
-
     return (
-      <div className={`flex flex-row-reverse items-center gap-0.5 ${className}`}>
+      <div
+        className={`flex flex-row-reverse items-center gap-0.5 ${className}`}
+      >
         {penalty && (
-          <StatusBadge textColor="text-orange-500" borderColorClass="border-gray-500" additionalClasses="bg-black/80 inline-block min-w-6">
+          <StatusBadge
+            textColor="text-orange-500"
+            borderColorClass="border-gray-500"
+            additionalClasses="bg-black/80 inline-block min-w-6"
+          >
             {'\u00A0'}
           </StatusBadge>
         )}
         {slowdown && (
-          <StatusBadge textColor="text-orange-500" borderColorClass="border-gray-500" animate additionalClasses="bg-black/80 inline-block min-w-6">
+          <StatusBadge
+            textColor="text-orange-500"
+            borderColorClass="border-gray-500"
+            animate
+            additionalClasses="bg-black/80 inline-block min-w-6"
+          >
             {'\u00A0'}
           </StatusBadge>
         )}
         {repair && (
-          <StatusBadge textColor="text-orange-500" borderColorClass="border-gray-500" additionalClasses="bg-black/80 items-center justify-center">
-            <span className="inline-block w-[0.8em] h-[0.8em] bg-orange-500 rounded-full"/>
+          <StatusBadge
+            textColor="text-orange-500"
+            borderColorClass="border-gray-500"
+            additionalClasses="bg-black/80 items-center justify-center"
+          >
+            <span className="inline-block w-[0.8em] h-[0.8em] bg-orange-500 rounded-full" />
           </StatusBadge>
         )}
         {dnf && (
-          <StatusBadge borderColorClass="border-red-500">
-            DNF
-          </StatusBadge>
+          <StatusBadge borderColorClass="border-red-500">DNF</StatusBadge>
         )}
         {tow && (
           <StatusBadge borderColorClass="border-orange-500" animate>
@@ -121,7 +145,7 @@ export const DriverStatusBadges = memo(
         )}
         {lastPit && !out && (
           <StatusBadge borderColorClass="border-yellow-500">
-             L {pitLap} {pitDuration}
+            L {pitLap} {pitDuration}
           </StatusBadge>
         )}
       </div>

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/PitStatusCell.spec.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/PitStatusCell.spec.tsx
@@ -24,21 +24,15 @@ describe('PitStatusCell', () => {
   });
 
   it('renders empty cell when hidden', () => {
-    const { container } = renderInTable(
-      <PitStatusCell />
-    );
-    
+    const { container } = renderInTable(<PitStatusCell />);
+
     const td = container.querySelector('td[data-column="pitStatus"]');
     expect(td).toBeTruthy();
     expect(td?.textContent).toBe('');
   });
 
   it('uses a wider width when showPitTime is enabled', () => {
-    const { container } = renderInTable(
-      <PitStatusCell
-        showPitTime={true}
-      />
-    );
+    const { container } = renderInTable(<PitStatusCell showPitTime={true} />);
 
     const td = container.querySelector('td[data-column="pitStatus"]');
     expect(td?.className).toContain('w-[7rem]');
@@ -68,5 +62,54 @@ describe('PitStatusCell', () => {
     );
 
     expect(container.textContent).not.toContain('OUT');
+  });
+
+  describe('pitExitAfterSF — pit exit close to start/finish line', () => {
+    it('keeps OUT visible after crossing S/F when pitExitAfterSF is true', () => {
+      // Driver pitted on lap 5, has now crossed S/F (lastLap=6) but pit exit
+      // was in the last 15% of the lap so OUT should still show
+      const { container } = renderInTable(
+        <PitStatusCell
+          onPitRoad={false}
+          lastPitLap={5}
+          lastLap={6}
+          carTrackSurface={1}
+          pitExitAfterSF={true}
+        />
+      );
+
+      expect(container.textContent).toContain('OUT');
+    });
+
+    it('does not keep OUT after two S/F crossings when pitExitAfterSF is true', () => {
+      // Driver pitted on lap 5, has now crossed S/F twice (lastLap=7) — OUT
+      // should be gone even with pitExitAfterSF
+      const { container } = renderInTable(
+        <PitStatusCell
+          onPitRoad={false}
+          lastPitLap={5}
+          lastLap={7}
+          carTrackSurface={1}
+          pitExitAfterSF={true}
+        />
+      );
+
+      expect(container.textContent).not.toContain('OUT');
+    });
+
+    it('does not extend OUT when pitExitAfterSF is false', () => {
+      // Normal track: once S/F is crossed, OUT disappears
+      const { container } = renderInTable(
+        <PitStatusCell
+          onPitRoad={false}
+          lastPitLap={5}
+          lastLap={6}
+          carTrackSurface={1}
+          pitExitAfterSF={false}
+        />
+      );
+
+      expect(container.textContent).not.toContain('OUT');
+    });
   });
 });

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/PitStatusCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/PitStatusCell.tsx
@@ -13,6 +13,12 @@ interface PitStatusCellProps {
   pitStopDuration?: number | null;
   showPitTime?: boolean;
   pitLapDisplayMode?: string;
+  /**
+   * True when the pit lane exit is in the last 15% of the lap, meaning the
+   * start/finish line is reached very shortly after exiting pits. When true,
+   * OUT persists for one extra lap count so it remains visible for a full lap.
+   */
+  pitExitAfterSF?: boolean;
 }
 
 export const PitStatusCell = memo(
@@ -27,7 +33,8 @@ export const PitStatusCell = memo(
     dnf,
     pitStopDuration,
     showPitTime = false,
-    pitLapDisplayMode
+    pitLapDisplayMode,
+    pitExitAfterSF,
   }: PitStatusCellProps) => {
     const widthClass = showPitTime ? 'w-[7rem]' : 'w-[4.5rem]';
     const tow =
@@ -43,14 +50,12 @@ export const PitStatusCell = memo(
         prevCarTrackSurface == undefined ||
         currentSessionType != 'Race');
     const lastPit =
-      !onPitRoad &&
-      !!lastPitLap &&
-      lastPitLap > 1 &&
-      carTrackSurface != -1;
+      !onPitRoad && !!lastPitLap && lastPitLap > 1 && carTrackSurface != -1;
     const out =
       !onPitRoad &&
       !!lastPitLap &&
-      lastPitLap == lastLap &&
+      (lastPitLap == lastLap ||
+        (!!pitExitAfterSF && lastPitLap + 1 == lastLap)) &&
       carTrackSurface != -1;
 
     return (
@@ -69,6 +74,7 @@ export const PitStatusCell = memo(
           pitStopDuration={pitStopDuration}
           showPitTime={showPitTime}
           pitLapDisplayMode={pitLapDisplayMode}
+          pitExitAfterSF={pitExitAfterSF}
         />
       </td>
     );


### PR DESCRIPTION
## Description

Fixes incorrect OUT/L-label behaviour in the pit status cell on tracks where the pit lane exit is close to the start/finish line (e.g. Daytona, Indianapolis).

**Root cause:** `CarIdxLap` increments the moment a car crosses the S/F line. On tracks where the pit exit is in the last ~15% of the lap, a driver exits pits and reaches the S/F line almost immediately. This caused:
1. The **OUT** badge to disappear after only a few percent of the track, instead of persisting for a full out-lap.
2. The **laps-since-last-pit** counter (L X) to read one lap too high — e.g. showing L3 when the driver was only on their 2nd lap out of the pits.

**Fix:** `usePitLaneStore` already tracks `pitExitPct`. When that value is greater than `0.85` (pit exit in the last 15% of the lap), a `pitExitAfterSF` flag is derived in `DriverInfoRow` and threaded down to `PitStatusCell` and `DriverStatusBadges`.

- **OUT visibility** (`PitStatusCell`): extended by one lap count when `pitExitAfterSF` is true — `lastPitLap === lastLap || (pitExitAfterSF && lastPitLap + 1 === lastLap)`.
- **Laps-since-last-pit label** (`DriverStatusBadges`): when `pitExitAfterSF` is true, uses `lap - lastPitLap` instead of `lap - lastPitLap + 1` to avoid counting the tiny partial lap as a full one.

## Screenshots

### Before
- OUT disappears immediately after crossing the S/F line on affected tracks
- L-label shows L3 when driver is only on 2nd lap out of pits

### After
- OUT remains visible until the driver crosses the S/F line a second time after exiting pits
- L-label correctly shows L2 on the 2nd lap out, L3 on the 3rd, etc.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
