### PR TITLE
fix: show most-recent lap deltas in Relative widget instead of oldest

### DIFF
--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -243,7 +243,7 @@ export const Relative = () => {
           delta={(settings?.delta?.enabled ?? true) ? result.delta : undefined}
           lapTimeDeltas={
             lapTimeDeltasEnabled
-              ? (lapDeltasByCarIdx?.[result.carIdx] ?? [])
+              ? (lapDeltasByCarIdx?.[result.carIdx]?.slice(-numLapDeltas) ?? [])
               : undefined
           }
           numLapDeltasToShow={lapTimeDeltasEnabled ? numLapDeltas : undefined}


### PR DESCRIPTION
## Description

The Relative widget's lap time deltas column appeared to be "frozen" for the first ~10 laps of a race, then started updating but always lagged the actual recent laps. The Standings widget showed the correct values from the same data.

**Root cause:** [`LapTimeDeltasCell`](src/frontend/components/Standings/components/DriverInfoRow/cells/LapTimeDeltasCell.tsx) renders the **first N entries** of the `lapTimeDeltas` array (indices `[0..N-1]`), expecting the array to already be trimmed to the most-recent N laps.

- [`createStandings.ts`](src/frontend/components/Standings/createStandings.ts) sliced the array via `.slice(-numLapsToShow)` before handing it to the cell, so Standings showed the most recent laps as intended.
- [`Relative.tsx`](src/frontend/components/Standings/Relative.tsx) passed the full 10-lap buffer unsliced, so the cell rendered the **oldest** N laps.

`calculateLapDeltas` in [`useDriverStandings.tsx`](src/frontend/components/Standings/hooks/useDriverStandings.tsx) returns deltas in oldest→newest order, and `LapTimesStore` caps history at `LAP_TIME_AVG_WINDOW = 10` laps. With `numLapsToShow=3`, the displayed indices `[0,1,2]` always pointed at laps 1-3 until the buffer started evicting older entries on lap 11. After that the displayed values slid one entry per lap but always lagged actual recent laps by `(10 - N)` laps.

**Fix:** Mirror the Standings code path by slicing the deltas to the most-recent N before passing them to `DriverInfoRow`:

```diff
 lapTimeDeltas={
   lapTimeDeltasEnabled
-    ? (lapDeltasByCarIdx?.[result.carIdx] ?? [])
+    ? (lapDeltasByCarIdx?.[result.carIdx]?.slice(-numLapDeltas) ?? [])
     : undefined
 }
```

Tested in iRacing AI session — deltas now update each lap as expected.

## Screenshots

### Before
Lap deltas in Relative remained on values from the first laps of the session for ~10 laps, then began sliding but always lagged the most recent lap times.

### After
Lap deltas reflect the most recent N completed laps, matching the Standings widget's behaviour.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via \`npm test\`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run \`npm run lint\` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The relative standings display now shows only the most recent lap time differences instead of historical data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->