### PR TITLE
fix: driver tag Add New when groups are filtered

### DIFF
--- a/src/frontend/components/Settings/sections/DriverTagsSettings.tsx
+++ b/src/frontend/components/Settings/sections/DriverTagsSettings.tsx
@@ -13,6 +13,7 @@ import {
 import { PRESET_DRIVER_TAGS } from '../../../constants/driverTagBadges';
 import { renderDriverIcon } from '@irdashies/utils/driverIcons';
 import { IconPicker } from '../IconPicker';
+import { GroupSelect } from './GroupSelect';
 import { useDriverTagGlobalSettings } from './useDriverTagGlobalSettings';
 
 type IconMode = 'name' | 'image';
@@ -136,11 +137,12 @@ export const DriverTagsSettings = () => {
     const key = `new-${Date.now()}`;
     const firstGroup =
       PRESET_DRIVER_TAGS[0]?.id ?? settings.groups[0]?.id ?? '';
+    const defaultGroup = activeGroupFilter ?? firstGroup;
     setEntryDrafts((prev) => [
       ...prev,
-      { uiKey: key, id: '', name: '', label: '', groupId: firstGroup },
+      { uiKey: key, id: '', name: '', label: '', groupId: defaultGroup },
     ]);
-  }, [settings.groups]);
+  }, [settings.groups, activeGroupFilter]);
 
   const updateEntryDraft = useCallback(
     (key: string, field: 'id' | 'name' | 'label', value: string) => {
@@ -1031,22 +1033,13 @@ export const DriverTagsSettings = () => {
                   placeholder="Badge label"
                   className="px-2 py-1 bg-slate-700 rounded w-full"
                 />
-                <select
+                <GroupSelect
                   value={row.groupId}
-                  onChange={(e) => updateEntryGroup(row.uiKey, e.target.value)}
-                  className="px-2 py-1 bg-slate-700 rounded w-full"
-                >
-                  {PRESET_DRIVER_TAGS.map((g) => (
-                    <option key={g.id} value={g.id}>
-                      {g.name}
-                    </option>
-                  ))}
-                  {(settings.groups ?? []).map((g) => (
-                    <option key={g.id} value={g.id}>
-                      {g.name}
-                    </option>
-                  ))}
-                </select>
+                  onChange={(value) => updateEntryGroup(row.uiKey, value)}
+                  groups={allGroups}
+                  displayStyle={settings.display?.displayStyle}
+                  iconWeight={settings.display?.iconWeight}
+                />
                 <button
                   onClick={() => removeEntry(row.uiKey)}
                   className="w-full px-2 py-1 bg-red-600 rounded"

--- a/src/frontend/components/Settings/sections/GroupSelect.tsx
+++ b/src/frontend/components/Settings/sections/GroupSelect.tsx
@@ -1,0 +1,188 @@
+import { useState, useRef, useEffect } from 'react';
+import type { TagGroup } from '@irdashies/types';
+import { renderDriverIcon } from '@irdashies/utils/driverIcons';
+import { CaretDownIcon } from '@phosphor-icons/react';
+
+interface GroupSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  groups: (
+    | TagGroup
+    | { id: string; name: string; icon: unknown; color: number }
+  )[];
+  displayStyle?: 'tag' | 'badge';
+  iconWeight?: 'fill' | 'regular';
+}
+
+const renderIcon = (
+  icon: unknown,
+  size: number,
+  className?: string,
+  colorNum?: number,
+  style?: React.CSSProperties,
+  fallbackStyle?: React.CSSProperties,
+  weight?: string
+) =>
+  renderDriverIcon(
+    icon,
+    size,
+    className,
+    colorNum,
+    style,
+    fallbackStyle,
+    weight
+  );
+
+export const GroupSelect = ({
+  value,
+  onChange,
+  groups,
+  displayStyle = 'badge',
+  iconWeight,
+}: GroupSelectProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedGroup = groups.find((g) => g.id === value);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () =>
+        document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen]);
+
+  return (
+    <div className="relative w-full" ref={containerRef}>
+      <button
+        onClick={() => setIsOpen((v) => !v)}
+        className="px-2 py-1 bg-slate-700 rounded w-full text-left flex items-center justify-between gap-2 hover:bg-slate-600 transition-colors"
+      >
+        <div className="flex items-center gap-2 min-w-0 flex-1">
+          {selectedGroup && (
+            <>
+              {displayStyle === 'tag' ? (
+                <span
+                  style={{
+                    display: 'inline-block',
+                    width: 12,
+                    height: 12,
+                    borderRadius: 3,
+                    background: selectedGroup.color
+                      ? `#${(selectedGroup.color & 0xffffff).toString(16).padStart(6, '0')}`
+                      : '#888',
+                    flexShrink: 0,
+                  }}
+                />
+              ) : (
+                <span
+                  className="inline-flex items-center leading-none flex-shrink-0"
+                  aria-hidden="true"
+                >
+                  {selectedGroup.icon &&
+                  typeof selectedGroup.icon === 'string' &&
+                  selectedGroup.icon.startsWith('data:') ? (
+                    <div style={{ width: 16, height: 16 }}>
+                      <img
+                        src={selectedGroup.icon}
+                        alt={selectedGroup.name}
+                        className="object-contain"
+                      />
+                    </div>
+                  ) : (
+                    renderIcon(
+                      selectedGroup.icon,
+                      14,
+                      undefined,
+                      selectedGroup.color,
+                      undefined,
+                      undefined,
+                      iconWeight
+                    )
+                  )}
+                </span>
+              )}
+              <span className="truncate text-sm">{selectedGroup.name}</span>
+            </>
+          )}
+        </div>
+        <CaretDownIcon
+          size={16}
+          weight="bold"
+          className={`flex-shrink-0 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full left-0 right-0 mt-1 bg-slate-700 rounded border border-slate-600 shadow-lg z-10 max-h-60 overflow-y-auto">
+          {groups.map((g) => (
+            <button
+              key={g.id}
+              onClick={() => {
+                onChange(g.id);
+                setIsOpen(false);
+              }}
+              className={`w-full px-2 py-2 flex items-center gap-2 text-left text-sm transition-colors ${
+                g.id === value
+                  ? 'bg-sky-600 text-white'
+                  : 'text-slate-200 hover:bg-slate-600'
+              }`}
+            >
+              {displayStyle === 'tag' ? (
+                <span
+                  style={{
+                    display: 'inline-block',
+                    width: 12,
+                    height: 12,
+                    borderRadius: 3,
+                    background: g.color
+                      ? `#${(g.color & 0xffffff).toString(16).padStart(6, '0')}`
+                      : '#888',
+                    flexShrink: 0,
+                  }}
+                />
+              ) : (
+                <span className="inline-flex items-center leading-none flex-shrink-0">
+                  {g.icon &&
+                  typeof g.icon === 'string' &&
+                  g.icon.startsWith('data:') ? (
+                    <div style={{ width: 16, height: 16 }}>
+                      <img
+                        src={g.icon}
+                        alt={g.name}
+                        className="object-contain"
+                      />
+                    </div>
+                  ) : (
+                    renderIcon(
+                      g.icon,
+                      14,
+                      undefined,
+                      g.color,
+                      undefined,
+                      undefined,
+                      iconWeight
+                    )
+                  )}
+                </span>
+              )}
+              <span className="truncate">{g.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+GroupSelect.displayName = 'GroupSelect';


### PR DESCRIPTION
# PR: Fix driver tag "Add New" when groups are filtered

## Description

Fixes the issue where clicking "Add New" in the Driver Tags settings ignored the active group filter and always defaulted to the first preset group. Now, when a group filter is applied, new driver tags are assigned to the filtered group by default.

Additionally, replaced the basic HTML `<select>` dropdown with a custom `GroupSelect` component that displays group icons and colors inline, providing better visual context when assigning tags to groups.

### How Tested

- [x] Tested in Driver Tags settings with group filters applied
- [x] Verified "Add New" defaults to filtered group when a filter is active
- [x] Verified "Add New" defaults to first group when no filter is active
- [x] Tested group selection dropdown displays icons and colors correctly

## Screenshots

### Before
Basic HTML `<select>` dropdown with group names only, "Add New" always uses first group regardless of filter.

### After
Custom `GroupSelect` dropdown showing group icons/colors with inline preview, "Add New" respects active group filter.

<img width="717" height="746" alt="Screenshot 2026-04-16 123359" src="https://github.com/user-attachments/assets/d736ae2b-a936-45dd-b741-5f8efc0bbdd8" />

<img width="208" height="335" alt="Screenshot 2026-04-16 122518" src="https://github.com/user-attachments/assets/ad60853a-c0f5-4665-a317-afa80e3e144a" />

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)

## Checklist

- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code

## Files Changed

### Modified
- `src/frontend/components/Settings/sections/DriverTagsSettings.tsx`
  - Added `activeGroupFilter` to `handleAddNew` dependency array
  - Use `activeGroupFilter` as default group when creating new entry
  - Replaced HTML `<select>` with custom `GroupSelect` component

### Created
- `src/frontend/components/Settings/sections/GroupSelect.tsx`
  - New custom dropdown component with group icon/color preview
  - Handles both 'tag' and 'badge' display styles
  - Click-outside detection to close dropdown
