### PR TITLE
fix: fixed irating change in relative

### DIFF
--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -4,6 +4,7 @@ import {
   useTelemetry,
   useSessionDrivers,
   useSessionQualifyingResults,
+  useSessionIsOfficial,
   useCurrentSessionType,
   useCarLap,
   usePitLap,
@@ -15,7 +16,7 @@ import {
   useTelemetryValuesRounded,
 } from '@irdashies/context';
 
-import { Standings, type LastTimeState } from '../createStandings';
+import { Standings, augmentStandingsWithIRating, groupStandingsByClass, type LastTimeState } from '../createStandings';
 import { GlobalFlags, SessionState } from '@irdashies/types';
 import { useDriverLivePositions } from './useDriverLivePositions';
 import { useRelativeSettings } from './useRelativeSettings';
@@ -162,6 +163,7 @@ export const useDriverStandings = () => {
   const sessionPositions = useSessionPositions(sessionNum);
   const sessionFastestLaps = useSessionFastestLaps(sessionNum);
   const fastestLapCarIdx = sessionFastestLaps?.[0]?.CarIdx;
+  const isOfficial = useSessionIsOfficial();
 
   const driverStandings: Standings[] = useMemo(() => {
     // Create Map lookups for O(1) access instead of O(n) find() calls
@@ -282,7 +284,17 @@ export const useDriverStandings = () => {
       };
     });
 
-    return standings.filter((s) => !!s).sort((a, b) => a.position - b.position);
+    const filteredStandings = standings
+      .filter((s) => !!s)
+      .sort((a, b) => a.position - b.position);
+
+    if (sessionType !== 'Race' || !isOfficial) {
+      return filteredStandings;
+    }
+
+    return augmentStandingsWithIRating(groupStandingsByClass(filteredStandings))
+      .flatMap(([, classStandings]) => classStandings)
+      .sort((a, b) => (a?.position ?? 0) - (b?.position ?? 0));
   }, [
     sessionPositions,
     sessionState,
@@ -296,6 +308,7 @@ export const useDriverStandings = () => {
     radioTransmitCarIdx,
     driverLivePositions,
     fastestLapCarIdx,
+    isOfficial,
   ]);
 
   return driverStandings;


### PR DESCRIPTION
## Description

Fixed display of iRating change in relatives

## Before

<img width="180" height="140" alt="image" src="https://github.com/user-attachments/assets/f414dcf7-e0ad-4ceb-aad7-57c7f3ffe543" />

## After

<img width="196" height="140" alt="image" src="https://github.com/user-attachments/assets/75b006a9-a634-46f0-812c-8fa883f7bd5f" />

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [X] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have run `npm run lint` and fixed any issues
- [X] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
