### PR TITLE
fix: driver tag causes driver name to not show in relatives

### DIFF
--- a/src/frontend/components/Standings/Relative.stories.tsx
+++ b/src/frontend/components/Standings/Relative.stories.tsx
@@ -1119,3 +1119,105 @@ export const SingleDriverWithTag: Story = {
     layout: 'padded',
   },
 };
+
+// Regression: when driverTag is reordered BEFORE driverName, the driver name
+// must still render. Previously this caused the name cell to collapse in the
+// Relative widget (but not in Standings) due to fragile table-auto column
+// width allocation interacting with `w-full max-w-0` on the name <td>.
+const reorderedDisplayOrder = [
+  'position',
+  'carNumber',
+  'countryFlags',
+  'driverTag',
+  'driverName',
+  'pitStatus',
+  'carManufacturer',
+  'badge',
+  'delta',
+];
+
+const reorderedRelativeConfig = {
+  ...relativeConfig,
+  displayOrder: reorderedDisplayOrder,
+} as import('@irdashies/types').RelativeWidgetSettings['config'];
+
+const reorderedHiddenRowBaseProps = {
+  ...hiddenRowBaseProps,
+  config: reorderedRelativeConfig,
+};
+
+const SingleRelativeDriverWithTagReorderedComponent = () => (
+  <div className="w-full bg-slate-800/70 rounded-sm p-2 text-white">
+    <table className="w-full table-auto text-sm border-separate border-spacing-y-0.5">
+      <tbody>
+        <DriverInfoRow
+          carIdx={10}
+          {...reorderedHiddenRowBaseProps}
+          displayOrder={reorderedDisplayOrder}
+        />
+        <DriverInfoRow
+          carIdx={11}
+          {...reorderedHiddenRowBaseProps}
+          displayOrder={reorderedDisplayOrder}
+        />
+        <DriverInfoRow
+          carIdx={12}
+          {...reorderedHiddenRowBaseProps}
+          displayOrder={reorderedDisplayOrder}
+        />
+        <DriverInfoRow
+          carIdx={1}
+          carNumber="99"
+          classColor={0xff5888}
+          name="Jane Smith"
+          isPlayer={true}
+          hasFastestTime={false}
+          delta={0}
+          position={3}
+          lap={5}
+          license="A 4.99"
+          rating={4999}
+          onPitRoad={false}
+          onTrack={true}
+          radioActive={false}
+          isMultiClass={false}
+          flairId={223}
+          tireCompound={1}
+          carId={122}
+          currentSessionType="Race"
+          dnf={false}
+          repair={false}
+          penalty={false}
+          slowdown={false}
+          resolvedTag={singleDriverTagRelative}
+          hasAnyDriverTag={true}
+          config={reorderedRelativeConfig}
+          displayOrder={reorderedDisplayOrder}
+        />
+        <DriverInfoRow
+          carIdx={13}
+          {...reorderedHiddenRowBaseProps}
+          displayOrder={reorderedDisplayOrder}
+        />
+        <DriverInfoRow
+          carIdx={14}
+          {...reorderedHiddenRowBaseProps}
+          displayOrder={reorderedDisplayOrder}
+        />
+        <DriverInfoRow
+          carIdx={15}
+          {...reorderedHiddenRowBaseProps}
+          displayOrder={reorderedDisplayOrder}
+        />
+      </tbody>
+    </table>
+  </div>
+);
+
+export const SingleDriverWithTagReordered: Story = {
+  decorators: [TelemetryDecorator()],
+  render: () => <SingleRelativeDriverWithTagReorderedComponent />,
+  parameters: {
+    layout: 'padded',
+  },
+};

--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -99,6 +99,7 @@ export const Relative = () => {
           penalty={false}
           slowdown={false}
           hideCarManufacturer={hideCarManufacturer}
+          hasAnyDriverTag={hasAnyTag}
           compactMode={generalSettings?.compactMode}
         />
       ));
@@ -153,6 +154,7 @@ export const Relative = () => {
             slowdown={false}
             deltaDecimalPlaces={settings?.delta?.precision}
             hideCarManufacturer={hideCarManufacturer}
+            hasAnyDriverTag={hasAnyTag}
             compactMode={generalSettings?.compactMode}
           />
         );

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverNameCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverNameCell.tsx
@@ -154,7 +154,7 @@ export const DriverNameCell = memo(
     return (
       <td
         data-column="driverName"
-        className={`w-full max-w-0 ${compactMode !== 'ultra' ? ' px-1 py-0.5' : ''}`}
+        className={`w-full max-w-0${compactMode !== 'ultra' ? ' px-1 py-0.5' : ''}`}
       >
         <div className="flex items-center overflow-hidden">
           <span


### PR DESCRIPTION
Summary of what was wrong and what changed:

Root cause: Placeholder rows in Relative.tsx (both the "no player" block and the "missing slot" block) were rendered without hasAnyDriverTag. Since hasAnyDriverTag ?? false defaults to false, those rows skipped the driverTag <td> entirely, while the real player row (which does get hasAnyDriverTag={hasAnyTag}) included it. This caused a column offset under table-auto — the player's driverName column was sized by the placeholder rows' carManufacturer column (a narrow icon), collapsing the name to near-zero width.

Why Standings doesn't have this bug: No placeholder rows — every row is a real driver with the same cell count.

Fix: Added hasAnyDriverTag={hasAnyTag} to both placeholder row blocks (Relative.tsx:102 and Relative.tsx:155), ensuring all rows have identical <td> structure.

## Screenshots

### Before
<img width="684" height="301" alt="Screenshot 2026-04-11 100220" src="https://github.com/user-attachments/assets/307ebc2b-402b-44ef-bf4f-69967a08951e" />

### After
<img width="676" height="303" alt="Screenshot 2026-04-11 100133" src="https://github.com/user-attachments/assets/fc21ad0c-7876-47f3-8786-740bd669f9cf" />