### PR TITLE
feat: add speed unit selection to Pitlane Helper

### DIFF
--- a/src/frontend/components/PitlaneHelper/PitlaneHelper.spec.tsx
+++ b/src/frontend/components/PitlaneHelper/PitlaneHelper.spec.tsx
@@ -364,7 +364,11 @@ describe('PitlaneHelper', () => {
   });
 
   describe('Speed Display', () => {
-    it('displays speed delta in km/h when limitKph > limitMph', () => {
+    it('displays speed delta in km/h when speedUnit is km/h', () => {
+      vi.mocked(usePitlaneHelperSettings).mockReturnValue({
+        ...defaultConfig,
+        speedUnit: 'km/h',
+      });
       vi.mocked(usePitSpeed).mockReturnValue({
         limitKph: 72,
         limitMph: 45,
@@ -386,7 +390,11 @@ describe('PitlaneHelper', () => {
       expect(getByText('72')).toBeInTheDocument();
     });
 
-    it('displays speed delta in mph when limitMph > limitKph', () => {
+    it('displays speed delta in mph when speedUnit is mph', () => {
+      vi.mocked(usePitlaneHelperSettings).mockReturnValue({
+        ...defaultConfig,
+        speedUnit: 'mph',
+      });
       vi.mocked(usePitSpeed).mockReturnValue({
         limitKph: 45,
         limitMph: 72,
@@ -406,6 +414,62 @@ describe('PitlaneHelper', () => {
       expect(getByText('-5.0')).toBeInTheDocument();
       expect(getByText('mph')).toBeInTheDocument();
       expect(getByText('72')).toBeInTheDocument();
+    });
+
+    it('displays speed delta in km/h when speedUnit is auto and DisplayUnits is metric', () => {
+      vi.mocked(usePitlaneHelperSettings).mockReturnValue({
+        ...defaultConfig,
+        speedUnit: 'auto',
+      });
+      vi.mocked(context.useTelemetryValue).mockImplementation((key) => {
+        if (key === 'DisplayUnits') return 1; // metric
+        return undefined;
+      });
+      vi.mocked(usePitSpeed).mockReturnValue({
+        limitKph: 72,
+        limitMph: 45,
+        speedKph: 67,
+        speedMph: 41.6,
+        deltaKph: -5.0,
+        deltaMph: -3.1,
+        colorClass: 'text-green-500',
+        isPulsing: false,
+        isSpeeding: false,
+        isSeverelyOver: false,
+      });
+
+      const { getByText } = render(<PitlaneHelper />);
+
+      expect(getByText('-5.0')).toBeInTheDocument();
+      expect(getByText('km/h')).toBeInTheDocument();
+    });
+
+    it('displays speed delta in mph when speedUnit is auto and DisplayUnits is imperial', () => {
+      vi.mocked(usePitlaneHelperSettings).mockReturnValue({
+        ...defaultConfig,
+        speedUnit: 'auto',
+      });
+      vi.mocked(context.useTelemetryValue).mockImplementation((key) => {
+        if (key === 'DisplayUnits') return 0; // imperial
+        return undefined;
+      });
+      vi.mocked(usePitSpeed).mockReturnValue({
+        limitKph: 72,
+        limitMph: 45,
+        speedKph: 67,
+        speedMph: 41.6,
+        deltaKph: -5.0,
+        deltaMph: -3.1,
+        colorClass: 'text-green-500',
+        isPulsing: false,
+        isSpeeding: false,
+        isSeverelyOver: false,
+      });
+
+      const { getByText } = render(<PitlaneHelper />);
+
+      expect(getByText('-3.1')).toBeInTheDocument();
+      expect(getByText('mph')).toBeInTheDocument();
     });
 
     it('shows green color when under speed limit', () => {

--- a/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
+++ b/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
@@ -305,8 +305,8 @@ export const PitlaneHelperBody = ({
                 }`}
               >
                 <PitSpeedBar
-                  speedKph={speed.speedKph}
-                  limitKph={speed.limitKph}
+                  speedKph={displayKph ? speed.speedKph : speed.speedMph}
+                  limitKph={displayKph ? speed.limitKph : speed.limitMph}
                   orientation={config.speedBarOrientation}
                 />
               </div>

--- a/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
+++ b/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
@@ -305,8 +305,8 @@ export const PitlaneHelperBody = ({
                 }`}
               >
                 <PitSpeedBar
-                  speedKph={displayKph ? speed.speedKph : speed.speedMph}
-                  limitKph={displayKph ? speed.limitKph : speed.limitMph}
+                  speed={displayKph ? speed.speedKph : speed.speedMph}
+                  limit={displayKph ? speed.limitKph : speed.limitMph}
                   orientation={config.speedBarOrientation}
                 />
               </div>

--- a/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
+++ b/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
@@ -37,6 +37,7 @@ export const PitlaneHelper = () => {
 
   const surface = (useTelemetryValue('PlayerTrackSurface') ?? 3) as number;
   const onPitRoadTelemetry = useTelemetryValue<boolean>('OnPitRoad') ?? false;
+  const displayUnits = useTelemetryValue('DisplayUnits') as number | undefined;
 
   // Core data hooks - must be called in same order every render
   const speed = usePitSpeed();
@@ -59,8 +60,10 @@ export const PitlaneHelper = () => {
     return null;
   }
 
-  // Determine which speed unit to display (prefer user's unit from limit)
-  const displayKph = speed.limitKph > speed.limitMph;
+  // Determine which speed unit to display based on user setting
+  const speedUnit = config?.speedUnit ?? 'auto';
+  const displayKph =
+    speedUnit === 'km/h' || (speedUnit === 'auto' && (displayUnits ?? 0) === 1);
 
   // Determine if we're on pit road
   // Surface=2 means in pit blend zone (before pit entry line)
@@ -126,8 +129,10 @@ const PitlaneHelperDisplay = ({
     return null;
   }
 
-  // Determine which speed unit to display (prefer user's unit from limit)
-  const displayKph = speed.limitKph > speed.limitMph;
+  // Determine which speed unit to display based on user setting
+  // Demo mode doesn't have telemetry, so 'auto' falls back to km/h (iRacing default)
+  const speedUnit = config?.speedUnit ?? 'auto';
+  const displayKph = speedUnit !== 'mph';
 
   // Early pitbox warning: show when on pit road AND pitbox is within threshold of pit entry
   const onPitRoad = surface === 2;

--- a/src/frontend/components/PitlaneHelper/components/PitSpeedBar.tsx
+++ b/src/frontend/components/PitlaneHelper/components/PitSpeedBar.tsx
@@ -1,10 +1,10 @@
 import { memo } from 'react';
 
 export interface PitSpeedBarProps {
-  /** Current speed in km/h */
-  speedKph: number;
-  /** Pit speed limit in km/h */
-  limitKph: number;
+  /** Current speed in display units */
+  speed: number;
+  /** Pit speed limit in display units */
+  limit: number;
   /** orientation */
   orientation: 'horizontal' | 'vertical' | undefined;
 }
@@ -14,23 +14,23 @@ export interface PitSpeedBarProps {
  * The limit is marked at the midpoint of the bar. The fill grows upward
  * from zero and changes colour based on proximity to the limit.
  *
- * - Green:  more than 5 km/h below limit
- * - Amber:  within 5 km/h below limit
+ * - Green:  more than 5 units below limit
+ * - Amber:  within 5 units below limit
  * - Red:    at or above limit
  */
 export const PitSpeedBar = memo(
-  ({ speedKph, limitKph, orientation }: PitSpeedBarProps) => {
+  ({ speed, limit, orientation }: PitSpeedBarProps) => {
     // The bar represents 0 → 2× the limit. The midpoint (50%) = limit.
-    const maxSpeed = limitKph * 2;
-    const clampedSpeed = Math.max(0, Math.min(speedKph, maxSpeed));
+    const maxSpeed = limit * 2;
+    const clampedSpeed = Math.max(0, Math.min(speed, maxSpeed));
     const fillPercent = (clampedSpeed / maxSpeed) * 100;
 
-    const deltaKph = speedKph - limitKph;
+    const delta = speed - limit;
 
     let fillColor = 'rgb(34, 197, 94)'; // green-500
-    if (deltaKph >= 0) {
+    if (delta >= 0) {
       fillColor = 'rgb(239, 68, 68)'; // red-500
-    } else if (deltaKph > -5) {
+    } else if (delta > -5) {
       fillColor = 'rgb(234, 179, 8)'; // yellow-500
     }
 
@@ -38,7 +38,7 @@ export const PitSpeedBar = memo(
       return (
         <div className="h-full flex flex-col flex-1 relative items-center gap-1">
           <span className="text-sm text-white font-medium tabular-nums leading-none">
-            {speedKph.toFixed(1)}
+            {speed.toFixed(1)}
           </span>
 
           {/* Bar */}
@@ -67,7 +67,7 @@ export const PitSpeedBar = memo(
         <div className="flex justify-between items-center text-xs">
           <span className="text-slate-400">Speed</span>
           <span className="text-white font-medium tabular-nums">
-            {speedKph.toFixed(1)}
+            {speed.toFixed(1)}
           </span>
         </div>
         {/* Horizontal bar */}
@@ -79,7 +79,6 @@ export const PitSpeedBar = memo(
           {/* Midpoint marker */}
           <div className="absolute left-1/2 top-0 h-full border-l-2 border-white/70" />
         </div>
-        
       </div>
     );
   }

--- a/src/frontend/components/Settings/sections/PitlaneHelperSettings.tsx
+++ b/src/frontend/components/Settings/sections/PitlaneHelperSettings.tsx
@@ -140,6 +140,17 @@ export const PitlaneHelperSettings = () => {
                           handleConfigChange({ speedLimitStyle: v })
                         }
                       />
+
+                      <SettingButtonGroupRow<'mph' | 'km/h' | 'auto'>
+                        title="Speed Unit"
+                        value={settings.config.speedUnit ?? 'auto'}
+                        options={[
+                          { label: 'Auto', value: 'auto' },
+                          { label: 'MPH', value: 'mph' },
+                          { label: 'KM/H', value: 'km/h' },
+                        ]}
+                        onChange={(v) => handleConfigChange({ speedUnit: v })}
+                      />
                     </SettingsSection>
                   )}
 

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1016,6 +1016,7 @@ export const defaultDashboard: {
         showPastPitBox: false,
         showSpeedSummary: true,
         showSpeedDelta: true,
+        speedUnit: 'auto',
         speedLimitStyle: 'text',
         progressBarOrientation: 'horizontal',
         speedBarOrientation: 'horizontal',

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -459,6 +459,7 @@ export interface PitlaneHelperConfig {
   showSpeedBar?: boolean;
   showSpeedSummary: boolean;
   showSpeedDelta: boolean;
+  speedUnit?: 'mph' | 'km/h' | 'auto';
   speedLimitStyle?: 'none' | 'text' | 'european' | 'american';
   showPitExitInputs?: boolean;
   pitExitInputs?: { throttle: boolean; clutch: boolean };


### PR DESCRIPTION
## Description

Adds a speed unit setting to the Pitlane Helper widget, allowing users to choose between MPH, KM/H, or Auto (syncs with the iRacing display units setting).

Previously the widget used a heuristic — whichever of `limitKph` or `limitMph` was the larger number determined the unit. This was unreliable. Now the unit is explicitly config-driven.

Changes:
- `PitlaneHelperConfig` — added `speedUnit?: 'mph' | 'km/h' | 'auto'`
- `PitlaneHelper.tsx` — reads `DisplayUnits` telemetry for Auto mode; applies the correct unit to both the speed delta display and the `PitSpeedBar`
- `PitlaneHelperSettings.tsx` — adds a "Speed Unit" button group (Auto / MPH / KM/H) under the Speed Summary section
- `defaultDashboard.ts` — adds `speedUnit: 'auto'` to the pitlane helper default config
- Tests updated and expanded to cover all three unit modes

## Screenshots

### Before
Speed unit was determined automatically by comparing the kph and mph limit values.

### After
User can explicitly select MPH, KM/H, or Auto (follows iRacing unit preference) in settings.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)