### PR TITLE
fix: sessionBar styling

### DIFF
--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -103,7 +103,7 @@ export const SessionBar = ({
   const isUltra = generalSettings?.compactMode === 'ultra';
   const isCompact = generalSettings?.compactMode === 'compact';
 
-  const pyClass = isUltra ? 'py-0' : isCompact ? 'py-1' : 'py-2';
+  const pyClass = isUltra ? 'py-0' : 'py-1';
   const gapClass = isUltra ? 'gap-x-2' : isCompact ? 'gap-x-4' : 'gap-x-6';
   const pxClass = standalone
     ? isUltra
@@ -255,9 +255,9 @@ export const SessionBar = ({
         const lapValue =
           lapsMode === 'Remaining'
             ? Math.min(
-              Math.max(Math.ceil(effectiveTotal) - lapDisplay + 1, 0),
-              Math.ceil(effectiveTotal)
-            )
+                Math.max(Math.ceil(effectiveTotal) - lapDisplay + 1, 0),
+                Math.ceil(effectiveTotal)
+              )
             : lapDisplay;
         if (state >= SessionState.Checkered)
           return (
@@ -422,20 +422,20 @@ export const SessionBar = ({
     effectiveBarSettings?.displayOrder ||
     (position === 'header'
       ? [
-        'sessionName',
-        'sessionTime',
-        'sessionLaps',
-        'localTime',
-        'brakeBias',
-        'incidentCount',
-      ]
+          'sessionName',
+          'sessionTime',
+          'sessionLaps',
+          'localTime',
+          'brakeBias',
+          'incidentCount',
+        ]
       : [
-        'localTime',
-        'trackWetness',
-        'sessionLaps',
-        'airTemperature',
-        'trackTemperature',
-      ]);
+          'localTime',
+          'trackWetness',
+          'sessionLaps',
+          'airTemperature',
+          'trackTemperature',
+        ]);
 
   // Filter and order items based on settings
   const itemsToRender = displayOrder
@@ -485,7 +485,7 @@ export const SessionBar = ({
 
   return (
     <div
-      className={`${pxClass} ${pyClass} flex items-center text-sm ${standalone ? `w-full justify-between ${gapClass}` : 'justify-between'} ${!isCompact && !isUltra && !standalone ? (position === 'header' ? 'mb-3' : 'mt-3') : ''}`}
+      className={`${pxClass} ${pyClass} flex items-center text-sm ${standalone ? `w-full justify-between ${gapClass}` : 'justify-between'}`}
     >
       {itemsToRender}
     </div>

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -103,7 +103,7 @@ export const SessionBar = ({
   const isUltra = generalSettings?.compactMode === 'ultra';
   const isCompact = generalSettings?.compactMode === 'compact';
 
-  const pyClass = isUltra ? 'py-0' : 'py-1';
+  const pyClass = isUltra ? 'py-0' : isCompact ? 'py-1' : 'py-2';
   const gapClass = isUltra ? 'gap-x-2' : isCompact ? 'gap-x-4' : 'gap-x-6';
   const pxClass = standalone
     ? isUltra
@@ -485,7 +485,7 @@ export const SessionBar = ({
 
   return (
     <div
-      className={`${pxClass} ${pyClass} flex items-center text-sm ${standalone ? `w-full justify-between ${gapClass}` : 'justify-between'}`}
+      className={`bg-slate-900/70 ${pxClass} ${pyClass} flex items-center text-sm ${standalone ? `w-full justify-between ${gapClass}` : 'justify-between'} ${!isCompact && !isUltra && !standalone ? (position === 'header' ? 'mb-3' : 'mt-3') : ''}`}
     >
       {itemsToRender}
     </div>


### PR DESCRIPTION
Revert updates to sessionBar from commit 01ca6788c086b4ca72f2aac2c27bb3b9fcfd03d4 https://github.com/tariknz/irdashies/pull/504

The commit removed styling in the sessionBar.

Commit SessionBar (footer)
<img width="929" height="226" alt="Screenshot 2026-04-23 012914" src="https://github.com/user-attachments/assets/c47cd64b-b29d-4396-bde7-204ecf21bf17" />

Reverted (this commit)
<img width="927" height="167" alt="Screenshot 2026-04-23 012837" src="https://github.com/user-attachments/assets/1390d62a-0336-4823-829e-a599cb3309d0" />
