### PR TITLE
fix: multi-class colors

### DIFF
--- a/src/frontend/utils/colors.ts
+++ b/src/frontend/utils/colors.ts
@@ -6,16 +6,41 @@ export interface TailwindStyles {
   borderColor: string;
 }
 
+// iRacing car class decimals to color names (6 known tiers)
+const IRACING_CLASS_COLOR_MAP: Record<number, string> = {
+  16767577: 'yellow', // Class 1 - fastest
+  3395327: 'blue', // Class 2
+  16734344: 'red', // Class 3
+  11430911: 'cyan', // Class 4
+  5504887: 'pink', // Class 5
+  13849600: 'purple', // Class 6 - slowest
+};
+
+// Color names to hex values for classColorMap lookup
+const COLOR_NAME_TO_HEX: Record<string, string> = {
+  yellow: '#ffda59',
+  blue: '#33ceff',
+  red: '#ef4444',
+  cyan: '#06b6d4',
+  pink: '#ff5888',
+  purple: '#ae6bff',
+};
+
 export const getTailwindStyle = (
   color?: number,
   highlightColor?: number,
   isMultiClass = false
 ): TailwindStyles => {
-  if (!isMultiClass) {
-    color = highlightColor;
+  let hex: string | undefined;
+
+  if (isMultiClass && color !== undefined) {
+    const colorName = IRACING_CLASS_COLOR_MAP[color];
+    if (colorName) {
+      hex = COLOR_NAME_TO_HEX[colorName];
+    }
+  } else if (highlightColor !== undefined) {
+    hex = `#${highlightColor.toString(16).padStart(6, '0')}`;
   }
-  const hex =
-    color !== undefined ? `#${color.toString(16).padStart(6, '0')}` : 0;
   const classColorMap: Record<string, TailwindStyles> = {
     '#ffda59': {
       driverIcon: 'bg-yellow-800 border-yellow-500',
@@ -160,7 +185,7 @@ export const getTailwindStyle = (
   };
 
   return (
-    classColorMap[hex] ??
+    (hex ? classColorMap[hex] : undefined) ??
     classColorMap['#ffffff'] ?? {
       driverIcon: 'bg-sky-800 border-sky-500',
       classHeader: 'bg-sky-500 border-sky-500',


### PR DESCRIPTION
# Car Class Color Mapping Implementation

## Description

Replace unreliable iRacing decimal-to-hex conversion with static decimal-to-Tailwind mapping for car class colors. The previous `toString(16)` approach failed to match game UI colors and couldn't handle offline AI sessions where `CarClassShortName` is null.

**Changes made to `src/frontend/utils/colors.ts`:**

1. **Added `IRACING_CLASS_COLOR_MAP`** (lines 9-17) — Static mapping of 6 known car class color tiers from iRacing decimals to color names:
   - `16767577` → `'yellow'` (Class 1 - fastest)
   - `3395327` → `'blue'` (Class 2)
   - `16734344` → `'red'` (Class 3)
   - `11430911` → `'cyan'` (Class 4)
   - `5504887` → `'pink'` (Class 5)
   - `13849600` → `'purple'` (Class 6 - slowest)

2. **Added `COLOR_NAME_TO_HEX`** (lines 19-27) — Bridge mapping from color names to existing hex values in `classColorMap`

3. **Refactored `getTailwindStyle()` function** (lines 29-43):
   - For multi-class sessions: lookup iRacing decimal in `IRACING_CLASS_COLOR_MAP`, then bridge to hex via `COLOR_NAME_TO_HEX`
   - For single-class: fallback to existing `highlightColor` hex conversion logic
   - Unknown/future car class colors default to sky-500 (unchanged fallback behavior)

4. **Fixed type safety** (line 188) — Explicit ternary operator `hex ? classColorMap[hex] : undefined` ensures proper TypeScript type narrowing

## Benefits

✅ Removes dependency on unreliable `toString(16)` hex conversion  
✅ Works for both online and offline AI sessions  
✅ Simple, maintainable static mapping  
✅ Easy to extend if new car class colors discovered  
✅ No performance impact (object literal lookup)  

## Screenshots

### Before
<img width="926" height="568" alt="Screenshot 2026-04-22 164501" src="https://github.com/user-attachments/assets/ac5c1b82-bca6-4c89-8662-1ca9c0277351" />

Note the class colors of each class/car, which is in order from fastest to slowest class.

### After

Matches iRacing.
<img width="925" height="570" alt="Screenshot 2026-04-22 164318" src="https://github.com/user-attachments/assets/cee0e943-2cd5-47f7-9d52-135f55e947de" />
<img width="496" height="447" alt="Screenshot 2026-04-22 164326" src="https://github.com/user-attachments/assets/11080187-01ce-476c-b35f-0b99820ad732" />
<img width="502" height="400" alt="Screenshot 2026-04-22 164333" src="https://github.com/user-attachments/assets/56be0b78-323d-4a13-82e1-90f65fb6567f" />
<img width="498" height="399" alt="Screenshot 2026-04-22 164338" src="https://github.com/user-attachments/assets/36d9fb1f-653c-4f85-8d5a-d52e1e78d8d6" />
<img width="500" height="401" alt="Screenshot 2026-04-22 164344" src="https://github.com/user-attachments/assets/1798404f-1544-4765-95e1-1c10e262c8a6" />
<img width="513" height="359" alt="Screenshot 2026-04-22 164351" src="https://github.com/user-attachments/assets/af16bb4f-b08d-4080-bb4c-ee7518c38c7a" />


## Testing

- ✅ All existing tests pass (6/6)
- ✅ TypeScript strict mode passes
- ✅ ESLint passes with no warnings
- ✅ No breaking changes to public API

## Future Extensibility

If new car class colors are discovered:
1. Identify the iRacing decimal
2. Determine target Tailwind color
3. Add entry to `IRACING_CLASS_COLOR_MAP` and `COLOR_NAME_TO_HEX`

## Files Modified

- `src/frontend/utils/colors.ts` — Color mapping logic

## Notes

- Hex conversion for `highlightColor` parameter preserved for backward compatibility
- Six-color mapping covers standard multi-class sessions (GTP, GT3, TCR, etc.)