### PR TITLE
feat: Configurable decimals places for delta times

### DIFF
--- a/src/frontend/components/Settings/sections/RelativeSettings.tsx
+++ b/src/frontend/components/Settings/sections/RelativeSettings.tsx
@@ -373,29 +373,52 @@ const DisplaySettingsList = ({
             {setting.hasSubSetting &&
               setting.configKey === 'lapTimeDeltas' &&
               settings.config.lapTimeDeltas.enabled && (
-                <div className="flex items-center justify-between pl-8 mt-2 indent-8">
-                  <span className="text-sm text-slate-300">
-                    Number of Laps to Show
-                  </span>
-                  <select
-                    value={settings.config.lapTimeDeltas.numLaps}
-                    onChange={(e) =>
-                      handleConfigChange({
-                        lapTimeDeltas: {
-                          ...settings.config.lapTimeDeltas,
-                          numLaps: parseInt(e.target.value),
-                        },
-                      })
-                    }
-                    className="bg-slate-700 text-white rounded-md px-2 py-1"
-                  >
-                    <option value={1}>1</option>
-                    <option value={2}>2</option>
-                    <option value={3}>3</option>
-                    <option value={4}>4</option>
-                    <option value={5}>5</option>
-                  </select>
-                </div>
+                <>
+                  <div className="flex items-center justify-between pl-8 mt-2 indent-8">
+                    <span className="text-sm text-slate-300">
+                      Number of Laps to Show
+                    </span>
+                    <select
+                      value={settings.config.lapTimeDeltas.numLaps}
+                      onChange={(e) =>
+                        handleConfigChange({
+                          lapTimeDeltas: {
+                            ...settings.config.lapTimeDeltas,
+                            numLaps: parseInt(e.target.value),
+                          },
+                        })
+                      }
+                      className="bg-slate-700 text-white rounded-md px-2 py-1"
+                    >
+                      <option value={1}>1</option>
+                      <option value={2}>2</option>
+                      <option value={3}>3</option>
+                      <option value={4}>4</option>
+                      <option value={5}>5</option>
+                    </select>
+                  </div>
+                  <div className="flex items-center justify-between pl-8 mt-2 indent-8">
+                    <span className="text-sm text-slate-300">
+                      Decimal Places
+                    </span>
+                    <select
+                      value={settings.config.lapTimeDeltas.decimalPlaces ?? 1}
+                      onChange={(e) =>
+                        handleConfigChange({
+                          lapTimeDeltas: {
+                            ...settings.config.lapTimeDeltas,
+                            decimalPlaces: parseInt(e.target.value, 10),
+                          },
+                        })
+                      }
+                      className="bg-slate-700 text-white rounded-md px-2 py-1"
+                    >
+                      <option value={1}>1</option>
+                      <option value={2}>2</option>
+                      <option value={3}>3</option>
+                    </select>
+                  </div>
+                </>
               )}
           </DraggableSettingItem>
         );

--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -140,29 +140,52 @@ const DisplaySettingsList = ({
             {setting.hasSubSetting &&
               setting.configKey === 'lapTimeDeltas' &&
               settings.config.lapTimeDeltas.enabled && (
-                <div className="flex items-center justify-between pl-8 mt-2 indent-8">
-                  <span className="text-sm text-slate-300">
-                    Number of Laps to Show
-                  </span>
-                  <select
-                    value={settings.config.lapTimeDeltas.numLaps}
-                    onChange={(e) =>
-                      handleConfigChange({
-                        lapTimeDeltas: {
-                          ...settings.config.lapTimeDeltas,
-                          numLaps: parseInt(e.target.value),
-                        },
-                      })
-                    }
-                    className="bg-slate-700 text-white rounded-md px-2 py-1"
-                  >
-                    <option value={1}>1</option>
-                    <option value={2}>2</option>
-                    <option value={3}>3</option>
-                    <option value={4}>4</option>
-                    <option value={5}>5</option>
-                  </select>
-                </div>
+                <>
+                  <div className="flex items-center justify-between pl-8 mt-2 indent-8">
+                    <span className="text-sm text-slate-300">
+                      Number of Laps to Show
+                    </span>
+                    <select
+                      value={settings.config.lapTimeDeltas.numLaps}
+                      onChange={(e) =>
+                        handleConfigChange({
+                          lapTimeDeltas: {
+                            ...settings.config.lapTimeDeltas,
+                            numLaps: parseInt(e.target.value),
+                          },
+                        })
+                      }
+                      className="bg-slate-700 text-white rounded-md px-2 py-1"
+                    >
+                      <option value={1}>1</option>
+                      <option value={2}>2</option>
+                      <option value={3}>3</option>
+                      <option value={4}>4</option>
+                      <option value={5}>5</option>
+                    </select>
+                  </div>
+                  <div className="flex items-center justify-between pl-8 mt-2 indent-8">
+                    <span className="text-sm text-slate-300">
+                      Decimal Places
+                    </span>
+                    <select
+                      value={settings.config.lapTimeDeltas.decimalPlaces ?? 1}
+                      onChange={(e) =>
+                        handleConfigChange({
+                          lapTimeDeltas: {
+                            ...settings.config.lapTimeDeltas,
+                            decimalPlaces: parseInt(e.target.value, 10),
+                          },
+                        })
+                      }
+                      className="bg-slate-700 text-white rounded-md px-2 py-1"
+                    >
+                      <option value={1}>1</option>
+                      <option value={2}>2</option>
+                      <option value={3}>3</option>
+                    </select>
+                  </div>
+                </>
               )}
             {setting.hasSubSetting &&
               setting.configKey === 'avgLapTime' &&

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.ReorderableConfig.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.ReorderableConfig.stories.tsx
@@ -367,7 +367,7 @@ const RelativeWithReorderableConfig = () => {
       compound: { enabled: true },
       brakeBias: { enabled: false },
       driverTag: { enabled: false },
-      lapTimeDeltas: { enabled: false, numLaps: 3 },
+      lapTimeDeltas: { enabled: false, numLaps: 3, decimalPlaces: 1 },
       displayOrder: displayOrder,
       titleBar: { enabled: true, progressBar: { enabled: true } },
       headerBar: {

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -574,6 +574,11 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
             emptyLapDeltaPlaceholders={emptyLapDeltaPlaceholders}
             isPlayer={isPlayer}
             compactMode={compactMode}
+            decimalPlaces={
+              config && 'lapTimeDeltas' in config
+                ? (config.lapTimeDeltas.decimalPlaces ?? 1)
+                : 1
+            }
           />
         ),
       },

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/LapTimeDeltasCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/LapTimeDeltasCell.tsx
@@ -5,6 +5,7 @@ interface LapTimeDeltasCellProps {
   emptyLapDeltaPlaceholders: number[] | null;
   isPlayer: boolean;
   compactMode?: string;
+  decimalPlaces?: number;
 }
 
 export const LapTimeDeltasCell = memo(
@@ -13,6 +14,7 @@ export const LapTimeDeltasCell = memo(
     emptyLapDeltaPlaceholders,
     isPlayer,
     compactMode,
+    decimalPlaces,
   }: LapTimeDeltasCellProps) => {
     const pxClass = compactMode === 'ultra' ? '' : 'px-1';
 
@@ -31,7 +33,7 @@ export const LapTimeDeltasCell = memo(
                 data-column="lapTimeDelta"
                 className={`w-auto ${pxClass} text-center whitespace-nowrap ${deltaValue > 0 ? 'text-green-400' : 'text-red-400'}`}
               >
-                {Math.abs(deltaValue).toFixed(1)}
+                {Math.abs(deltaValue).toFixed(decimalPlaces)}
               </td>
             );
           } else {

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -84,6 +84,7 @@ export const defaultDashboard: {
         lapTimeDeltas: {
           enabled: false,
           numLaps: 3,
+          decimalPlaces: 1,
         },
         avgLapTime: {
           enabled: false,
@@ -443,6 +444,7 @@ export const defaultDashboard: {
         lapTimeDeltas: {
           enabled: false,
           numLaps: 3,
+          decimalPlaces: 1,
         },
         displayOrder: [
           'position',

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -151,7 +151,7 @@ export interface StandingsConfig {
   };
   compound: { enabled: boolean };
   carManufacturer: { enabled: boolean; hideIfSingleMake?: boolean };
-  lapTimeDeltas: { enabled: boolean; numLaps: number };
+  lapTimeDeltas: { enabled: boolean; numLaps: number; decimalPlaces: number };
   avgLapTime: { enabled: boolean; numLaps: number; timeFormat: TimeFormat };
   titleBar: { enabled: boolean; progressBar: { enabled: boolean } };
   headerBar: SessionBarConfig;
@@ -192,7 +192,7 @@ export interface RelativeConfig {
   teamName: { enabled: boolean };
   pitStatus: PitStatusConfig;
   driverTag: { enabled: boolean; widthPx?: number };
-  lapTimeDeltas: { enabled: boolean; numLaps: number };
+  lapTimeDeltas: { enabled: boolean; numLaps: number; decimalPlaces: number };
   displayOrder: string[];
   useLivePosition?: boolean;
   sessionVisibility: SessionVisibilitySettings;


### PR DESCRIPTION
## Description

Adds the possibility to chose the decimal places for the delta times in the Standings and Relative widget. User can choose up to 3 decimals, with 1 being the default.

## Screenshots

Menu
<img width="868" height="185" alt="スクリーンショット 2026-06-01 131456" src="https://github.com/user-attachments/assets/abb250b4-198a-4e60-8edf-0e6ddd375272" />

In-game (example with 2 decimals)
<img width="532" height="212" alt="2decim_places" src="https://github.com/user-attachments/assets/c65e7657-31a9-45fa-b2b5-7c9900fd6d4c" />

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a "Decimal Places" configuration option for lap time delta values in Standings and Relative widgets. Users can now customize the display precision of lap timing data, selecting from 1 to 3 decimal places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->