### PR TITLE
fix: info bar opacity changes opacity

### DIFF
--- a/src/frontend/components/Settings/sections/InformationBarSettings.tsx
+++ b/src/frontend/components/Settings/sections/InformationBarSettings.tsx
@@ -17,6 +17,7 @@ import {
 } from '../components/SessionBarItemsList';
 import { SessionVisibility } from '../components/SessionVisibility';
 import { DEFAULT_SESSION_BAR_DISPLAY_ORDER } from '../sessionBarConstants';
+import { SettingDivider } from '../components/SettingDivider';
 
 const SETTING_ID = 'infobar';
 const defaultConfig = getWidgetDefaultConfig('infobar');
@@ -150,23 +151,23 @@ export const InformationBarSettings = () => {
             )}
 
             {activeTab === 'visibility' && (
-              <>
-                <SettingsSection title="General Visibility">
-                  <SettingToggleRow
-                    title="Show only when on track"
-                    description="Hide the widget when you are not in the car"
-                    enabled={settings.config.showOnlyWhenOnTrack}
-                    onToggle={(v) =>
-                      handleConfigChange({ showOnlyWhenOnTrack: v })
-                    }
-                  />
-                </SettingsSection>
-
+              <SettingsSection title="Session Visibility">
                 <SessionVisibility
                   sessionVisibility={settings.config.sessionVisibility}
                   handleConfigChange={handleConfigChange}
                 />
-              </>
+
+                <SettingDivider />
+
+                <SettingToggleRow
+                  title="Show only when on track"
+                  description="Hide the widget when you are not in the car"
+                  enabled={settings.config.showOnlyWhenOnTrack}
+                  onToggle={(v) =>
+                    handleConfigChange({ showOnlyWhenOnTrack: v })
+                  }
+                />
+              </SettingsSection>
             )}
           </div>
         </div>

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -479,7 +479,7 @@ export const SessionBar = ({
 
   return (
     <div
-      className={`bg-slate-900/70 ${pxClass} ${pyClass} flex items-center text-sm ${standalone ? `w-full justify-between ${gapClass}` : 'justify-between'} ${!isCompact && !isUltra && !standalone ? (position === 'header' ? 'mb-3' : 'mt-3') : ''}`}
+      className={`${pxClass} ${pyClass} flex items-center text-sm ${standalone ? `w-full justify-between ${gapClass}` : 'justify-between'} ${!isCompact && !isUltra && !standalone ? (position === 'header' ? 'mb-3' : 'mt-3') : ''}`}
     >
       {itemsToRender}
     </div>


### PR DESCRIPTION
## Description

Removed hard coded opacity so the opacity slider actually makes a difference.

Also tidied up layout of session visibility options.

## Screenshots

<img width="540" height="185" alt="image" src="https://github.com/user-attachments/assets/4b0388f1-89ed-4a58-8e38-fe684bb2b3d0" />

### Before
<img width="740" height="45" alt="image" src="https://github.com/user-attachments/assets/31d31be0-f72e-421b-8040-7cf113714022" />

### After
<img width="740" height="35" alt="image" src="https://github.com/user-attachments/assets/b95333ee-89c1-48e0-aa8a-91f8db75f19a" />

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
