### PR TITLE
fix: scale font for faster cars from behind

### DIFF
--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
@@ -67,12 +67,12 @@ export const FasterCarsFromBehindDisplay = ({
 
   return (
     <div
-      className={`w-full rounded-sm font-bold ${background} ${animate}`}
+      className={`w-full rounded-sm ${background} ${animate}`}
     >
       <div className={`flex p-1 ${(settings?.showName || settings?.showBadge) && settings?.showDistance ? 'justify-between' : settings?.showDistance ? 'justify-end' : 'justify-start'}`}>
         <div className="flex gap-1">
           {settings?.showName && (
-            <div className="rounded-sm bg-gray-700 p-1">{name}</div>
+            <div className="rounded-sm text-lg bg-gray-700 p-1 px-2">{name}</div>
           )}
           {settings?.showBadge && (
             <div className="flex align-center">
@@ -85,7 +85,7 @@ export const FasterCarsFromBehindDisplay = ({
           )}
         </div>
         {settings?.showDistance && (
-          <div className="rounded-sm bg-gray-700 p-1">{distance?.toFixed(1)}</div>
+          <div className="rounded-sm text-lg bg-gray-700 p-1 px-2">{distance?.toFixed(1)}</div>
         )}
       </div>
 


### PR DESCRIPTION
## Description

Added font-sizes to this widget so it scales along with the selected font size.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [X] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have run `npm run lint` and fixed any issues
- [X] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
