### PR TITLE
fix: session time during gridding

### DIFF
--- a/src/frontend/components/Standings/hooks/useSessionLapCount.tsx
+++ b/src/frontend/components/Standings/hooks/useSessionLapCount.tsx
@@ -159,8 +159,9 @@ export const useSessionLapCount = () => {
       (sessionState ?? 0) === SessionState.GetInCar
     ) {
       const remaining = timeRemaining ?? 0;
-      if (remaining > 1800) {
-        result.timeRemaining = Math.max(0, (timeTotal ?? 0) - (time ?? 0));
+      const total = timeTotal ?? 0;
+      if (remaining === 604800 && total === 604800) {
+        result.timeRemaining = -1;
       } else {
         result.timeRemaining = remaining;
       }

--- a/src/frontend/components/Standings/hooks/useSessionLapCount.tsx
+++ b/src/frontend/components/Standings/hooks/useSessionLapCount.tsx
@@ -154,7 +154,19 @@ export const useSessionLapCount = () => {
     result.currentLap = isPostCheckered
       ? (checkeredLap ?? currentLap ?? 0)
       : (currentLap ?? 0);
-    result.timeRemaining = timeRemaining ?? 0;
+    if (
+      sessionType === 'Race' &&
+      (sessionState ?? 0) === SessionState.GetInCar
+    ) {
+      const remaining = timeRemaining ?? 0;
+      if (remaining > 1800) {
+        result.timeRemaining = Math.max(0, (timeTotal ?? 0) - (time ?? 0));
+      } else {
+        result.timeRemaining = remaining;
+      }
+    } else {
+      result.timeRemaining = timeRemaining ?? 0;
+    }
     result.greenFlagTimestamp = greenFlagTimestamp ?? 0;
 
     return result;
@@ -162,6 +174,7 @@ export const useSessionLapCount = () => {
     sessionLaps,
     currentLap,
     sessionState,
+    sessionType,
     time,
     timeTotal,
     timeRemaining,

--- a/src/frontend/components/Standings/hooks/useSessionLapCount.tsx
+++ b/src/frontend/components/Standings/hooks/useSessionLapCount.tsx
@@ -160,7 +160,7 @@ export const useSessionLapCount = () => {
     ) {
       const remaining = timeRemaining ?? 0;
       const total = timeTotal ?? 0;
-      if (remaining === 604800 && total === 604800) {
+      if (remaining >= 604800 && total >= 604800) {
         result.timeRemaining = -1;
       } else {
         result.timeRemaining = remaining;


### PR DESCRIPTION
During some sessions, the sessionTimeRemain and sessionTimeTotal from the SDK return back 604800 during the gridding process. This causes the Session Time in the sessionBar to show as 168 Hours. If in the grid phase, and the time remaining and time total are both 168h, then show nothing for the time as we don't have the information available.

## Before
<img width="930" height="535" alt="Screenshot 2026-04-14 194054" src="https://github.com/user-attachments/assets/3f1a9bd5-4dd3-42df-b3f3-ec0e6816507b" />

## After
<img width="922" height="596" alt="Screenshot 2026-04-18 105419" src="https://github.com/user-attachments/assets/242e2ec2-e161-4fc0-b5dc-2b56480fb1de" />