### PR TITLE
fix: prevent blank overlay renderers (Infinity class positions, error boundaries, crash recovery)

### DIFF
--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -199,6 +199,39 @@ export class OverlayManager {
       this.displayBoundsInfo.delete(display.id);
     });
 
+    browserWindow.webContents.on('render-process-gone', (_event, details) => {
+      logger.error(
+        `[OverlayManager] Renderer process gone for display ${display.id}${isPrimary ? ' (PRIMARY)' : ''}: reason=${details.reason}, exitCode=${details.exitCode}`
+      );
+
+      if (this.isQuitting) return;
+
+      // Clean up stale entry so recreate doesn't early-return
+      this.displayWindows.delete(display.id);
+      this.displayBoundsInfo.delete(display.id);
+
+      // Small delay so Electron can fully clean up before a new window is created
+      setTimeout(() => {
+        if (this.isQuitting) return;
+        logger.info(
+          `[OverlayManager] Recreating renderer for display ${display.id}`
+        );
+        this.createWindowForDisplay(display, isPrimary);
+      }, 1000);
+    });
+
+    browserWindow.on('unresponsive', () => {
+      logger.warn(
+        `[OverlayManager] Renderer unresponsive for display ${display.id}${isPrimary ? ' (PRIMARY)' : ''}`
+      );
+    });
+
+    browserWindow.on('responsive', () => {
+      logger.info(
+        `[OverlayManager] Renderer responsive again for display ${display.id}${isPrimary ? ' (PRIMARY)' : ''}`
+      );
+    });
+
     // Track readiness of both events to avoid race condition
     let boundsReady = false;
     let pageLoaded = false;

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -13,6 +13,7 @@ import { Settings } from './components/Settings/Settings';
 import { ThemeManager } from './components/ThemeManager/ThemeManager';
 import { HideUIWrapper } from './components/HideUIWrapper/HideUIWrapper';
 import { OverlayContainer } from './components/OverlayContainer';
+import { ErrorBoundary } from './components/ErrorBoundary/ErrorBoundary';
 
 /**
  * Check if this window is the settings window based on URL hash
@@ -52,22 +53,26 @@ const App = () => {
 
   if (isSettings) {
     return (
-      <DashboardProvider bridge={window.dashboardBridge}>
-        <SettingsApp />
-      </DashboardProvider>
+      <ErrorBoundary label="settings" resetAfterMs={2000}>
+        <DashboardProvider bridge={window.dashboardBridge}>
+          <SettingsApp />
+        </DashboardProvider>
+      </ErrorBoundary>
     );
   }
 
   return (
-    <DashboardProvider bridge={window.dashboardBridge}>
-      <RunningStateProvider bridge={window.irsdkBridge}>
-        <SessionProvider bridge={window.irsdkBridge} />
-        <TelemetryProvider bridge={window.irsdkBridge} />
-        <PitLaneProvider bridge={window.pitLaneBridge} />
-        <ReferenceStoreProvider bridge={window.referenceLapsBridge} />
-        <OverlayApp />
-      </RunningStateProvider>
-    </DashboardProvider>
+    <ErrorBoundary label="overlay" resetAfterMs={2000}>
+      <DashboardProvider bridge={window.dashboardBridge}>
+        <RunningStateProvider bridge={window.irsdkBridge}>
+          <SessionProvider bridge={window.irsdkBridge} />
+          <TelemetryProvider bridge={window.irsdkBridge} />
+          <PitLaneProvider bridge={window.pitLaneBridge} />
+          <ReferenceStoreProvider bridge={window.referenceLapsBridge} />
+          <OverlayApp />
+        </RunningStateProvider>
+      </DashboardProvider>
+    </ErrorBoundary>
   );
 };
 

--- a/src/frontend/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/frontend/components/ErrorBoundary/ErrorBoundary.tsx
@@ -10,35 +10,50 @@ interface Props {
   /**
    * Auto-reset interval in ms. When set, the boundary clears its error state
    * after this delay so transient telemetry-induced errors recover automatically.
+   * Resets are capped at maxResets to avoid an infinite loop for irrecoverable
+   * errors (e.g. out-of-disk-space).
    */
   resetAfterMs?: number;
+  /** Maximum number of auto-resets before giving up. Defaults to 3. */
+  maxResets?: number;
 }
 
 interface State {
   hasError: boolean;
+  resetCount: number;
 }
 
 export class ErrorBoundary extends Component<Props, State> {
-  state: State = { hasError: false };
+  state: State = { hasError: false, resetCount: 0 };
   private resetTimer: ReturnType<typeof setTimeout> | null = null;
 
-  static getDerivedStateFromError(): State {
+  static getDerivedStateFromError(): Partial<State> {
     return { hasError: true };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    const { label = 'unknown', resetAfterMs } = this.props;
+    const { label = 'unknown', resetAfterMs, maxResets = 3 } = this.props;
+    const { resetCount } = this.state;
+
     logger.error(
-      `[ErrorBoundary:${label}] ${error.message}`,
+      `[ErrorBoundary:${label}] ${error.message} (attempt ${resetCount + 1}/${maxResets})`,
       error.stack,
       info.componentStack
     );
 
-    if (resetAfterMs && this.resetTimer === null) {
+    const canReset = resetAfterMs && resetCount < maxResets;
+    if (canReset && this.resetTimer === null) {
       this.resetTimer = setTimeout(() => {
         this.resetTimer = null;
-        this.setState({ hasError: false });
+        this.setState((s) => ({
+          hasError: false,
+          resetCount: s.resetCount + 1,
+        }));
       }, resetAfterMs);
+    } else if (!canReset && resetAfterMs) {
+      logger.error(
+        `[ErrorBoundary:${label}] Giving up after ${maxResets} resets — widget will remain hidden`
+      );
     }
   }
 

--- a/src/frontend/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/frontend/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+import logger from '@irdashies/utils/logger';
+
+interface Props {
+  children: ReactNode;
+  /** Identifier (e.g. widget id, "app") included in logs to locate the failure. */
+  label?: string;
+  /** Optional fallback UI; defaults to invisible so an overlay stays out of the way. */
+  fallback?: ReactNode;
+  /**
+   * Auto-reset interval in ms. When set, the boundary clears its error state
+   * after this delay so transient telemetry-induced errors recover automatically.
+   */
+  resetAfterMs?: number;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+  private resetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    const { label = 'unknown', resetAfterMs } = this.props;
+    logger.error(
+      `[ErrorBoundary:${label}] ${error.message}`,
+      error.stack,
+      info.componentStack
+    );
+
+    if (resetAfterMs && this.resetTimer === null) {
+      this.resetTimer = setTimeout(() => {
+        this.resetTimer = null;
+        this.setState({ hasError: false });
+      }, resetAfterMs);
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.resetTimer !== null) {
+      clearTimeout(this.resetTimer);
+      this.resetTimer = null;
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? null;
+    }
+    return this.props.children;
+  }
+}

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -4,6 +4,7 @@ import type { WidgetLayout } from '@irdashies/types';
 import { WidgetContainer } from '../WidgetContainer';
 import { WIDGET_MAP } from '../../WidgetIndex';
 import { XIcon } from '@phosphor-icons/react';
+import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 
 export const OverlayContainer = memo(() => {
   const {
@@ -98,7 +99,12 @@ export const OverlayContainer = memo(() => {
             onLayoutChange={handleLayoutChange}
           >
             {running || widget.alwaysEnabled ? (
-              <WidgetComponent {...widget.config} />
+              <ErrorBoundary
+                label={`widget:${widget.type || widget.id}`}
+                resetAfterMs={2000}
+              >
+                <WidgetComponent {...widget.config} />
+              </ErrorBoundary>
             ) : null}
           </WidgetContainer>
         );

--- a/src/frontend/components/TrackMap/hooks/useDriverProgress.tsx
+++ b/src/frontend/components/TrackMap/hooks/useDriverProgress.tsx
@@ -61,12 +61,16 @@ export const useDriverProgress = () => {
     }
     // Build carIdx -> effective class position map
     const effectivePosition: Record<number, number> = {};
+    const isRankedPosition = (carIdx: number): boolean => {
+      const pos = carIdxClassPosition?.[carIdx];
+      return pos !== undefined && isFinite(pos) && pos > 0;
+    };
     for (const classDrivers of Object.values(byClass)) {
-      const numRanked = classDrivers.filter(
-        (d) => (carIdxClassPosition?.[d.CarIdx] ?? 0) > 0
+      const numRanked = classDrivers.filter((d) =>
+        isRankedPosition(d.CarIdx)
       ).length;
       const unranked = classDrivers
-        .filter((d) => (carIdxClassPosition?.[d.CarIdx] ?? 0) <= 0)
+        .filter((d) => !isRankedPosition(d.CarIdx))
         .sort((a, b) => {
           const qA = qualifyingPositionByCarIdx.get(a.CarIdx);
           const qB = qualifyingPositionByCarIdx.get(b.CarIdx);
@@ -87,10 +91,9 @@ export const useDriverProgress = () => {
       .map((driver) => ({
         driver,
         isPlayer: driver.CarIdx === driverIdx,
-        classPosition:
-          (carIdxClassPosition?.[driver.CarIdx] ?? 0) > 0
-            ? carIdxClassPosition?.[driver.CarIdx]
-            : effectivePosition[driver.CarIdx],
+        classPosition: isRankedPosition(driver.CarIdx)
+          ? carIdxClassPosition?.[driver.CarIdx]
+          : effectivePosition[driver.CarIdx],
       }));
   }, [drivers, driverIdx, paceCarIdx, carIdxClassPosition, qualifyingResults]);
 

--- a/src/frontend/components/TrackMap/trackDrawingUtils.ts
+++ b/src/frontend/components/TrackMap/trackDrawingUtils.ts
@@ -164,12 +164,14 @@ export const drawDrivers = (
   driverLivePositions: Record<number, number>,
   carIdxIsOnPitRoad?: number[]
 ) => {
+  const safePosition = (pos: number | undefined): number =>
+    pos !== undefined && isFinite(pos) ? pos : 0;
   Object.values(calculatePositions)
     .sort((a, b) => {
       if (a.isPlayer !== b.isPlayer) {
         return Number(a.isPlayer) - Number(b.isPlayer); // draws player last to be on top
       }
-      return (b.sessionPosition ?? 0) - (a.sessionPosition ?? 0); // draws leader on top
+      return safePosition(b.sessionPosition) - safePosition(a.sessionPosition); // draws leader on top
     })
     .forEach(({ driver, position, isPlayer, sessionPosition }) => {
       let color = driverColors[driver.CarIdx];


### PR DESCRIPTION
## Description

Fixes a regression where overlay renderer windows (most reproducibly on multi-display setups, but possible on any setup) go blank mid-session and never recover, requiring an app restart to use the affected display again.

### Root cause

PR #503 (\`feat: highlight leader\`) added a new sort comparator to \`drawDrivers\` in \`trackDrawingUtils.ts\` so the leader is drawn on top of other cars:

\`\`\`ts
return (b.sessionPosition ?? 0) - (a.sessionPosition ?? 0);
\`\`\`

\`sessionPosition\` ultimately comes from \`CarIdxClassPosition\` via \`useDriverProgress\`. iRacing reports \`Infinity\` for cars that aren't currently ranked (very common right after a session join, during gridding, after a session/series transition, and for non-class cars). The existing \`(carIdxClassPosition?.[carIdx] ?? 0) > 0\` checks throughout that hook do **not** filter Infinity (\`Infinity > 0\` is \`true\`), so Infinity flowed through to \`sessionPosition\`. The new comparator then computes \`Infinity - Infinity = NaN\`, which produces undefined ordering in \`Array.sort\` and breaks the subsequent \`forEach\` render loop in unpredictable ways.

Because \`App.tsx\` had no React error boundary, any uncaught throw in any provider or widget unmounted the entire React tree. The Electron renderer process stayed alive, the BrowserWindow stayed visible, but the DOM was empty — so the overlay just looked \"frozen\" or blank forever, with no useful error in the logs.

### Changes

**1. Infinity guards in TrackMap (\`useDriverProgress.tsx\`, \`trackDrawingUtils.ts\`)**

Replaces \`(pos ?? 0) > 0\` checks with an \`isFinite(pos) && pos > 0\` helper, so Infinity is correctly treated as \"unranked\" and falls into the qualifying / car-number fallback ordering — same pattern already used by \`useDriverPositions.tsx\` for the Standings widget. Adds defence-in-depth in the new sort comparator so any non-finite \`sessionPosition\` is treated as 0, preventing NaN from ever reaching \`Array.sort\`.

**2. App-level and per-widget React error boundaries (new \`ErrorBoundary.tsx\`)**

Adds a small \`ErrorBoundary\` component and wraps:

- The app root in \`App.tsx\` (one boundary for the overlay app, one for the settings app)
- Each widget inside \`OverlayContainer\` so a single broken widget cannot take down the rest of that display's overlays

Errors are logged via the existing frontend logger (which forwards to electron-log via IPC, so they survive in the log file). The boundary auto-resets after 2 seconds so a transient telemetry-induced error self-recovers without user intervention. The fallback UI is intentionally invisible by default — the overlay is a transparent compositor on top of iRacing, so a visible error banner would be more disruptive than a brief gap.

**3. Electron renderer crash recovery (\`overlayManager.ts\`)**

Defence in depth for a different failure mode: if a renderer process actually dies (OOM, segfault, killed by the OS), Electron's \`render-process-gone\` event now logs which display was affected (with reason and exit code) and recreates the window after a 1 second delay. Also adds \`unresponsive\` / \`responsive\` handlers for IPC-blocked renderer diagnosis. The existing \`did-finish-load\` path already re-sends \`containerBoundsInfo\` and re-triggers \`onWindowReadyCallbacks\`, so the SDK bridge re-broadcasts state to the recreated window automatically.

### Why these three together

The Infinity guard fixes the specific bug introduced by #503 that's blanking overlays today. The error boundary catches any future regression of the same shape (a widget throws → whole renderer dies silently) so this class of bug is recoverable rather than fatal. The Electron handlers cover the remaining case where the renderer process itself is gone, not just React. None of the three alone is sufficient: the Infinity fix without boundaries leaves the codebase one bad PR away from the same outcome; boundaries without the Infinity fix would mask the bug as a continuous crash loop; crash recovery alone never fired because the process wasn't actually crashing.

### Tested

- Vitest TrackMap suite (\`npm run test\` in \`src/frontend/components/TrackMap\`) — all 28 tests pass
- \`npx tsc --noEmit\` — no type errors
- ESLint — no warnings
- Reproduction scenario: a session where iRacing returns Infinity for any \`CarIdxClassPosition\` entry (gridding, post-session transition, multi-class with non-ranked cars) — the renderer no longer blanks

## Screenshots

N/A — no visual changes when things are working. The behavioural change is that the overlay no longer goes blank.

### Before

Centre-screen overlay goes blank mid-session on multi-display setups. No errors in the log. Window stays alive but shows nothing. App restart is the only recovery.

### After

Overlay continues to render. If any widget does throw, the failure is logged with the widget id and the boundary auto-resets within 2 seconds.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via \`npm test\`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run \`npm run lint\` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)