### PR TITLE
fix: quiet hot-path logger.warn/info in interpolation and fuel calc

### DIFF
--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -1175,7 +1175,7 @@ export function useFuelCalculation(
     // Guard against invalid lapsRemaining - SOLUTION 5
     // Sanity check para lapsRemaining
     if (lapsRemaining > 1000) {
-      logger.warn(
+      logger.debug(
         `[FuelCalculator] Unrealistic lapsRemaining (${lapsRemaining}) capped at 1000`
       );
       lapsRemaining = 1000;

--- a/src/frontend/components/Standings/interpolation.ts
+++ b/src/frontend/components/Standings/interpolation.ts
@@ -25,20 +25,18 @@ export function interpolateAtPoint(
   // We cannot interpolate PCHIP across the finish line without extra logic for the X-axis wrap.
   // For now, if p1 is missing or wrapped inappropriately, we fall back to p0 (clamping).
   if (!p0) {
-    logger.info('P1 is missing!');
+    logger.debug('P1 is missing!');
     return null; // Off-track or sparse map gap
   }
 
   if (!p1) {
-    logger.info('P2 is missing!');
+    logger.debug('P2 is missing!');
     return p0.timeElapsedSinceStart; // End of data, return last known time
   }
 
   // 4. Validate Tangents
   if (p0.tangent === undefined || p1.tangent === undefined) {
-    // Fallback if PCHIP wasn't run: simple linear interpolation could go here,
-    // but better to warn.
-    logger.warn('Missing tangents for PCHIP interpolation');
+    logger.debug('Missing tangents for PCHIP interpolation');
     return null;
   }
 


### PR DESCRIPTION
## Summary
- `Standings/interpolation.ts` — drop `logger.warn` (missing PCHIP tangents) and two `logger.info` calls (P1/P2 missing) to `debug`. `interpolateAtPoint` runs per driver, per frame via `calculateReferenceDelta`/`calculateReferenceGap`, so these would spam ~60×N times/sec when their guard conditions hit.
- `FuelCalculator/useFuelCalculation.tsx` — drop the "Unrealistic lapsRemaining capped at 1000" `logger.warn` to `debug`. Sits in the main fuel-calc memo that recomputes on every telemetry update.

These are recoverable internal states (already handled with fallbacks/clamps), not user-actionable, so `debug` is the right level.

## Test plan
- [ ] Run app against iRacing with a missing/incomplete reference lap; confirm log file no longer floods with "Missing tangents" / "P1 is missing".
- [ ] Trigger fuel-calc edge case (very low consumption + high fuel) and confirm "Unrealistic lapsRemaining" no longer spams the log.
- [ ] Verify reference-lap gaps and fuel calc still behave correctly (no functional change — only log level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)