### PR TITLE
fix: allow 0 non-class drivers in standings

### DIFF
--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -681,9 +681,8 @@ export const StandingsSettings = () => {
                     <SettingSelectRow
                       title="Top drivers to always show in player's class"
                       value={settings.config.driverStandings.numTopDrivers.toString()}
-                      options={Array.from({ length: 10 }, (_, i) => {
-                        const num = i + 1;
-                        return { label: num.toString(), value: num.toString() };
+                      options={Array.from({ length: 11 }, (_, i) => {
+                        return { label: i.toString(), value: i.toString() };
                       })}
                       onChange={(v) =>
                         handleConfigChange({
@@ -809,7 +808,7 @@ export const StandingsSettings = () => {
                         getItemConfig={(id) => {
                           const item =
                             settings.config.headerBar[
-                              id as keyof typeof settings.config.headerBar
+                            id as keyof typeof settings.config.headerBar
                             ];
                           if (
                             typeof item === 'object' &&
@@ -823,7 +822,7 @@ export const StandingsSettings = () => {
                         updateItemConfig={(id, config) => {
                           const item =
                             settings.config.headerBar[
-                              id as keyof typeof settings.config.headerBar
+                            id as keyof typeof settings.config.headerBar
                             ];
                           if (
                             typeof item === 'object' &&
@@ -892,7 +891,7 @@ export const StandingsSettings = () => {
                         getItemConfig={(id) => {
                           const item =
                             settings.config.footerBar[
-                              id as keyof typeof settings.config.footerBar
+                            id as keyof typeof settings.config.footerBar
                             ];
                           if (
                             typeof item === 'object' &&
@@ -906,7 +905,7 @@ export const StandingsSettings = () => {
                         updateItemConfig={(id, config) => {
                           const item =
                             settings.config.footerBar[
-                              id as keyof typeof settings.config.footerBar
+                            id as keyof typeof settings.config.footerBar
                             ];
                           if (
                             typeof item === 'object' &&

--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -648,9 +648,8 @@ export const StandingsSettings = () => {
                     <SettingSelectRow
                       title="Drivers to show in other classes"
                       value={settings.config.driverStandings.numNonClassDrivers.toString()}
-                      options={Array.from({ length: 10 }, (_, i) => {
-                        const num = i + 1;
-                        return { label: num.toString(), value: num.toString() };
+                      options={Array.from({ length: 11 }, (_, i) => {
+                        return { label: i.toString(), value: i.toString() };
                       })}
                       onChange={(v) =>
                         handleConfigChange({

--- a/src/frontend/components/Standings/Relative.stories.tsx
+++ b/src/frontend/components/Standings/Relative.stories.tsx
@@ -719,7 +719,9 @@ const RelativeWithoutHeader = () => {
           <tbody>{rows}</tbody>
         </table>
         {/* Keep SessionBar here */}
-        <SessionBar settings={settings.footerBar} position="footer" />
+        {settings?.footerBar && (
+          <SessionBar settings={settings.footerBar} position="footer" />
+        )}
       </div>
     );
   }
@@ -737,7 +739,9 @@ const RelativeWithoutHeader = () => {
         <tbody>{rows}</tbody>
       </table>
       {/* Keep SessionBar here */}
-      <SessionBar settings={settings.footerBar} position="footer" />
+      {settings?.footerBar && (
+        <SessionBar settings={settings.footerBar} position="footer" />
+      )}
     </div>
   );
 };
@@ -946,7 +950,9 @@ const RelativeWithoutFooter = () => {
       <div className="w-full h-full">
         <TitleBar titleBarSettings={settings?.titleBar} />
         {/* Keep SessionBar here */}
-        <SessionBar settings={settings.headerBar} position="header" />
+        {settings?.headerBar && (
+          <SessionBar settings={settings.headerBar} position="header" />
+        )}
         <table className="w-full table-auto text-sm border-separate border-spacing-y-0.5">
           <tbody>{rows}</tbody>
         </table>
@@ -964,7 +970,9 @@ const RelativeWithoutFooter = () => {
     >
       <TitleBar titleBarSettings={settings?.titleBar} />
       {/* Keep SessionBar here */}
-      <SessionBar settings={settings.headerBar} position="header" />
+      {settings?.headerBar && (
+        <SessionBar settings={settings.headerBar} position="header" />
+      )}
       <table className="w-full table-auto text-sm border-separate border-spacing-y-0.5">
         <tbody>{rows}</tbody>
       </table>

--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -250,7 +250,7 @@ export const Relative = () => {
     return (
       <div className="w-full h-full">
         <TitleBar titleBarSettings={settings?.titleBar} />
-        {(settings?.headerBar?.enabled ?? false) && (
+        {settings?.headerBar && (settings.headerBar.enabled ?? false) && (
           <SessionBar settings={settings.headerBar} position="header" />
         )}
         <table
@@ -258,7 +258,7 @@ export const Relative = () => {
         >
           <tbody>{rows}</tbody>
         </table>
-        {(settings?.footerBar?.enabled ?? true) && (
+        {settings?.footerBar && (settings.footerBar.enabled ?? true) && (
           <SessionBar settings={settings.footerBar} position="footer" />
         )}
       </div>
@@ -273,7 +273,7 @@ export const Relative = () => {
       }}
     >
       <TitleBar titleBarSettings={settings?.titleBar} />
-      {(settings?.headerBar?.enabled ?? false) && (
+      {settings?.headerBar && (settings.headerBar.enabled ?? false) && (
         <SessionBar settings={settings.headerBar} position="header" />
       )}
       <table
@@ -281,7 +281,7 @@ export const Relative = () => {
       >
         <tbody>{rows}</tbody>
       </table>
-      {(settings?.footerBar?.enabled ?? true) && (
+      {settings?.footerBar && (settings.footerBar.enabled ?? true) && (
         <SessionBar settings={settings.footerBar} position="footer" />
       )}
     </div>

--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -270,17 +270,23 @@ export const MultiClassPCCWithClio: Story = {
 export const MultiClassPlayground: Story = {
   argTypes: {
     numNonClassDrivers: {
-      control: { type: 'number', min: 0, max: 20 },
+      control: { type: 'number', min: 0, max: 10 },
       name: 'Drivers from other classes',
+    },
+    numTopDrivers: {
+      control: { type: 'number', min: 0, max: 10 },
+      name: "Top drivers to always show in player's class",
     },
   },
   args: {
     numNonClassDrivers: 3,
+    numTopDrivers: 3,
   },
   decorators: [
     (Story, context) => {
-      const { numNonClassDrivers } = context.args as {
+      const { numNonClassDrivers, numTopDrivers } = context.args as {
         numNonClassDrivers: number;
+        numTopDrivers: number;
       };
       const standingsConfig = defaultDashboard.widgets.find(
         (w) => w.id === 'standings'
@@ -292,6 +298,7 @@ export const MultiClassPlayground: Story = {
           driverStandings: {
             ...standingsConfig?.driverStandings,
             numNonClassDrivers,
+            numTopDrivers,
           },
         },
       })(Story, context);

--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -279,7 +279,9 @@ export const MultiClassPlayground: Story = {
   },
   decorators: [
     (Story, context) => {
-      const { numNonClassDrivers } = context.args;
+      const { numNonClassDrivers } = context.args as {
+        numNonClassDrivers: number;
+      };
       const standingsConfig = defaultDashboard.widgets.find(
         (w) => w.id === 'standings'
       )?.config as any;

--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -479,7 +479,9 @@ const StandingsWithoutHeader = () => {
         </tbody>
       </table>
       {/* Keep SessionBar here */}
-      <SessionBar settings={settings.footerBar} position="footer" />
+      {settings?.footerBar && (
+        <SessionBar settings={settings.footerBar} position="footer" />
+      )}
     </div>
   );
 };
@@ -525,7 +527,9 @@ const StandingsWithoutFooter = () => {
     >
       <TitleBar titleBarSettings={settings?.titleBar} />
       {/* Keep SessionBar here */}
-      <SessionBar settings={settings.headerBar} position="header" />
+      {settings?.headerBar && (
+        <SessionBar settings={settings.headerBar} position="header" />
+      )}
       <table className="w-full table-auto text-sm border-separate border-spacing-y-0.5">
         <tbody>
           {standings.map(([classId, classStandings]) =>

--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -267,6 +267,36 @@ export const MultiClassPCCWithClio: Story = {
   decorators: [TelemetryDecorator('/test-data/1731637331038')],
 };
 
+export const MultiClassPlayground: Story = {
+  argTypes: {
+    numNonClassDrivers: {
+      control: { type: 'number', min: 0, max: 20 },
+      name: 'Drivers from other classes',
+    },
+  },
+  args: {
+    numNonClassDrivers: 3,
+  },
+  decorators: [
+    (Story, context) => {
+      const { numNonClassDrivers } = context.args;
+      const standingsConfig = defaultDashboard.widgets.find(
+        (w) => w.id === 'standings'
+      )?.config as any;
+
+      return TelemetryDecoratorWithConfig('/test-data/1731637331038', {
+        standings: {
+          ...standingsConfig,
+          driverStandings: {
+            ...standingsConfig?.driverStandings,
+            numNonClassDrivers,
+          },
+        },
+      })(Story, context);
+    },
+  ],
+};
+
 export const SupercarsRace: Story = {
   decorators: [TelemetryDecorator('/test-data/1732274253573')],
 };

--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -20,7 +20,7 @@ import {
   useSessionLaps,
 } from '@irdashies/context';
 import { generateMockDataFromPath } from '../../../app/bridge/iracingSdk/mock-data/generateMockData';
-import type { DashboardBridge } from '@irdashies/types';
+import type { DashboardBridge, StandingsConfig } from '@irdashies/types';
 import { defaultDashboard } from '@irdashies/types';
 import { useState, useEffect, Fragment } from 'react';
 import { DriverClassHeader } from './components/DriverClassHeader/DriverClassHeader';
@@ -284,7 +284,7 @@ export const MultiClassPlayground: Story = {
       };
       const standingsConfig = defaultDashboard.widgets.find(
         (w) => w.id === 'standings'
-      )?.config as any;
+      )?.config as StandingsConfig;
 
       return TelemetryDecoratorWithConfig('/test-data/1731637331038', {
         standings: {

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -82,7 +82,7 @@ export const Standings = () => {
       }}
     >
       <TitleBar titleBarSettings={settings?.titleBar} />
-      {(settings?.headerBar?.enabled ?? true) && (
+      {settings?.headerBar && (settings.headerBar.enabled ?? true) && (
         <SessionBar settings={settings.headerBar} position="header" />
       )}
       <table
@@ -257,7 +257,7 @@ export const Standings = () => {
           })}
         </tbody>
       </table>
-      {(settings?.footerBar?.enabled ?? true) && (
+      {settings?.footerBar && (settings.footerBar.enabled ?? true) && (
         <SessionBar settings={settings.footerBar} position="footer" />
       )}
     </div>

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -247,11 +247,12 @@ export const Standings = () => {
                     </Fragment>
                   );
                 })}
-                {index < standings.length - 1 && !isCompact && (
-                  <tr>
-                    <td colSpan={100} className="h-2"></td>
-                  </tr>
-                )}
+                {standings.slice(index + 1).some(([, content]) => content.length > 0) &&
+                  !isCompact && (
+                    <tr>
+                      <td colSpan={100} className="h-2"></td>
+                    </tr>
+                  )}
               </Fragment>
             ) : null;
           })}


### PR DESCRIPTION
allow 0 non-class drivers in standings so users can render only their driver class.
allow 0 top-drivers in player's class in standings.
fix brokenstandings/relatives stories due to type errors on header/footer bar.
added Multi-class playground story for num non-class drivers - can be extended in the future for additional options.

## Screenshots
![Screenshot 2026-04-11 at 8 00 10 AM](https://github.com/user-attachments/assets/07d88b6c-6c3b-43b0-9d90-c1ab46c2dfac)
Multi-class had minimum of 1 driver listed per non-class

![Screenshot 2026-04-11 at 8 00 38 AM](https://github.com/user-attachments/assets/8d79f4b6-19f7-49f7-afae-ca4d1c4a688b)
Allow showing 0 non-class drivers
Extra padding on bottom of class table surfaced

![Screenshot 2026-04-11 at 8 01 02 AM](https://github.com/user-attachments/assets/2918d033-6840-42cd-b962-42580e03522e)
Extra padding on bottom fo class table removed

![Screenshot 2026-04-11 at 8 15 55 AM](https://github.com/user-attachments/assets/591a300f-e494-477a-af3c-ceaa12e310df)
Don't require any leaders in player's class to be rendered