### PR TITLE
fix/feat: "show only when on track" for lap timer

### DIFF
--- a/src/frontend/components/LapTimeLog/LapTimeLog.spec.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.spec.tsx
@@ -38,6 +38,7 @@ const mockSettings = (
       practice: true,
       offlineTesting: true,
     },
+    showOnlyWhenOnTrack: true,
   };
 
   return {

--- a/src/frontend/components/LapTimeLog/LapTimeLog.stories.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.stories.tsx
@@ -56,6 +56,7 @@ const mockConfig = (
       practice: true,
       offlineTesting: true,
     },
+    showOnlyWhenOnTrack: true,
   };
 
   return {
@@ -150,7 +151,7 @@ export const DirtyLap: Story = {
     ...baseArgs,
     dirty: true,
     settings: mockConfig({
-      delta: { enabled: true, method: 'lastlap' },      
+      delta: { enabled: true, method: 'lastlap' },
       showLastLap: false,
       showBestLap: false,
       history: { enabled: false, count: 5 },

--- a/src/frontend/components/LapTimeLog/LapTimeLog.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.tsx
@@ -206,7 +206,7 @@ export const LapTimeLogDisplay = ({
               </div>
               {settings.delta.enabled && (
                 <div
-                  className={`absolute right-2 text-center tabular-nums ${
+                  className={`absolute right-2 text-[0.9em] text-center tabular-nums ${
                     !dirty && delta && deltaIsGreen
                       ? 'text-green-400'
                       : !dirty && delta && deltaIsRed

--- a/src/frontend/components/LapTimeLog/LapTimeLog.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.tsx
@@ -28,14 +28,13 @@ export const LapTimeLog = () => {
     data.settings?.sessionVisibility
   );
 
-  if (!isSessionVisible) return <></>;
-
-  // Show only when on track setting
-  if (data.settings?.showOnlyWhenOnTrack && !isDriving) {
+  // session visible?
+  if (!data.settings || playerIndex === undefined || !isSessionVisible) {
     return null;
   }
 
-  if (!data.settings || playerIndex === undefined || !isSessionVisible) {
+  // Show only when on track setting
+  if (data.settings?.showOnlyWhenOnTrack && !isDriving) {
     return null;
   }
 

--- a/src/frontend/components/LapTimeLog/LapTimeLog.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.tsx
@@ -60,7 +60,7 @@ export const LapTimeLog = () => {
   return (
     <LapTimeLogDisplay
       settings={data.settings}
-      current={data.current}
+      current={isDriving ? data.current : undefined}
       lastlap={data.lastlap}
       bestlap={data.bestlap}
       reference={data.reference}

--- a/src/frontend/components/LapTimeLog/LapTimeLog.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.tsx
@@ -28,12 +28,14 @@ export const LapTimeLog = () => {
     data.settings?.sessionVisibility
   );
 
-  if (
-    !data.settings ||
-    playerIndex === undefined ||
-    !isSessionVisible ||
-    !isDriving
-  ) {
+  if (!isSessionVisible) return <></>;
+
+  // Show only when on track setting
+  if (data.settings?.showOnlyWhenOnTrack && !isDriving) {
+    return null;
+  }
+
+  if (!data.settings || playerIndex === undefined || !isSessionVisible) {
     return null;
   }
 

--- a/src/frontend/components/Settings/sections/LapTimeLogSettings.tsx
+++ b/src/frontend/components/Settings/sections/LapTimeLogSettings.tsx
@@ -13,6 +13,7 @@ import { SettingSliderRow } from '../components/SettingSliderRow';
 import { SettingToggleRow } from '../components/SettingToggleRow';
 import { SettingSelectRow } from '../components/SettingSelectRow';
 import { SettingButtonGroupRow } from '../components/SettingButtonGroupRow';
+import { SettingDivider } from '../components/SettingDivider';
 
 const SETTING_ID = 'laptimelog';
 
@@ -46,7 +47,7 @@ export const LapTimeLogSettings = () => {
   return (
     <BaseSettingsSection
       title="Lap Timer"
-      description="Configure settings for the Lap Timer widget. Note: The widget automatically hides while you're in the garage, in a pit stall, or on pit road."
+      description="Configure settings for the Lap Timer widget. Select the lap times you want to see and the display options."
       settings={settings}
       onSettingsChange={setSettings}
       widgetId={SETTING_ID}
@@ -282,6 +283,17 @@ export const LapTimeLogSettings = () => {
                 <SessionVisibility
                   sessionVisibility={settings.config.sessionVisibility}
                   handleConfigChange={handleConfigChange}
+                />
+
+                <SettingDivider />
+
+                <SettingToggleRow
+                  title="Show only when on track"
+                  description="If enabled, lap times will only be shown when driving"
+                  enabled={settings.config.showOnlyWhenOnTrack ?? true}
+                  onToggle={(newValue) =>
+                    handleConfigChange({ showOnlyWhenOnTrack: newValue })
+                  }
                 />
               </SettingsSection>
             )}

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -943,11 +943,12 @@ export const defaultDashboard: {
         },
         sessionVisibility: {
           race: true,
-          loneQualify: false,
+          loneQualify: true,
           openQualify: true,
           practice: true,
           offlineTesting: true,
         },
+        showOnlyWhenOnTrack: true,
       },
     },
     {

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -491,6 +491,7 @@ export interface LapTimeLogConfig {
   background: { opacity: number };
   foreground: { opacity: number };
   sessionVisibility: SessionVisibilitySettings;
+  showOnlyWhenOnTrack: boolean;
 }
 
 export interface SlowCarAheadConfig {


### PR DESCRIPTION
## Description

Added "show only when on track" option to the visibility settings for the Lap Timer

## Screenshots

<img width="567" height="534" alt="image" src="https://github.com/user-attachments/assets/daf4eea3-2c5b-4f5f-96ff-8e5797816c7b" />

## Type of Change

- [X] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [X] I have discussed this change in the discord server
- [X] I have tested this in iRacing (either in an online session or with AI)
- [X] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have run `npm run lint` and fixed any issues
- [X] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
