### PR TITLE
feat: unified size of flags in standings/relative (meatball, black flag, sl…

### DIFF
--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -1158,6 +1158,128 @@ const LapHistorySeeder = () => {
   return null;
 };
 
+const baseConfig = {
+  badge: { enabled: true, badgeFormat: 'license-color-rating-bw' },
+  driverName: {
+    enabled: true,
+    showStatusBadges: true,
+    removeNumbersFromName: false,
+  },
+  carNumber: { enabled: true },
+  position: { enabled: true },
+  delta: { enabled: true },
+  gap: { enabled: false },
+  interval: { enabled: false },
+  fastestTime: { enabled: false },
+  lastTime: { enabled: false },
+} as import('@irdashies/types').StandingsWidgetSettings['config'];
+
+const baseDriverProps = {
+  classColor: 0x4488ff,
+  isPlayer: false,
+  hasFastestTime: false,
+  delta: 1.2,
+  position: 1,
+  lap: 10,
+  license: 'A 4.50',
+  rating: 4500,
+  onPitRoad: false,
+  onTrack: true,
+  radioActive: false,
+  isMultiClass: false,
+  currentSessionType: 'Race' as const,
+  dnf: false,
+  repair: false,
+  penalty: false,
+  slowdown: false,
+  config: baseConfig,
+};
+
+const WithFlagsComponent = () => (
+  <div className="w-full bg-slate-800/70 rounded-sm p-2 text-white">
+    <table className="w-full table-auto text-sm border-separate border-spacing-y-0.5">
+      <tbody>
+        <DriverInfoRow
+          {...baseDriverProps}
+          carIdx={10}
+          carNumber="4"
+          name="Alex Martin"
+          position={1}
+          delta={0}
+        />
+        <DriverInfoRow
+          {...baseDriverProps}
+          carIdx={11}
+          carNumber="77"
+          name="Sophie Williams"
+          position={2}
+          delta={-1.4}
+          hasFastestTime={true}
+        />
+        <DriverInfoRow
+          {...baseDriverProps}
+          carIdx={1}
+          carNumber="14"
+          name="James Black"
+          position={3}
+          delta={2.1}
+          penalty={true}
+        />
+        <DriverInfoRow
+          {...baseDriverProps}
+          carIdx={2}
+          carNumber="27"
+          name="Mark Slowdown"
+          position={4}
+          delta={3.5}
+          slowdown={true}
+        />
+        <DriverInfoRow
+          {...baseDriverProps}
+          carIdx={3}
+          carNumber="88"
+          name="Tom Repair"
+          position={5}
+          delta={4.2}
+          repair={true}
+        />
+        <DriverInfoRow
+          {...baseDriverProps}
+          carIdx={4}
+          carNumber="33"
+          name="David Pit"
+          position={6}
+          delta={5.8}
+          repair={true}
+          onPitRoad={true}
+          onTrack={false}
+          carTrackSurface={2}
+        />
+        <DriverInfoRow
+          {...baseDriverProps}
+          carIdx={5}
+          carNumber="55"
+          name="Chris Outlap"
+          position={7}
+          delta={9.1}
+          lastPitLap={10}
+          lastLap={10}
+          carTrackSurface={1}
+        />
+      </tbody>
+    </table>
+  </div>
+);
+
+export const WithFlags: Story = {
+  name: 'With Flags as badges',
+  decorators: [TelemetryDecorator()],
+  render: () => <WithFlagsComponent />,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
 export const AvgLapTime: Story = {
   name: 'Avg Lap Time Column',
   render: () => (

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverStatusBadges.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverStatusBadges.tsx
@@ -29,6 +29,9 @@ const StatusBadge = ({
   );
 };
 
+// Shared classes for penalty / slowdown / meatball — matches original penalty badge dimensions
+const flagBadgeClasses = 'bg-black/80 inline-block min-w-6';
+
 interface DriverStatusBadgesProps {
   repair?: boolean;
   penalty?: boolean;
@@ -104,28 +107,32 @@ export const DriverStatusBadges = memo(
           <StatusBadge
             textColor="text-orange-500"
             borderColorClass="border-gray-500"
-            additionalClasses="bg-black/80 inline-block min-w-6"
+            additionalClasses={flagBadgeClasses}
           >
-            {'\u00A0'}
+            {' '}
           </StatusBadge>
         )}
         {slowdown && (
-          <StatusBadge
-            textColor="text-orange-500"
-            borderColorClass="border-gray-500"
-            animate
-            additionalClasses="bg-black/80 inline-block min-w-6"
+          <span
+            className={`text-orange-500 text-xs border-2 rounded-md text-center text-nowrap px-2 m-0 leading-tight border-gray-500 animate-pulse ${flagBadgeClasses}`}
+            style={{
+              background:
+                'linear-gradient(to bottom right, black calc(50% - 1px), white calc(50% + 1px))',
+            }}
           >
-            {'\u00A0'}
-          </StatusBadge>
+            {' '}
+          </span>
         )}
         {repair && (
           <StatusBadge
             textColor="text-orange-500"
             borderColorClass="border-gray-500"
-            additionalClasses="bg-black/80 items-center justify-center"
+            additionalClasses={`${flagBadgeClasses} relative`}
           >
-            <span className="inline-block w-[0.8em] h-[0.8em] bg-orange-500 rounded-full" />
+            {' '}
+            <span className="absolute inset-0 flex items-center justify-center">
+              <span className="w-[0.8em] h-[0.8em] bg-orange-500 rounded-full" />
+            </span>
           </StatusBadge>
         )}
         {dnf && (


### PR DESCRIPTION
Unified size of flags in standings/relative (meatball, black flag, slowdown) and the new flag for slowdown

## Description



## Screenshots

### Before
<!-- Screenshot or description of the current behaviour -->

### After

<img width="449" height="201" alt="image" src="https://github.com/user-attachments/assets/db0ee56c-ec08-4869-a2e2-95a6f9cdcb3e" />

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [x] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
