### PR TITLE
fix(standings): position bug + perf(sectordelta): drop 60Hz re-renders

### DIFF
--- a/src/frontend/components/SectorDelta/SectorDelta.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.tsx
@@ -1,7 +1,11 @@
 import { useEffect } from 'react';
 import { GhostIcon, WarningIcon } from '@phosphor-icons/react';
 import { useSectorDeltas, useSectorTimingStore } from '@irdashies/context';
-import { useSessionVisibility, useTelemetryValue } from '@irdashies/context';
+import {
+  useSessionVisibility,
+  useTelemetryValue,
+  useTelemetryValueRounded,
+} from '@irdashies/context';
 import { useReferenceLapSectorTimes } from '@irdashies/context';
 import type { SectorDeltaConfig } from '@irdashies/types';
 import type { TimeFormat } from '@irdashies/types';
@@ -84,7 +88,8 @@ export const SectorDelta = ({
     currentSectorIdx,
   } = useSectorDeltas();
   const isOnTrack = useTelemetryValue('IsOnTrack');
-  const lapDistPct = useTelemetryValue('LapDistPct') ?? 0;
+  // 3dp ≈ 5m on a 5km track — sub-pixel for the sector progress bar.
+  const lapDistPct = useTelemetryValueRounded('LapDistPct', 3) ?? 0;
   const { refSectorTimes, hasGhostLap } = useReferenceLapSectorTimes();
 
   const useGhost = ghostComparison === 'prefer-ghost' && hasGhostLap;

--- a/src/frontend/components/SectorDelta/hooks/useLiveSectorDelta.ts
+++ b/src/frontend/components/SectorDelta/hooks/useLiveSectorDelta.ts
@@ -4,7 +4,7 @@ import {
   useSessionStore,
   useDriverCarIdx,
   useReferenceLapStore,
-  useTelemetryValue,
+  useTelemetryValueRounded,
 } from '@irdashies/context';
 import { calculateReferenceDelta } from '../../Standings/relativeGapHelpers';
 
@@ -23,8 +23,10 @@ import { calculateReferenceDelta } from '../../Standings/relativeGapHelpers';
  * is invalid (reset/teleport).
  */
 export const useLiveSectorDelta = (useGhostFile: boolean): number | null => {
-  const lapDistPct = useTelemetryValue('LapDistPct') ?? 0;
-  const sessionTime = useTelemetryValue('SessionTime') ?? 0;
+  // 4dp matches the reference-lap interpolation step (REFERENCE_INTERVAL = 0.0025);
+  // 2dp on SessionTime gives 10ms resolution which exceeds the 0.1s display.
+  const lapDistPct = useTelemetryValueRounded('LapDistPct', 4) ?? 0;
+  const sessionTime = useTelemetryValueRounded('SessionTime', 2) ?? 0;
 
   const sectorEntryTime = useSectorTimingStore((s) => s.sectorEntryTime);
   const sectorEntryValid = useSectorTimingStore((s) => s.sectorEntryValid);

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -361,7 +361,7 @@ export const createDriverStandings = (
         !mappedCarIdxs.has(driver.CarIdx)
     )
     .sort(sortByCarNumber)
-    .map((driver) => {
+    .map((driver, index) => {
       // Assign per-class position: count of drivers in their class + 1
       const classId = driver.CarClassID;
       const classPosition = (classPositionCounts.get(classId) ?? 0) + 1;
@@ -369,7 +369,7 @@ export const createDriverStandings = (
 
       return {
         carIdx: driver.CarIdx,
-        position: mapped.length + classPositionCounts.size,
+        position: mapped.length + index + 1,
         classPosition,
         isPlayer: driver.CarIdx === session.playerIdx,
         driver: {

--- a/src/frontend/context/TelemetryStore/TelemetryStore.tsx
+++ b/src/frontend/context/TelemetryStore/TelemetryStore.tsx
@@ -4,6 +4,7 @@ import { useStoreWithEqualityFn } from 'zustand/traditional';
 import {
   arrayCompare,
   arrayCompareRounded,
+  scalarCompareRounded,
   telemetryCompare,
 } from './telemetryCompare';
 
@@ -69,4 +70,20 @@ export const useTelemetryValuesRounded = (
     useTelemetryStore,
     (state) => (state.telemetry?.[key]?.value ?? []) as number[],
     (a, b) => arrayCompareRounded(precision, a, b)
+  );
+
+/**
+ * Returns the first telemetry value for a given key, only triggering re-renders
+ * when the value changes beyond the given decimal precision. Use for
+ * high-frequency scalar telemetry (e.g. LapDistPct, SessionTime) where
+ * sub-threshold changes don't produce meaningful UI updates.
+ */
+export const useTelemetryValueRounded = (
+  key: keyof Telemetry,
+  precision: number
+): number | undefined =>
+  useStoreWithEqualityFn(
+    useTelemetryStore,
+    (state) => state.telemetry?.[key]?.value?.[0] as number | undefined,
+    (a, b) => scalarCompareRounded(precision, a, b)
   );

--- a/src/frontend/context/TelemetryStore/telemetryCompare.spec.ts
+++ b/src/frontend/context/TelemetryStore/telemetryCompare.spec.ts
@@ -3,6 +3,7 @@ import {
   telemetryCompare,
   arrayCompare,
   arrayCompareRounded,
+  scalarCompareRounded,
 } from './telemetryCompare';
 import type { TelemetryVar } from '@irdashies/types';
 
@@ -121,5 +122,38 @@ describe('arrayCompareRounded', () => {
     // 0.005 rounds to 0.01 at precision 2, 0.004 rounds to 0.00
     expect(arrayCompareRounded(2, [0.004], [0.005])).toBe(false);
     expect(arrayCompareRounded(2, [0.004], [0.004])).toBe(true);
+  });
+});
+
+describe('scalarCompareRounded', () => {
+  it('should return true if both are undefined', () => {
+    expect(scalarCompareRounded(2, undefined, undefined)).toBe(true);
+  });
+
+  it('should return false if only one is undefined', () => {
+    expect(scalarCompareRounded(2, 1.0, undefined)).toBe(false);
+    expect(scalarCompareRounded(2, undefined, 1.0)).toBe(false);
+  });
+
+  it('should return true for values equal at given precision', () => {
+    expect(scalarCompareRounded(2, 1.001, 1.002)).toBe(true);
+  });
+
+  it('should return false for values differing beyond precision', () => {
+    expect(scalarCompareRounded(2, 1.001, 1.014)).toBe(false);
+  });
+
+  it('should return true for exactly equal values', () => {
+    expect(scalarCompareRounded(4, 0.1234, 0.1234)).toBe(true);
+  });
+
+  it('should respect precision boundary correctly', () => {
+    expect(scalarCompareRounded(2, 0.004, 0.005)).toBe(false);
+    expect(scalarCompareRounded(2, 0.004, 0.004)).toBe(true);
+  });
+
+  it('should handle zero correctly', () => {
+    expect(scalarCompareRounded(2, 0, 0)).toBe(true);
+    expect(scalarCompareRounded(2, 0, undefined)).toBe(false);
   });
 });

--- a/src/frontend/context/TelemetryStore/telemetryCompare.ts
+++ b/src/frontend/context/TelemetryStore/telemetryCompare.ts
@@ -52,3 +52,19 @@ export const arrayCompareRounded = (
   }
   return true;
 };
+
+/**
+ * Compares two scalars for equality within a given decimal precision.
+ * Use for high-frequency scalar telemetry (e.g. LapDistPct, SessionTime) where
+ * sub-threshold changes don't produce meaningful UI updates.
+ */
+export const scalarCompareRounded = (
+  precision: number,
+  a?: number,
+  b?: number
+) => {
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  const factor = Math.pow(10, precision);
+  return Math.round(a * factor) === Math.round(b * factor);
+};


### PR DESCRIPTION
## Summary

Two independent fixes from an audit of changes since v0.2.1.

### 1. `fix:` standings position for not-yet-in-results drivers in multi-class

Introduced in #518. `notYetInResults` (drivers without lap times) assigned the global `position` field as `mapped.length + classPositionCounts.size`, where `.size` is the number of distinct class IDs in the map — not an incrementing counter. Every such driver got the same `position`, breaking ordering after the position-based sort in `useDriverStandings`. Switched to `mapped.length + index + 1`.

### 2. `perf:` round `LapDistPct` / `SessionTime` in SectorDelta to drop 60Hz re-renders

Introduced in #488. `SectorDelta` and `useLiveSectorDelta` subscribed to `useTelemetryValue('LapDistPct')` and `'SessionTime'` — both unrounded scalar floats updating every tick — so the component re-rendered and the PCHIP-interpolation `useMemo` re-ran 60×/sec.

Added `useTelemetryValueRounded` as a scalar mirror of the existing `useTelemetryValuesRounded` array hook and used it in the SectorDelta consumers. `useSectorTiming` is intentionally left unrounded — it interpolates between consecutive frames to detect sector boundary crossings and needs the full signal (same reasoning as `CarSpeedsStore` per `AGENTS.md`).

Precision choices follow `AGENTS.md`:
- `LapDistPct`, 3dp — progress bar (~5m on a 5km track, sub-pixel)
- `LapDistPct`, 4dp — `useLiveSectorDelta`, matches `REFERENCE_INTERVAL = 0.0025`
- `SessionTime`, 2dp — 10ms; display rounds to 0.1s anyway

## Test plan

- [x] `npm run test` (744 passing)
- [x] `npm run lint` (clean, including `tsc --noEmit`)
- [ ] Multi-class race with drivers who haven't yet set a lap — confirm they appear at the bottom in stable car-number order
- [ ] Single-class warmup — confirm ordering unchanged
- [ ] On-track with SectorDelta widget visible — confirm sector progress bar still animates smoothly and live delta updates
- [ ] React DevTools profiler on SectorDelta — confirm renders/sec dropped from ~60 to a handful

🤖 Generated with [Claude Code](https://claude.com/claude-code)