### PR TITLE
feat: enhanced incident display

### DIFF
--- a/src/app/irsdk/types/weekend-info.ts
+++ b/src/app/irsdk/types/weekend-info.ts
@@ -27,6 +27,8 @@ export interface WeekendOptions {
   HardcoreLevel: number;
   NumJokerLaps: number;
   IncidentLimit: string;
+  IncidentWarningInitialLimit: number;
+  IncidentWarningSubsequentLimit: number;
   FastRepairsLimit: number;
   GreenWhiteCheckeredLimit: number;
 }

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.stories.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.stories.tsx
@@ -100,16 +100,63 @@ const IncidentDisplay = ({
   );
 };
 
-export const Incidents: StoryObj<IncidentDisplayProps> = {
-  args: {
-    incidents: 4,
-    incidentLimit: 17,
-    incidentWarningInitialLimit: null,
-    incidentWarningSubsequentLimit: null,
+interface IncidentsArgs {
+  incidents: string;
+  incidentLimit: string;
+  incidentWarningInitialLimit: string;
+  incidentWarningSubsequentLimit: string;
+}
+
+const incidentsMeta: Meta<IncidentsArgs> = {
+  title: 'widgets/Standings/components/SessionBar/Incidents',
+  argTypes: {
+    incidents: {
+      control: { type: 'text' },
+      description: 'Current incident count (empty = null)',
+    },
+    incidentLimit: {
+      control: { type: 'text' },
+      description: 'Total DQ limit (empty = null)',
+    },
+    incidentWarningInitialLimit: {
+      control: { type: 'text' },
+      description: 'Initial penalty threshold (empty = null)',
+    },
+    incidentWarningSubsequentLimit: {
+      control: { type: 'text' },
+      description: 'Subsequent penalty interval (empty = null)',
+    },
   },
-  render: (args) => (
-    <div className="bg-slate-900/70 px-3 py-2 flex items-center text-sm justify-start">
-      <IncidentDisplay {...args} />
-    </div>
-  ),
+};
+
+export const Incidents: StoryObj<IncidentsArgs> = {
+  ...incidentsMeta,
+  args: {
+    incidents: '4',
+    incidentLimit: '17',
+    incidentWarningInitialLimit: '',
+    incidentWarningSubsequentLimit: '',
+  },
+  render: (args: IncidentsArgs) => {
+    const parseValue = (val: string | number | null): number | null => {
+      if (val === '' || val === null || val === undefined) return null;
+      const num = Number(val);
+      return isNaN(num) ? null : num;
+    };
+
+    return (
+      <div className="bg-slate-900/70 px-3 py-2 flex items-center text-sm justify-start">
+        <IncidentDisplay
+          incidents={parseValue(args.incidents) ?? 0}
+          incidentLimit={parseValue(args.incidentLimit)}
+          incidentWarningInitialLimit={parseValue(
+            args.incidentWarningInitialLimit
+          )}
+          incidentWarningSubsequentLimit={parseValue(
+            args.incidentWarningSubsequentLimit
+          )}
+        />
+      </div>
+    );
+  },
 };

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.stories.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.stories.tsx
@@ -33,3 +33,83 @@ export const Standalone: Story = {
     standalone: true,
   },
 };
+
+interface IncidentDisplayProps {
+  incidents: number;
+  incidentLimit: number | null;
+  incidentWarningInitialLimit: number | null;
+  incidentWarningSubsequentLimit: number | null;
+}
+
+const IncidentDisplay = ({
+  incidents,
+  incidentLimit,
+  incidentWarningInitialLimit,
+  incidentWarningSubsequentLimit,
+}: IncidentDisplayProps) => {
+  const getIncidentDisplay = (
+    incidents: number,
+    initial: number | string | undefined | null,
+    subsequent: number | string | undefined | null,
+    limit: number | string | undefined | null
+  ): string => {
+    if (limit === 'unlimited' || !limit) {
+      return `${incidents} / ∞ x`;
+    }
+    if (
+      initial &&
+      initial !== 'unlimited' &&
+      (initial as number) >= (limit as number)
+    ) {
+      initial = undefined;
+    }
+    if (!initial || initial === 'unlimited') {
+      return `${incidents} / ${limit} x`;
+    }
+    if (!subsequent || subsequent === 'unlimited') {
+      if (incidents < (initial as number)) {
+        return `${incidents} / ${initial} / ${limit} x`;
+      } else {
+        return `${incidents} / ${limit} x`;
+      }
+    }
+    if (incidents < (initial as number)) {
+      return `${incidents} / ${initial} / ${limit} x`;
+    }
+    const initialNum = initial as number;
+    const subsequentNum = subsequent as number;
+    const roundsCompleted = Math.floor(
+      (incidents - initialNum) / subsequentNum
+    );
+    const nextPenalty = initialNum + (roundsCompleted + 1) * subsequentNum;
+    if (nextPenalty >= (limit as number)) {
+      return `${incidents} / ${limit} x`;
+    }
+    return `${incidents} / ${nextPenalty} / ${limit} x`;
+  };
+
+  return (
+    <div className="flex justify-end tabular-nums text-lg font-mono">
+      {getIncidentDisplay(
+        incidents,
+        incidentWarningInitialLimit,
+        incidentWarningSubsequentLimit,
+        incidentLimit
+      )}
+    </div>
+  );
+};
+
+export const Incidents: StoryObj<IncidentDisplayProps> = {
+  args: {
+    incidents: 4,
+    incidentLimit: 17,
+    incidentWarningInitialLimit: null,
+    incidentWarningSubsequentLimit: null,
+  },
+  render: (args) => (
+    <div className="bg-slate-900/70 px-3 py-2 flex items-center text-sm justify-start">
+      <IncidentDisplay {...args} />
+    </div>
+  ),
+};

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.stories.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { SessionBar } from './SessionBar';
+import { getIncidentDisplay } from './getIncidentDisplay';
 import { TelemetryDecorator } from '../../../../../../.storybook/telemetryDecorator';
 import { getWidgetDefaultConfig } from '@irdashies/types';
 
@@ -47,47 +48,6 @@ const IncidentDisplay = ({
   incidentWarningInitialLimit,
   incidentWarningSubsequentLimit,
 }: IncidentDisplayProps) => {
-  const getIncidentDisplay = (
-    incidents: number,
-    initial: number | string | undefined | null,
-    subsequent: number | string | undefined | null,
-    limit: number | string | undefined | null
-  ): string => {
-    if (limit === 'unlimited' || !limit) {
-      return `${incidents} / ∞ x`;
-    }
-    if (
-      initial &&
-      initial !== 'unlimited' &&
-      (initial as number) >= (limit as number)
-    ) {
-      initial = undefined;
-    }
-    if (!initial || initial === 'unlimited') {
-      return `${incidents} / ${limit} x`;
-    }
-    if (!subsequent || subsequent === 'unlimited') {
-      if (incidents < (initial as number)) {
-        return `${incidents} / ${initial} / ${limit} x`;
-      } else {
-        return `${incidents} / ${limit} x`;
-      }
-    }
-    if (incidents < (initial as number)) {
-      return `${incidents} / ${initial} / ${limit} x`;
-    }
-    const initialNum = initial as number;
-    const subsequentNum = subsequent as number;
-    const roundsCompleted = Math.floor(
-      (incidents - initialNum) / subsequentNum
-    );
-    const nextPenalty = initialNum + (roundsCompleted + 1) * subsequentNum;
-    if (nextPenalty >= (limit as number)) {
-      return `${incidents} / ${limit} x`;
-    }
-    return `${incidents} / ${nextPenalty} / ${limit} x`;
-  };
-
   return (
     <div className="flex justify-end tabular-nums text-lg font-mono">
       {getIncidentDisplay(

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -120,7 +120,12 @@ export const SessionBar = ({
 
   const session = useCurrentSessionType();
   const displayUnits = useTelemetryValue('DisplayUnits'); // 0 = imperial, 1 = metric
-  const { incidentLimit, incidents } = useDriverIncidents();
+  const {
+    incidentLimit,
+    incidents,
+    incidentWarningInitialLimit,
+    incidentWarningSubsequentLimit,
+  } = useDriverIncidents();
   const {
     currentLap,
     time,
@@ -144,6 +149,63 @@ export const SessionBar = ({
   const { totalRaceLaps, isFixedLapRace } = useTotalRaceLaps();
   const { totalRaceTime, adjustedRaceTime } = useTotalRaceTime();
   const trackDisplayName = useTrackDisplayName();
+
+  // Helper to format incident display with penalties
+  const getIncidentDisplay = (
+    incidents: number,
+    initial: number | string | undefined,
+    subsequent: number | string | undefined,
+    limit: number | string | undefined
+  ): string => {
+    // If limit is unlimited, show infinity
+    if (limit === 'unlimited' || !limit) {
+      return `${incidents} / ∞ x`;
+    }
+
+    // If initial penalty >= limit, it's irrelevant (DQ happens first)
+    if (
+      initial &&
+      initial !== 'unlimited' &&
+      (initial as number) >= (limit as number)
+    ) {
+      initial = undefined;
+    }
+
+    // If no initial penalty configured, show basic display
+    if (!initial || initial === 'unlimited') {
+      return `${incidents} / ${limit} x`;
+    }
+
+    // We have initial penalty, check for subsequent
+    if (!subsequent || subsequent === 'unlimited') {
+      // Only initial penalty, no recurrence
+      if (incidents < (initial as number)) {
+        return `${incidents} / ${initial} / ${limit} x`;
+      } else {
+        return `${incidents} / ${limit} x`;
+      }
+    }
+
+    // Full subsequent penalty tracking
+    if (incidents < (initial as number)) {
+      return `${incidents} / ${initial} / ${limit} x`;
+    }
+
+    const initialNum = initial as number;
+    const subsequentNum = subsequent as number;
+
+    // Which round of subsequent penalties?
+    const roundsCompleted = Math.floor(
+      (incidents - initialNum) / subsequentNum
+    );
+    const nextPenalty = initialNum + (roundsCompleted + 1) * subsequentNum;
+
+    if (nextPenalty >= (limit as number)) {
+      return `${incidents} / ${limit} x`;
+    }
+
+    return `${incidents} / ${nextPenalty} / ${limit} x`;
+  };
 
   // Define all possible items with their render functions
   const itemDefinitions = {
@@ -288,9 +350,13 @@ export const SessionBar = ({
         effectiveBarSettings?.incidentCount?.enabled ??
         (position === 'header' ? true : false),
       render: () => (
-        <div className="flex justify-end">
-          {incidents}
-          {incidentLimit ? ' / ' + incidentLimit : ''} x
+        <div className="flex justify-end tabular-nums">
+          {getIncidentDisplay(
+            incidents,
+            incidentWarningInitialLimit,
+            incidentWarningSubsequentLimit,
+            incidentLimit
+          )}
         </div>
       ),
     },

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -29,6 +29,7 @@ import { useSessionCurrentTime } from '../../hooks/useSessionCurrentTime';
 import { usePrecipitation } from '../../hooks/usePrecipitation';
 import { SessionState } from '@irdashies/types';
 import { WindArrow } from '../../../shared/WindArrow';
+import { getIncidentDisplay } from './getIncidentDisplay';
 
 // compact=true (total time): trims trailing zero components, never shows seconds
 // compact=false (elapsed/remaining): always shows full HH:MM:SS
@@ -149,63 +150,6 @@ export const SessionBar = ({
   const { totalRaceLaps, isFixedLapRace } = useTotalRaceLaps();
   const { totalRaceTime, adjustedRaceTime } = useTotalRaceTime();
   const trackDisplayName = useTrackDisplayName();
-
-  // Helper to format incident display with penalties
-  const getIncidentDisplay = (
-    incidents: number,
-    initial: number | string | undefined,
-    subsequent: number | string | undefined,
-    limit: number | string | undefined
-  ): string => {
-    // If limit is unlimited, show infinity
-    if (limit === 'unlimited' || !limit) {
-      return `${incidents} / ∞ x`;
-    }
-
-    // If initial penalty >= limit, it's irrelevant (DQ happens first)
-    if (
-      initial &&
-      initial !== 'unlimited' &&
-      (initial as number) >= (limit as number)
-    ) {
-      initial = undefined;
-    }
-
-    // If no initial penalty configured, show basic display
-    if (!initial || initial === 'unlimited') {
-      return `${incidents} / ${limit} x`;
-    }
-
-    // We have initial penalty, check for subsequent
-    if (!subsequent || subsequent === 'unlimited') {
-      // Only initial penalty, no recurrence
-      if (incidents < (initial as number)) {
-        return `${incidents} / ${initial} / ${limit} x`;
-      } else {
-        return `${incidents} / ${limit} x`;
-      }
-    }
-
-    // Full subsequent penalty tracking
-    if (incidents < (initial as number)) {
-      return `${incidents} / ${initial} / ${limit} x`;
-    }
-
-    const initialNum = initial as number;
-    const subsequentNum = subsequent as number;
-
-    // Which round of subsequent penalties?
-    const roundsCompleted = Math.floor(
-      (incidents - initialNum) / subsequentNum
-    );
-    const nextPenalty = initialNum + (roundsCompleted + 1) * subsequentNum;
-
-    if (nextPenalty >= (limit as number)) {
-      return `${incidents} / ${limit} x`;
-    }
-
-    return `${incidents} / ${nextPenalty} / ${limit} x`;
-  };
 
   // Define all possible items with their render functions
   const itemDefinitions = {

--- a/src/frontend/components/Standings/components/SessionBar/getIncidentDisplay.ts
+++ b/src/frontend/components/Standings/components/SessionBar/getIncidentDisplay.ts
@@ -1,0 +1,45 @@
+export const getIncidentDisplay = (
+  incidents: number,
+  initial: number | string | undefined | null,
+  subsequent: number | string | undefined | null,
+  limit: number | string | undefined | null
+): string => {
+  if (limit === 'unlimited' || !limit) {
+    return `${incidents} / ∞ x`;
+  }
+
+  if (
+    initial &&
+    initial !== 'unlimited' &&
+    (initial as number) >= (limit as number)
+  ) {
+    initial = undefined;
+  }
+
+  if (!initial || initial === 'unlimited') {
+    return `${incidents} / ${limit} x`;
+  }
+
+  if (!subsequent || subsequent === 'unlimited') {
+    if (incidents < (initial as number)) {
+      return `${incidents} / ${initial} / ${limit} x`;
+    }
+    return `${incidents} / ${limit} x`;
+  }
+
+  if (incidents < (initial as number)) {
+    return `${incidents} / ${initial} / ${limit} x`;
+  }
+
+  const initialNum = initial as number;
+  const subsequentNum = subsequent as number;
+
+  const roundsCompleted = Math.floor((incidents - initialNum) / subsequentNum);
+  const nextPenalty = initialNum + (roundsCompleted + 1) * subsequentNum;
+
+  if (nextPenalty >= (limit as number)) {
+    return `${incidents} / ${limit} x`;
+  }
+
+  return `${incidents} / ${nextPenalty} / ${limit} x`;
+};

--- a/src/frontend/components/Standings/hooks/useDriverIncidents.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverIncidents.tsx
@@ -4,9 +4,19 @@ export const useDriverIncidents = () => {
   const incidentLimit = useSessionStore(
     (state) => state.session?.WeekendInfo?.WeekendOptions?.IncidentLimit
   );
+  const incidentWarningInitialLimit = useSessionStore(
+    (state) =>
+      state.session?.WeekendInfo?.WeekendOptions?.IncidentWarningInitialLimit
+  );
+  const incidentWarningSubsequentLimit = useSessionStore(
+    (state) =>
+      state.session?.WeekendInfo?.WeekendOptions?.IncidentWarningSubsequentLimit
+  );
   const incidents = useTelemetryValue('PlayerCarTeamIncidentCount') || 0;
   return {
     incidents,
-    incidentLimit: incidentLimit === 'unlimited' ? '' : incidentLimit,
+    incidentLimit,
+    incidentWarningInitialLimit,
+    incidentWarningSubsequentLimit,
   };
 };


### PR DESCRIPTION
# PR: Full Incident Counts

## Description

Enhanced incident display to show complete penalty structure including initial incident limit and subsequent incident count penalties. This allows drivers to see not just their current incident count and total DQ limit, but also the intermediate penalty thresholds.

**Key changes:**
- Extract `IncidentWarningInitialLimit` and `IncidentWarningSubsequentLimit` from WeekendInfo
- Format incident display as `current / initial or subsequent / limit x` (with smart logic to hide irrelevant thresholds)
- Calculate next penalty threshold dynamically based on subsequent penalty recurrence
- Display "∞" for unlimited incident limits

**Display format examples:**
- Base structure: `4 / 17 x`
- Initial penalty only: `5 / 10 / 17 x` (5 incidents, 10-incident initial penalty, 17 DQ limit)
- With recurrence: `12 / 15 / 17 x` (12 incidents, 10 initial, +5 subsequent each round, next at 15, DQ at 17)
- Unlimited limit: `4 / ∞ x`

## Screenshots

### Before
Session bar showed only current incident count and total limit:
```
4 / 17 x
```

### After
Session bar now shows the complete penalty structure:
```
4 / 8 / 17 x
```
With intermediate penalties dynamically calculated based on session rules.

In SessionBar
<img width="396" height="135" alt="Screenshot 2026-04-16 143751" src="https://github.com/user-attachments/assets/53e7b302-8487-469d-bce7-50a37e69968c" />

Basic 4 / 17 x
<img width="273" height="305" alt="Screenshot 2026-04-16 144637" src="https://github.com/user-attachments/assets/6af77741-9730-4ca3-ba3e-ec7151c86983" />

Higher limit with first initial penalty
<img width="268" height="309" alt="Screenshot 2026-04-16 144656" src="https://github.com/user-attachments/assets/c3d80db5-4478-4d30-ab8b-7ce48741fc7a" />

Higher limit with first initial penalty, plus subsequent limit. Subsequent not utilized until after initial limit is reached.
<img width="250" height="310" alt="Screenshot 2026-04-16 144709" src="https://github.com/user-attachments/assets/0b901ce4-31a3-4b47-8191-c8d9dea94f1c" />

After initial limit is reached, subsequent limit is used to show the driver when the next penalty will be (in this case at 25 incidents total)
<img width="226" height="311" alt="Screenshot 2026-04-16 144724" src="https://github.com/user-attachments/assets/47be8480-dd56-4bf7-81dd-481f0627c2a1" />

Once driver reaches the final subsequent penalty, driver is only shown final DQ incident limit.
<img width="235" height="309" alt="Screenshot 2026-04-16 144755" src="https://github.com/user-attachments/assets/5f584e26-bd52-4644-b4ec-fecf04c24705" />

Unlimited incident limit
<img width="417" height="313" alt="Screenshot 2026-04-16 150040" src="https://github.com/user-attachments/assets/5e48f628-f8f0-4f77-b7b6-44f90fa5b194" />
<img width="365" height="133" alt="Screenshot 2026-04-16 150351" src="https://github.com/user-attachments/assets/0b29fdec-87a1-4ca4-b85a-497e879d9884" />

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Technical Details

### Modified Files

#### `src/app/irsdk/types/weekend-info.ts`
- Added `IncidentWarningInitialLimit: number` — incident threshold before first penalty
- Added `IncidentWarningSubsequentLimit: number` — recurring penalty interval after initial

#### `src/frontend/components/Standings/components/SessionBar/SessionBar.tsx`
- Extracted new incident fields from `useDriverIncidents()`
- Implemented `getIncidentDisplay()` helper that:
  - Handles unlimited limits (shows "∞")
  - Skips initial penalty if it equals or exceeds DQ limit
  - Calculates next penalty based on subsequent recurrence
  - Returns formatted string: `current / [initial] or [next-threshold] / limit x`
- Updated incident count render to use new display helper
- Added `tabular-nums` class for monospace digit alignment

#### `src/frontend/components/Standings/hooks/useDriverIncidents.tsx`
- Returns unmodified `incidentLimit` (removed string conversion)
- Exports `incidentWarningInitialLimit`
- Exports `incidentWarningSubsequentLimit`

#### `src/frontend/components/Standings/components/SessionBar/SessionBar.stories.tsx`
- Added `IncidentDisplay` story component to showcase all penalty scenarios
- Story accepts props for testing different limit configurations

## Checklist

- [] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incident counter now displays multiple warning thresholds (initial and subsequent) and shows next-penalty info when applicable.
  * Unlimited incident limits are rendered clearly (using ∞) and numeric counts use improved tabular alignment.
  * Storybook includes a new "Incidents" preview to demonstrate the updated counter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->