### PR TITLE
chore: bump download to v0.3.0 and add Sector Delta widget

### DIFF
--- a/site/src/sections/Hero.tsx
+++ b/site/src/sections/Hero.tsx
@@ -66,7 +66,7 @@ export function Hero() {
         <div className="flex flex-col items-center gap-2">
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
-              href="https://github.com/tariknz/irdashies/releases/download/v0.2.1/irdashies-0.2.1.Setup.exe"
+              href="https://github.com/tariknz/irdashies/releases/download/v0.3.0/irdashies-0.3.0.Setup.exe"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-8 py-3 bg-red-600 hover:bg-red-700 text-white font-bold uppercase tracking-wide text-sm rounded-sm transition-colors"

--- a/site/src/sections/LivePreview.tsx
+++ b/site/src/sections/LivePreview.tsx
@@ -1,10 +1,49 @@
 import {
-  useState,
   useCallback,
   useEffect,
   useRef,
+  useState,
   useSyncExternalStore,
 } from 'react';
+
+// Frontend widget components
+import {
+  BlindSpotMonitor,
+  FasterCarsFromBehind,
+  Flag,
+  FlatTrackMap,
+  FuelCalculator,
+  InformationBar,
+  Input,
+  LapTimeLog,
+  PitlaneHelper,
+  Relative,
+  RejoinIndicator,
+  SectorDelta,
+  SlowCarAhead,
+  Standings,
+  Tachometer,
+  TrackMap,
+  Weather,
+} from '../../../src/frontend/WidgetIndex';
+import { SectorTimingUpdater } from '../../../src/frontend/components/OverlayContainer/SectorTimingUpdater';
+import { defaultDashboard } from '../../../src/types/defaultDashboard';
+
+// Site-local components and utilities
+import { DashboardReady } from '../components/DashboardReady';
+import { PreviewSettingsButton } from '../components/PreviewSettingsPanel';
+import { WidgetErrorBoundary } from '../components/WidgetErrorBoundary';
+import { LivePreviewProvider } from '../utils/mockSetup';
+
+// Sibling sections
+import { ActiveWidgetSync } from './ActiveWidgetSync';
+import { CoachMarks } from './CoachMarks';
+import {
+  PreviewWidgetItem,
+  WidgetFrame,
+  useWidgetConfig,
+  type WidgetPosition,
+} from './PreviewWidgetItem';
 
 const MOBILE_QUERY = '(max-width: 639px)';
 const mobileMedia =
@@ -21,34 +60,31 @@ function getSnapshotMobile() {
 function useIsMobile() {
   return useSyncExternalStore(subscribeMobile, getSnapshotMobile);
 }
-import { LivePreviewProvider } from '../utils/mockSetup';
-import { WidgetErrorBoundary } from '../components/WidgetErrorBoundary';
-import { DashboardReady } from '../components/DashboardReady';
-import { Standings } from '../../../src/frontend/components/Standings/Standings';
-import { Relative } from '../../../src/frontend/components/Standings/Relative';
-import { Input } from '../../../src/frontend/components/Input';
-import { Tachometer } from '../../../src/frontend/components/Tachometer/Tachometer';
-import { Weather } from '../../../src/frontend/components/Weather';
-import { Flag } from '../../../src/frontend/components/Flag';
-import { InformationBar } from '../../../src/frontend/components/InformationBar/InformationBar';
-import { TrackMap } from '../../../src/frontend/components/TrackMap/TrackMap';
-import { FlatTrackMap } from '../../../src/frontend/components/TrackMap/FlatTrackMap';
-import { FasterCarsFromBehind } from '../../../src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind';
-import { FuelCalculator } from '../../../src/frontend/components/FuelCalculator';
-import { BlindSpotMonitor } from '../../../src/frontend/components/BlindSpotMonitor/BlindSpotMonitor';
-import { RejoinIndicator } from '../../../src/frontend/components/RejoinIndicator/RejoinIndicator';
-import { PitlaneHelper } from '../../../src/frontend/components/PitlaneHelper/PitlaneHelper';
-import { LapTimeLog } from '../../../src/frontend/components/LapTimeLog/LapTimeLog';
-import { SlowCarAhead } from '../../../src/frontend/components/SlowCarAhead/SlowCarAhead';
-import { PreviewSettingsButton } from '../components/PreviewSettingsPanel';
-import { defaultDashboard } from '../../../src/types/defaultDashboard';
-import { CoachMarks } from './CoachMarks';
-import {
-  PreviewWidgetItem,
-  WidgetFrame,
-  type WidgetPosition,
-} from './PreviewWidgetItem';
-import { ActiveWidgetSync } from './ActiveWidgetSync';
+
+/**
+ * Static widget rendering used by the mobile path — needs a real component so
+ * `useWidgetConfig` (a hook) can run.
+ */
+function MobileWidget({
+  widgetId,
+  label,
+  component: Component,
+}: {
+  widgetId: string;
+  label: string;
+  component: React.ComponentType<unknown>;
+}) {
+  const config = useWidgetConfig(widgetId);
+  return (
+    <div className="relative w-full h-full">
+      <WidgetFrame>
+        <WidgetErrorBoundary widgetName={label}>
+          <Component {...config} />
+        </WidgetErrorBoundary>
+      </WidgetFrame>
+    </div>
+  );
+}
 
 /** Look up a widget's default layout size from the project's defaultDashboard. */
 function getDefaultSize(widgetId: string): { width: number; height: number } {
@@ -59,7 +95,20 @@ function getDefaultSize(widgetId: string): { width: number; height: number } {
   };
 }
 
-const AVAILABLE_WIDGETS = [
+/**
+ * Component is typed as `ComponentType<unknown>` so widgets that take config
+ * as direct props (e.g. SectorDelta) fit alongside widgets that take none.
+ * Config is read from the dashboard at render time and spread onto the
+ * component, mirroring OverlayContainer in the real app.
+ */
+interface AvailableWidget {
+  id: string;
+  label: string;
+  component: React.ComponentType<unknown>;
+  defaultOn: boolean;
+}
+
+const AVAILABLE_WIDGETS: readonly AvailableWidget[] = [
   {
     id: 'standings',
     label: 'Standings',
@@ -98,7 +147,7 @@ const AVAILABLE_WIDGETS = [
   {
     id: 'fuel',
     label: 'Fuel Calculator',
-    component: FuelCalculator,
+    component: FuelCalculator as React.ComponentType<unknown>,
     defaultOn: false,
   },
   {
@@ -131,7 +180,13 @@ const AVAILABLE_WIDGETS = [
     component: SlowCarAhead,
     defaultOn: false,
   },
-] as const;
+  {
+    id: 'sectordelta',
+    label: 'Sector Delta',
+    component: SectorDelta as React.ComponentType<unknown>,
+    defaultOn: false,
+  },
+];
 
 // Default-on widgets: relative (top-left), track map (top-right),
 // input (bottom-center). Positions are computed once the canvas is measured.
@@ -277,6 +332,7 @@ export function LivePreview() {
         }}
       >
         <ActiveWidgetSync activeWidgets={activeWidgets} />
+        <SectorTimingUpdater />
         {/* Preview frame */}
         <div className="mx-auto w-full max-w-450 flex-1 flex flex-col min-h-0">
           <div className="relative rounded-sm border border-slate-700/50 overflow-hidden carbon-fiber flex-1 flex flex-col">
@@ -361,15 +417,12 @@ export function LivePreview() {
                         activeWidgets.has(w.id)
                       );
                       if (!active) return null;
-                      const Component = active.component;
                       return (
-                        <div className="relative w-full h-full">
-                          <WidgetFrame>
-                            <WidgetErrorBoundary widgetName={active.label}>
-                              <Component />
-                            </WidgetErrorBoundary>
-                          </WidgetFrame>
-                        </div>
+                        <MobileWidget
+                          widgetId={active.id}
+                          label={active.label}
+                          component={active.component}
+                        />
                       );
                     })()
                   : // Desktop: draggable/resizable widgets

--- a/site/src/sections/PreviewWidgetItem.tsx
+++ b/site/src/sections/PreviewWidgetItem.tsx
@@ -8,7 +8,10 @@ import {
   type CSSProperties,
 } from 'react';
 import { ArrowsOutCardinal, X } from '@phosphor-icons/react';
-import { useGeneralSettings } from '../../../src/frontend/context/DashboardContext/DashboardContext';
+import {
+  useDashboard,
+  useGeneralSettings,
+} from '../../../src/frontend/context/DashboardContext/DashboardContext';
 import { WidgetErrorBoundary } from '../components/WidgetErrorBoundary';
 import {
   useDragWidget,
@@ -52,6 +55,17 @@ export function WidgetFrame({ children }: { children: ReactNode }) {
 }
 
 /**
+ * Look up a widget's config from the dashboard. Mirrors how OverlayContainer
+ * spreads `widget.config` as props onto the registered widget component, so
+ * widgets that take config as direct props (e.g. SectorDelta) get it here too.
+ */
+export function useWidgetConfig(widgetId: string): Record<string, unknown> {
+  const { currentDashboard } = useDashboard();
+  const widget = currentDashboard?.widgets?.find((w) => w.id === widgetId);
+  return (widget?.config ?? {}) as Record<string, unknown>;
+}
+
+/**
  * A single draggable/resizable widget in the preview canvas.
  */
 export const PreviewWidgetItem = memo(function PreviewWidgetItem({
@@ -67,7 +81,7 @@ export const PreviewWidgetItem = memo(function PreviewWidgetItem({
 }: {
   widgetId: string;
   label: string;
-  component: React.ComponentType;
+  component: React.ComponentType<unknown>;
   position: WidgetPosition;
   isSelected: boolean;
   onPositionChange: (id: string, pos: WidgetPosition) => void;
@@ -75,6 +89,7 @@ export const PreviewWidgetItem = memo(function PreviewWidgetItem({
   onDeselect: () => void;
   onDoubleClick: (id: string) => void;
 }) {
+  const config = useWidgetConfig(widgetId);
   const [localLayout, setLocalLayout] = useState(position);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
@@ -173,7 +188,7 @@ export const PreviewWidgetItem = memo(function PreviewWidgetItem({
         {/* Widget content */}
         <WidgetFrame>
           <WidgetErrorBoundary widgetName={label}>
-            <Component />
+            <Component {...config} />
           </WidgetErrorBoundary>
         </WidgetFrame>
       </div>

--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -19,6 +19,29 @@ import { InformationBar } from './components/InformationBar/InformationBar';
 import { SlowCarAhead } from './components/SlowCarAhead/SlowCarAhead';
 import { SectorDelta } from './components/SectorDelta/SectorDelta';
 
+export {
+  Standings,
+  Input,
+  Relative,
+  TrackMap,
+  FlatTrackMap,
+  Weather,
+  FasterCarsFromBehind,
+  FuelCalculator,
+  BlindSpotMonitor,
+  GarageCover,
+  RejoinIndicator,
+  TelemetryInspector,
+  PitlaneHelper,
+  Tachometer,
+  Flag,
+  TwitchChat,
+  LapTimeLog,
+  InformationBar,
+  SlowCarAhead,
+  SectorDelta,
+};
+
 // TODO: type this better, right now the config comes from settings
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const WIDGET_MAP: Record<


### PR DESCRIPTION
## Description

Updates the marketing site for the v0.3.0 release.

- Download CTA in the Hero now points at `v0.3.0`
- Adds the Sector Delta widget to the live preview toolbar so visitors can try it
- Mounts `SectorTimingUpdater` inside `LivePreviewProvider` — without it the sector store is empty and the widget short-circuits to `null`
- `PreviewWidgetItem` now reads `widget.config` from the dashboard context and spreads it onto the rendered component, mirroring `OverlayContainer` in the real app. Needed because `SectorDelta` (unlike most widgets) takes its config as direct props
- `AVAILABLE_WIDGETS` retyped as `React.ComponentType<unknown>` so prop-taking widgets (`SectorDelta`, `FuelCalculator`) sit alongside no-prop ones
- `WidgetIndex.tsx` now re-exports the widget components, so the site imports them in one block instead of 17 deep-path imports

## Screenshots

### Before
v0.2.1 download link, no Sector Delta button in the live-preview toolbar.

### After
v0.3.0 download link; SECTOR DELTA button in the toolbar enables the new widget showing six sector cards with live deltas and an in-sector progress bar.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (no functional changes)

## Checklist

- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] Verified visually in the dev server (Chrome DevTools): widget renders, no console errors, settings panel still works through the dashboard context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SectorDelta widget for detailed sector timing analysis, comparison, and performance tracking across race sessions.
  * Enhanced widget preview system to properly load, display, and test widget configurations in real-time before deployment.

* **Updates**
  * Latest release download link updated to version 0.3.0 with improved widget management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->