### PR TITLE
fix: Relative wrong value on soon to be lapped cars

### DIFF
--- a/src/frontend/components/Standings/relativeGapHelpers.ts
+++ b/src/frontend/components/Standings/relativeGapHelpers.ts
@@ -138,10 +138,11 @@ export function calculateReferenceDelta(
 
   let calculatedDelta = timeOpponent - timePlayer;
   const lapTime = referenceLap.finishTime - referenceLap.startTime;
+  const trackPctDiff = opponentTrackPct - playerTrackPct;
 
-  if (calculatedDelta <= -lapTime / 2) {
+  if (trackPctDiff <= -0.5) {
     calculatedDelta += lapTime;
-  } else if (calculatedDelta >= lapTime / 2) {
+  } else if (trackPctDiff >= 0.5) {
     calculatedDelta -= lapTime;
   }
 


### PR DESCRIPTION
## Description

  Adjusts the wrap-around logic for relative gap calculations by   
  using track percentage difference instead of the raw time delta. 
  Previously, the logic incorrectly triggered a lap adjustment when
  the time delta exceeded half a lap, regardless of physical       
  proximity. This update uses a 50% track distance threshold       
  (trackPctDiff >= 0.5) to correctly identify when an opponent is  
  actually a half lap ahead or behind, ensuring accurate gap reporting  
  even on tracks with high time variance or when large gaps exist  
  between cars. Soon to be lapped cars were sometimes reported with
  negative gap and vice versa.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
