### PR TITLE
fix: standings positions in multi-class

### DIFF
--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -22,7 +22,12 @@ import {
 import { generateMockDataFromPath } from '../../../app/bridge/iracingSdk/mock-data/generateMockData';
 import type { DashboardBridge, StandingsConfig } from '@irdashies/types';
 import { defaultDashboard } from '@irdashies/types';
-import { useState, useEffect, Fragment } from 'react';
+import {
+  calculateIRatingGain,
+  type CalculationResult,
+  type RaceResult,
+} from '@irdashies/utils/iratingGain';
+import { useState, useEffect, Fragment, useMemo } from 'react';
 import { DriverClassHeader } from './components/DriverClassHeader/DriverClassHeader';
 import { DriverInfoRow } from './components/DriverInfoRow/DriverInfoRow';
 import type { ResolvedDriverTag } from './hooks/useDriverTagMap';
@@ -267,6 +272,175 @@ export const MultiClassPCCWithClio: Story = {
   decorators: [TelemetryDecorator('/test-data/1731637331038')],
 };
 
+// Component that calculates irating change for the standings (demo only)
+const StandingsWithIRatingCalculation = () => {
+  const settings = useStandingsSettings();
+  const { isDriving } = useDrivingState();
+  const standings = useDriverStandings(settings);
+  const classStats = useCarClassStats();
+  const numCarClasses = useWeekendInfoNumCarClasses();
+  const isMultiClass = (numCarClasses ?? 0) > 1;
+  const highlightColor = useHighlightColor();
+
+  useLapTimesStoreUpdater();
+  usePitLapStoreUpdater();
+
+  // Manually apply irating calculation for demo purposes
+  const standingsWithIRating = useMemo(() => {
+    const grouped = standings.map(([classId, classStandings]) => {
+      const raceResultsInput: RaceResult<number>[] = classStandings
+        .filter((s) => !!s.classPosition)
+        .map((driverStanding) => ({
+          driver: driverStanding.carIdx,
+          finishRank: driverStanding.classPosition ?? 0,
+          startIRating: driverStanding.driver.rating,
+          started: true,
+        }));
+
+      if (raceResultsInput.length === 0) {
+        return [classId, classStandings] as [string, typeof classStandings];
+      }
+
+      const iratingResults = calculateIRatingGain(raceResultsInput);
+      const iratingMap = new Map<number, number>();
+      iratingResults.forEach((result: CalculationResult<number>) => {
+        iratingMap.set(result.raceResult.driver, result.iratingChange);
+      });
+
+      const augmented = classStandings.map((s) => ({
+        ...s,
+        iratingChange: iratingMap.get(s.carIdx),
+      }));
+      return [classId, augmented] as [string, typeof augmented];
+    });
+    return grouped;
+  }, [standings]);
+
+  if (settings?.showOnlyWhenOnTrack && !isDriving) {
+    return <></>;
+  }
+
+  return (
+    <div
+      className={`w-full bg-slate-800/(--bg-opacity) rounded-sm p-2 text-white overflow-hidden`}
+      style={{
+        ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 0}%`,
+      }}
+    >
+      <TitleBar titleBarSettings={settings?.titleBar} />
+      <table className="w-full table-auto text-sm border-separate border-spacing-y-0.5">
+        <tbody>
+          {standingsWithIRating.map(([classId, classStandings]) =>
+            classStandings.length > 0 ? (
+              <Fragment key={classId}>
+                <DriverClassHeader
+                  key={classId}
+                  className={classStats?.[classId]?.shortName}
+                  classColor={
+                    isMultiClass ? classStats?.[classId]?.color : highlightColor
+                  }
+                  totalDrivers={classStats?.[classId]?.total}
+                  sof={classStats?.[classId]?.sof}
+                  highlightColor={highlightColor}
+                  isMultiClass={isMultiClass}
+                  colSpan={100}
+                />
+                {classStandings.map((result) => (
+                  <DriverInfoRow
+                    key={result.carIdx}
+                    carIdx={result.carIdx}
+                    classColor={result.carClass.color}
+                    carNumber={
+                      (settings?.carNumber?.enabled ?? true)
+                        ? result.driver?.carNum || ''
+                        : undefined
+                    }
+                    name={result.driver?.name || ''}
+                    isPlayer={result.isPlayer}
+                    hasFastestTime={result.hasFastestTime}
+                    delta={settings?.delta?.enabled ? result.delta : undefined}
+                    gap={settings?.gap?.enabled ? result.gap : undefined}
+                    interval={
+                      settings?.interval?.enabled ? result.interval : undefined
+                    }
+                    position={result.classPosition}
+                    lap={result.lap}
+                    iratingChangeValue={
+                      settings?.iratingChange?.enabled
+                        ? result.iratingChange
+                        : undefined
+                    }
+                    lastTime={
+                      settings?.lastTime?.enabled ? result.lastTime : undefined
+                    }
+                    fastestTime={
+                      settings?.fastestTime?.enabled
+                        ? result.fastestTime
+                        : undefined
+                    }
+                    lastTimeState={
+                      settings?.lastTime?.enabled
+                        ? result.lastTimeState
+                        : undefined
+                    }
+                    onPitRoad={result.onPitRoad}
+                    onTrack={result.onTrack}
+                    radioActive={result.radioActive}
+                    isMultiClass={isMultiClass}
+                    flairId={
+                      (settings?.countryFlags?.enabled ?? true)
+                        ? result.driver?.flairId
+                        : undefined
+                    }
+                    tireCompound={
+                      (settings?.compound?.enabled ?? true)
+                        ? result.tireCompound
+                        : undefined
+                    }
+                    carId={result.carId}
+                    lastPitLap={result.lastPitLap}
+                    lastLap={result.lastLap}
+                    carTrackSurface={result.carTrackSurface}
+                    prevCarTrackSurface={result.prevCarTrackSurface}
+                    license={
+                      settings?.badge?.enabled
+                        ? result.driver?.license
+                        : undefined
+                    }
+                    rating={
+                      settings?.badge?.enabled
+                        ? result.driver?.rating
+                        : undefined
+                    }
+                    lapTimeDeltas={
+                      settings?.lapTimeDeltas?.enabled
+                        ? result.lapTimeDeltas
+                        : undefined
+                    }
+                    numLapDeltasToShow={
+                      settings?.lapTimeDeltas?.enabled
+                        ? settings.lapTimeDeltas.numLaps
+                        : undefined
+                    }
+                    displayOrder={settings?.displayOrder}
+                    currentSessionType={result.currentSessionType}
+                    config={settings}
+                    highlightColor={highlightColor}
+                    dnf={result.dnf}
+                    repair={result.repair}
+                    penalty={result.penalty}
+                    slowdown={result.slowdown}
+                  />
+                ))}
+              </Fragment>
+            ) : null
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
 export const MultiClassPlayground: Story = {
   argTypes: {
     numNonClassDrivers: {
@@ -282,6 +456,7 @@ export const MultiClassPlayground: Story = {
     numNonClassDrivers: 3,
     numTopDrivers: 3,
   },
+  render: () => <StandingsWithIRatingCalculation />,
   decorators: [
     (Story, context) => {
       const { numNonClassDrivers, numTopDrivers } = context.args as {
@@ -295,6 +470,7 @@ export const MultiClassPlayground: Story = {
       return TelemetryDecoratorWithConfig('/test-data/1731637331038', {
         standings: {
           ...standingsConfig,
+          iratingChange: { enabled: true },
           driverStandings: {
             ...standingsConfig?.driverStandings,
             numNonClassDrivers,

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -342,6 +342,17 @@ export const createDriverStandings = (
   // they complete a lap. Drivers yet to set a time won't be in results at all.
   // Keep them visible at the bottom, sorted by car number.
   const mappedCarIdxs = new Set(mapped.map((s) => s.carIdx));
+
+  // Build per-class position counts from drivers who have completed laps
+  const classPositionCounts = new Map<number, number>();
+  mapped.forEach((standing) => {
+    const classId = standing.carClass.id;
+    classPositionCounts.set(
+      classId,
+      (classPositionCounts.get(classId) ?? 0) + 1
+    );
+  });
+
   const notYetInResults = (session.drivers ?? [])
     .filter(
       (driver) =>
@@ -350,50 +361,57 @@ export const createDriverStandings = (
         !mappedCarIdxs.has(driver.CarIdx)
     )
     .sort(sortByCarNumber)
-    .map((driver, index) => ({
-      carIdx: driver.CarIdx,
-      position: mapped.length + index + 1,
-      classPosition: mapped.length + index + 1,
-      isPlayer: driver.CarIdx === session.playerIdx,
-      driver: {
-        name: driver.UserName,
-        carNum: driver.CarNumber,
-        license: driver.LicString,
-        rating: driver.IRating,
-        flairId: driver.FlairID,
-        teamName: driver.TeamName,
-      },
-      fastestTime: -1,
-      hasFastestTime: false,
-      lastTime: -1,
-      lastTimeState: undefined as LastTimeState,
-      onPitRoad: telemetry?.carIdxOnPitRoadValue?.[driver.CarIdx] ?? false,
-      onTrack:
-        (telemetry?.carIdxTrackSurfaceValue?.[driver.CarIdx] ??
-          TrackLocation.NotInWorld) > TrackLocation.NotInWorld,
-      tireCompound: telemetry?.carIdxTireCompoundValue?.[driver.CarIdx] ?? 0,
-      carClass: {
-        id: driver.CarClassID,
-        color: driver.CarClassColor,
-        name: driver.CarClassShortName,
-        relativeSpeed: driver.CarClassRelSpeed,
-        estLapTime: driver.CarClassEstLapTime,
-      },
-      radioActive: telemetry.radioTransmitCarIdx?.includes(driver.CarIdx),
-      carId: driver.CarID,
-      lapTimeDeltas: undefined,
-      lastPitLap: lastPitLap[driver.CarIdx] ?? undefined,
-      lastLap: lastLap[driver.CarIdx] ?? undefined,
-      prevCarTrackSurface: prevCarTrackSurface[driver.CarIdx] ?? undefined,
-      carTrackSurface:
-        telemetry?.carIdxTrackSurfaceValue?.[driver.CarIdx] ?? undefined,
-      currentSessionType: currentSession.sessionType,
-      dnf: false,
-      repair: false,
-      penalty: false,
-      slowdown: false,
-      relativePct: 0,
-    }));
+    .map((driver) => {
+      // Assign per-class position: count of drivers in their class + 1
+      const classId = driver.CarClassID;
+      const classPosition = (classPositionCounts.get(classId) ?? 0) + 1;
+      classPositionCounts.set(classId, classPosition);
+
+      return {
+        carIdx: driver.CarIdx,
+        position: mapped.length + classPositionCounts.size,
+        classPosition,
+        isPlayer: driver.CarIdx === session.playerIdx,
+        driver: {
+          name: driver.UserName,
+          carNum: driver.CarNumber,
+          license: driver.LicString,
+          rating: driver.IRating,
+          flairId: driver.FlairID,
+          teamName: driver.TeamName,
+        },
+        fastestTime: -1,
+        hasFastestTime: false,
+        lastTime: -1,
+        lastTimeState: undefined as LastTimeState,
+        onPitRoad: telemetry?.carIdxOnPitRoadValue?.[driver.CarIdx] ?? false,
+        onTrack:
+          (telemetry?.carIdxTrackSurfaceValue?.[driver.CarIdx] ??
+            TrackLocation.NotInWorld) > TrackLocation.NotInWorld,
+        tireCompound: telemetry?.carIdxTireCompoundValue?.[driver.CarIdx] ?? 0,
+        carClass: {
+          id: driver.CarClassID,
+          color: driver.CarClassColor,
+          name: driver.CarClassShortName,
+          relativeSpeed: driver.CarClassRelSpeed,
+          estLapTime: driver.CarClassEstLapTime,
+        },
+        radioActive: telemetry.radioTransmitCarIdx?.includes(driver.CarIdx),
+        carId: driver.CarID,
+        lapTimeDeltas: undefined,
+        lastPitLap: lastPitLap[driver.CarIdx] ?? undefined,
+        lastLap: lastLap[driver.CarIdx] ?? undefined,
+        prevCarTrackSurface: prevCarTrackSurface[driver.CarIdx] ?? undefined,
+        carTrackSurface:
+          telemetry?.carIdxTrackSurfaceValue?.[driver.CarIdx] ?? undefined,
+        currentSessionType: currentSession.sessionType,
+        dnf: false,
+        repair: false,
+        penalty: false,
+        slowdown: false,
+        relativePct: 0,
+      };
+    });
 
   return [...mapped, ...notYetInResults];
 };

--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -16,7 +16,12 @@ import {
   useTelemetryValuesRounded,
 } from '@irdashies/context';
 
-import { Standings, augmentStandingsWithIRating, groupStandingsByClass, type LastTimeState } from '../createStandings';
+import {
+  Standings,
+  augmentStandingsWithIRating,
+  groupStandingsByClass,
+  type LastTimeState,
+} from '../createStandings';
 import { GlobalFlags, SessionState } from '@irdashies/types';
 import { useDriverLivePositions } from './useDriverLivePositions';
 import { useRelativeSettings } from './useRelativeSettings';
@@ -228,7 +233,7 @@ export const useDriverStandings = () => {
             driver.carIdx
           );
           classPosition = qualifyingPosition
-            ? qualifyingPosition.Position + 1
+            ? qualifyingPosition.ClassPosition + 1
             : undefined;
         } else {
           const sessionPosition = sessionPositionsMap.get(driver.carIdx);


### PR DESCRIPTION
# Fix: Standings & iRating Change Now Use Class Positions in Multi-Class

## Description

Fixed driver position calculations in multi-class sessions to use **class-specific positions** instead of full field positions. This affects:

1. **Driver Standings Display** - Drivers are now sorted and positioned within their class, not globally
2. **iRating Change Calculations** - iRating gains/losses now correctly calculated based on class finish position, not overall field position

### Problem
- In multi-class races, iRating changes were calculated using full field position (e.g., position 15 overall even if 2nd in class)
- Driver standings showed incorrect positions when mixed with other classes
- Qualifying positions were incorrectly pulling full field position instead of class position

### Solution
- Track per-class position counts while building standings
- Use `ClassPosition` for qualifying drivers instead of `Position`
- Demo story component (`StandingsWithIRatingCalculation`) shows iRating calculations working correctly with class positions

## Changes Made

### `src/frontend/components/Standings/createStandings.ts`
- Build `classPositionCounts` map while processing drivers who completed laps
- Assign `classPosition` for "not yet in results" drivers based on their class count, not overall count
- Fix full field `position` calculation to use proper class position increment

### `src/frontend/components/Standings/hooks/useDriverPositions.tsx`
- Change qualifying position lookup from `qualifyingPosition.Position` → `qualifyingPosition.ClassPosition`
- Ensures class-based positions are used consistently

### `src/frontend/components/Standings/Standings.stories.tsx`
- Add `StandingsWithIRatingCalculation` demo component that manually applies irating calculations
- Import `calculateIRatingGain` utility to show iRating changes computed with class positions
- Update `MultiClassPlayground` story to render the new demo component with iRating enabled

## Testing

Tested with mock data from multi-class race (1731637331038):
- Drivers in different classes now show correct positions within their class
- iRating change calculations reflect class-based finishing positions
- Storybook story `MultiClassPlayground` demonstrates iRating values computed correctly

**Tested on iRacing:** Multi-class race with multiple car classes - positions and iRating display correctly per class.

## Screenshots

### Before
Driver positions in multi-class used full field position
iRating calculated as if Class A driver finished 4th overall instead of 3rd in class.
<img width="483" height="742" alt="Screenshot_2026-04-24_095302" src="https://github.com/user-attachments/assets/bda5d267-a39e-4492-8601-d9b888c6af0a" />

### After
Driver positions grouped and numbered per class
iRating correctly calculated based on class finish position.
<img width="488" height="743" alt="Screenshot_2026-04-24_095321" src="https://github.com/user-attachments/assets/42199c7c-1a5f-4cb2-9e9e-f40296d622b0" />

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)