### PR TITLE
feat(sector-delta): continuous scrolling strip with position-pinned center

### DIFF
--- a/src/frontend/components/SectorDelta/SectorDelta.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.tsx
@@ -10,8 +10,8 @@ import { useReferenceLapSectorTimes } from '@irdashies/context';
 import type { SectorDeltaConfig } from '@irdashies/types';
 import type { TimeFormat } from '@irdashies/types';
 import type { SectorColor } from '@irdashies/context';
-import { formatTime } from '@irdashies/utils/time';
 import { useLiveSectorDelta } from './hooks/useLiveSectorDelta';
+import { useCarouselWindow } from './hooks/useCarouselWindow';
 import {
   computeGhostSectorColor,
   getSectorDeltaThresholdFractions,
@@ -51,8 +51,9 @@ const SECTOR_CARD: Record<
 };
 
 function timeFormatToDecimalPlaces(timeFormat: TimeFormat): number {
-  if (timeFormat === 'full' || timeFormat === 'seconds-full') return 3;
-  if (timeFormat === 'mixed' || timeFormat === 'seconds-mixed') return 1;
+  if (timeFormat === 'seconds-full' || timeFormat === 'full') return 3;
+  if (timeFormat === 'seconds-2') return 2;
+  if (timeFormat === 'seconds-mixed' || timeFormat === 'mixed') return 1;
   return 0;
 }
 
@@ -62,10 +63,10 @@ function formatDelta(
   timeFormat: TimeFormat
 ): string {
   if (lapTime === null) return '--';
-  if (bestTime === null) return formatTime(lapTime, timeFormat);
+  const dp = timeFormatToDecimalPlaces(timeFormat);
+  if (bestTime === null) return lapTime.toFixed(dp);
   const delta = lapTime - bestTime;
   const sign = delta >= 0 ? '+' : '';
-  const dp = timeFormatToDecimalPlaces(timeFormat);
   return `${sign}${delta.toFixed(dp)}`;
 }
 
@@ -73,9 +74,12 @@ export const SectorDelta = ({
   background,
   showOnlyWhenOnTrack,
   sessionVisibility,
-  timeFormat = 'full',
+  timeFormat = 'seconds-full',
   ghostComparison = 'prefer-ghost',
+  trackIncidentSectors = true,
   thresholds,
+  maxSectorsShown,
+  alwaysScroll = false,
 }: SectorDeltaProps) => {
   const {
     sectors,
@@ -85,17 +89,16 @@ export const SectorDelta = ({
     previousLapSectorTimes,
     previousLapSectorUnclean,
     sessionBestSectorTimes,
+    previousSessionBestSectorTimes,
     currentSectorIdx,
   } = useSectorDeltas();
   const isOnTrack = useTelemetryValue('IsOnTrack');
-  // 3dp ≈ 5m on a 5km track — sub-pixel for the sector progress bar.
   const lapDistPct = useTelemetryValueRounded('LapDistPct', 3) ?? 0;
   const { refSectorTimes, hasGhostLap } = useReferenceLapSectorTimes();
 
   const useGhost = ghostComparison === 'prefer-ghost' && hasGhostLap;
   const liveSectorDelta = useLiveSectorDelta(useGhost);
 
-  // How far (0–1) through the current sector the player is
   const sectorStart = sectors[currentSectorIdx]?.SectorStartPct ?? 0;
   const sectorEnd = sectors[currentSectorIdx + 1]?.SectorStartPct ?? 1;
   const sectorProgress =
@@ -112,89 +115,109 @@ export const SectorDelta = ({
     setThresholds(green, yellow);
   }, [thresholds, setThresholds]);
 
+  const setTrackIncidentSectors = useSectorTimingStore(
+    (s) => s.setTrackIncidentSectors
+  );
+  useEffect(() => {
+    setTrackIncidentSectors(trackIncidentSectors);
+  }, [trackIncidentSectors, setTrackIncidentSectors]);
+
+  const { isWindowed, extendedIndices, slotWidth, containerRef, stripStyle } =
+    useCarouselWindow(
+      currentSectorIdx,
+      sectorProgress,
+      sectors.length,
+      maxSectorsShown,
+      alwaysScroll
+    );
+
   if (!useSessionVisibility(sessionVisibility)) return null;
   if (showOnlyWhenOnTrack && !isOnTrack) return null;
   if (sectors.length === 0) return null;
 
   const opacity = (background?.opacity ?? 80) / 100;
 
-  return (
-    <div
-      className="flex flex-row items-center gap-1 p-1 rounded-sm"
-      style={{ backgroundColor: `rgba(15, 23, 42, ${opacity})` }}
-    >
-      {useGhost && (
-        <div className="flex items-center justify-center px-1 text-slate-400 flex-shrink-0">
-          <GhostIcon size={14} weight="fill" />
-        </div>
-      )}
-      {sectors.map((sector, i) => {
-        const isCurrent = i === currentSectorIdx;
-        const displayTime = isCurrent
-          ? (previousLapSectorTimes[i] ?? null)
-          : (currentLapSectorTimes[i] ?? previousLapSectorTimes[i] ?? null);
-        const isUnclean = isCurrent
-          ? previousLapSectorUnclean[i]
-          : currentLapSectorTimes[i] != null
-            ? currentLapSectorUnclean[i]
-            : previousLapSectorUnclean[i];
+  /** Renders the card content for a given sector index. */
+  const renderCard = (i: number, cardKey: string | number) => {
+    const sector = sectors[i];
+    if (!sector) return null;
 
-        const colorKey: SectorColor = useGhost
-          ? computeGhostSectorColor(
-              displayTime,
-              refSectorTimes[i] ?? null,
-              thresholds
-            )
-          : (sectorColors[i] ?? 'default');
+    const isCurrent = i === currentSectorIdx;
+    const displayTime = isCurrent
+      ? (previousLapSectorTimes[i] ?? null)
+      : (currentLapSectorTimes[i] ?? previousLapSectorTimes[i] ?? null);
+    const isUnclean = isCurrent
+      ? previousLapSectorUnclean[i]
+      : currentLapSectorTimes[i] != null
+        ? currentLapSectorUnclean[i]
+        : previousLapSectorUnclean[i];
 
-        const refTime = useGhost
-          ? (refSectorTimes[i] ?? null)
-          : (sessionBestSectorTimes[i] ?? null);
+    const colorKey: SectorColor = useGhost
+      ? computeGhostSectorColor(
+          displayTime,
+          refSectorTimes[i] ?? null,
+          thresholds
+        )
+      : (sectorColors[i] ?? 'default');
 
-        const dp = timeFormatToDecimalPlaces(timeFormat);
-        const delta =
-          isCurrent && liveSectorDelta !== null
-            ? `${liveSectorDelta >= 0 ? '+' : ''}${liveSectorDelta.toFixed(dp)}`
-            : formatDelta(displayTime, refTime, timeFormat);
-        const card = SECTOR_CARD[colorKey];
+    const refTime = useGhost
+      ? (refSectorTimes[i] ?? null)
+      : colorKey === 'purple'
+        ? (previousSessionBestSectorTimes[i] ?? null)
+        : (sessionBestSectorTimes[i] ?? null);
 
-        return (
-          <div
-            key={sector.SectorNum}
-            className={[
-              'relative flex flex-col items-center justify-center rounded-sm px-2 py-1 flex-1 min-w-0 overflow-hidden',
-              card.bg,
-              card.accent,
-            ].join(' ')}
-          >
-            <span className="text-xs font-semibold text-slate-400 leading-none mb-0.5">
-              S{sector.SectorNum + 1}
-            </span>
-            <span
-              className={[
-                'inline-flex items-center gap-1 text-sm font-bold leading-none tabular-nums',
-                card.text,
-                isCurrent ? 'opacity-70' : '',
-              ].join(' ')}
-            >
-              <span>{delta}</span>
-              {isUnclean && (
-                <WarningIcon
-                  size={10}
-                  weight="fill"
-                  className="text-amber-300 shrink-0"
-                />
-              )}
-            </span>
-            {isCurrent && (
+    const dp = timeFormatToDecimalPlaces(timeFormat);
+    const delta =
+      isCurrent && liveSectorDelta !== null
+        ? `${liveSectorDelta >= 0 ? '+' : ''}${liveSectorDelta.toFixed(dp)}`
+        : formatDelta(displayTime, refTime, timeFormat);
+    const cardStyle = SECTOR_CARD[colorKey];
+
+    return (
+      <div
+        key={cardKey}
+        className={[
+          'relative flex flex-col items-center justify-center rounded-sm px-2 py-1 overflow-hidden',
+          isWindowed ? 'flex-none' : 'flex-1 min-w-0',
+          cardStyle.bg,
+          cardStyle.accent,
+        ].join(' ')}
+        style={isWindowed ? { width: slotWidth } : undefined}
+      >
+        <span className="text-xs font-semibold text-slate-400 leading-none mb-0.5">
+          S{sector.SectorNum + 1}
+        </span>
+        <span
+          className={[
+            'inline-flex items-center gap-1 text-sm font-bold leading-none tabular-nums',
+            cardStyle.text,
+            isCurrent ? 'opacity-70' : '',
+          ].join(' ')}
+        >
+          <span>{delta}</span>
+          {isUnclean && (
+            <WarningIcon
+              size={10}
+              weight="fill"
+              className="text-amber-300 shrink-0"
+            />
+          )}
+        </span>
+        {isCurrent && (
+          <>
+            <div
+              className={
+                isWindowed
+                  ? 'absolute top-0 left-0 bottom-0'
+                  : 'absolute top-0 left-0 bottom-0 transition-[width] duration-200 ease-linear'
+              }
+              style={{
+                width: `${sectorProgress * 100}%`,
+                backgroundColor: 'rgba(56, 189, 248, 0.4)',
+              }}
+            />
+            {!isWindowed && (
               <>
-                <div
-                  className="absolute top-0 left-0 bottom-0 transition-[width] duration-200 ease-linear"
-                  style={{
-                    width: `${sectorProgress * 100}%`,
-                    backgroundColor: 'rgba(56, 189, 248, 0.4)',
-                  }}
-                />
                 <div className="absolute top-0 left-0 bottom-0 w-[2px] bg-sky-400" />
                 <div
                   className="absolute top-0 left-0 h-[2px] bg-sky-400 transition-[width] duration-200 ease-linear"
@@ -206,9 +229,39 @@ export const SectorDelta = ({
                 />
               </>
             )}
+          </>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="flex flex-row items-center gap-1 p-1 rounded-sm"
+      style={{ backgroundColor: `rgba(15, 23, 42, ${opacity})` }}
+    >
+      {useGhost && (
+        <div className="flex items-center justify-center px-1 text-slate-400 flex-shrink-0">
+          <GhostIcon size={14} weight="fill" />
+        </div>
+      )}
+
+      {isWindowed ? (
+        // Continuous scroll mode: strip translates every frame to keep the
+        // player's exact track position pinned to the horizontal center.
+        // Partial cards are visible on both edges.
+        <div ref={containerRef} className="flex-1 overflow-hidden relative">
+          <div className="flex flex-row gap-1" style={stripStyle}>
+            {extendedIndices.map((sectorIdx, slotPosition) =>
+              renderCard(sectorIdx, slotPosition)
+            )}
           </div>
-        );
-      })}
+          <div className="absolute inset-y-0 left-1/2 w-px bg-sky-400/60 pointer-events-none" />
+        </div>
+      ) : (
+        // Normal mode: all sectors visible, each card expands to fill width
+        sectors.map((sector, i) => renderCard(i, sector.SectorNum))
+      )}
     </div>
   );
 };

--- a/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
+++ b/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
@@ -1,0 +1,99 @@
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type React from 'react';
+
+const GAP = 4; // gap-1 = 4px
+
+/**
+ * Builds an extended sector index list with buffer sectors on each side:
+ *   [ ...last bufferExtra sectors, ...all sectors, ...first bufferExtra sectors ]
+ *
+ * This ensures the strip has visible content near the lap start/end boundary
+ * without any special-casing — the pre/post sectors scroll into view naturally.
+ */
+function buildExtendedIndices(
+  totalSectors: number,
+  bufferExtra: number
+): number[] {
+  return Array.from({ length: totalSectors + 2 * bufferExtra }, (_, i) => {
+    const rawIdx = i - bufferExtra;
+    return ((rawIdx % totalSectors) + totalSectors) % totalSectors;
+  });
+}
+
+/**
+ * Drives a continuously scrolling sector strip centered on the player's
+ * exact track position. The strip translates every time sectorProgress
+ * changes (i.e. every lapDistPct update), so the current position is
+ * always pinned to the horizontal center of the viewport.
+ *
+ * Partial sector cards are visible on both edges at all times.
+ */
+export function useCarouselWindow(
+  currentSectorIdx: number,
+  sectorProgress: number,
+  totalSectors: number,
+  maxSectorsShown: number | undefined,
+  alwaysScroll = false
+) {
+  const isWindowed =
+    alwaysScroll || (maxSectorsShown != null && totalSectors > maxSectorsShown);
+
+  const [slotWidth, setSlotWidth] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // When alwaysScroll is on but maxSectorsShown is unset, fit all sectors.
+  const effectiveMaxShown =
+    maxSectorsShown ?? (isWindowed ? totalSectors : undefined);
+
+  useLayoutEffect(() => {
+    if (!isWindowed || !effectiveMaxShown || !containerRef.current) return;
+
+    const measure = () => {
+      if (!containerRef.current) return;
+      setSlotWidth(
+        (containerRef.current.offsetWidth - (effectiveMaxShown - 1) * GAP) /
+          effectiveMaxShown
+      );
+    };
+
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, [isWindowed, effectiveMaxShown]);
+
+  // Extra sectors rendered before sector 0 and after the last sector.
+  // Enough to fill half the visible window so the edges are always covered.
+  const bufferExtra =
+    isWindowed && effectiveMaxShown ? Math.ceil(effectiveMaxShown / 2) + 1 : 0;
+
+  const extendedIndices = useMemo(
+    () =>
+      isWindowed && effectiveMaxShown && totalSectors > 0
+        ? buildExtendedIndices(totalSectors, bufferExtra)
+        : [],
+    [isWindowed, effectiveMaxShown, totalSectors, bufferExtra]
+  );
+
+  // Pixel width of one slot (card + trailing gap), and total container width
+  const step = slotWidth + GAP;
+  const containerWidth = effectiveMaxShown ? effectiveMaxShown * step - GAP : 0;
+
+  // Position in the strip of the player's exact track point.
+  // Uses whole-card steps for completed sectors, then fractional slotWidth
+  // within the current card (gap is not traversed mid-card).
+  const stripPosition =
+    (bufferExtra + currentSectorIdx) * step + sectorProgress * slotWidth;
+
+  const stripStyle: React.CSSProperties = isWindowed
+    ? { transform: `translateX(${containerWidth / 2 - stripPosition}px)` }
+    : {};
+
+  return {
+    isWindowed,
+    extendedIndices,
+    slotWidth,
+    containerRef,
+    stripStyle,
+  };
+}

--- a/src/frontend/components/Settings/sections/SectorDeltaSettings.tsx
+++ b/src/frontend/components/Settings/sections/SectorDeltaSettings.tsx
@@ -92,15 +92,12 @@ export const SectorDeltaSettings = () => {
                   />
                   <SettingSelectRow
                     title="Time Format"
-                    description="Format for displaying sector times and deltas."
-                    value={settings.config.timeFormat ?? 'full'}
+                    description="Decimal precision for sector times and deltas. Always shown as total seconds."
+                    value={settings.config.timeFormat ?? 'seconds-full'}
                     options={[
-                      { label: '1:42.123', value: 'full' },
-                      { label: '1:42.1', value: 'mixed' },
-                      { label: '1:42', value: 'minutes' },
                       { label: '42.123', value: 'seconds-full' },
+                      { label: '42.12', value: 'seconds-2' },
                       { label: '42.1', value: 'seconds-mixed' },
-                      { label: '42', value: 'seconds' },
                     ]}
                     onChange={(v) => handleConfigChange({ timeFormat: v })}
                   />
@@ -117,6 +114,43 @@ export const SectorDeltaSettings = () => {
                     ]}
                     onChange={(v) => handleConfigChange({ ghostComparison: v })}
                   />
+                  <SettingToggleRow
+                    title="Track incident sectors"
+                    description="When enabled, sectors with incidents are recorded and shown with a warning icon. When disabled, sectors with incidents are discarded."
+                    enabled={settings.config.trackIncidentSectors ?? true}
+                    onToggle={(v) =>
+                      handleConfigChange({ trackIncidentSectors: v })
+                    }
+                  />
+                  <SettingToggleRow
+                    title="Always scroll"
+                    description="Keep the strip continuously scrolling with your position pinned to the center, even when all sectors fit in the widget."
+                    enabled={settings.config.alwaysScroll ?? false}
+                    onToggle={(v) => handleConfigChange({ alwaysScroll: v })}
+                  />
+                  <SettingToggleRow
+                    title="Limit visible sectors"
+                    description="Show only a fixed number of sectors at once. On tracks with more sectors, the widget becomes a sliding carousel centered on your current sector."
+                    enabled={settings.config.maxSectorsShown != null}
+                    onToggle={(v) =>
+                      handleConfigChange({
+                        maxSectorsShown: v ? 5 : undefined,
+                      })
+                    }
+                  />
+                  {settings.config.maxSectorsShown != null && (
+                    <SettingSliderRow
+                      title="Max Sectors Shown"
+                      description="Number of sector cards visible at once. The current sector is centered in the window."
+                      value={settings.config.maxSectorsShown}
+                      min={3}
+                      max={12}
+                      step={1}
+                      onChange={(v) =>
+                        handleConfigChange({ maxSectorsShown: v })
+                      }
+                    />
+                  )}
                 </SettingsSection>
 
                 <SettingDivider />

--- a/src/frontend/components/Settings/sections/TrackMapSettings.tsx
+++ b/src/frontend/components/Settings/sections/TrackMapSettings.tsx
@@ -5,7 +5,9 @@ import {
   SettingsTabType,
   getWidgetDefaultConfig,
 } from '@irdashies/types';
+import type { SectorDeltaConfig } from '@irdashies/types';
 import { useDashboard } from '@irdashies/context';
+import { getSectorDeltaThresholdPercentages } from '../../SectorDelta/sectorColorUtils';
 import { TabButton } from '../components/TabButton';
 import { SessionVisibility } from '../components/SessionVisibility';
 import { SettingsSection } from '../components/SettingSection';
@@ -20,6 +22,15 @@ const defaultConfig = getWidgetDefaultConfig('map');
 
 export const TrackMapSettings = () => {
   const { currentDashboard } = useDashboard();
+
+  const sectorDeltaThresholds = (
+    currentDashboard?.widgets.find((w) => w.id === 'sectordelta')?.config as
+      | SectorDeltaConfig
+      | undefined
+  )?.thresholds;
+  const { green: greenPct, yellow: yellowPct } =
+    getSectorDeltaThresholdPercentages(sectorDeltaThresholds);
+
   const savedSettings = currentDashboard?.widgets.find(
     (w) => w.id === SETTING_ID
   ) as TrackMapWidgetSettings | undefined;
@@ -126,7 +137,7 @@ export const TrackMapSettings = () => {
 
                 <SettingToggleRow
                   title="Sector Colors"
-                  description="Color each sector based on your session performance (purple: session best, green: within 0.5%, yellow: within 1%, red: 1%+ off pace)"
+                  description={`Color each sector based on your session performance (purple: session best, green: within ${greenPct}%, yellow: within ${yellowPct}%, red: ${yellowPct}%+ off pace). Thresholds are set in Sector Delta settings.`}
                   enabled={settings.config.sectorColoring?.enabled ?? false}
                   onToggle={(newValue) =>
                     handleConfigChange({

--- a/src/frontend/components/TrackMap/hooks/useSectorTiming.tsx
+++ b/src/frontend/components/TrackMap/hooks/useSectorTiming.tsx
@@ -2,13 +2,20 @@ import { useEffect, useRef } from 'react';
 import {
   useSectorTimingStore,
   useSectorColors,
+  useDashboard,
   type SectorColor,
 } from '@irdashies/context';
 import { useTelemetryValue, useSessionStore } from '@irdashies/context';
+import type { SectorDeltaConfig } from '@irdashies/types';
+import { getSectorDeltaThresholdFractions } from '../../SectorDelta/sectorColorUtils';
 
 /**
  * Feeds player telemetry into the SectorTimingStore each tick and returns
  * the current per-sector performance colors.
+ *
+ * Also syncs SectorDelta threshold settings so the TrackMap sector coloring
+ * always uses the same thresholds as the SectorDelta widget, even when the
+ * SectorDelta widget is not mounted.
  *
  * Call this hook once at the overlay-container level so any widget can consume
  * sector timing state, even when the track map is not mounted.
@@ -20,6 +27,23 @@ export const useSectorTiming = (): SectorColor[] => {
   const markCurrentSectorUnclean = useSectorTimingStore(
     (s) => s.markCurrentSectorUnclean
   );
+  const setThresholds = useSectorTimingStore((s) => s.setThresholds);
+
+  const { currentDashboard } = useDashboard();
+  const sectorDeltaThresholds = (
+    currentDashboard?.widgets.find((w) => w.id === 'sectordelta')?.config as
+      | SectorDeltaConfig
+      | undefined
+  )?.thresholds;
+
+  // Keep the store thresholds in sync with the SectorDelta widget config so
+  // the TrackMap sector coloring matches the SectorDelta widget.
+  useEffect(() => {
+    const { green, yellow } = getSectorDeltaThresholdFractions(
+      sectorDeltaThresholds
+    );
+    setThresholds(green, yellow);
+  }, [sectorDeltaThresholds, setThresholds]);
 
   const lapDistPct = useTelemetryValue('LapDistPct');
   const sessionTime = useTelemetryValue('SessionTime');

--- a/src/frontend/context/SectorTimingStore/SectorTimingStore.tsx
+++ b/src/frontend/context/SectorTimingStore/SectorTimingStore.tsx
@@ -77,6 +77,9 @@ interface SectorTimingState {
 
   // Per-sector timing results (null = not yet completed)
   sessionBestSectorTimes: (number | null)[];
+  // The session best for each sector before it was most recently beaten.
+  // Used to show the improvement delta when a sector turns purple.
+  previousSessionBestSectorTimes: (number | null)[];
   currentLapSectorUnclean: boolean[];
   previousLapSectorUnclean: boolean[];
 
@@ -87,11 +90,18 @@ interface SectorTimingState {
   greenThreshold: number;
   yellowThreshold: number;
 
+  // Whether to record sectors that contained an incident (x).
+  // false = discard unclean sector times entirely (keeps previous best).
+  trackIncidentSectors: boolean;
+
   // Called each telemetry tick with the player's current position and time
   tick: (lapDistPct: number, sessionTime: number, isOnTrack: boolean) => void;
 
   // Update color thresholds and recompute existing sector colors immediately.
   setThresholds: (green: number, yellow: number) => void;
+
+  // Update incident-tracking setting.
+  setTrackIncidentSectors: (v: boolean) => void;
 
   // Reset all timing data (e.g. on new session or track change)
   reset: () => void;
@@ -220,6 +230,7 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
   sectorEntryValid: false,
   sectorEntryUnclean: false,
   sessionBestSectorTimes: [],
+  previousSessionBestSectorTimes: [],
   sectorColors: [],
   currentLapSectorTimes: [],
   previousLapSectorTimes: [],
@@ -227,6 +238,7 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
   previousLapSectorUnclean: [],
   greenThreshold: DEFAULT_GREEN_THRESHOLD,
   yellowThreshold: DEFAULT_YELLOW_THRESHOLD,
+  trackIncidentSectors: true,
 
   setSectors: (sectors: Sector[]) => {
     const sorted = [...sectors].sort(
@@ -245,6 +257,7 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
       sectors: sorted,
       sectorColors: sorted.map(() => 'default' as SectorColor),
       sessionBestSectorTimes: sorted.map(() => null),
+      previousSessionBestSectorTimes: sorted.map(() => null),
       currentLapSectorTimes: sorted.map(() => null),
       previousLapSectorTimes: sorted.map(() => null),
       currentLapSectorUnclean: sorted.map(() => false),
@@ -299,6 +312,7 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
 
     if (isWrapAround) {
       const newSessionBests = [...state.sessionBestSectorTimes];
+      const newPreviousSessionBests = [...state.previousSessionBestSectorTimes];
       const newColors = [...state.sectorColors];
       const newPreviousTimes = [...state.previousLapSectorTimes];
       const newPreviousUnclean = [...state.previousLapSectorUnclean];
@@ -314,25 +328,30 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
       );
 
       if (sectorEntryValid) {
-        // Record and color the last sector at the S/F crossing.
-        const sectorTime = crossingTime - sectorEntryTime;
-        const completedIdx = currentSectorIdx;
+        const isUnclean = state.sectorEntryUnclean;
+        const shouldRecord = state.trackIncidentSectors || !isUnclean;
 
-        if (
-          newSessionBests[completedIdx] === null ||
-          sectorTime < (newSessionBests[completedIdx] as number)
-        )
-          newSessionBests[completedIdx] = sectorTime;
+        if (shouldRecord) {
+          // Record and color the last sector at the S/F crossing.
+          const sectorTime = crossingTime - sectorEntryTime;
+          const completedIdx = currentSectorIdx;
 
-        newColors[completedIdx] = computeSectorColor(
-          sectorTime,
-          newSessionBests[completedIdx],
-          greenThreshold,
-          yellowThreshold
-        );
-        // Update previousLapSectorTimes immediately for the completed sector.
-        newPreviousTimes[completedIdx] = sectorTime;
-        newPreviousUnclean[completedIdx] = state.sectorEntryUnclean;
+          const oldBest = newSessionBests[completedIdx];
+          if (oldBest === null || sectorTime < oldBest) {
+            newPreviousSessionBests[completedIdx] = oldBest;
+            newSessionBests[completedIdx] = sectorTime;
+          }
+
+          newColors[completedIdx] = computeSectorColor(
+            sectorTime,
+            newSessionBests[completedIdx],
+            greenThreshold,
+            yellowThreshold
+          );
+          // Update previousLapSectorTimes immediately for the completed sector.
+          newPreviousTimes[completedIdx] = sectorTime;
+          newPreviousUnclean[completedIdx] = isUnclean;
+        }
       }
 
       set({
@@ -343,6 +362,7 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
         lastLapDistPct: lapDistPct,
         lastSessionTime: sessionTime,
         sessionBestSectorTimes: newSessionBests,
+        previousSessionBestSectorTimes: newPreviousSessionBests,
         sectorColors: newColors,
         previousLapSectorTimes: newPreviousTimes,
         previousLapSectorUnclean: newPreviousUnclean,
@@ -401,6 +421,7 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
     const newCurrentLapUnclean = [...state.currentLapSectorUnclean];
     const newPreviousUnclean = [...state.previousLapSectorUnclean];
     const newSessionBests = [...state.sessionBestSectorTimes];
+    const newPreviousSessionBests = [...state.previousSessionBestSectorTimes];
     const newColors = [...state.sectorColors];
 
     // Interpolate the exact moment the sector boundary was crossed.
@@ -414,30 +435,34 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
     );
 
     if (sectorEntryValid) {
-      const sectorTime = crossingTime - sectorEntryTime;
-      const completedIdx = currentSectorIdx;
+      const isUnclean = state.sectorEntryUnclean;
+      const shouldRecord = state.trackIncidentSectors || !isUnclean;
 
-      if (
-        newSessionBests[completedIdx] === null ||
-        sectorTime < (newSessionBests[completedIdx] as number)
-      ) {
-        newSessionBests[completedIdx] = sectorTime;
+      if (shouldRecord) {
+        const sectorTime = crossingTime - sectorEntryTime;
+        const completedIdx = currentSectorIdx;
+
+        const oldBest = newSessionBests[completedIdx];
+        if (oldBest === null || sectorTime < oldBest) {
+          newPreviousSessionBests[completedIdx] = oldBest;
+          newSessionBests[completedIdx] = sectorTime;
+        }
+
+        const color = computeSectorColor(
+          sectorTime,
+          newSessionBests[completedIdx],
+          greenThreshold,
+          yellowThreshold
+        );
+
+        newColors[completedIdx] = color;
+        newCurrentLapTimes[completedIdx] = sectorTime;
+        newCurrentLapUnclean[completedIdx] = isUnclean;
+        // Update previousLapSectorTimes immediately so the reference is always
+        // current regardless of resets or incomplete laps.
+        newPreviousTimes[completedIdx] = sectorTime;
+        newPreviousUnclean[completedIdx] = isUnclean;
       }
-
-      const color = computeSectorColor(
-        sectorTime,
-        newSessionBests[completedIdx],
-        greenThreshold,
-        yellowThreshold
-      );
-
-      newColors[completedIdx] = color;
-      newCurrentLapTimes[completedIdx] = sectorTime;
-      newCurrentLapUnclean[completedIdx] = state.sectorEntryUnclean;
-      // Update previousLapSectorTimes immediately so the reference is always
-      // current regardless of resets or incomplete laps.
-      newPreviousTimes[completedIdx] = sectorTime;
-      newPreviousUnclean[completedIdx] = state.sectorEntryUnclean;
     }
 
     set({
@@ -447,6 +472,7 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
       sectorEntryTime: crossingTime,
       lastSessionTime: sessionTime,
       sessionBestSectorTimes: newSessionBests,
+      previousSessionBestSectorTimes: newPreviousSessionBests,
       sectorColors: newColors,
       currentLapSectorTimes: newCurrentLapTimes,
       previousLapSectorTimes: newPreviousTimes,
@@ -475,6 +501,8 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
     });
   },
 
+  setTrackIncidentSectors: (v: boolean) => set({ trackIncidentSectors: v }),
+
   reset: () =>
     set((state) => ({
       currentSectorIdx: 0,
@@ -484,6 +512,7 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
       sectorEntryValid: false,
       sectorEntryUnclean: false,
       sessionBestSectorTimes: state.sectors.map(() => null),
+      previousSessionBestSectorTimes: state.sectors.map(() => null),
       sectorColors: state.sectors.map(() => 'default' as SectorColor),
       currentLapSectorTimes: state.sectors.map(() => null),
       previousLapSectorTimes: state.sectors.map(() => null),
@@ -542,6 +571,7 @@ export const useSectorDeltas = () =>
       currentLapSectorUnclean: s.currentLapSectorUnclean,
       previousLapSectorUnclean: s.previousLapSectorUnclean,
       sessionBestSectorTimes: s.sessionBestSectorTimes,
+      previousSessionBestSectorTimes: s.previousSessionBestSectorTimes,
       currentSectorIdx: s.currentSectorIdx,
     }),
     shallow

--- a/src/frontend/utils/time.ts
+++ b/src/frontend/utils/time.ts
@@ -3,6 +3,7 @@ export type TimeFormat =
   | 'mixed'
   | 'minutes'
   | 'seconds-full'
+  | 'seconds-2'
   | 'seconds-mixed'
   | 'seconds'
   | 'duration'

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1138,8 +1138,9 @@ export const defaultDashboard: {
       },
       config: {
         background: { opacity: 80 },
-        timeFormat: 'full',
+        timeFormat: 'seconds-full',
         ghostComparison: 'prefer-ghost',
+        trackIncidentSectors: true,
         showOnlyWhenOnTrack: true,
         sessionVisibility: {
           race: true,

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -17,6 +17,7 @@ export type TimeFormat =
   | 'mixed'
   | 'minutes'
   | 'seconds-full'
+  | 'seconds-2'
   | 'seconds-mixed'
   | 'seconds';
 
@@ -525,6 +526,13 @@ export interface SectorDeltaConfig {
    * 'session-best-only' – always compare against session best
    */
   ghostComparison: 'prefer-ghost' | 'session-best-only';
+  /**
+   * Whether to record and display sectors that contained an incident (x).
+   * true  – record the sector time and show a warning icon
+   * false – discard the sector time entirely (keeps previous best)
+   * Defaults to true when omitted.
+   */
+  trackIncidentSectors?: boolean;
   showOnlyWhenOnTrack: boolean;
   sessionVisibility: SessionVisibilitySettings;
   /**
@@ -535,6 +543,17 @@ export interface SectorDeltaConfig {
     green: number; // e.g. 0.5 means within 0.5% → green
     yellow: number; // e.g. 1.0 means within 1.0% → yellow; above = red
   };
+  /**
+   * Maximum number of sector cards to show at once. When the track has more
+   * sectors than this, the widget becomes a sliding carousel centered on the
+   * current sector. Omit (or undefined) to always show all sectors.
+   */
+  maxSectorsShown?: number;
+  /**
+   * Always use the continuous-scroll mode, even when all sectors fit in the
+   * widget. The center line stays pinned to your exact track position.
+   */
+  alwaysScroll?: boolean;
 }
 
 // ===========================


### PR DESCRIPTION
## Summary

- Adds a scroll mode to the Sector Delta widget where the strip continuously translates so the player's **exact track position is always pinned to the horizontal center** of the viewport — if you're 30% through sector 3, that point is at the center line
- A static sky-blue vertical line marks the center at all times
- `maxSectorsShown` setting controls card width; when the track has more sectors than the limit the widget automatically enters scroll mode
- `alwaysScroll` setting forces scroll mode even when all sectors fit
- In scroll mode, sector-start edge indicators are hidden (replaced by the center line) and the fill transition is removed to stay in sync with strip motion
- Extended index buffer pre-renders sectors either side of the lap boundary for seamless wrap-around
- Extended index array memoized — only rebuilds on session/config change, not every telemetry tick
- Also fixes `seconds-2` missing from the shared `TimeFormat` union in `utils/time.ts`, adds `previousSessionBestSectorTimes` to `SectorTimingStore`, and syncs SectorDelta thresholds into TrackMap sector coloring

## Test plan

- [ ] Enable `alwaysScroll` — strip moves continuously as you drive, center line tracks position
- [ ] Enable `maxSectorsShown` (e.g. 5) on a 12-sector track — partial cards at edges, center line correct
- [ ] Verify center line stays aligned with the right edge of the progress fill
- [ ] Verify normal (non-scroll) mode is unchanged
- [ ] Lap boundary: strip wraps cleanly from last sector back to first

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added carousel scrolling view for sector cards with configurable visible count
  * Incident sector tracking toggle to include or exclude unclean sectors
  * Option to force continuous scrolling view
  * New "seconds-2" decimal precision time format
  * Previous session best sector times now tracked and displayed

* **Improvements**
  * Sector delta time precision now automatically derived from format type
  * Sector color thresholds now dynamically synchronized with Sector Delta settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->