### PR TITLE
feat: add Battle widget

### DIFF
--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -21,6 +21,7 @@ import { SlowCarAhead } from './components/SlowCarAhead/SlowCarAhead';
 import { SectorDelta } from './components/SectorDelta/SectorDelta';
 import { HeartRate } from './components/HeartRate/HeartRate';
 import { CornerNameOverlay } from './components/CornerNameOverlay';
+import { Battle } from './components/Battle/Battle';
 import type { WidgetConfigMap } from '@irdashies/types';
 import type { ElementType } from 'react';
 
@@ -48,6 +49,7 @@ export {
   SectorDelta,
   HeartRate,
   CornerNameOverlay,
+  Battle,
 };
 
 export const WIDGET_MAP: Record<keyof WidgetConfigMap, ElementType> = {
@@ -74,6 +76,7 @@ export const WIDGET_MAP: Record<keyof WidgetConfigMap, ElementType> = {
   sectordelta: SectorDelta,
   heartrate: HeartRate,
   cornername: CornerNameOverlay,
+  battle: Battle,
 };
 
 export type WidgetId = keyof WidgetConfigMap;

--- a/src/frontend/components/Battle/Battle.stories.tsx
+++ b/src/frontend/components/Battle/Battle.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { Battle } from './Battle';
+import { TelemetryDecorator } from '@irdashies/storybook';
+
+export default {
+  component: Battle,
+  title: 'widgets/Battle',
+} as Meta<typeof Battle>;
+
+type Story = StoryObj<typeof Battle>;
+
+export const Primary: Story = {
+  render: () => <Battle />,
+  decorators: [TelemetryDecorator('/test-data/1747384033336')],
+};

--- a/src/frontend/components/Battle/Battle.tsx
+++ b/src/frontend/components/Battle/Battle.tsx
@@ -172,7 +172,10 @@ const BattleRow = memo(
             className={`w-auto text-center px-2 whitespace-nowrap ${positionBg} ${positionText}`}
             style={highlightStyle}
           >
-            {liveClassPosition ?? entry?.classPosition ?? '—'}
+            {(() => {
+              const p = liveClassPosition ?? entry?.classPosition;
+              return p !== undefined && isFinite(p) ? p : '—';
+            })()}
           </td>
         );
       } else if (key === 'carNumber' && settings?.carNumber?.enabled) {
@@ -347,11 +350,12 @@ export const Battle = () => {
       (s) => s.carIdx !== paceCarIdx && s.carClass?.id === playerClassId
     );
 
-    const positionFor = (carIdx: number) =>
-      hasLivePositions
+    const positionFor = (carIdx: number): number | undefined => {
+      const pos = hasLivePositions
         ? liveClassPositions[carIdx]
-        : (sameClass.find((s) => s.carIdx === carIdx)?.classPosition ??
-          Infinity);
+        : sameClass.find((s) => s.carIdx === carIdx)?.classPosition;
+      return pos !== undefined && isFinite(pos) ? pos : undefined;
+    };
 
     sameClass.sort((a, b) => {
       const pa = positionFor(a.carIdx) ?? Infinity;

--- a/src/frontend/components/Battle/Battle.tsx
+++ b/src/frontend/components/Battle/Battle.tsx
@@ -9,10 +9,18 @@ import {
   useGeneralSettings,
   useBattleGapStoreUpdater,
   useBattleGapSnapshot,
+  useWeekendInfoNumCarClasses,
+  useCarIdxSpeed,
+  useTelemetryValue,
+  useSessionStore,
 } from '@irdashies/context';
 import { formatTime } from '@irdashies/utils/time';
+import { getTailwindStyle } from '@irdashies/utils/colors';
 import { useBattleSettings } from './hooks/useBattleSettings';
-import { useDriverRelatives, useHighlightColor } from '../Standings/hooks';
+import { useHighlightColor, useDriverRelatives } from '../Standings/hooks';
+import { useDriverStandings } from '../Standings/hooks/useDriverPositions';
+import { useDriverLivePositions } from '../Standings/hooks/useDriverLivePositions';
+import type { Standings } from '../Standings/createStandings';
 
 // Format an absolute gap value for display
 const formatGap = (gap: number | null | undefined, dp: number): string => {
@@ -23,10 +31,8 @@ const formatGap = (gap: number | null | undefined, dp: number): string => {
 type Trend = 'good' | 'bad' | 'flat' | 'none';
 
 /**
- * Compute the delta trend for the AHEAD car.
- * gapAhead is a negative number (ahead car is in front).
- * Smaller absolute value = gap closing = GOOD for player (green).
- * Larger absolute value = gap growing = BAD for player (red).
+ * Delta for the AHEAD car.
+ * Gap closing (absolute value shrinking) = GOOD (green).
  */
 const aheadDelta = (
   liveGap: number | null,
@@ -38,15 +44,13 @@ const aheadDelta = (
   if (Math.abs(delta) < 0.005) return { text: '—', trend: 'flat' };
   return {
     text: `${Math.abs(delta).toFixed(dp)}s`,
-    trend: delta < 0 ? 'good' : 'bad', // closing = good
+    trend: delta < 0 ? 'good' : 'bad',
   };
 };
 
 /**
- * Compute the delta trend for the BEHIND car.
- * gapBehind is a positive number (behind car is behind us).
- * Smaller absolute value = gap shrinking = BAD for player (red).
- * Larger absolute value = gap growing = GOOD for player (green).
+ * Delta for the BEHIND car.
+ * Gap shrinking (car behind catching up) = BAD (red).
  */
 const behindDelta = (
   liveGap: number | null,
@@ -58,7 +62,7 @@ const behindDelta = (
   if (Math.abs(delta) < 0.005) return { text: '—', trend: 'flat' };
   return {
     text: `${Math.abs(delta).toFixed(dp)}s`,
-    trend: delta < 0 ? 'bad' : 'good', // closing = bad
+    trend: delta < 0 ? 'bad' : 'good',
   };
 };
 
@@ -70,114 +74,165 @@ const trendClass = (trend: Trend) => {
 };
 
 interface BattleRowProps {
-  position?: number;
-  classPosition?: number;
-  carNum?: string;
-  name: string;
-  stintLaps?: number;
-  lastTime?: number;
-  lastTimeFormat?: import('@irdashies/types').TimeFormat;
-  /** Formatted live gap string */
+  entry?: Standings;
   gap?: string;
-  /** Formatted previous-lap gap string */
   prevGap?: string;
   delta?: { text: string; trend: Trend };
   isPlayer?: boolean;
   highlightColor?: number;
+  isMultiClass: boolean;
   settings?: ReturnType<typeof useBattleSettings>;
   displayOrder?: string[];
-  /** Whether the gap columns should render at all (controls width reservation) */
   showGapColumns: boolean;
+  stintLaps?: number;
+  lastTimeFormat?: import('@irdashies/types').TimeFormat;
+  speedKph?: number;
+  isMetricSpeed?: boolean;
+  rowIndex: number;
 }
 
 const BattleRow = memo(
   ({
-    position,
-    classPosition,
-    carNum,
-    name,
-    stintLaps,
-    lastTime,
-    lastTimeFormat = 'mixed',
+    entry,
     gap,
     prevGap,
     delta,
     isPlayer,
     highlightColor,
+    isMultiClass,
     settings,
     displayOrder = [],
     showGapColumns,
+    stintLaps,
+    lastTimeFormat = 'mixed',
+    speedKph,
+    isMetricSpeed = true,
+    rowIndex,
   }: BattleRowProps) => {
-    const rowBg = isPlayer ? 'bg-amber-300/20' : 'bg-slate-700/70';
-    const textColor = isPlayer ? 'text-amber-300' : 'text-white';
-    const mutedColor = isPlayer ? 'text-amber-300/60' : 'text-white/55';
+    const onTrack = entry?.onTrack ?? true;
+    const onPitRoad = entry?.onPitRoad ?? false;
+    const isLapped = entry?.lappedState === 'behind';
+    const isLappingAhead = entry?.lappedState === 'ahead';
+    const offTrack = entry?.carTrackSurface === 0;
+
+    // Match Relative/DriverInfoRow row className pattern exactly.
+    const rowClasses = [
+      !onTrack || onPitRoad ? 'text-white/60' : '',
+      isPlayer ? 'text-amber-300' : '',
+      isPlayer
+        ? 'bg-yellow-500/20'
+        : rowIndex % 2 === 0
+          ? 'bg-slate-800/70'
+          : 'bg-slate-900/70',
+      !isPlayer && isLapped ? 'text-blue-400' : '',
+      !isPlayer && isLappingAhead ? 'text-red-400' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+    const mutedColor = 'text-white/55';
     const highlightStyle =
       isPlayer && highlightColor
         ? { color: `#${highlightColor.toString(16).padStart(6, '0')}` }
         : {};
 
+    const tailwindStyles = useMemo(
+      () =>
+        getTailwindStyle(entry?.carClass?.color, highlightColor, isMultiClass),
+      [entry?.carClass?.color, highlightColor, isMultiClass]
+    );
+
     const cols: React.JSX.Element[] = [];
     const ordered = displayOrder.length
       ? displayOrder
-      : ['position', 'carNumber', 'driverName', 'stint', 'lastTime', 'gap'];
+      : [
+          'position',
+          'carNumber',
+          'driverName',
+          'stint',
+          'lastTime',
+          'speed',
+          'gap',
+        ];
 
     for (const key of ordered) {
       if (key === 'position' && settings?.position?.enabled) {
+        // Match PositionCell: plain number, class-colour bg for player,
+        // off-track yellow override. No P/C prefix.
+        const positionBg = offTrack
+          ? 'bg-yellow-400'
+          : isPlayer
+            ? tailwindStyles.classHeader
+            : '';
+        const positionText = offTrack ? 'text-yellow-900' : '';
         cols.push(
           <td
             key="pos"
-            className={`px-1 whitespace-nowrap text-center w-0 ${textColor}`}
+            className={`w-auto text-center px-2 whitespace-nowrap ${positionBg} ${positionText}`}
             style={highlightStyle}
           >
-            {position != null ? `P${position}` : '—'}
-            {classPosition != null && classPosition !== position ? (
-              <span className={`ml-0.5 ${mutedColor}`}>C{classPosition}</span>
-            ) : null}
+            {entry?.classPosition != null ? entry.classPosition : '—'}
           </td>
         );
       } else if (key === 'carNumber' && settings?.carNumber?.enabled) {
         cols.push(
-          <td key="carnum" className="px-0 w-0">
-            {carNum != null && (
-              <span className="inline-block bg-sky-900 border-l-2 border-sky-400 text-white px-1.5 py-0.5 min-w-7 text-center">
-                #{carNum}
-              </span>
-            )}
+          <td
+            key="carnum"
+            className={`w-auto ${entry != null ? `${tailwindStyles.driverIcon} border-l-4` : ''} text-white text-right px-1 whitespace-nowrap`}
+          >
+            {entry != null ? `#${entry.driver?.carNum}` : ''}
           </td>
         );
       } else if (key === 'driverName' && settings?.driverName?.enabled) {
         cols.push(
           <td
             key="name"
-            className={`px-1.5 w-full truncate max-w-0 ${textColor}`}
+            className="px-1 py-0.5 w-full truncate max-w-0"
             style={highlightStyle}
           >
-            {name || '—'}
+            {entry?.driver?.name || '—'}
           </td>
         );
       } else if (key === 'stint' && settings?.stint?.enabled) {
         cols.push(
           <td
             key="stint"
-            className={`px-1.5 whitespace-nowrap tabular-nums text-center w-0 ${mutedColor}`}
+            className={`px-2 whitespace-nowrap tabular-nums text-center w-auto ${mutedColor}`}
           >
             {stintLaps != null && stintLaps > 0 ? `${stintLaps}L` : '—'}
           </td>
         );
       } else if (key === 'lastTime' && settings?.lastTime?.enabled) {
+        // Match LastTimeCell: session-fastest purple, personal-best green.
+        const lastTimeColor =
+          entry?.lastTimeState === 'session-fastest'
+            ? 'text-purple-400'
+            : entry?.lastTimeState === 'personal-best'
+              ? 'text-green-400'
+              : '';
         cols.push(
           <td
             key="last"
-            className={`px-1.5 whitespace-nowrap tabular-nums text-right w-0 ${textColor}`}
+            className={`w-auto px-2 whitespace-nowrap ${lastTimeColor}`}
           >
-            {lastTime && lastTime > 0
-              ? formatTime(lastTime, lastTimeFormat)
+            {entry?.lastTime && entry.lastTime > 0
+              ? formatTime(entry.lastTime, lastTimeFormat)
               : '—'}
           </td>
         );
+      } else if (key === 'speed' && settings?.speed?.enabled) {
+        const displaySpeed =
+          speedKph != null && speedKph > 0
+            ? Math.round(isMetricSpeed ? speedKph : speedKph / 1.60934)
+            : null;
+        cols.push(
+          <td
+            key="speed"
+            className={`px-1.5 whitespace-nowrap tabular-nums text-right w-0 ${mutedColor}`}
+          >
+            {displaySpeed != null ? `${displaySpeed}` : '—'}
+          </td>
+        );
       } else if (key === 'gap' && settings?.gap?.enabled) {
-        // Always render the three gap cells to keep column widths stable.
-        // On the player row (or when there's no opponent) they're blank.
         const deltaVal = delta ?? { text: '', trend: 'none' as Trend };
         const showData = !isPlayer && showGapColumns;
         cols.push(
@@ -214,7 +269,7 @@ const BattleRow = memo(
       }
     }
 
-    return <tr className={`${rowBg} rounded-sm`}>{cols}</tr>;
+    return <tr className={rowClasses}>{cols}</tr>;
   }
 );
 BattleRow.displayName = 'BattleRow';
@@ -226,40 +281,120 @@ export const Battle = () => {
   const isSessionVisible = useSessionVisibility(settings?.sessionVisibility);
   const focusCarIdx = useFocusCarIdx();
   const highlightColor = useHighlightColor();
+  const numCarClasses = useWeekendInfoNumCarClasses();
+  const isMultiClass = (numCarClasses ?? 0) > 1;
 
   usePitLapStoreUpdater();
 
-  const relatives = useDriverRelatives({ buffer: 1 });
+  // Full driver list with metadata (name, car class, etc.). NOTE: this list's
+  // ordering is by SDK CarIdxPosition which only updates at the start/finish line,
+  // so we never use its index ordering — we re-sort by live class position below.
+  const allStandings = useDriverStandings();
+
+  // Live class positions: derived from CarIdxLapCompleted + CarIdxLapDistPct,
+  // updates every frame, grouped by class, pace car already excluded.
+  // This is what makes mid-lap overtakes appear immediately in the widget.
+  const liveClassPositions = useDriverLivePositions({ enabled: true });
+
+  // useDriverRelatives provides live (60fps, reference-lap interpolated) gap timing.
+  // Use a large buffer so the entire field is included with live deltas attached —
+  // we look up the position-neighbours by carIdx, so they must always be present
+  // regardless of physical track proximity.
+  const relatives = useDriverRelatives({ buffer: 64 });
+
+  // Pace car must be excluded from neighbour selection. useDriverStandings does
+  // not filter it (only useDriverRelatives does), so we filter it here too.
+  const paceCarIdx =
+    useSessionStore((s) => s.session?.DriverInfo?.PaceCarIdx) ?? -1;
+
   const pitLaps = usePitLap();
   const carLaps = useCarLap();
   const gapSnapshot = useBattleGapSnapshot();
 
-  const playerEntry = useMemo(
-    () => relatives.find((r) => r.isPlayer),
-    [relatives]
-  );
+  // Build a carIdx → live delta map from relatives for O(1) lookups.
+  // Updates every frame as relatives recomputes from telemetry.
+  const relativeDeltaMap = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const r of relatives) {
+      if (r.delta != null) map.set(r.carIdx, r.delta);
+    }
+    return map;
+  }, [relatives]);
 
-  const aheadEntry = useMemo(() => {
-    if (!playerEntry) return undefined;
-    const playerRelIdx = relatives.indexOf(playerEntry);
-    return playerRelIdx > 0 ? relatives[playerRelIdx - 1] : undefined;
-  }, [relatives, playerEntry]);
+  // Identify player and position-neighbours by LIVE class position.
+  // Steps:
+  //   1. Find the player in allStandings (just to grab their class id + entry).
+  //   2. Filter standings to the player's class, exclude pace car.
+  //   3. Sort by liveClassPositions[carIdx] — this updates every frame.
+  //   4. Pick the entries immediately above and below the player.
+  // Falls back to standings classPosition (CarIdxClassPosition) when live positions
+  // are unavailable (non-race sessions, replay, etc).
+  const { playerEntry, aheadEntry, behindEntry } = useMemo(() => {
+    const player = allStandings.find((s) => s.isPlayer);
+    if (!player)
+      return {
+        playerEntry: undefined,
+        aheadEntry: undefined,
+        behindEntry: undefined,
+      };
 
-  const behindEntry = useMemo(() => {
-    if (!playerEntry) return undefined;
-    const playerRelIdx = relatives.indexOf(playerEntry);
-    return playerRelIdx < relatives.length - 1
-      ? relatives[playerRelIdx + 1]
-      : undefined;
-  }, [relatives, playerEntry]);
+    const playerClassId = player.carClass?.id;
+    const hasLivePositions = Object.keys(liveClassPositions).length > 0;
 
-  // Live gaps from useDriverRelatives delta.
-  // aheadEntry.delta is negative (car is in front).
-  // behindEntry.delta is positive (car is behind).
-  const liveGapAhead = aheadEntry?.delta ?? null;
-  const liveGapBehind = behindEntry != null ? -(behindEntry.delta ?? 0) : null;
+    const sameClass = allStandings.filter(
+      (s) => s.carIdx !== paceCarIdx && s.carClass?.id === playerClassId
+    );
+
+    const positionFor = (carIdx: number) =>
+      hasLivePositions
+        ? liveClassPositions[carIdx]
+        : (sameClass.find((s) => s.carIdx === carIdx)?.classPosition ??
+          Infinity);
+
+    sameClass.sort((a, b) => {
+      const pa = positionFor(a.carIdx) ?? Infinity;
+      const pb = positionFor(b.carIdx) ?? Infinity;
+      return pa - pb;
+    });
+
+    const playerIdx = sameClass.findIndex((s) => s.isPlayer);
+    if (playerIdx === -1)
+      return {
+        playerEntry: player,
+        aheadEntry: undefined,
+        behindEntry: undefined,
+      };
+
+    return {
+      playerEntry: sameClass[playerIdx],
+      aheadEntry: playerIdx > 0 ? sameClass[playerIdx - 1] : undefined,
+      behindEntry:
+        playerIdx < sameClass.length - 1 ? sameClass[playerIdx + 1] : undefined,
+    };
+  }, [allStandings, liveClassPositions, paceCarIdx]);
+
+  // Live gaps from the reference-lap-interpolated deltas (updates every frame).
+  // relatives delta: positive = car is ahead of player, negative = car is behind.
+  const liveGapAhead = useMemo(() => {
+    if (!aheadEntry) return null;
+    const d = relativeDeltaMap.get(aheadEntry.carIdx);
+    return d != null ? Math.abs(d) : null;
+  }, [aheadEntry, relativeDeltaMap]);
+
+  const liveGapBehind = useMemo(() => {
+    if (!behindEntry) return null;
+    const d = relativeDeltaMap.get(behindEntry.carIdx);
+    return d != null ? Math.abs(d) : null;
+  }, [behindEntry, relativeDeltaMap]);
 
   useBattleGapStoreUpdater({ liveGapAhead, liveGapBehind });
+
+  // Speed: derived from CarIdxLapDistPct movement, in km/h.
+  const carSpeeds = useCarIdxSpeed();
+  const displayUnits = useTelemetryValue('DisplayUnits'); // 0 = imperial, 1 = metric
+  const speedUnit = settings?.speed?.unit ?? 'auto';
+  const isMetricSpeed =
+    speedUnit === 'auto' ? displayUnits === 1 : speedUnit === 'km/h';
 
   const stintLaps = (carIdx: number) => {
     const currentLap = carLaps?.[carIdx] ?? 0;
@@ -271,8 +406,8 @@ export const Battle = () => {
   const dp = settings?.gap?.decimalPlaces ?? 2;
   const timeFormat = settings?.lastTime?.timeFormat ?? 'mixed';
   const displayOrder = settings?.displayOrder;
+  const gapEnabled = settings?.gap?.enabled ?? true;
 
-  // Compact mode from general settings
   const isCompact =
     generalSettings?.compactMode === 'compact' ||
     generalSettings?.compactMode === 'ultra';
@@ -284,91 +419,85 @@ export const Battle = () => {
   if (settings?.showOnlyWhenOnTrack && !isDriving) return <></>;
   if (!playerEntry && focusCarIdx === undefined) return <></>;
 
-  // Whether gap columns are enabled at all
-  const gapEnabled = settings?.gap?.enabled ?? true;
-
   return (
     <div
-      className="w-full bg-slate-800/(--bg-opacity) rounded-sm overflow-hidden"
+      className={`w-full bg-slate-800/(--bg-opacity) rounded-sm ${!isCompact ? 'p-2' : ''} overflow-hidden`}
       style={{
         ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
       }}
     >
-      <div className={`${isCompact ? 'px-1 py-0.5' : 'px-1.5 py-1'}`}>
-        <table
-          className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
-        >
-          <tbody>
-            {/* Ahead row — shows live gap */}
-            <BattleRow
-              position={aheadEntry?.position}
-              classPosition={aheadEntry?.classPosition}
-              carNum={aheadEntry?.driver?.carNum}
-              name={aheadEntry?.driver?.name ?? ''}
-              stintLaps={aheadEntry ? stintLaps(aheadEntry.carIdx) : undefined}
-              lastTime={aheadEntry?.lastTime}
-              lastTimeFormat={timeFormat}
-              gap={gapEnabled ? formatGap(liveGapAhead, dp) : undefined}
-              prevGap={
-                gapEnabled ? formatGap(gapSnapshot.gapAhead, dp) : undefined
-              }
-              delta={
-                gapEnabled
-                  ? aheadDelta(liveGapAhead, gapSnapshot.gapAhead, dp)
-                  : undefined
-              }
-              isPlayer={false}
-              highlightColor={highlightColor}
-              settings={settings}
-              displayOrder={displayOrder}
-              showGapColumns={aheadEntry != null}
-            />
-            {/* Player row */}
-            <BattleRow
-              position={playerEntry?.position}
-              classPosition={playerEntry?.classPosition}
-              carNum={playerEntry?.driver?.carNum}
-              name={playerEntry?.driver?.name ?? ''}
-              stintLaps={
-                playerEntry ? stintLaps(playerEntry.carIdx) : undefined
-              }
-              lastTime={playerEntry?.lastTime}
-              lastTimeFormat={timeFormat}
-              isPlayer
-              highlightColor={highlightColor}
-              settings={settings}
-              displayOrder={displayOrder}
-              showGapColumns={false}
-            />
-            {/* Behind row — shows live gap */}
-            <BattleRow
-              position={behindEntry?.position}
-              classPosition={behindEntry?.classPosition}
-              carNum={behindEntry?.driver?.carNum}
-              name={behindEntry?.driver?.name ?? ''}
-              stintLaps={
-                behindEntry ? stintLaps(behindEntry.carIdx) : undefined
-              }
-              lastTime={behindEntry?.lastTime}
-              lastTimeFormat={timeFormat}
-              gap={gapEnabled ? formatGap(liveGapBehind, dp) : undefined}
-              prevGap={
-                gapEnabled ? formatGap(gapSnapshot.gapBehind, dp) : undefined
-              }
-              delta={
-                gapEnabled
-                  ? behindDelta(liveGapBehind, gapSnapshot.gapBehind, dp)
-                  : undefined
-              }
-              isPlayer={false}
-              highlightColor={highlightColor}
-              settings={settings}
-              displayOrder={displayOrder}
-              showGapColumns={behindEntry != null}
-            />
-          </tbody>
-        </table>
-      </div>
+      <table
+        className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
+      >
+        <tbody>
+          <BattleRow
+            entry={aheadEntry}
+            gap={gapEnabled ? formatGap(liveGapAhead, dp) : undefined}
+            prevGap={
+              gapEnabled ? formatGap(gapSnapshot.gapAhead, dp) : undefined
+            }
+            delta={
+              gapEnabled
+                ? aheadDelta(liveGapAhead, gapSnapshot.gapAhead, dp)
+                : undefined
+            }
+            isPlayer={false}
+            highlightColor={highlightColor}
+            isMultiClass={isMultiClass}
+            settings={settings}
+            displayOrder={displayOrder}
+            showGapColumns={aheadEntry != null}
+            stintLaps={aheadEntry ? stintLaps(aheadEntry.carIdx) : undefined}
+            lastTimeFormat={timeFormat}
+            speedKph={
+              aheadEntry != null ? carSpeeds[aheadEntry.carIdx] : undefined
+            }
+            isMetricSpeed={isMetricSpeed}
+            rowIndex={0}
+          />
+          <BattleRow
+            entry={playerEntry}
+            isPlayer
+            highlightColor={highlightColor}
+            isMultiClass={isMultiClass}
+            settings={settings}
+            displayOrder={displayOrder}
+            showGapColumns={false}
+            stintLaps={playerEntry ? stintLaps(playerEntry.carIdx) : undefined}
+            lastTimeFormat={timeFormat}
+            speedKph={
+              playerEntry != null ? carSpeeds[playerEntry.carIdx] : undefined
+            }
+            isMetricSpeed={isMetricSpeed}
+            rowIndex={1}
+          />
+          <BattleRow
+            entry={behindEntry}
+            gap={gapEnabled ? formatGap(liveGapBehind, dp) : undefined}
+            prevGap={
+              gapEnabled ? formatGap(gapSnapshot.gapBehind, dp) : undefined
+            }
+            delta={
+              gapEnabled
+                ? behindDelta(liveGapBehind, gapSnapshot.gapBehind, dp)
+                : undefined
+            }
+            isPlayer={false}
+            highlightColor={highlightColor}
+            isMultiClass={isMultiClass}
+            settings={settings}
+            displayOrder={displayOrder}
+            showGapColumns={behindEntry != null}
+            stintLaps={behindEntry ? stintLaps(behindEntry.carIdx) : undefined}
+            lastTimeFormat={timeFormat}
+            speedKph={
+              behindEntry != null ? carSpeeds[behindEntry.carIdx] : undefined
+            }
+            isMetricSpeed={isMetricSpeed}
+            rowIndex={2}
+          />
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/src/frontend/components/Battle/Battle.tsx
+++ b/src/frontend/components/Battle/Battle.tsx
@@ -75,6 +75,7 @@ const trendClass = (trend: Trend) => {
 
 interface BattleRowProps {
   entry?: Standings;
+  liveClassPosition?: number;
   gap?: string;
   prevGap?: string;
   delta?: { text: string; trend: Trend };
@@ -94,6 +95,7 @@ interface BattleRowProps {
 const BattleRow = memo(
   ({
     entry,
+    liveClassPosition,
     gap,
     prevGap,
     delta,
@@ -170,7 +172,7 @@ const BattleRow = memo(
             className={`w-auto text-center px-2 whitespace-nowrap ${positionBg} ${positionText}`}
             style={highlightStyle}
           >
-            {entry?.classPosition != null ? entry.classPosition : '—'}
+            {liveClassPosition ?? entry?.classPosition ?? '—'}
           </td>
         );
       } else if (key === 'carNumber' && settings?.carNumber?.enabled) {
@@ -329,7 +331,7 @@ export const Battle = () => {
   //   4. Pick the entries immediately above and below the player.
   // Falls back to standings classPosition (CarIdxClassPosition) when live positions
   // are unavailable (non-race sessions, replay, etc).
-  const { playerEntry, aheadEntry, behindEntry } = useMemo(() => {
+  const { playerEntry, aheadEntry, behindEntry, positionFor } = useMemo(() => {
     const player = allStandings.find((s) => s.isPlayer);
     if (!player)
       return {
@@ -370,6 +372,7 @@ export const Battle = () => {
       aheadEntry: playerIdx > 0 ? sameClass[playerIdx - 1] : undefined,
       behindEntry:
         playerIdx < sameClass.length - 1 ? sameClass[playerIdx + 1] : undefined,
+      positionFor,
     };
   }, [allStandings, liveClassPositions, paceCarIdx]);
 
@@ -432,6 +435,9 @@ export const Battle = () => {
         <tbody>
           <BattleRow
             entry={aheadEntry}
+            liveClassPosition={
+              aheadEntry ? positionFor?.(aheadEntry.carIdx) : undefined
+            }
             gap={gapEnabled ? formatGap(liveGapAhead, dp) : undefined}
             prevGap={
               gapEnabled ? formatGap(gapSnapshot.gapAhead, dp) : undefined
@@ -457,6 +463,9 @@ export const Battle = () => {
           />
           <BattleRow
             entry={playerEntry}
+            liveClassPosition={
+              playerEntry ? positionFor?.(playerEntry.carIdx) : undefined
+            }
             isPlayer
             highlightColor={highlightColor}
             isMultiClass={isMultiClass}
@@ -473,6 +482,9 @@ export const Battle = () => {
           />
           <BattleRow
             entry={behindEntry}
+            liveClassPosition={
+              behindEntry ? positionFor?.(behindEntry.carIdx) : undefined
+            }
             gap={gapEnabled ? formatGap(liveGapBehind, dp) : undefined}
             prevGap={
               gapEnabled ? formatGap(gapSnapshot.gapBehind, dp) : undefined

--- a/src/frontend/components/Battle/Battle.tsx
+++ b/src/frontend/components/Battle/Battle.tsx
@@ -1,0 +1,374 @@
+import { memo, useMemo } from 'react';
+import {
+  useDrivingState,
+  useSessionVisibility,
+  usePitLapStoreUpdater,
+  usePitLap,
+  useCarLap,
+  useFocusCarIdx,
+  useGeneralSettings,
+  useBattleGapStoreUpdater,
+  useBattleGapSnapshot,
+} from '@irdashies/context';
+import { formatTime } from '@irdashies/utils/time';
+import { useBattleSettings } from './hooks/useBattleSettings';
+import { useDriverRelatives, useHighlightColor } from '../Standings/hooks';
+
+// Format an absolute gap value for display
+const formatGap = (gap: number | null | undefined, dp: number): string => {
+  if (gap == null || !isFinite(gap)) return '—';
+  return `${Math.abs(gap).toFixed(dp)}s`;
+};
+
+type Trend = 'good' | 'bad' | 'flat' | 'none';
+
+/**
+ * Compute the delta trend for the AHEAD car.
+ * gapAhead is a negative number (ahead car is in front).
+ * Smaller absolute value = gap closing = GOOD for player (green).
+ * Larger absolute value = gap growing = BAD for player (red).
+ */
+const aheadDelta = (
+  liveGap: number | null,
+  prevGap: number | null,
+  dp: number
+): { text: string; trend: Trend } => {
+  if (liveGap == null || prevGap == null) return { text: '', trend: 'none' };
+  const delta = Math.abs(liveGap) - Math.abs(prevGap);
+  if (Math.abs(delta) < 0.005) return { text: '—', trend: 'flat' };
+  return {
+    text: `${Math.abs(delta).toFixed(dp)}s`,
+    trend: delta < 0 ? 'good' : 'bad', // closing = good
+  };
+};
+
+/**
+ * Compute the delta trend for the BEHIND car.
+ * gapBehind is a positive number (behind car is behind us).
+ * Smaller absolute value = gap shrinking = BAD for player (red).
+ * Larger absolute value = gap growing = GOOD for player (green).
+ */
+const behindDelta = (
+  liveGap: number | null,
+  prevGap: number | null,
+  dp: number
+): { text: string; trend: Trend } => {
+  if (liveGap == null || prevGap == null) return { text: '', trend: 'none' };
+  const delta = Math.abs(liveGap) - Math.abs(prevGap);
+  if (Math.abs(delta) < 0.005) return { text: '—', trend: 'flat' };
+  return {
+    text: `${Math.abs(delta).toFixed(dp)}s`,
+    trend: delta < 0 ? 'bad' : 'good', // closing = bad
+  };
+};
+
+const trendClass = (trend: Trend) => {
+  if (trend === 'good') return 'text-green-400';
+  if (trend === 'bad') return 'text-red-400';
+  if (trend === 'flat') return 'text-slate-400';
+  return 'text-transparent';
+};
+
+interface BattleRowProps {
+  position?: number;
+  classPosition?: number;
+  carNum?: string;
+  name: string;
+  stintLaps?: number;
+  lastTime?: number;
+  lastTimeFormat?: import('@irdashies/types').TimeFormat;
+  /** Formatted live gap string */
+  gap?: string;
+  /** Formatted previous-lap gap string */
+  prevGap?: string;
+  delta?: { text: string; trend: Trend };
+  isPlayer?: boolean;
+  highlightColor?: number;
+  settings?: ReturnType<typeof useBattleSettings>;
+  displayOrder?: string[];
+  /** Whether the gap columns should render at all (controls width reservation) */
+  showGapColumns: boolean;
+}
+
+const BattleRow = memo(
+  ({
+    position,
+    classPosition,
+    carNum,
+    name,
+    stintLaps,
+    lastTime,
+    lastTimeFormat = 'mixed',
+    gap,
+    prevGap,
+    delta,
+    isPlayer,
+    highlightColor,
+    settings,
+    displayOrder = [],
+    showGapColumns,
+  }: BattleRowProps) => {
+    const rowBg = isPlayer ? 'bg-amber-300/20' : 'bg-slate-700/70';
+    const textColor = isPlayer ? 'text-amber-300' : 'text-white';
+    const mutedColor = isPlayer ? 'text-amber-300/60' : 'text-white/55';
+    const highlightStyle =
+      isPlayer && highlightColor
+        ? { color: `#${highlightColor.toString(16).padStart(6, '0')}` }
+        : {};
+
+    const cols: React.JSX.Element[] = [];
+    const ordered = displayOrder.length
+      ? displayOrder
+      : ['position', 'carNumber', 'driverName', 'stint', 'lastTime', 'gap'];
+
+    for (const key of ordered) {
+      if (key === 'position' && settings?.position?.enabled) {
+        cols.push(
+          <td
+            key="pos"
+            className={`px-1 whitespace-nowrap text-center w-0 ${textColor}`}
+            style={highlightStyle}
+          >
+            {position != null ? `P${position}` : '—'}
+            {classPosition != null && classPosition !== position ? (
+              <span className={`ml-0.5 ${mutedColor}`}>C{classPosition}</span>
+            ) : null}
+          </td>
+        );
+      } else if (key === 'carNumber' && settings?.carNumber?.enabled) {
+        cols.push(
+          <td key="carnum" className="px-0 w-0">
+            {carNum != null && (
+              <span className="inline-block bg-sky-900 border-l-2 border-sky-400 text-white px-1.5 py-0.5 min-w-7 text-center">
+                #{carNum}
+              </span>
+            )}
+          </td>
+        );
+      } else if (key === 'driverName' && settings?.driverName?.enabled) {
+        cols.push(
+          <td
+            key="name"
+            className={`px-1.5 w-full truncate max-w-0 ${textColor}`}
+            style={highlightStyle}
+          >
+            {name || '—'}
+          </td>
+        );
+      } else if (key === 'stint' && settings?.stint?.enabled) {
+        cols.push(
+          <td
+            key="stint"
+            className={`px-1.5 whitespace-nowrap tabular-nums text-center w-0 ${mutedColor}`}
+          >
+            {stintLaps != null && stintLaps > 0 ? `${stintLaps}L` : '—'}
+          </td>
+        );
+      } else if (key === 'lastTime' && settings?.lastTime?.enabled) {
+        cols.push(
+          <td
+            key="last"
+            className={`px-1.5 whitespace-nowrap tabular-nums text-right w-0 ${textColor}`}
+          >
+            {lastTime && lastTime > 0
+              ? formatTime(lastTime, lastTimeFormat)
+              : '—'}
+          </td>
+        );
+      } else if (key === 'gap' && settings?.gap?.enabled) {
+        // Always render the three gap cells to keep column widths stable.
+        // On the player row (or when there's no opponent) they're blank.
+        const deltaVal = delta ?? { text: '', trend: 'none' as Trend };
+        const showData = !isPlayer && showGapColumns;
+        cols.push(
+          <td
+            key="gap"
+            className={`px-1.5 whitespace-nowrap tabular-nums text-right w-0 border-l border-white/10 ${showData ? 'text-white/85' : 'text-transparent'}`}
+          >
+            {showData ? (gap ?? '—') : '—'}
+          </td>,
+          <td
+            key="prev"
+            className={`px-1.5 whitespace-nowrap tabular-nums text-right w-0 text-white/40 ${!showData ? 'text-transparent' : ''}`}
+          >
+            {showData ? (prevGap ?? '—') : '—'}
+          </td>,
+          <td
+            key="delta"
+            className={`pr-2 whitespace-nowrap tabular-nums text-right w-0 ${showData ? trendClass(deltaVal.trend) : 'text-transparent'}`}
+          >
+            {showData &&
+            deltaVal.trend !== 'none' &&
+            deltaVal.trend !== 'flat' ? (
+              <>
+                {deltaVal.trend === 'good' ? '\u25BC' : '\u25B2'}{' '}
+                {deltaVal.text}
+              </>
+            ) : showData ? (
+              deltaVal.text
+            ) : (
+              '—'
+            )}
+          </td>
+        );
+      }
+    }
+
+    return <tr className={`${rowBg} rounded-sm`}>{cols}</tr>;
+  }
+);
+BattleRow.displayName = 'BattleRow';
+
+export const Battle = () => {
+  const settings = useBattleSettings();
+  const generalSettings = useGeneralSettings();
+  const { isDriving } = useDrivingState();
+  const isSessionVisible = useSessionVisibility(settings?.sessionVisibility);
+  const focusCarIdx = useFocusCarIdx();
+  const highlightColor = useHighlightColor();
+
+  usePitLapStoreUpdater();
+
+  const relatives = useDriverRelatives({ buffer: 1 });
+  const pitLaps = usePitLap();
+  const carLaps = useCarLap();
+  const gapSnapshot = useBattleGapSnapshot();
+
+  const playerEntry = useMemo(
+    () => relatives.find((r) => r.isPlayer),
+    [relatives]
+  );
+
+  const aheadEntry = useMemo(() => {
+    if (!playerEntry) return undefined;
+    const playerRelIdx = relatives.indexOf(playerEntry);
+    return playerRelIdx > 0 ? relatives[playerRelIdx - 1] : undefined;
+  }, [relatives, playerEntry]);
+
+  const behindEntry = useMemo(() => {
+    if (!playerEntry) return undefined;
+    const playerRelIdx = relatives.indexOf(playerEntry);
+    return playerRelIdx < relatives.length - 1
+      ? relatives[playerRelIdx + 1]
+      : undefined;
+  }, [relatives, playerEntry]);
+
+  // Live gaps from useDriverRelatives delta.
+  // aheadEntry.delta is negative (car is in front).
+  // behindEntry.delta is positive (car is behind).
+  const liveGapAhead = aheadEntry?.delta ?? null;
+  const liveGapBehind = behindEntry != null ? -(behindEntry.delta ?? 0) : null;
+
+  useBattleGapStoreUpdater({ liveGapAhead, liveGapBehind });
+
+  const stintLaps = (carIdx: number) => {
+    const currentLap = carLaps?.[carIdx] ?? 0;
+    const lastPit = pitLaps?.[carIdx] ?? 0;
+    if (currentLap <= 0) return undefined;
+    return lastPit > 0 ? currentLap - lastPit : currentLap;
+  };
+
+  const dp = settings?.gap?.decimalPlaces ?? 2;
+  const timeFormat = settings?.lastTime?.timeFormat ?? 'mixed';
+  const displayOrder = settings?.displayOrder;
+
+  // Compact mode from general settings
+  const isCompact =
+    generalSettings?.compactMode === 'compact' ||
+    generalSettings?.compactMode === 'ultra';
+  const tableBorderSpacing = isCompact
+    ? 'border-spacing-y-0'
+    : 'border-spacing-y-0.5';
+
+  if (!isSessionVisible) return <></>;
+  if (settings?.showOnlyWhenOnTrack && !isDriving) return <></>;
+  if (!playerEntry && focusCarIdx === undefined) return <></>;
+
+  // Whether gap columns are enabled at all
+  const gapEnabled = settings?.gap?.enabled ?? true;
+
+  return (
+    <div
+      className="w-full bg-slate-800/(--bg-opacity) rounded-sm overflow-hidden"
+      style={{
+        ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
+      }}
+    >
+      <div className={`${isCompact ? 'px-1 py-0.5' : 'px-1.5 py-1'}`}>
+        <table
+          className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
+        >
+          <tbody>
+            {/* Ahead row — shows live gap */}
+            <BattleRow
+              position={aheadEntry?.position}
+              classPosition={aheadEntry?.classPosition}
+              carNum={aheadEntry?.driver?.carNum}
+              name={aheadEntry?.driver?.name ?? ''}
+              stintLaps={aheadEntry ? stintLaps(aheadEntry.carIdx) : undefined}
+              lastTime={aheadEntry?.lastTime}
+              lastTimeFormat={timeFormat}
+              gap={gapEnabled ? formatGap(liveGapAhead, dp) : undefined}
+              prevGap={
+                gapEnabled ? formatGap(gapSnapshot.gapAhead, dp) : undefined
+              }
+              delta={
+                gapEnabled
+                  ? aheadDelta(liveGapAhead, gapSnapshot.gapAhead, dp)
+                  : undefined
+              }
+              isPlayer={false}
+              highlightColor={highlightColor}
+              settings={settings}
+              displayOrder={displayOrder}
+              showGapColumns={aheadEntry != null}
+            />
+            {/* Player row */}
+            <BattleRow
+              position={playerEntry?.position}
+              classPosition={playerEntry?.classPosition}
+              carNum={playerEntry?.driver?.carNum}
+              name={playerEntry?.driver?.name ?? ''}
+              stintLaps={
+                playerEntry ? stintLaps(playerEntry.carIdx) : undefined
+              }
+              lastTime={playerEntry?.lastTime}
+              lastTimeFormat={timeFormat}
+              isPlayer
+              highlightColor={highlightColor}
+              settings={settings}
+              displayOrder={displayOrder}
+              showGapColumns={false}
+            />
+            {/* Behind row — shows live gap */}
+            <BattleRow
+              position={behindEntry?.position}
+              classPosition={behindEntry?.classPosition}
+              carNum={behindEntry?.driver?.carNum}
+              name={behindEntry?.driver?.name ?? ''}
+              stintLaps={
+                behindEntry ? stintLaps(behindEntry.carIdx) : undefined
+              }
+              lastTime={behindEntry?.lastTime}
+              lastTimeFormat={timeFormat}
+              gap={gapEnabled ? formatGap(liveGapBehind, dp) : undefined}
+              prevGap={
+                gapEnabled ? formatGap(gapSnapshot.gapBehind, dp) : undefined
+              }
+              delta={
+                gapEnabled
+                  ? behindDelta(liveGapBehind, gapSnapshot.gapBehind, dp)
+                  : undefined
+              }
+              isPlayer={false}
+              highlightColor={highlightColor}
+              settings={settings}
+              displayOrder={displayOrder}
+              showGapColumns={behindEntry != null}
+            />
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/components/Battle/Battle.tsx
+++ b/src/frontend/components/Battle/Battle.tsx
@@ -2,7 +2,6 @@ import { memo, useMemo } from 'react';
 import {
   useDrivingState,
   useSessionVisibility,
-  usePitLapStoreUpdater,
   usePitLap,
   useCarLap,
   useFocusCarIdx,
@@ -288,8 +287,6 @@ export const Battle = () => {
   const highlightColor = useHighlightColor();
   const numCarClasses = useWeekendInfoNumCarClasses();
   const isMultiClass = (numCarClasses ?? 0) > 1;
-
-  usePitLapStoreUpdater();
 
   // Full driver list with metadata (name, car class, etc.). NOTE: this list's
   // ordering is by SDK CarIdxPosition which only updates at the start/finish line,

--- a/src/frontend/components/Battle/hooks/useBattleSettings.tsx
+++ b/src/frontend/components/Battle/hooks/useBattleSettings.tsx
@@ -1,0 +1,10 @@
+import { useDashboard } from '@irdashies/context';
+import { BattleWidgetSettings } from '@irdashies/types';
+
+export const useBattleSettings = ():
+  | BattleWidgetSettings['config']
+  | undefined => {
+  const { currentDashboard } = useDashboard();
+  const widget = currentDashboard?.widgets.find((w) => w.id === 'battle');
+  return widget?.config as unknown as BattleWidgetSettings['config'];
+};

--- a/src/frontend/components/OverlayContainer/PitLapUpdater.tsx
+++ b/src/frontend/components/OverlayContainer/PitLapUpdater.tsx
@@ -1,13 +1,16 @@
 import { usePitLapStoreUpdater } from '@irdashies/context';
 import { useStandingsSettings, useRelativeSettings } from '../Standings/hooks';
+import { useBattleSettings } from '../Battle/hooks/useBattleSettings';
 
 export const PitLapUpdater = () => {
   const standingsSettings = useStandingsSettings();
   const relativeSettings = useRelativeSettings();
+  const battleSettings = useBattleSettings();
 
   const enabled = !!(
     standingsSettings?.pitStatus?.enabled ||
-    relativeSettings?.pitStatus?.enabled
+    relativeSettings?.pitStatus?.enabled ||
+    battleSettings?.stint?.enabled
   );
 
   usePitLapStoreUpdater(enabled);

--- a/src/frontend/components/Settings/SettingsLoader.tsx
+++ b/src/frontend/components/Settings/SettingsLoader.tsx
@@ -29,6 +29,7 @@ import { SlowCarAheadSettings } from './sections/SlowCarAheadSettings';
 import { SectorDeltaSettings } from './sections/SectorDeltaSettings';
 import { HeartRateSettings } from './sections/HeartRateSettings';
 import { CornerNameSettings } from './sections/CornerNameSettings';
+import { BattleSettings } from './sections/BattleSettings';
 
 interface SettingsLoaderProps {
   previewMode?: boolean;
@@ -97,6 +98,8 @@ export const SettingsLoader = ({ previewMode }: SettingsLoaderProps = {}) => {
       return <HeartRateSettings />;
     case 'cornername':
       return <CornerNameSettings />;
+    case 'battle':
+      return <BattleSettings />;
     default:
       return widget ? (
         <div className="text-red-400">No settings available for {type}</div>

--- a/src/frontend/components/Settings/menuItems.ts
+++ b/src/frontend/components/Settings/menuItems.ts
@@ -52,6 +52,12 @@ export const generalItems: MenuItem[] = [
 
 export const widgetItems: MenuItem[] = [
   {
+    to: '/settings/battle',
+    path: '/battle',
+    label: 'Battle',
+    widgetType: 'battle',
+  },
+  {
     to: '/settings/blindspotmonitor',
     path: '/blindspotmonitor',
     label: 'Blind Spot Monitor',

--- a/src/frontend/components/Settings/sections/BattleSettings.tsx
+++ b/src/frontend/components/Settings/sections/BattleSettings.tsx
@@ -1,0 +1,271 @@
+import { useState, useEffect } from 'react';
+import { BaseSettingsSection } from '../components/BaseSettingsSection';
+import {
+  BattleWidgetSettings,
+  SettingsTabType,
+  TimeFormat,
+  getWidgetDefaultConfig,
+} from '@irdashies/types';
+import { useDashboard } from '@irdashies/context';
+import { TabButton } from '../components/TabButton';
+import { SortableList } from '../../SortableList';
+import { DraggableSettingItem } from '../components/DraggableSettingItem';
+import { SessionVisibility } from '../components/SessionVisibility';
+import { SettingDivider } from '../components/SettingDivider';
+import { SettingsSection } from '../components/SettingSection';
+import { SettingToggleRow } from '../components/SettingToggleRow';
+import { SettingSliderRow } from '../components/SettingSliderRow';
+import { SettingSelectRow } from '../components/SettingSelectRow';
+
+const SETTING_ID = 'battle';
+
+interface SortableSetting {
+  id: string;
+  label: string;
+  configKey: keyof BattleWidgetSettings['config'];
+  hasSubSetting?: boolean;
+}
+
+const sortableSettings: SortableSetting[] = [
+  { id: 'position', label: 'Position', configKey: 'position' },
+  { id: 'carNumber', label: 'Car Number', configKey: 'carNumber' },
+  { id: 'driverName', label: 'Driver Name', configKey: 'driverName' },
+  { id: 'stint', label: 'Stint', configKey: 'stint' },
+  {
+    id: 'lastTime',
+    label: 'Last Time',
+    configKey: 'lastTime',
+    hasSubSetting: true,
+  },
+  {
+    id: 'gap',
+    label: 'Gap / Prev / Delta',
+    configKey: 'gap',
+    hasSubSetting: true,
+  },
+];
+
+const TIME_FORMAT_OPTIONS: { label: string; value: TimeFormat }[] = [
+  { label: 'Full (1:23.456)', value: 'full' },
+  { label: 'Mixed (1:23.4)', value: 'mixed' },
+  { label: 'Minutes (1:23)', value: 'minutes' },
+  { label: 'Seconds full (83.456)', value: 'seconds-full' },
+  { label: 'Seconds mixed (83.4)', value: 'seconds-mixed' },
+  { label: 'Seconds (83)', value: 'seconds' },
+];
+
+const defaultConfig = getWidgetDefaultConfig('battle');
+
+interface DisplaySettingsListProps {
+  itemsOrder: string[];
+  onReorder: (newOrder: string[]) => void;
+  settings: BattleWidgetSettings;
+  handleConfigChange: (
+    changes: Partial<BattleWidgetSettings['config']>
+  ) => void;
+}
+
+const DisplaySettingsList = ({
+  itemsOrder,
+  onReorder,
+  settings,
+  handleConfigChange,
+}: DisplaySettingsListProps) => {
+  const items = itemsOrder
+    .map((id) => sortableSettings.find((s) => s.id === id))
+    .filter((s): s is SortableSetting => s != null);
+
+  return (
+    <SortableList
+      items={items}
+      onReorder={(newItems) => onReorder(newItems.map((i) => i.id))}
+      renderItem={(setting, sortableProps) => {
+        const configValue = settings.config[setting.configKey];
+        const isEnabled = (configValue as { enabled: boolean }).enabled;
+
+        return (
+          <DraggableSettingItem
+            key={setting.id}
+            label={setting.label}
+            enabled={isEnabled}
+            onToggle={(enabled) => {
+              const cv = settings.config[setting.configKey] as {
+                enabled: boolean;
+                [key: string]: unknown;
+              };
+              handleConfigChange({
+                [setting.configKey]: { ...cv, enabled },
+              });
+            }}
+            sortableProps={sortableProps}
+          >
+            {setting.hasSubSetting &&
+              setting.configKey === 'lastTime' &&
+              settings.config.lastTime.enabled && (
+                <div className="pl-8 mt-2">
+                  <SettingSelectRow
+                    title="Time Format"
+                    value={settings.config.lastTime.timeFormat}
+                    options={TIME_FORMAT_OPTIONS}
+                    onChange={(v) =>
+                      handleConfigChange({
+                        lastTime: {
+                          ...settings.config.lastTime,
+                          timeFormat: v,
+                        },
+                      })
+                    }
+                  />
+                </div>
+              )}
+            {setting.hasSubSetting &&
+              setting.configKey === 'gap' &&
+              settings.config.gap.enabled && (
+                <div className="pl-8 mt-2">
+                  <SettingSelectRow
+                    title="Decimal Places"
+                    value={String(settings.config.gap.decimalPlaces)}
+                    options={[
+                      { label: '1 (0.0s)', value: '1' },
+                      { label: '2 (0.00s)', value: '2' },
+                      { label: '3 (0.000s)', value: '3' },
+                    ]}
+                    onChange={(v) =>
+                      handleConfigChange({
+                        gap: {
+                          ...settings.config.gap,
+                          decimalPlaces: parseInt(v),
+                        },
+                      })
+                    }
+                  />
+                </div>
+              )}
+          </DraggableSettingItem>
+        );
+      }}
+    />
+  );
+};
+
+export const BattleSettings = () => {
+  const { currentDashboard } = useDashboard();
+
+  const savedSettings = currentDashboard?.widgets.find(
+    (w) => w.id === SETTING_ID
+  ) as BattleWidgetSettings | undefined;
+
+  const [settings, setSettings] = useState<BattleWidgetSettings>({
+    id: SETTING_ID,
+    enabled: savedSettings?.enabled ?? false,
+    config:
+      (savedSettings?.config as BattleWidgetSettings['config']) ??
+      defaultConfig,
+  });
+
+  const [activeTab, setActiveTab] = useState<SettingsTabType>(
+    () => (localStorage.getItem('battleTab') as SettingsTabType) || 'display'
+  );
+
+  useEffect(() => {
+    localStorage.setItem('battleTab', activeTab);
+  }, [activeTab]);
+
+  if (!currentDashboard) return <>Loading...</>;
+
+  return (
+    <BaseSettingsSection
+      title="Battle"
+      description="Shows the cars immediately ahead and behind the player with gap information"
+      settings={settings as BattleWidgetSettings}
+      onSettingsChange={(s) => setSettings(s as BattleWidgetSettings)}
+      widgetId={SETTING_ID}
+    >
+      {(handleConfigChange) => (
+        <div className="space-y-4">
+          {/* Tabs */}
+          <div className="flex border-b border-slate-700/50">
+            <TabButton
+              id="display"
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+            >
+              Display
+            </TabButton>
+            <TabButton
+              id="options"
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+            >
+              Options
+            </TabButton>
+            <TabButton
+              id="visibility"
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+            >
+              Visibility
+            </TabButton>
+          </div>
+
+          <div>
+            {/* DISPLAY TAB */}
+            {activeTab === 'display' && (
+              <SettingsSection title="Columns">
+                <DisplaySettingsList
+                  itemsOrder={
+                    settings.config.displayOrder ?? defaultConfig.displayOrder
+                  }
+                  onReorder={(newOrder) =>
+                    handleConfigChange({ displayOrder: newOrder })
+                  }
+                  settings={settings}
+                  handleConfigChange={handleConfigChange}
+                />
+              </SettingsSection>
+            )}
+
+            {/* OPTIONS TAB */}
+            {activeTab === 'options' && (
+              <SettingsSection title="Options">
+                <SettingSliderRow
+                  title="Background Opacity"
+                  description="Opacity of the widget background"
+                  value={settings.config.background.opacity}
+                  units="%"
+                  min={0}
+                  max={100}
+                  step={1}
+                  onChange={(v) =>
+                    handleConfigChange({ background: { opacity: v } })
+                  }
+                />
+
+                <SettingDivider />
+
+                <SettingToggleRow
+                  title="Show only when on track"
+                  description="If enabled, widget will only be shown when driving"
+                  enabled={settings.config.showOnlyWhenOnTrack}
+                  onToggle={(v) =>
+                    handleConfigChange({ showOnlyWhenOnTrack: v })
+                  }
+                />
+              </SettingsSection>
+            )}
+
+            {/* VISIBILITY TAB */}
+            {activeTab === 'visibility' && (
+              <SettingsSection title="Session Visibility">
+                <SessionVisibility
+                  sessionVisibility={settings.config.sessionVisibility}
+                  handleConfigChange={handleConfigChange}
+                />
+              </SettingsSection>
+            )}
+          </div>
+        </div>
+      )}
+    </BaseSettingsSection>
+  );
+};

--- a/src/frontend/components/Settings/sections/BattleSettings.tsx
+++ b/src/frontend/components/Settings/sections/BattleSettings.tsx
@@ -16,6 +16,7 @@ import { SettingsSection } from '../components/SettingSection';
 import { SettingToggleRow } from '../components/SettingToggleRow';
 import { SettingSliderRow } from '../components/SettingSliderRow';
 import { SettingSelectRow } from '../components/SettingSelectRow';
+import { SettingButtonGroupRow } from '../components/SettingButtonGroupRow';
 
 const SETTING_ID = 'battle';
 
@@ -35,6 +36,12 @@ const sortableSettings: SortableSetting[] = [
     id: 'lastTime',
     label: 'Last Time',
     configKey: 'lastTime',
+    hasSubSetting: true,
+  },
+  {
+    id: 'speed',
+    label: 'Speed',
+    configKey: 'speed',
     hasSubSetting: true,
   },
   {
@@ -113,6 +120,26 @@ const DisplaySettingsList = ({
                           ...settings.config.lastTime,
                           timeFormat: v,
                         },
+                      })
+                    }
+                  />
+                </div>
+              )}
+            {setting.hasSubSetting &&
+              setting.configKey === 'speed' &&
+              settings.config.speed.enabled && (
+                <div className="pl-8 mt-2">
+                  <SettingButtonGroupRow<'auto' | 'mph' | 'km/h'>
+                    title="Unit"
+                    value={settings.config.speed.unit}
+                    options={[
+                      { label: 'Auto', value: 'auto' },
+                      { label: 'MPH', value: 'mph' },
+                      { label: 'KM/H', value: 'km/h' },
+                    ]}
+                    onChange={(v) =>
+                      handleConfigChange({
+                        speed: { ...settings.config.speed, unit: v },
                       })
                     }
                   />

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/PositionCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/PositionCell.tsx
@@ -37,7 +37,7 @@ export const PositionCell = memo(
         data-column="position"
         className={`w-auto text-center ${pxClass} whitespace-nowrap ${positionColor} ${textColor}`}
       >
-        {position}
+        {position !== undefined && isFinite(position) ? position : ''}
       </td>
     );
   }

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -265,7 +265,9 @@ export const createDriverStandings = (
       return {
         carIdx: result.CarIdx,
         position: result.Position,
-        classPosition: result.ClassPosition + 1,
+        classPosition: isFinite(result.ClassPosition)
+          ? result.ClassPosition + 1
+          : undefined,
         delta: calculateDelta(
           result.CarIdx,
           result.FastestTime,

--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -225,7 +225,7 @@ export const useDriverStandings = () => {
         if (livePosition !== undefined) classPosition = livePosition;
       }
 
-      if (classPosition <= 0) {
+      if (!classPosition || !isFinite(classPosition) || classPosition <= 0) {
         // Class position can become 0 or negative in some edge cases
         // Before race start it seems to be fine to default to qualifying position
         // During the race class position should be available

--- a/src/frontend/constants/widgetNames.ts
+++ b/src/frontend/constants/widgetNames.ts
@@ -28,6 +28,7 @@ export const WIDGET_NAMES: Record<WidgetId, string> = {
   sectordelta: 'Sector Delta',
   heartrate: 'Heart Rate',
   cornername: 'Corner Names',
+  battle: 'Battle',
 };
 
 /**

--- a/src/frontend/context/BattleGapStore/BattleGapStore.ts
+++ b/src/frontend/context/BattleGapStore/BattleGapStore.ts
@@ -1,0 +1,69 @@
+import { create } from 'zustand';
+import { useStoreWithEqualityFn } from 'zustand/traditional';
+
+export interface BattleGapSnapshot {
+  /** Gap to the car ahead (negative = ahead, positive = behind relative to player) */
+  gapAhead: number | null;
+  /** Gap to the car behind (positive = behind) */
+  gapBehind: number | null;
+  /** Previous lap snapshot */
+  prevGapAhead: number | null;
+  prevGapBehind: number | null;
+  /** The player lap on which the snapshot was taken */
+  snapshotLap: number;
+}
+
+interface BattleGapState extends BattleGapSnapshot {
+  /** Update snapshot when the player completes a new lap */
+  snapshot: (
+    gapAhead: number | null,
+    gapBehind: number | null,
+    playerLap: number
+  ) => void;
+  reset: () => void;
+}
+
+const initialState: BattleGapSnapshot = {
+  gapAhead: null,
+  gapBehind: null,
+  prevGapAhead: null,
+  prevGapBehind: null,
+  snapshotLap: -1,
+};
+
+export const useBattleGapStore = create<BattleGapState>((set, get) => ({
+  ...initialState,
+  snapshot: (gapAhead, gapBehind, playerLap) => {
+    const { snapshotLap, gapAhead: prevAhead, gapBehind: prevBehind } = get();
+
+    // Only snapshot once per lap
+    if (playerLap === snapshotLap) return;
+
+    set({
+      prevGapAhead: prevAhead,
+      prevGapBehind: prevBehind,
+      gapAhead,
+      gapBehind,
+      snapshotLap: playerLap,
+    });
+  },
+  reset: () => set({ ...initialState }),
+}));
+
+export const useBattleGapSnapshot = (): BattleGapSnapshot =>
+  useStoreWithEqualityFn(
+    useBattleGapStore,
+    (s) => ({
+      gapAhead: s.gapAhead,
+      gapBehind: s.gapBehind,
+      prevGapAhead: s.prevGapAhead,
+      prevGapBehind: s.prevGapBehind,
+      snapshotLap: s.snapshotLap,
+    }),
+    (a, b) =>
+      a.gapAhead === b.gapAhead &&
+      a.gapBehind === b.gapBehind &&
+      a.prevGapAhead === b.prevGapAhead &&
+      a.prevGapBehind === b.prevGapBehind &&
+      a.snapshotLap === b.snapshotLap
+  );

--- a/src/frontend/context/BattleGapStore/BattleGapStoreUpdater.tsx
+++ b/src/frontend/context/BattleGapStore/BattleGapStoreUpdater.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from 'react';
+import { useBattleGapStore } from './BattleGapStore';
+import { useFocusCarIdx } from '../shared/useFocusCarIdx';
+import { useTelemetryValues } from '../TelemetryStore/TelemetryStore';
+
+interface BattleGapStoreUpdaterProps {
+  /** Live gap to the car immediately ahead of the player (negative = ahead) */
+  liveGapAhead: number | null;
+  /** Live gap to the car immediately behind the player (positive = behind) */
+  liveGapBehind: number | null;
+}
+
+/**
+ * Watches for the player completing a new lap and snapshots the live gaps at
+ * that moment, creating a per-lap Gap / Prev / Delta comparison.
+ */
+export const useBattleGapStoreUpdater = ({
+  liveGapAhead,
+  liveGapBehind,
+}: BattleGapStoreUpdaterProps) => {
+  const focusCarIdx = useFocusCarIdx();
+  const carIdxLap = useTelemetryValues('CarIdxLap');
+  const snapshot = useBattleGapStore((s) => s.snapshot);
+  const reset = useBattleGapStore((s) => s.reset);
+
+  const prevLapRef = useRef<number>(-1);
+
+  // Reset store when focus car changes (e.g. new session or spectator mode switch)
+  useEffect(() => {
+    reset();
+    prevLapRef.current = -1;
+  }, [focusCarIdx, reset]);
+
+  useEffect(() => {
+    if (focusCarIdx === undefined) return;
+
+    const currentLap = carIdxLap?.[focusCarIdx] ?? -1;
+    if (currentLap <= 0) return;
+
+    if (currentLap !== prevLapRef.current) {
+      prevLapRef.current = currentLap;
+      snapshot(liveGapAhead, liveGapBehind, currentLap);
+    }
+  }, [carIdxLap, focusCarIdx, liveGapAhead, liveGapBehind, snapshot]);
+};

--- a/src/frontend/context/index.ts
+++ b/src/frontend/context/index.ts
@@ -17,5 +17,7 @@ export * from './LapTimesStore/LapTimesStoreUpdater';
 export * from './SectorTimingStore/SectorTimingStore';
 export * from './PushToPassStore/PushToPassStore';
 export * from './PushToPassStore/PushToPassStoreUpdater';
+export * from './BattleGapStore/BattleGapStore';
+export * from './BattleGapStore/BattleGapStoreUpdater';
 export * from './shared';
 export * from './PersonalBestStore/PersonalBestStore';

--- a/src/frontend/context/shared/useResetOnDisconnect.ts
+++ b/src/frontend/context/shared/useResetOnDisconnect.ts
@@ -4,6 +4,7 @@ import { useTelemetryStore } from '../TelemetryStore/TelemetryStore';
 import { useCarSpeedsStore } from '../CarSpeedStore/CarSpeedsStore';
 import { useLapTimesStore } from '../LapTimesStore/LapTimesStore';
 import { usePitLapStore } from '../PitLapStore/PitLapStore';
+import { useBattleGapStore } from '../BattleGapStore/BattleGapStore';
 import { useFuelStore } from '../../components/FuelCalculator/FuelStore';
 import logger from '@irdashies/utils/logger';
 
@@ -25,6 +26,7 @@ export const useResetOnDisconnect = (running: boolean) => {
       useCarSpeedsStore.getState().resetCarSpeeds();
       useLapTimesStore.getState().reset();
       usePitLapStore.getState().reset();
+      useBattleGapStore.getState().reset();
       useFuelStore.getState().clearAllData();
     }
     prevRunning.current = running;

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1071,6 +1071,7 @@ export const defaultDashboard: {
         driverName: { enabled: true },
         stint: { enabled: true },
         lastTime: { enabled: true, timeFormat: 'mixed' },
+        speed: { enabled: false, unit: 'auto' },
         gap: { enabled: true, decimalPlaces: 2 },
         displayOrder: [
           'position',
@@ -1078,6 +1079,7 @@ export const defaultDashboard: {
           'driverName',
           'stint',
           'lastTime',
+          'speed',
           'gap',
         ],
         sessionVisibility: {

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1055,6 +1055,41 @@ export const defaultDashboard: {
       },
     },
     {
+      id: 'battle',
+      enabled: false,
+      layout: {
+        x: 300,
+        y: 100,
+        width: 460,
+        height: 100,
+      },
+      config: {
+        background: { opacity: 80 },
+        showOnlyWhenOnTrack: false,
+        position: { enabled: true },
+        carNumber: { enabled: true },
+        driverName: { enabled: true },
+        stint: { enabled: true },
+        lastTime: { enabled: true, timeFormat: 'mixed' },
+        gap: { enabled: true, decimalPlaces: 2 },
+        displayOrder: [
+          'position',
+          'carNumber',
+          'driverName',
+          'stint',
+          'lastTime',
+          'gap',
+        ],
+        sessionVisibility: {
+          race: true,
+          loneQualify: false,
+          openQualify: false,
+          practice: false,
+          offlineTesting: false,
+        },
+      },
+    },
+    {
       id: 'telemetryinspector',
       enabled: false,
       layout: {

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -617,6 +617,19 @@ export interface SectorDeltaConfig {
   alwaysScroll?: boolean;
 }
 
+export interface BattleConfig {
+  background: { opacity: number };
+  showOnlyWhenOnTrack: boolean;
+  position: { enabled: boolean };
+  carNumber: { enabled: boolean };
+  driverName: { enabled: boolean };
+  stint: { enabled: boolean };
+  lastTime: { enabled: boolean; timeFormat: TimeFormat };
+  gap: { enabled: boolean; decimalPlaces: number };
+  displayOrder: string[];
+  sessionVisibility: SessionVisibilitySettings;
+}
+
 // ===========================
 // Widget config map + typed widget
 // ===========================
@@ -652,6 +665,7 @@ export interface WidgetConfigMap {
   sectordelta: SectorDeltaConfig;
   heartrate: HeartRateConfig;
   cornername: CornerNameOverlayConfig;
+  battle: BattleConfig;
 }
 
 export type TypedDashboardWidget<
@@ -753,3 +767,4 @@ export type SectorDeltaWidgetSettings = BaseWidgetSettings<SectorDeltaConfig>;
 export type HeartRateWidgetSettings = BaseWidgetSettings<HeartRateConfig>;
 export type CornerNameWidgetSettings =
   BaseWidgetSettings<CornerNameOverlayConfig>;
+export type BattleWidgetSettings = BaseWidgetSettings<BattleConfig>;

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -625,6 +625,7 @@ export interface BattleConfig {
   driverName: { enabled: boolean };
   stint: { enabled: boolean };
   lastTime: { enabled: boolean; timeFormat: TimeFormat };
+  speed: { enabled: boolean; unit: 'mph' | 'km/h' | 'auto' };
   gap: { enabled: boolean; decimalPlaces: number };
   displayOrder: string[];
   sessionVisibility: SessionVisibilitySettings;


### PR DESCRIPTION
## Description

Adds a new **Battle** widget — a compact 3-row overlay showing the cars immediately ahead and behind the player in class position order, with live gap timing, per-lap gap snapshots, and trend indicators.

Tested with iRacing demo data, in race tests and reviewed against the relative/standings overlay patterns for consistency.

**Key features:**
- Live class position ordering via `CarIdxLapCompleted + CarIdxLapDistPct` — updates every frame mid-lap, so overtakes appear immediately
- Live gap timing via reference-lap interpolation (`useDriverRelatives` with buffer 64) at 60fps
- Gap / Prev-lap / Delta (Δ) three-column display with closing/opening trend arrows (green/red)
- Per-lap gap snapshot stored in `BattleGapStore` — snaps when `CarIdxLap` increments
- Configurable speed column (mph / km/h / auto) derived from `CarIdxLapDistPct` movement
- Stint length column (laps since last pit)
- Last lap time with session-fastest (purple) and personal-best (green) colouring
- All columns toggleable and reorderable in settings (Display tab)
- Session visibility, show-only-when-on-track, and background opacity options
- UX aligned with Relative widget: alternating row banding, off-track dimming, lapped/lapping-ahead indicators, class-colour position cell, container padding

## Screenshots

### After
<img width="644" height="582" alt="image" src="https://github.com/user-attachments/assets/cdcff304-6f73-4e33-a9ec-737d7c1139a7" />
<img width="515" height="77" alt="image" src="https://github.com/user-attachments/assets/7fd00181-096d-45d5-9e34-e36390d9c1e4" />
*I know the position value is missing from the current driver row, its updated in the code. 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the **Battle** widget with real-time car-ahead/car-behind gaps and related stats.
  * Added **Battle** configuration, including display customization and visibility controls, plus a dedicated settings page/menu entry.
  * Added lap-based battle-gap tracking and live battle table updates.

* **Bug Fixes**
  * Fixed **position** and **class position** displays to avoid showing invalid/non-finite values.
  * Ensured battle-gap tracking resets when disconnecting and only snapshots once per lap.
  * Updated pit-lap updating to respect Battle stint visibility settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->