### PR TITLE
fix: show irating change in prac/qual

### DIFF
--- a/src/frontend/components/Standings/hooks/useDriverStandings.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverStandings.tsx
@@ -15,6 +15,7 @@ import {
   usePitLap,
   usePrevCarTrackSurface,
   useLapTimeHistory,
+  useWeekendInfoEventType,
 } from '@irdashies/context';
 import {
   createDriverStandings,
@@ -99,6 +100,7 @@ export const useDriverStandings = (
   const carIdxTireCompound = useTelemetryValues<number[]>('CarIdxTireCompound');
   const carIdxSessionFlags = useTelemetryValues<number[]>('CarIdxSessionFlags');
   const isOfficial = useSessionIsOfficial();
+  const eventType = useWeekendInfoEventType();
   const lastPitLap = usePitLap();
   const lastLap = useCarLap();
   const prevCarTrackSurface = usePrevCarTrackSurface();
@@ -166,9 +168,9 @@ export const useDriverStandings = (
         ? augmentStandingsWithPositionChange(groupedByClass, qualifyingResults)
         : groupedByClass;
 
-    // Calculate iRating changes for race sessions
+    // Calculate iRating changes for official race weekends
     const iratingAugmentedGroupedByClass =
-      sessionType === 'Race' && isOfficial
+      eventType === 'Race' && isOfficial
         ? augmentStandingsWithIRating(positionChangeAugmentedGroupedByClass)
         : positionChangeAugmentedGroupedByClass;
 
@@ -218,6 +220,7 @@ export const useDriverStandings = (
     lapDeltasForCalc,
     useLivePositionStandings,
     isOfficial,
+    eventType,
     gapEnabled,
     intervalEnabled,
     carIdxLap,


### PR DESCRIPTION
iRating change would only show in an official session, in the "Race" subsession. This update places the check on the EventType instead of the sessionType, checking for "Race" EventType. iRating Change will show in practice/qualifying/race, as long as it's an official race session. It will not show for practice sessions outside of the official lobby.

Before/After Practice
<img width="925" height="278" alt="Screenshot 2026-04-23 030314" src="https://github.com/user-attachments/assets/c6fc39b7-5a60-4b9b-b84e-5d7e779d10ff" />

<img width="923" height="271" alt="Screenshot 2026-04-23 030245" src="https://github.com/user-attachments/assets/7581dd1c-a5d4-4ba6-afc1-5cccbad9fcb7" />

Before/After Qualifying
<img width="923" height="274" alt="Screenshot 2026-04-23 030422" src="https://github.com/user-attachments/assets/c8232172-9ed5-431a-8588-852a7d9eeff8" />

<img width="928" height="277" alt="Screenshot 2026-04-23 030436" src="https://github.com/user-attachments/assets/edbc544d-a68f-44e4-a249-810f75b5143a" />

After Qualifying and positions changed
<img width="930" height="278" alt="Screenshot 2026-04-23 030515" src="https://github.com/user-attachments/assets/727b5e76-1c89-4fcf-81c0-74c22fb6c022" />

Race remains unchanged
<img width="929" height="276" alt="Screenshot 2026-04-23 030540" src="https://github.com/user-attachments/assets/41600290-1300-4d38-af99-04c23bf7daa7" />
