### PR TITLE
site: improve contrast, add coach marks, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
-# iRacing Dashies
+# irDashies - Real-time iRacing Overlays
 
 <div align="center" style="padding-bottom: 20px;">
   <img src="./docs/assets/icons/logo.svg" alt="Logo" width="200" height="200">
+
+**[www.irdashies.com](https://www.irdashies.com)**
+
 </div>
 
-Welcome to the iRacing Dashies project! This repository contains the code and documentation for building iRacing overlays.
+An open-source platform for building real-time iRacing overlays and utilities using React and Electron. Designed to be approachable for web developers — no iRacing SDK, C++, or even iRacing installation required to get started.
 
-This is an open-source project that aims to provide a platform to build overlays and utilities for iRacing using React and Electron.
-
-This is built with the intention of being easily approachable by developers who are familiar with web development as well as not needing to have a deep understanding of the iRacing SDK, C++, or even needing to run iRacing at all.
-
-This project is still in the early stages of development, so there may be bugs and many missing features. If you are interested in contributing please reach out and we can discuss how we can collaborate.
+For bug reports, feature requests, or to get involved, join our [Discord](https://discord.gg/YMAqduF2Ft).
 
 ## Try it out
 

--- a/site/src/App.tsx
+++ b/site/src/App.tsx
@@ -14,7 +14,7 @@ function PreviewFallback() {
   return (
     <section id="preview" className="py-24 px-6">
       <div className="max-w-6xl mx-auto">
-        <div className="h-[600px] bg-slate-900/40 border border-slate-800/50 rounded-sm flex items-center justify-center">
+        <div className="h-150 bg-slate-900/40 border border-slate-800/50 rounded-sm flex items-center justify-center">
           <div className="text-slate-500 text-sm uppercase tracking-wide font-bold">
             Loading preview...
           </div>
@@ -31,7 +31,7 @@ export function App() {
         href="https://github.com/tariknz/irdashies"
         target="_blank"
         rel="noopener noreferrer"
-        className="fixed top-4 right-4 z-50 flex items-center gap-2 px-3 py-2 bg-slate-800/80 hover:bg-slate-700/80 backdrop-blur-sm border border-slate-700/50 rounded-sm text-slate-300 hover:text-white text-sm font-medium transition-colors"
+        className="fixed top-4 right-4 z-50 hidden sm:flex items-center gap-2 px-3 py-2 bg-slate-800/80 hover:bg-slate-700/80 backdrop-blur-sm border border-slate-700/50 rounded-sm text-slate-300 hover:text-white text-sm font-medium transition-colors"
       >
         <GithubLogo size={20} weight="fill" />
         GitHub

--- a/site/src/components/PreviewSettingsPanel.tsx
+++ b/site/src/components/PreviewSettingsPanel.tsx
@@ -156,7 +156,7 @@ export function PreviewSettingsButton({
     <>
       <button
         onClick={() => setInternalOpen(true)}
-        className="flex items-center gap-1.5 px-2.5 py-1 rounded-sm text-[10px] font-bold uppercase tracking-wide text-red-600 border border-red-600/40 bg-red-600/5 hover:bg-red-600/15 hover:border-red-600/60 transition-colors"
+        className="flex items-center gap-1.5 px-2.5 py-1 rounded-sm text-[10px] font-bold uppercase tracking-wide text-white border border-red-600 bg-red-600/20 hover:bg-red-600/40 hover:border-red-500 transition-colors"
       >
         <GearSix size={12} weight="bold" />
         Configure

--- a/site/src/sections/ActiveWidgetSync.tsx
+++ b/site/src/sections/ActiveWidgetSync.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+import { useDashboard } from '../../../src/frontend/context/DashboardContext/DashboardContext';
+
+/**
+ * Syncs the toolbar's activeWidgets set into the dashboard context so the
+ * settings panel's enabled toggle stays in sync with the Frame toolbar.
+ */
+export function ActiveWidgetSync({
+  activeWidgets,
+}: {
+  activeWidgets: Set<string>;
+}) {
+  const { currentDashboard, onDashboardUpdated } = useDashboard();
+  const prevActiveRef = useRef<Set<string>>(activeWidgets);
+
+  useEffect(() => {
+    if (!currentDashboard || !onDashboardUpdated) return;
+    // Only sync when activeWidgets actually changed (skip initial render)
+    if (prevActiveRef.current === activeWidgets) return;
+    prevActiveRef.current = activeWidgets;
+
+    const needsUpdate = currentDashboard.widgets.some((w) => {
+      const id = w.type ?? w.id;
+      return w.enabled !== activeWidgets.has(id);
+    });
+
+    if (!needsUpdate) return;
+
+    const updatedWidgets = currentDashboard.widgets.map((w) => {
+      const id = w.type ?? w.id;
+      const shouldBeEnabled = activeWidgets.has(id);
+      if (w.enabled === shouldBeEnabled) return w;
+      return { ...w, enabled: shouldBeEnabled };
+    });
+
+    onDashboardUpdated({ ...currentDashboard, widgets: updatedWidgets });
+  }, [activeWidgets, currentDashboard, onDashboardUpdated]);
+
+  return null;
+}

--- a/site/src/sections/CoachMarks.tsx
+++ b/site/src/sections/CoachMarks.tsx
@@ -1,0 +1,69 @@
+import { useState, useCallback, useEffect } from 'react';
+import {
+  ArrowsOutCardinal,
+  ArrowUp,
+  CursorClick,
+  GearSix,
+} from '@phosphor-icons/react';
+
+/**
+ * First-visit coach marks overlay — three callouts pointing at the toolbar,
+ * a widget, and the configure button. Dismissed on first click anywhere.
+ */
+export function CoachMarks({ onDismiss }: { onDismiss: () => void }) {
+  const [fading, setFading] = useState(false);
+
+  const dismiss = useCallback(() => {
+    setFading(true);
+    setTimeout(onDismiss, 300);
+  }, [onDismiss]);
+
+  useEffect(() => {
+    const handler = () => dismiss();
+    window.addEventListener('pointerdown', handler, { once: true });
+    return () => window.removeEventListener('pointerdown', handler);
+  }, [dismiss]);
+
+  return (
+    <div
+      className={[
+        'absolute inset-0 z-50 pointer-events-none transition-opacity duration-300',
+        fading ? 'opacity-0' : 'opacity-100',
+      ].join(' ')}
+    >
+      {/* Scrim */}
+      <div className="absolute inset-0 bg-black/30" />
+
+      {/* Callout: toolbar toggles — top-left, below toolbar */}
+      <div className="absolute top-14 left-16 flex flex-col items-start gap-2 animate-pulse">
+        <ArrowUp size={24} className="text-sky-400 ml-5" />
+        <div className="bg-sky-500 text-white text-sm font-semibold px-4 py-2 rounded-md shadow-lg flex items-center gap-2">
+          <CursorClick size={18} />
+          Click to enable / disable widgets
+        </div>
+      </div>
+
+      {/* Callout: configure button — top-right, below toolbar */}
+      <div className="absolute top-14 right-4 flex flex-col items-end gap-2 animate-pulse">
+        <ArrowUp size={24} className="text-sky-400 mr-5" />
+        <div className="bg-sky-500 text-white text-sm font-semibold px-4 py-2 rounded-md shadow-lg flex items-center gap-2">
+          <GearSix size={18} />
+          Customize widget settings
+        </div>
+      </div>
+
+      {/* Callout: widget interaction — center of canvas */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-2 animate-pulse">
+        <div className="bg-sky-500 text-white text-sm font-semibold px-4 py-2 rounded-md shadow-lg flex items-center gap-2">
+          <ArrowsOutCardinal size={18} />
+          Drag widgets to move, double-click for settings
+        </div>
+      </div>
+
+      {/* Dismiss hint */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 translate-y-12 bg-black/50 text-white/80 text-sm uppercase tracking-widest font-semibold px-4 py-1.5 rounded-md">
+        Click anywhere to dismiss
+      </div>
+    </div>
+  );
+}

--- a/site/src/sections/LivePreview.tsx
+++ b/site/src/sections/LivePreview.tsx
@@ -58,7 +58,7 @@ const AVAILABLE_WIDGETS = [
     id: 'standings',
     label: 'Standings',
     component: Standings,
-    defaultOn: true,
+    defaultOn: false,
   },
   { id: 'relative', label: 'Relative', component: Relative, defaultOn: true },
   { id: 'input', label: 'Input Trace', component: Input, defaultOn: true },
@@ -68,7 +68,7 @@ const AVAILABLE_WIDGETS = [
     component: Tachometer,
     defaultOn: false,
   },
-  { id: 'weather', label: 'Weather', component: Weather, defaultOn: true },
+  { id: 'weather', label: 'Weather', component: Weather, defaultOn: false },
   { id: 'flag', label: 'Flag', component: Flag, defaultOn: false },
   {
     id: 'infobar',
@@ -127,44 +127,40 @@ const AVAILABLE_WIDGETS = [
   },
 ] as const;
 
-// Default-on widgets are laid out in three columns so they don't overlap.
-// Any widget toggled on later just appears at PAD,PAD with its default size.
+// Default-on widgets: relative (top-left), track map (top-right),
+// input (bottom-center). Positions are computed once the canvas is measured.
 
 const PAD = 20;
-const GAP = 10;
 
-const standingsSize = getDefaultSize('standings');
-const relativeSize = getDefaultSize('relative');
-const mapSize = getDefaultSize('map');
-const inputSize = getDefaultSize('input');
-const weatherSize = getDefaultSize('weather');
+function buildDefaultPositions(
+  canvasW: number,
+  canvasH: number
+): Record<string, WidgetPosition> {
+  const positions: Record<string, WidgetPosition> = Object.fromEntries(
+    AVAILABLE_WIDGETS.map((w) => {
+      const size = getDefaultSize(w.id);
+      return [w.id, { x: PAD, y: PAD, ...size }];
+    })
+  );
 
-// Column x positions
-const COL1_X = PAD;
-const COL2_X = COL1_X + standingsSize.width + PAD;
-const COL3_X = COL2_X + Math.max(relativeSize.width, mapSize.width) + PAD;
+  const relativeSize = getDefaultSize('relative');
+  const mapSize = getDefaultSize('map');
+  const inputSize = getDefaultSize('input');
 
-// Col 2 running y
-const col2RelativeBottom = PAD + relativeSize.height + GAP;
-const col2MapBottom = col2RelativeBottom + mapSize.height + GAP;
+  positions['relative'] = { x: PAD, y: PAD, ...relativeSize };
+  positions['map'] = {
+    x: canvasW - mapSize.width - PAD,
+    y: PAD,
+    ...mapSize,
+  };
+  positions['input'] = {
+    x: Math.round((canvasW - inputSize.width) / 2),
+    y: canvasH - inputSize.height - PAD,
+    ...inputSize,
+  };
 
-// Build positions: default-on widgets get careful placement,
-// everything else falls back to top-left with its default size.
-const DEFAULT_POSITIONS: Record<string, WidgetPosition> = Object.fromEntries(
-  AVAILABLE_WIDGETS.map((w) => {
-    const size = getDefaultSize(w.id);
-    return [w.id, { x: PAD, y: PAD, ...size }];
-  })
-);
-
-// Override positions for default-on widgets so they don't overlap
-Object.assign(DEFAULT_POSITIONS, {
-  standings: { x: COL1_X, y: PAD, ...standingsSize },
-  relative: { x: COL2_X, y: PAD, ...relativeSize },
-  map: { x: COL2_X, y: col2RelativeBottom, ...mapSize },
-  input: { x: COL2_X, y: col2MapBottom, ...inputSize },
-  weather: { x: COL3_X, y: PAD, ...weatherSize },
-});
+  return positions;
+}
 
 /**
  * Wraps a widget in the overlay-window theme container.
@@ -365,12 +361,32 @@ export function LivePreview() {
     () => new Set(AVAILABLE_WIDGETS.filter((w) => w.defaultOn).map((w) => w.id))
   );
   const [positions, setPositions] = useState<Record<string, WidgetPosition>>(
-    () => ({ ...DEFAULT_POSITIONS })
+    () => buildDefaultPositions(1200, 700)
   );
   const [selectedWidget, setSelectedWidget] = useState<string | null>(null);
   const [settingsOpenWidget, setSettingsOpenWidget] = useState<string | null>(
     null
   );
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const hasLaidOut = useRef(false);
+
+  // Measure the canvas once it's rendered and recompute default positions
+  useEffect(() => {
+    const el = canvasRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver((entries) => {
+      if (hasLaidOut.current) return;
+      const { width, height } = entries[0].contentRect;
+      if (width > 0 && height > 0) {
+        hasLaidOut.current = true;
+        setPositions(buildDefaultPositions(width, height));
+        observer.disconnect();
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   const toggleWidget = (id: string) => {
     setActiveWidgets((prev) => {
@@ -410,20 +426,24 @@ export function LivePreview() {
       className="relative min-h-screen flex flex-col py-8 px-6"
     >
       {/* Compact section header */}
-      <div className="mx-auto w-full max-w-[1800px] mb-4">
+      <div className="mx-auto w-full max-w-450 mb-4">
         <h2 className="text-2xl md:text-3xl font-black uppercase tracking-tight">
           See It In <span className="text-red-600">Action</span>
-          <span className="text-sm font-normal normal-case tracking-normal text-slate-500 ml-4">
-            Drag to reposition, resize from edges, toggle widgets below
-          </span>
         </h2>
+        <p className="text-sm text-slate-400 mt-1">
+          Toggle widgets in the toolbar to enable them. Click a widget to select
+          it, drag to reposition, resize from edges, or double-click for
+          settings.
+        </p>
       </div>
 
       <LivePreviewProvider
         onDashboardSaved={(dashboard) => {
           setActiveWidgets((prev) => {
             const next = new Set(prev);
-            const widgetIds = new Set(AVAILABLE_WIDGETS.map((w) => w.id));
+            const widgetIds = new Set<string>(
+              AVAILABLE_WIDGETS.map((w) => w.id)
+            );
             for (const widget of dashboard.widgets) {
               const id = widget.type ?? widget.id;
               if (!widgetIds.has(id)) continue;
@@ -440,7 +460,7 @@ export function LivePreview() {
       >
         <ActiveWidgetSync activeWidgets={activeWidgets} />
         {/* Preview frame */}
-        <div className="mx-auto w-full max-w-[1800px] flex-1 flex flex-col min-h-0">
+        <div className="mx-auto w-full max-w-450 flex-1 flex flex-col min-h-0">
           <div className="relative rounded-sm border border-slate-700/50 overflow-hidden carbon-fiber flex-1 flex flex-col">
             {/* Frame toolbar — traffic lights + controls integrated */}
             <div className="flex-none flex items-center gap-3 px-4 py-2 bg-slate-900/80 border-b border-slate-700/50">
@@ -464,7 +484,7 @@ export function LivePreview() {
                       'px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide rounded-sm transition-all border whitespace-nowrap flex-none',
                       activeWidgets.has(widget.id)
                         ? 'border-red-600/50 bg-red-600/10 text-slate-200'
-                        : 'border-transparent text-slate-600 hover:text-slate-400 hover:bg-slate-800/50',
+                        : 'border-slate-700/50 text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 hover:border-slate-600/50',
                     ].join(' ')}
                   >
                     {widget.label}
@@ -488,6 +508,7 @@ export function LivePreview() {
 
             {/* Widget canvas — absolute positioned like the real DashboardView */}
             <div
+              ref={canvasRef}
               className="relative flex-1 overflow-hidden"
               onClick={() => setSelectedWidget(null)}
             >

--- a/site/src/sections/LivePreview.tsx
+++ b/site/src/sections/LivePreview.tsx
@@ -32,7 +32,13 @@ import {
   useResizeWidget,
   ResizeHandles,
 } from '../../../src/frontend/components/WidgetContainer';
-import { ArrowsOutCardinal, X } from '@phosphor-icons/react';
+import {
+  ArrowsOutCardinal,
+  ArrowUp,
+  CursorClick,
+  GearSix,
+  X,
+} from '@phosphor-icons/react';
 import { PreviewSettingsButton } from '../components/PreviewSettingsPanel';
 import { defaultDashboard } from '../../../src/types/defaultDashboard';
 import { useDashboard } from '../../../src/frontend/context/DashboardContext/DashboardContext';
@@ -356,6 +362,68 @@ function ActiveWidgetSync({ activeWidgets }: { activeWidgets: Set<string> }) {
   return null;
 }
 
+/**
+ * First-visit coach marks overlay — three callouts pointing at the toolbar,
+ * a widget, and the configure button. Dismissed on first click anywhere.
+ */
+function CoachMarks({ onDismiss }: { onDismiss: () => void }) {
+  const [fading, setFading] = useState(false);
+
+  const dismiss = useCallback(() => {
+    setFading(true);
+    setTimeout(onDismiss, 300);
+  }, [onDismiss]);
+
+  useEffect(() => {
+    const handler = () => dismiss();
+    window.addEventListener('pointerdown', handler, { once: true });
+    return () => window.removeEventListener('pointerdown', handler);
+  }, [dismiss]);
+
+  return (
+    <div
+      className={[
+        'absolute inset-0 z-50 pointer-events-none transition-opacity duration-300',
+        fading ? 'opacity-0' : 'opacity-100',
+      ].join(' ')}
+    >
+      {/* Scrim */}
+      <div className="absolute inset-0 bg-black/30" />
+
+      {/* Callout: toolbar toggles — top-left, below toolbar */}
+      <div className="absolute top-14 left-16 flex flex-col items-start gap-2 animate-pulse">
+        <ArrowUp size={24} className="text-sky-400 ml-5" />
+        <div className="bg-sky-500 text-white text-sm font-semibold px-4 py-2 rounded-md shadow-lg flex items-center gap-2">
+          <CursorClick size={18} />
+          Click to enable / disable widgets
+        </div>
+      </div>
+
+      {/* Callout: configure button — top-right, below toolbar */}
+      <div className="absolute top-14 right-4 flex flex-col items-end gap-2 animate-pulse">
+        <ArrowUp size={24} className="text-sky-400 mr-5" />
+        <div className="bg-sky-500 text-white text-sm font-semibold px-4 py-2 rounded-md shadow-lg flex items-center gap-2">
+          <GearSix size={18} />
+          Customize widget settings
+        </div>
+      </div>
+
+      {/* Callout: widget interaction — center of canvas */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-2 animate-pulse">
+        <div className="bg-sky-500 text-white text-sm font-semibold px-4 py-2 rounded-md shadow-lg flex items-center gap-2">
+          <ArrowsOutCardinal size={18} />
+          Drag widgets to move, double-click for settings
+        </div>
+      </div>
+
+      {/* Dismiss hint */}
+      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 translate-y-12 bg-black/50 text-white/80 text-sm uppercase tracking-widest font-semibold px-4 py-1.5 rounded-md">
+        Click anywhere to dismiss
+      </div>
+    </div>
+  );
+}
+
 export function LivePreview() {
   const [activeWidgets, setActiveWidgets] = useState<Set<string>>(
     () => new Set(AVAILABLE_WIDGETS.filter((w) => w.defaultOn).map((w) => w.id))
@@ -367,6 +435,7 @@ export function LivePreview() {
   const [settingsOpenWidget, setSettingsOpenWidget] = useState<string | null>(
     null
   );
+  const [showCoachMarks, setShowCoachMarks] = useState(true);
   const canvasRef = useRef<HTMLDivElement>(null);
   const hasLaidOut = useRef(false);
 
@@ -505,6 +574,11 @@ export function LivePreview() {
                 />
               </div>
             </div>
+
+            {/* Coach marks overlay */}
+            {showCoachMarks && (
+              <CoachMarks onDismiss={() => setShowCoachMarks(false)} />
+            )}
 
             {/* Widget canvas — absolute positioned like the real DashboardView */}
             <div

--- a/site/src/sections/LivePreview.tsx
+++ b/site/src/sections/LivePreview.tsx
@@ -3,12 +3,25 @@ import {
   useCallback,
   useEffect,
   useRef,
-  memo,
-  type ReactNode,
-  type CSSProperties,
+  useSyncExternalStore,
 } from 'react';
+
+const MOBILE_QUERY = '(max-width: 639px)';
+const mobileMedia =
+  typeof window !== 'undefined' ? window.matchMedia(MOBILE_QUERY) : null;
+
+function subscribeMobile(cb: () => void) {
+  mobileMedia?.addEventListener('change', cb);
+  return () => mobileMedia?.removeEventListener('change', cb);
+}
+function getSnapshotMobile() {
+  return mobileMedia?.matches ?? false;
+}
+
+function useIsMobile() {
+  return useSyncExternalStore(subscribeMobile, getSnapshotMobile);
+}
 import { LivePreviewProvider } from '../utils/mockSetup';
-import { useGeneralSettings } from '../../../src/frontend/context/DashboardContext/DashboardContext';
 import { WidgetErrorBoundary } from '../components/WidgetErrorBoundary';
 import { DashboardReady } from '../components/DashboardReady';
 import { Standings } from '../../../src/frontend/components/Standings/Standings';
@@ -27,28 +40,15 @@ import { RejoinIndicator } from '../../../src/frontend/components/RejoinIndicato
 import { PitlaneHelper } from '../../../src/frontend/components/PitlaneHelper/PitlaneHelper';
 import { LapTimeLog } from '../../../src/frontend/components/LapTimeLog/LapTimeLog';
 import { SlowCarAhead } from '../../../src/frontend/components/SlowCarAhead/SlowCarAhead';
-import {
-  useDragWidget,
-  useResizeWidget,
-  ResizeHandles,
-} from '../../../src/frontend/components/WidgetContainer';
-import {
-  ArrowsOutCardinal,
-  ArrowUp,
-  CursorClick,
-  GearSix,
-  X,
-} from '@phosphor-icons/react';
 import { PreviewSettingsButton } from '../components/PreviewSettingsPanel';
 import { defaultDashboard } from '../../../src/types/defaultDashboard';
-import { useDashboard } from '../../../src/frontend/context/DashboardContext/DashboardContext';
-
-interface WidgetPosition {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
+import { CoachMarks } from './CoachMarks';
+import {
+  PreviewWidgetItem,
+  WidgetFrame,
+  type WidgetPosition,
+} from './PreviewWidgetItem';
+import { ActiveWidgetSync } from './ActiveWidgetSync';
 
 /** Look up a widget's default layout size from the project's defaultDashboard. */
 function getDefaultSize(widgetId: string): { width: number; height: number } {
@@ -168,263 +168,8 @@ function buildDefaultPositions(
   return positions;
 }
 
-/**
- * Wraps a widget in the overlay-window theme container.
- * Reads theme settings from the dashboard's generalSettings via useGeneralSettings,
- * mirroring the real ThemeManager behaviour.
- */
-function WidgetFrame({ children }: { children: ReactNode }) {
-  const generalSettings = useGeneralSettings();
-  const fontSize = generalSettings?.fontSize ?? 'sm';
-  const colorPalette = generalSettings?.colorPalette ?? 'default';
-  const fontType = generalSettings?.fontType ?? 'lato';
-  const fontWeight = generalSettings?.fontWeight ?? 'normal';
-
-  return (
-    <div
-      className={[
-        'overlay-window',
-        `overlay-theme-${fontSize}`,
-        `overlay-theme-color-${colorPalette}`,
-        `overlay-theme-font-face-${fontType}`,
-        `overlay-theme-font-weight-${fontWeight}`,
-        'w-full h-full overflow-hidden',
-      ].join(' ')}
-    >
-      {children}
-    </div>
-  );
-}
-
-/**
- * A single draggable/resizable widget in the preview canvas.
- */
-const PreviewWidgetItem = memo(function PreviewWidgetItem({
-  widgetId,
-  label,
-  component: Component,
-  position,
-  isSelected,
-  onPositionChange,
-  onSelect,
-  onDeselect,
-  onDoubleClick,
-}: {
-  widgetId: string;
-  label: string;
-  component: React.ComponentType;
-  position: WidgetPosition;
-  isSelected: boolean;
-  onPositionChange: (id: string, pos: WidgetPosition) => void;
-  onSelect: (id: string) => void;
-  onDeselect: () => void;
-  onDoubleClick: (id: string) => void;
-}) {
-  const [localLayout, setLocalLayout] = useState(position);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined
-  );
-
-  useEffect(() => {
-    setLocalLayout(position);
-  }, [position]);
-
-  const handleLayoutChange = useCallback(
-    (newLayout: WidgetPosition) => {
-      setLocalLayout(newLayout);
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        onPositionChange(widgetId, newLayout);
-      }, 100);
-    },
-    [widgetId, onPositionChange]
-  );
-
-  const flushPendingSave = useCallback(() => {
-    if (debounceRef.current) {
-      clearTimeout(debounceRef.current);
-      debounceRef.current = undefined;
-    }
-    onPositionChange(widgetId, localLayout);
-  }, [widgetId, localLayout, onPositionChange]);
-
-  const { isDragging, dragHandleProps } = useDragWidget({
-    layout: localLayout,
-    onLayoutChange: handleLayoutChange,
-    enabled: true,
-  });
-
-  const { isResizing, getResizeHandleProps } = useResizeWidget({
-    layout: localLayout,
-    onLayoutChange: handleLayoutChange,
-    enabled: true,
-  });
-
-  const isInteracting = isDragging || isResizing;
-  const prevInteractingRef = useRef(isInteracting);
-
-  useEffect(() => {
-    const wasInteracting = prevInteractingRef.current;
-    prevInteractingRef.current = isInteracting;
-    if (wasInteracting && !isInteracting) {
-      flushPendingSave();
-    }
-  }, [isInteracting, flushPendingSave]);
-
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, []);
-
-  const containerStyle: CSSProperties = {
-    position: 'absolute',
-    left: localLayout.x,
-    top: localLayout.y,
-    width: localLayout.width,
-    height: localLayout.height,
-  };
-
-  return (
-    <div style={containerStyle} data-widget-id={widgetId}>
-      <div
-        {...dragHandleProps}
-        className="w-full h-full overflow-hidden text-white relative"
-        onClick={() => onSelect(widgetId)}
-        onDoubleClick={(e) => {
-          e.stopPropagation();
-          onDoubleClick(widgetId);
-        }}
-      >
-        {/* Selection border */}
-        {isSelected && (
-          <div className="absolute inset-0 border-dashed border-2 border-sky-500 pointer-events-none z-20 flex items-start justify-end p-2">
-            <div className="flex items-center gap-2 bg-sky-500 text-white text-sm font-semibold px-2 py-1 rounded pointer-events-auto">
-              <ArrowsOutCardinal size={14} />
-              <span>{label}</span>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDeselect();
-                }}
-                className="ml-1 hover:bg-sky-600 rounded p-0.5 transition-colors"
-                title="Close"
-              >
-                <X size={14} />
-              </button>
-            </div>
-          </div>
-        )}
-        {/* Widget content */}
-        <WidgetFrame>
-          <WidgetErrorBoundary widgetName={label}>
-            <Component />
-          </WidgetErrorBoundary>
-        </WidgetFrame>
-      </div>
-
-      <ResizeHandles getResizeHandleProps={getResizeHandleProps} />
-    </div>
-  );
-});
-
-/**
- * Syncs the toolbar's activeWidgets set into the dashboard context so the
- * settings panel's enabled toggle stays in sync with the Frame toolbar.
- */
-function ActiveWidgetSync({ activeWidgets }: { activeWidgets: Set<string> }) {
-  const { currentDashboard, onDashboardUpdated } = useDashboard();
-  const prevActiveRef = useRef<Set<string>>(activeWidgets);
-
-  useEffect(() => {
-    if (!currentDashboard || !onDashboardUpdated) return;
-    // Only sync when activeWidgets actually changed (skip initial render)
-    if (prevActiveRef.current === activeWidgets) return;
-    prevActiveRef.current = activeWidgets;
-
-    const needsUpdate = currentDashboard.widgets.some((w) => {
-      const id = w.type ?? w.id;
-      return w.enabled !== activeWidgets.has(id);
-    });
-
-    if (!needsUpdate) return;
-
-    const updatedWidgets = currentDashboard.widgets.map((w) => {
-      const id = w.type ?? w.id;
-      const shouldBeEnabled = activeWidgets.has(id);
-      if (w.enabled === shouldBeEnabled) return w;
-      return { ...w, enabled: shouldBeEnabled };
-    });
-
-    onDashboardUpdated({ ...currentDashboard, widgets: updatedWidgets });
-  }, [activeWidgets, currentDashboard, onDashboardUpdated]);
-
-  return null;
-}
-
-/**
- * First-visit coach marks overlay — three callouts pointing at the toolbar,
- * a widget, and the configure button. Dismissed on first click anywhere.
- */
-function CoachMarks({ onDismiss }: { onDismiss: () => void }) {
-  const [fading, setFading] = useState(false);
-
-  const dismiss = useCallback(() => {
-    setFading(true);
-    setTimeout(onDismiss, 300);
-  }, [onDismiss]);
-
-  useEffect(() => {
-    const handler = () => dismiss();
-    window.addEventListener('pointerdown', handler, { once: true });
-    return () => window.removeEventListener('pointerdown', handler);
-  }, [dismiss]);
-
-  return (
-    <div
-      className={[
-        'absolute inset-0 z-50 pointer-events-none transition-opacity duration-300',
-        fading ? 'opacity-0' : 'opacity-100',
-      ].join(' ')}
-    >
-      {/* Scrim */}
-      <div className="absolute inset-0 bg-black/30" />
-
-      {/* Callout: toolbar toggles — top-left, below toolbar */}
-      <div className="absolute top-14 left-16 flex flex-col items-start gap-2 animate-pulse">
-        <ArrowUp size={24} className="text-sky-400 ml-5" />
-        <div className="bg-sky-500 text-white text-sm font-semibold px-4 py-2 rounded-md shadow-lg flex items-center gap-2">
-          <CursorClick size={18} />
-          Click to enable / disable widgets
-        </div>
-      </div>
-
-      {/* Callout: configure button — top-right, below toolbar */}
-      <div className="absolute top-14 right-4 flex flex-col items-end gap-2 animate-pulse">
-        <ArrowUp size={24} className="text-sky-400 mr-5" />
-        <div className="bg-sky-500 text-white text-sm font-semibold px-4 py-2 rounded-md shadow-lg flex items-center gap-2">
-          <GearSix size={18} />
-          Customize widget settings
-        </div>
-      </div>
-
-      {/* Callout: widget interaction — center of canvas */}
-      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-2 animate-pulse">
-        <div className="bg-sky-500 text-white text-sm font-semibold px-4 py-2 rounded-md shadow-lg flex items-center gap-2">
-          <ArrowsOutCardinal size={18} />
-          Drag widgets to move, double-click for settings
-        </div>
-      </div>
-
-      {/* Dismiss hint */}
-      <div className="absolute top-1/2 left-1/2 -translate-x-1/2 translate-y-12 bg-black/50 text-white/80 text-sm uppercase tracking-widest font-semibold px-4 py-1.5 rounded-md">
-        Click anywhere to dismiss
-      </div>
-    </div>
-  );
-}
-
 export function LivePreview() {
+  const isMobile = useIsMobile();
   const [activeWidgets, setActiveWidgets] = useState<Set<string>>(
     () => new Set(AVAILABLE_WIDGETS.filter((w) => w.defaultOn).map((w) => w.id))
   );
@@ -459,6 +204,10 @@ export function LivePreview() {
 
   const toggleWidget = (id: string) => {
     setActiveWidgets((prev) => {
+      if (isMobile) {
+        // Radio behaviour: one widget at a time
+        return prev.has(id) ? new Set<string>() : new Set([id]);
+      }
       const next = new Set(prev);
       if (next.has(id)) {
         next.delete(id);
@@ -500,9 +249,9 @@ export function LivePreview() {
           See It In <span className="text-red-600">Action</span>
         </h2>
         <p className="text-sm text-slate-400 mt-1">
-          Toggle widgets in the toolbar to enable them. Click a widget to select
-          it, drag to reposition, resize from edges, or double-click for
-          settings.
+          {isMobile
+            ? 'Tap the toolbar to preview different widgets. Try the full interactive experience on desktop.'
+            : 'Toggle widgets in the toolbar to enable them. Click a widget to select it, drag to reposition, resize from edges, or double-click for settings.'}
         </p>
       </div>
 
@@ -531,17 +280,19 @@ export function LivePreview() {
         {/* Preview frame */}
         <div className="mx-auto w-full max-w-450 flex-1 flex flex-col min-h-0">
           <div className="relative rounded-sm border border-slate-700/50 overflow-hidden carbon-fiber flex-1 flex flex-col">
-            {/* Frame toolbar — traffic lights + controls integrated */}
+            {/* Frame toolbar */}
             <div className="flex-none flex items-center gap-3 px-4 py-2 bg-slate-900/80 border-b border-slate-700/50">
-              {/* Traffic lights */}
-              <div className="flex gap-1.5 flex-none">
-                <div className="w-2.5 h-2.5 rounded-full bg-red-500/60" />
-                <div className="w-2.5 h-2.5 rounded-full bg-yellow-500/60" />
-                <div className="w-2.5 h-2.5 rounded-full bg-green-500/60" />
-              </div>
-
-              {/* Divider */}
-              <div className="w-px h-4 bg-slate-700/60 flex-none" />
+              {/* Traffic lights — desktop only */}
+              {!isMobile && (
+                <>
+                  <div className="flex gap-1.5 flex-none">
+                    <div className="w-2.5 h-2.5 rounded-full bg-red-500/60" />
+                    <div className="w-2.5 h-2.5 rounded-full bg-yellow-500/60" />
+                    <div className="w-2.5 h-2.5 rounded-full bg-green-500/60" />
+                  </div>
+                  <div className="w-px h-4 bg-slate-700/60 flex-none" />
+                </>
+              )}
 
               {/* Widget toggles — scrollable */}
               <div className="flex items-center gap-2 flex-1 min-w-0 overflow-x-auto scrollbar-hide">
@@ -550,7 +301,10 @@ export function LivePreview() {
                     key={widget.id}
                     onClick={() => toggleWidget(widget.id)}
                     className={[
-                      'px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide rounded-sm transition-all border whitespace-nowrap flex-none',
+                      'font-bold uppercase tracking-wide rounded-sm transition-all border whitespace-nowrap flex-none',
+                      isMobile
+                        ? 'px-2.5 py-1 text-[11px]'
+                        : 'px-2 py-0.5 text-[10px]',
                       activeWidgets.has(widget.id)
                         ? 'border-red-600/50 bg-red-600/10 text-slate-200'
                         : 'border-slate-700/50 text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 hover:border-slate-600/50',
@@ -561,30 +315,32 @@ export function LivePreview() {
                 ))}
               </div>
 
-              {/* Divider */}
-              <div className="w-px h-4 bg-slate-700/60 flex-none" />
-
-              {/* Settings */}
-              <div className="flex-none">
-                <PreviewSettingsButton
-                  activeWidgets={activeWidgets}
-                  onToggleWidget={toggleWidget}
-                  openToWidget={settingsOpenWidget}
-                  onClose={() => setSettingsOpenWidget(null)}
-                />
-              </div>
+              {/* Settings — desktop only */}
+              {!isMobile && (
+                <>
+                  <div className="w-px h-4 bg-slate-700/60 flex-none" />
+                  <div className="flex-none">
+                    <PreviewSettingsButton
+                      activeWidgets={activeWidgets}
+                      onToggleWidget={toggleWidget}
+                      openToWidget={settingsOpenWidget}
+                      onClose={() => setSettingsOpenWidget(null)}
+                    />
+                  </div>
+                </>
+              )}
             </div>
 
-            {/* Coach marks overlay */}
-            {showCoachMarks && (
+            {/* Coach marks overlay — desktop only */}
+            {!isMobile && showCoachMarks && (
               <CoachMarks onDismiss={() => setShowCoachMarks(false)} />
             )}
 
-            {/* Widget canvas — absolute positioned like the real DashboardView */}
+            {/* Widget canvas */}
             <div
               ref={canvasRef}
               className="relative flex-1 overflow-hidden"
-              onClick={() => setSelectedWidget(null)}
+              onClick={isMobile ? undefined : () => setSelectedWidget(null)}
             >
               {/* Background video */}
               <video
@@ -596,27 +352,47 @@ export function LivePreview() {
               >
                 <source src="/preview-bg.mp4" type="video/mp4" />
               </video>
+
               <DashboardReady>
-                {AVAILABLE_WIDGETS.filter((w) => activeWidgets.has(w.id)).map(
-                  (widget) => {
-                    const pos = positions[widget.id];
-                    if (!pos) return null;
-                    return (
-                      <PreviewWidgetItem
-                        key={widget.id}
-                        widgetId={widget.id}
-                        label={widget.label}
-                        component={widget.component}
-                        position={pos}
-                        isSelected={selectedWidget === widget.id}
-                        onPositionChange={handlePositionChange}
-                        onSelect={handleSelect}
-                        onDeselect={handleDeselect}
-                        onDoubleClick={handleDoubleClick}
-                      />
-                    );
-                  }
-                )}
+                {isMobile
+                  ? // Mobile: single static widget, no interactions
+                    (() => {
+                      const active = AVAILABLE_WIDGETS.find((w) =>
+                        activeWidgets.has(w.id)
+                      );
+                      if (!active) return null;
+                      const Component = active.component;
+                      return (
+                        <div className="relative w-full h-full">
+                          <WidgetFrame>
+                            <WidgetErrorBoundary widgetName={active.label}>
+                              <Component />
+                            </WidgetErrorBoundary>
+                          </WidgetFrame>
+                        </div>
+                      );
+                    })()
+                  : // Desktop: draggable/resizable widgets
+                    AVAILABLE_WIDGETS.filter((w) =>
+                      activeWidgets.has(w.id)
+                    ).map((widget) => {
+                      const pos = positions[widget.id];
+                      if (!pos) return null;
+                      return (
+                        <PreviewWidgetItem
+                          key={widget.id}
+                          widgetId={widget.id}
+                          label={widget.label}
+                          component={widget.component}
+                          position={pos}
+                          isSelected={selectedWidget === widget.id}
+                          onPositionChange={handlePositionChange}
+                          onSelect={handleSelect}
+                          onDeselect={handleDeselect}
+                          onDoubleClick={handleDoubleClick}
+                        />
+                      );
+                    })}
               </DashboardReady>
             </div>
           </div>

--- a/site/src/sections/PreviewWidgetItem.tsx
+++ b/site/src/sections/PreviewWidgetItem.tsx
@@ -1,0 +1,184 @@
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  memo,
+  type ReactNode,
+  type CSSProperties,
+} from 'react';
+import { ArrowsOutCardinal, X } from '@phosphor-icons/react';
+import { useGeneralSettings } from '../../../src/frontend/context/DashboardContext/DashboardContext';
+import { WidgetErrorBoundary } from '../components/WidgetErrorBoundary';
+import {
+  useDragWidget,
+  useResizeWidget,
+  ResizeHandles,
+} from '../../../src/frontend/components/WidgetContainer';
+
+export interface WidgetPosition {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * Wraps a widget in the overlay-window theme container.
+ * Reads theme settings from the dashboard's generalSettings via useGeneralSettings,
+ * mirroring the real ThemeManager behaviour.
+ */
+export function WidgetFrame({ children }: { children: ReactNode }) {
+  const generalSettings = useGeneralSettings();
+  const fontSize = generalSettings?.fontSize ?? 'sm';
+  const colorPalette = generalSettings?.colorPalette ?? 'default';
+  const fontType = generalSettings?.fontType ?? 'lato';
+  const fontWeight = generalSettings?.fontWeight ?? 'normal';
+
+  return (
+    <div
+      className={[
+        'overlay-window',
+        `overlay-theme-${fontSize}`,
+        `overlay-theme-color-${colorPalette}`,
+        `overlay-theme-font-face-${fontType}`,
+        `overlay-theme-font-weight-${fontWeight}`,
+        'w-full h-full overflow-hidden',
+      ].join(' ')}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * A single draggable/resizable widget in the preview canvas.
+ */
+export const PreviewWidgetItem = memo(function PreviewWidgetItem({
+  widgetId,
+  label,
+  component: Component,
+  position,
+  isSelected,
+  onPositionChange,
+  onSelect,
+  onDeselect,
+  onDoubleClick,
+}: {
+  widgetId: string;
+  label: string;
+  component: React.ComponentType;
+  position: WidgetPosition;
+  isSelected: boolean;
+  onPositionChange: (id: string, pos: WidgetPosition) => void;
+  onSelect: (id: string) => void;
+  onDeselect: () => void;
+  onDoubleClick: (id: string) => void;
+}) {
+  const [localLayout, setLocalLayout] = useState(position);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+
+  useEffect(() => {
+    setLocalLayout(position);
+  }, [position]);
+
+  const handleLayoutChange = useCallback(
+    (newLayout: WidgetPosition) => {
+      setLocalLayout(newLayout);
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onPositionChange(widgetId, newLayout);
+      }, 100);
+    },
+    [widgetId, onPositionChange]
+  );
+
+  const flushPendingSave = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = undefined;
+    }
+    onPositionChange(widgetId, localLayout);
+  }, [widgetId, localLayout, onPositionChange]);
+
+  const { isDragging, dragHandleProps } = useDragWidget({
+    layout: localLayout,
+    onLayoutChange: handleLayoutChange,
+    enabled: true,
+  });
+
+  const { isResizing, getResizeHandleProps } = useResizeWidget({
+    layout: localLayout,
+    onLayoutChange: handleLayoutChange,
+    enabled: true,
+  });
+
+  const isInteracting = isDragging || isResizing;
+  const prevInteractingRef = useRef(isInteracting);
+
+  useEffect(() => {
+    const wasInteracting = prevInteractingRef.current;
+    prevInteractingRef.current = isInteracting;
+    if (wasInteracting && !isInteracting) {
+      flushPendingSave();
+    }
+  }, [isInteracting, flushPendingSave]);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const containerStyle: CSSProperties = {
+    position: 'absolute',
+    left: localLayout.x,
+    top: localLayout.y,
+    width: localLayout.width,
+    height: localLayout.height,
+  };
+
+  return (
+    <div style={containerStyle} data-widget-id={widgetId}>
+      <div
+        {...dragHandleProps}
+        className="w-full h-full overflow-hidden text-white relative"
+        onClick={() => onSelect(widgetId)}
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          onDoubleClick(widgetId);
+        }}
+      >
+        {/* Selection border */}
+        {isSelected && (
+          <div className="absolute inset-0 border-dashed border-2 border-sky-500 pointer-events-none z-20 flex items-start justify-end p-2">
+            <div className="flex items-center gap-2 bg-sky-500 text-white text-sm font-semibold px-2 py-1 rounded pointer-events-auto">
+              <ArrowsOutCardinal size={14} />
+              <span>{label}</span>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDeselect();
+                }}
+                className="ml-1 hover:bg-sky-600 rounded p-0.5 transition-colors"
+                title="Close"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          </div>
+        )}
+        {/* Widget content */}
+        <WidgetFrame>
+          <WidgetErrorBoundary widgetName={label}>
+            <Component />
+          </WidgetErrorBoundary>
+        </WidgetFrame>
+      </div>
+
+      <ResizeHandles getResizeHandleProps={getResizeHandleProps} />
+    </div>
+  );
+});

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -737,7 +737,7 @@ export const defaultDashboard: {
         x: 1102,
         y: 240,
         width: 300,
-        height: 420,
+        height: 520,
       },
       config: {
         showOnlyWhenOnTrack: true,


### PR DESCRIPTION
## Summary
- Improve contrast and readability across the marketing site
- Add coach marks to guide users through the live preview widget interaction
- Refactor LivePreview into smaller components (ActiveWidgetSync, PreviewWidgetItem, CoachMarks)
- Update README with new title, website link, and streamlined intro

## Test plan
- [ ] Verify site renders correctly with improved contrast
- [ ] Test coach marks appear and guide the user through the preview
- [ ] Check README renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)