### PR TITLE
fix(tachometer): scale LEDs by min(width, height) and let pill hug LEDs

### DIFF
--- a/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.tsx
+++ b/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.tsx
@@ -317,7 +317,7 @@ export const Tachometer = ({
           {shouldShowRpmBox && rpmOrientation === 'horizontal' && (
             <div
               id="rpm-text"
-              className={`bg-slate-800/(--bg-opacity) text-[30cqmin] absolute right-[-8em] flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
+              className={`bg-slate-800/(--bg-opacity) text-base absolute right-[-8em] flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
               style={{
                 ...getRpmBoxStyle(),
                 height: '2em',
@@ -347,7 +347,7 @@ export const Tachometer = ({
         {shouldShowRpmBox && rpmOrientation !== 'horizontal' && (
           <div
             id="rpm-text"
-            className={`bg-slate-800/(--bg-opacity) text-[20cqmin] flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
+            className={`bg-slate-800/(--bg-opacity) text-base flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
             style={{
               ...getRpmBoxStyle(),
               height: '1.5em',

--- a/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.tsx
+++ b/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.tsx
@@ -286,34 +286,38 @@ export const Tachometer = ({
         {/* LED lights */}
         <div
           id="ledcontainer"
-          className={`bg-slate-800/(--bg-opacity) h-full flex ${rpmOrientation === 'horizontal' ? 'relative' : 'flex-2'} items-center justify-center rounded-full px-4`}
+          className={`bg-slate-800/(--bg-opacity) flex ${rpmOrientation === 'horizontal' ? 'relative' : ''} items-center justify-center rounded-full`}
           style={{
             ['--bg-opacity' as string]: `${opacity ?? 80}%`,
+            padding: `4px min(40cqh, ${(42.5 / effectiveNumLights).toFixed(2)}cqw)`,
           }}
         >
           {Array.from({ length: effectiveNumLights }, (_, i) => (
-            <>
-              <div className="h-[80%] aspect-square p-0.5">
-                <div
-                  key={i}
-                  className="rounded-full w-full h-full border border-gray-600 transition-all duration-300"
-                  style={{
-                    backgroundColor: getLedColor(i),
-                    boxShadow: isLedActive(i)
-                      ? `0 0 4px ${getLedColor(i)}`
-                      : 'none',
-                  }}
-                  aria-label={`LED ${i + 1}`}
-                />
-              </div>
-            </>
+            <div
+              key={i}
+              className="aspect-square p-0.5"
+              style={{
+                width: `min(80cqh, ${(85 / effectiveNumLights).toFixed(2)}cqw)`,
+              }}
+            >
+              <div
+                className="rounded-full w-full h-full border border-gray-600 transition-all duration-300"
+                style={{
+                  backgroundColor: getLedColor(i),
+                  boxShadow: isLedActive(i)
+                    ? `0 0 4px ${getLedColor(i)}`
+                    : 'none',
+                }}
+                aria-label={`LED ${i + 1}`}
+              />
+            </div>
           ))}
 
           {/* RPM display - Horinztonal - shows when showRpmText is true OR when custom shift points exist */}
           {shouldShowRpmBox && rpmOrientation === 'horizontal' && (
             <div
               id="rpm-text"
-              className={`bg-slate-800/(--bg-opacity) text-[30cqh] absolute right-[-8em] flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
+              className={`bg-slate-800/(--bg-opacity) text-[30cqmin] absolute right-[-8em] flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
               style={{
                 ...getRpmBoxStyle(),
                 height: '2em',
@@ -343,7 +347,7 @@ export const Tachometer = ({
         {shouldShowRpmBox && rpmOrientation !== 'horizontal' && (
           <div
             id="rpm-text"
-            className={`bg-slate-800/(--bg-opacity) text-[20cqh] flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
+            className={`bg-slate-800/(--bg-opacity) text-[20cqmin] flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
             style={{
               ...getRpmBoxStyle(),
               height: '1.5em',


### PR DESCRIPTION
## Description

Tachometer LEDs and pill background now scale intelligently with both width and height instead of being height-only. Two related changes:

1. **LED size** is now `min(80cqh, (85/N)cqw)` — each LED is the smaller of 80% of widget height or its share of 85% of widget width. Wide+short widgets behave as before; tall+narrow widgets shrink LEDs to fit width instead of overflowing.
2. **Pill background** no longer locks to widget height (`h-full` removed) — it hugs the LEDs with proportional padding (4px vertical, half-LED-size horizontal so `rounded-full` ends still wrap cleanly around the end LEDs at any size).
3. **RPM/SHIFT readout** uses `cqmin` instead of `cqh` so the text scales with the smaller dimension and doesn't overflow narrow widgets.

Tested visually in Storybook across the demo and `CarComparison` (6/8/10-LED) stories at multiple aspect ratios. Not tested in iRacing.

## Screenshots

### Before
Pill stretched to full widget height regardless of LED size; LEDs locked to 80% of height even when widget was made wider.

<img width="498" height="161" alt="image" src="https://github.com/user-attachments/assets/3be81ba6-c4f1-4051-b998-f28aee102848" />


### After
Pill hugs the LEDs and keeps a consistent rounded shape; LEDs scale by whichever dimension is binding.

<img width="960" height="614" alt="Screen Recording 2026-04-27 at 10 33 00 AM" src="https://github.com/user-attachments/assets/dd742f25-a8a7-4e50-87be-ac4873c7f61f" />


## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced tachometer component layout responsiveness with improved sizing for LED indicators and RPM text display, ensuring consistent visual performance across different display sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->