### PR TITLE
fix: alias react-router-dom in site vite config

### DIFF
--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -30,6 +30,13 @@ export default defineConfig({
         __dirname,
         'node_modules/react/jsx-dev-runtime'
       ),
+      // Ensure single copy of react-router-dom — parent project components
+      // (e.g. SettingsLoader) use useParams from the same instance as the
+      // site's MemoryRouter
+      'react-router-dom': path.resolve(
+        __dirname,
+        'node_modules/react-router-dom'
+      ),
     },
   },
   css: {


### PR DESCRIPTION
## Summary
- Adds `react-router-dom` alias to site vite config to ensure a single instance in production builds
- Fixes settings panel showing "Select a widget to edit" instead of widget settings on the deployed site
- Root cause: production build bundled two separate `react-router-dom` instances (site vs parent), so `useParams` in `SettingsLoader` couldn't find the `MemoryRouter` context

## Test plan
- [x] Verified fix locally with production build (`npm run build` + `npx serve dist`)
- [x] Settings panel correctly shows widget settings when clicking menu items

🤖 Generated with [Claude Code](https://claude.com/claude-code)