### PR TITLE
feat: configurable Chromium flags in advanced settings

### DIFF
--- a/src/app/bridge/chromiumFlagsBridge.ts
+++ b/src/app/bridge/chromiumFlagsBridge.ts
@@ -1,0 +1,13 @@
+import { ipcMain } from 'electron';
+import type { ChromiumFlagsType } from '@irdashies/types';
+import { getChromiumFlags, saveChromiumFlags } from '../storage/chromiumFlags';
+
+export function setupChromiumFlagsBridge(): void {
+  ipcMain.handle('chromiumFlags:get', () => {
+    return getChromiumFlags();
+  });
+
+  ipcMain.handle('chromiumFlags:save', (_, flags: ChromiumFlagsType) => {
+    return saveChromiumFlags(flags);
+  });
+}

--- a/src/app/bridge/rendererExposeBridge.ts
+++ b/src/app/bridge/rendererExposeBridge.ts
@@ -14,6 +14,8 @@ import type {
   ReferenceLapBridge,
   KeybindingsBridge,
   KeybindingActionId,
+  ChromiumFlagsBridge,
+  ChromiumFlagsType,
 } from '@irdashies/types';
 
 export function exposeBridge() {
@@ -248,4 +250,10 @@ export function exposeBridge() {
     startRecording: () => ipcRenderer.invoke('keybindings:startRecording'),
     stopRecording: () => ipcRenderer.invoke('keybindings:stopRecording'),
   } as KeybindingsBridge);
+
+  contextBridge.exposeInMainWorld('chromiumFlagsBridge', {
+    getFlags: () => ipcRenderer.invoke('chromiumFlags:get'),
+    saveFlags: (flags: ChromiumFlagsType) =>
+      ipcRenderer.invoke('chromiumFlags:save', flags),
+  } as ChromiumFlagsBridge);
 }

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import { Notification } from 'electron';
 import { readData, writeData } from './storage/storage';
 import { getDashboard } from './storage/dashboards';
+import { getChromiumFlags } from './storage/chromiumFlags';
 import { trackSettingsWindowMovement } from './trackWindowMovement';
 import logger from './logger';
 
@@ -671,6 +672,57 @@ export class OverlayManager {
     if (dashboard?.generalSettings?.disableHardwareAcceleration) {
       app.disableHardwareAcceleration();
     }
+  }
+
+  /**
+   * Apply user-configured Chromium command-line switches.
+   * Must be called before the app is ready, as Chromium reads switches
+   * during GPU process initialization.
+   */
+  public setupChromiumFlags(): void {
+    const flags = getChromiumFlags();
+
+    const disableFeatures = new Set<string>(flags.disableFeatures ?? []);
+    if (flags.disableNativeWinOcclusion) {
+      disableFeatures.add('CalculateNativeWinOcclusion');
+    }
+    if (disableFeatures.size > 0) {
+      app.commandLine.appendSwitch(
+        'disable-features',
+        Array.from(disableFeatures).join(',')
+      );
+    }
+
+    const enableFeatures = flags.enableFeatures ?? [];
+    if (enableFeatures.length > 0) {
+      app.commandLine.appendSwitch('enable-features', enableFeatures.join(','));
+    }
+
+    if (flags.angleBackend && flags.angleBackend !== 'default') {
+      app.commandLine.appendSwitch('use-angle', flags.angleBackend);
+    }
+
+    if (flags.disableDirectComposition) {
+      app.commandLine.appendSwitch('disable-direct-composition');
+    }
+
+    const customSwitches = flags.customSwitches?.trim();
+    if (customSwitches) {
+      for (const rawLine of customSwitches.split(/\r?\n/)) {
+        const line = rawLine.trim().replace(/^--/, '');
+        if (!line || line.startsWith('#')) continue;
+        const eq = line.indexOf('=');
+        if (eq === -1) {
+          app.commandLine.appendSwitch(line);
+        } else {
+          const name = line.slice(0, eq).trim();
+          const value = line.slice(eq + 1).trim();
+          if (name) app.commandLine.appendSwitch(name, value);
+        }
+      }
+    }
+
+    logger.info('[OverlayManager] Applied Chromium flags', flags);
   }
 
   public setupAutoStart(): void {

--- a/src/app/storage/chromiumFlags.ts
+++ b/src/app/storage/chromiumFlags.ts
@@ -4,16 +4,47 @@ import { readData, writeData } from './storage';
 
 const STORAGE_KEY = 'chromiumFlags';
 
+const ANGLE_BACKENDS: ReadonlySet<
+  NonNullable<ChromiumFlagsType['angleBackend']>
+> = new Set(['default', 'gl', 'd3d11', 'd3d9', 'metal', 'vulkan']);
+
+function toStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((v): v is string => typeof v === 'string')
+    .map((v) => v.trim())
+    .filter(Boolean);
+}
+
+function normalizeFlags(input: unknown): ChromiumFlagsType {
+  const src = (input && typeof input === 'object' ? input : {}) as Record<
+    string,
+    unknown
+  >;
+  const angleBackend = ANGLE_BACKENDS.has(
+    src.angleBackend as NonNullable<ChromiumFlagsType['angleBackend']>
+  )
+    ? (src.angleBackend as ChromiumFlagsType['angleBackend'])
+    : 'default';
+
+  return {
+    disableNativeWinOcclusion: src.disableNativeWinOcclusion === true,
+    angleBackend,
+    disableDirectComposition: src.disableDirectComposition === true,
+    disableFeatures: toStringArray(src.disableFeatures),
+    enableFeatures: toStringArray(src.enableFeatures),
+    customSwitches:
+      typeof src.customSwitches === 'string' ? src.customSwitches : '',
+  };
+}
+
 export function getChromiumFlags(): ChromiumFlagsType {
-  const stored = readData<ChromiumFlagsType>(STORAGE_KEY);
-  if (!stored) {
-    return { ...DEFAULT_CHROMIUM_FLAGS };
-  }
-  return { ...DEFAULT_CHROMIUM_FLAGS, ...stored };
+  const stored = readData<unknown>(STORAGE_KEY);
+  return { ...DEFAULT_CHROMIUM_FLAGS, ...normalizeFlags(stored) };
 }
 
 export function saveChromiumFlags(flags: ChromiumFlagsType): ChromiumFlagsType {
-  const merged = { ...DEFAULT_CHROMIUM_FLAGS, ...flags };
+  const merged = { ...DEFAULT_CHROMIUM_FLAGS, ...normalizeFlags(flags) };
   writeData(STORAGE_KEY, merged);
   return merged;
 }

--- a/src/app/storage/chromiumFlags.ts
+++ b/src/app/storage/chromiumFlags.ts
@@ -1,0 +1,19 @@
+import type { ChromiumFlagsType } from '@irdashies/types';
+import { DEFAULT_CHROMIUM_FLAGS } from '@irdashies/types';
+import { readData, writeData } from './storage';
+
+const STORAGE_KEY = 'chromiumFlags';
+
+export function getChromiumFlags(): ChromiumFlagsType {
+  const stored = readData<ChromiumFlagsType>(STORAGE_KEY);
+  if (!stored) {
+    return { ...DEFAULT_CHROMIUM_FLAGS };
+  }
+  return { ...DEFAULT_CHROMIUM_FLAGS, ...stored };
+}
+
+export function saveChromiumFlags(flags: ChromiumFlagsType): ChromiumFlagsType {
+  const merged = { ...DEFAULT_CHROMIUM_FLAGS, ...flags };
+  writeData(STORAGE_KEY, merged);
+  return merged;
+}

--- a/src/frontend/components/Settings/sections/AdvancedSettings.tsx
+++ b/src/frontend/components/Settings/sections/AdvancedSettings.tsx
@@ -7,6 +7,7 @@ import {
   FileTextIcon,
 } from '@phosphor-icons/react';
 import { TelemetryInspectorSettings } from './TelemetryInspectorSettings';
+import { ChromiumFlagsSettings } from './ChromiumFlagsSettings';
 import { TabButton } from '../components/TabButton';
 import { SettingsTabType } from '@irdashies/types';
 import logger from '@irdashies/utils/logger';
@@ -121,6 +122,13 @@ export const AdvancedSettings = () => {
           >
             Telemetry Inspector
           </TabButton>
+          <TabButton
+            id="chromium"
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+          >
+            Chromium
+          </TabButton>
         </div>
       </div>
 
@@ -220,6 +228,12 @@ export const AdvancedSettings = () => {
             Debug widget to display raw telemetry and session values
           </p>
           <TelemetryInspectorSettings />
+        </div>
+      )}
+
+      {activeTab === 'chromium' && (
+        <div className="flex-1 min-h-0 pt-3">
+          <ChromiumFlagsSettings />
         </div>
       )}
     </div>

--- a/src/frontend/components/Settings/sections/ChromiumFlagsSettings.tsx
+++ b/src/frontend/components/Settings/sections/ChromiumFlagsSettings.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import type { ChromiumFlagsType } from '@irdashies/types';
+import { DEFAULT_CHROMIUM_FLAGS } from '@irdashies/types';
+import { SettingToggleRow } from '../components/SettingToggleRow';
+import { SettingSelectRow } from '../components/SettingSelectRow';
+import { SettingsSection } from '../components/SettingSection';
+import logger from '@irdashies/utils/logger';
+
+const ANGLE_OPTIONS: {
+  label: string;
+  value: NonNullable<ChromiumFlagsType['angleBackend']>;
+}[] = [
+  { label: 'Default (Chromium chooses)', value: 'default' },
+  { label: 'OpenGL (gl)', value: 'gl' },
+  { label: 'Direct3D 11 (d3d11)', value: 'd3d11' },
+  { label: 'Direct3D 9 (d3d9)', value: 'd3d9' },
+  { label: 'Vulkan', value: 'vulkan' },
+  { label: 'Metal (macOS)', value: 'metal' },
+];
+
+const PLACEHOLDER = `# One switch per line, no leading "--"
+# Examples:
+# disable-gpu-vsync
+# force-color-profile=srgb`;
+
+export const ChromiumFlagsSettings = () => {
+  const [flags, setFlags] = useState<ChromiumFlagsType | null>(null);
+
+  useEffect(() => {
+    window.chromiumFlagsBridge
+      ?.getFlags()
+      .then((loaded) => setFlags({ ...DEFAULT_CHROMIUM_FLAGS, ...loaded }))
+      .catch((err) => {
+        logger.error('Failed to load chromium flags', err);
+        setFlags({ ...DEFAULT_CHROMIUM_FLAGS });
+      });
+  }, []);
+
+  if (!flags) {
+    return <div className="px-4 text-sm text-slate-400">Loading...</div>;
+  }
+
+  const persist = (next: ChromiumFlagsType) => {
+    setFlags(next);
+    window.chromiumFlagsBridge?.saveFlags(next).catch((err) => {
+      logger.error('Failed to save chromium flags', err);
+    });
+  };
+
+  const update = <K extends keyof ChromiumFlagsType>(
+    key: K,
+    value: ChromiumFlagsType[K]
+  ) => {
+    persist({ ...flags, [key]: value });
+  };
+
+  const featuresToList = (text: string): string[] =>
+    text
+      .split(/[\s,]+/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto min-h-0 pb-4 space-y-6">
+        <p className="text-sm text-slate-400 px-4">
+          Override Chromium command-line switches. Use these only if you
+          experience rendering glitches like black flickering on transparent
+          overlays. These settings are stored locally per machine (separate from
+          dashboard.json) and require an app restart to take effect.
+        </p>
+
+        <SettingsSection title="Recommended fixes">
+          <SettingToggleRow
+            title="Disable native window occlusion"
+            description="Prevents Chromium from blanking the overlay when it incorrectly thinks the window is hidden. Most common fix for black flickering on NVIDIA GPUs (sets --disable-features=CalculateNativeWinOcclusion)."
+            enabled={flags.disableNativeWinOcclusion ?? false}
+            onToggle={(v) => update('disableNativeWinOcclusion', v)}
+          />
+
+          <SettingSelectRow
+            title="ANGLE graphics backend"
+            description="Forces Chromium's graphics backend. Switching to OpenGL often resolves NVIDIA RTX-series transparency bugs at a small performance cost (sets --use-angle)."
+            value={flags.angleBackend ?? 'default'}
+            options={ANGLE_OPTIONS}
+            onChange={(v) => update('angleBackend', v)}
+          />
+
+          <SettingToggleRow
+            title="Disable Direct Composition"
+            description="Disables Windows DirectComposition for transparent windows. Heavier fallback than the occlusion fix while still keeping GPU rendering enabled (sets --disable-direct-composition)."
+            enabled={flags.disableDirectComposition ?? false}
+            onToggle={(v) => update('disableDirectComposition', v)}
+          />
+        </SettingsSection>
+
+        <SettingsSection title="Additional features">
+          <div className="space-y-2">
+            <h4 className="text-md font-medium text-slate-300">
+              Disable features
+            </h4>
+            <p className="text-sm text-slate-500">
+              Comma- or space-separated feature names appended to{' '}
+              <code className="text-slate-400">--disable-features</code>.
+            </p>
+            <textarea
+              className="w-full bg-slate-800 border border-slate-600 rounded p-2 font-mono text-sm focus:outline-none focus:border-blue-500 resize-y min-h-[3rem]"
+              rows={2}
+              value={(flags.disableFeatures ?? []).join(', ')}
+              onChange={(e) =>
+                update('disableFeatures', featuresToList(e.target.value))
+              }
+              placeholder="e.g. HardwareMediaKeyHandling, WidgetLayering"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <h4 className="text-md font-medium text-slate-300">
+              Enable features
+            </h4>
+            <p className="text-sm text-slate-500">
+              Comma- or space-separated feature names appended to{' '}
+              <code className="text-slate-400">--enable-features</code>.
+            </p>
+            <textarea
+              className="w-full bg-slate-800 border border-slate-600 rounded p-2 font-mono text-sm focus:outline-none focus:border-blue-500 resize-y min-h-[3rem]"
+              rows={2}
+              value={(flags.enableFeatures ?? []).join(', ')}
+              onChange={(e) =>
+                update('enableFeatures', featuresToList(e.target.value))
+              }
+              placeholder="e.g. CanvasOopRasterization"
+            />
+          </div>
+        </SettingsSection>
+
+        <SettingsSection title="Custom switches">
+          <p className="text-sm text-slate-500">
+            Freeform Chromium switches, one per line. Format:{' '}
+            <code className="text-slate-400">switch-name</code> or{' '}
+            <code className="text-slate-400">switch-name=value</code> (no
+            leading <code className="text-slate-400">--</code>). Lines starting
+            with <code className="text-slate-400">#</code> are ignored.
+          </p>
+          <textarea
+            className="w-full bg-slate-800 border border-slate-600 rounded p-2 font-mono text-sm focus:outline-none focus:border-blue-500 resize-y min-h-[8rem]"
+            rows={6}
+            value={flags.customSwitches ?? ''}
+            onChange={(e) => update('customSwitches', e.target.value)}
+            placeholder={PLACEHOLDER}
+            spellCheck={false}
+          />
+        </SettingsSection>
+
+        <div className="px-4">
+          <button
+            type="button"
+            onClick={() => persist({ ...DEFAULT_CHROMIUM_FLAGS })}
+            className="text-xs text-amber-400 hover:text-amber-300 underline underline-offset-2 transition-colors cursor-pointer"
+          >
+            Reset all Chromium flags
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/components/Settings/sections/ChromiumFlagsSettings.tsx
+++ b/src/frontend/components/Settings/sections/ChromiumFlagsSettings.tsx
@@ -24,11 +24,19 @@ const PLACEHOLDER = `# One switch per line, no leading "--"
 # force-color-profile=srgb`;
 
 export const ChromiumFlagsSettings = () => {
-  const [flags, setFlags] = useState<ChromiumFlagsType | null>(null);
+  const [flags, setFlags] = useState<ChromiumFlagsType | null>(() => {
+    if (!window.chromiumFlagsBridge) {
+      logger.warn('chromiumFlagsBridge unavailable; using defaults');
+      return { ...DEFAULT_CHROMIUM_FLAGS };
+    }
+    return null;
+  });
 
   useEffect(() => {
+    if (!window.chromiumFlagsBridge) return;
+
     window.chromiumFlagsBridge
-      ?.getFlags()
+      .getFlags()
       .then((loaded) => setFlags({ ...DEFAULT_CHROMIUM_FLAGS, ...loaded }))
       .catch((err) => {
         logger.error('Failed to load chromium flags', err);

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -6,6 +6,7 @@ import type {
   ReferenceLapBridge,
   LogBridge,
   KeybindingsBridge,
+  ChromiumFlagsBridge,
 } from '@irdashies/types';
 
 declare global {
@@ -17,5 +18,6 @@ declare global {
     referenceLapsBridge: ReferenceLapBridge;
     logBridge: LogBridge;
     keybindingsBridge: KeybindingsBridge;
+    chromiumFlagsBridge: ChromiumFlagsBridge;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import { Analytics } from './app/analytics';
 import { setupReferenceLapsBridge } from './app/bridge/referenceLapsBridge';
 import { setupKeybindingsBridge } from './app/bridge/keybindingsBridge';
 import { setupLogBridge } from './app/bridge/logBridge';
+import { setupChromiumFlagsBridge } from './app/bridge/chromiumFlagsBridge';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) app.quit();
@@ -34,6 +35,7 @@ const overlayManager = new OverlayManager();
 const analytics = new Analytics();
 analytics.setupLogTransport();
 
+overlayManager.setupChromiumFlags();
 overlayManager.setupHardwareAcceleration();
 overlayManager.setupSingleInstanceLock();
 overlayManager.setupAutoStart();
@@ -55,6 +57,7 @@ app.on('ready', async () => {
   setupFuelCalculatorBridge();
   setupPitLaneBridge();
   setupReferenceLapsBridge();
+  setupChromiumFlagsBridge();
 
   // Start component server for browser components
   await startComponentServer(bridge, dashboardBridge);

--- a/src/types/chromiumFlags.ts
+++ b/src/types/chromiumFlags.ts
@@ -1,0 +1,49 @@
+/**
+ * Chromium / GPU command-line switches applied at app startup.
+ * Stored separately from the dashboard config because these are
+ * machine-specific (driver / GPU dependent) and should not travel
+ * with dashboard import/export.
+ */
+export interface ChromiumFlagsType {
+  /**
+   * Disables Chromium's native window occlusion detection. Common fix for
+   * black flickering on transparent always-on-top overlays — Chromium will
+   * sometimes wrongly detect the overlay as occluded and stop painting it.
+   */
+  disableNativeWinOcclusion?: boolean;
+  /**
+   * Forces the ANGLE graphics backend. 'default' lets Chromium choose
+   * (typically d3d11 on Windows). Switching to 'gl' often resolves NVIDIA
+   * RTX-series transparency bugs at a small performance cost.
+   */
+  angleBackend?: 'default' | 'gl' | 'd3d11' | 'd3d9' | 'metal' | 'vulkan';
+  /**
+   * Disables Windows DirectComposition for transparent windows. Heavier
+   * fallback than the occlusion fix while keeping GPU rendering enabled.
+   */
+  disableDirectComposition?: boolean;
+  /** Extra feature names appended to --disable-features (one per entry). */
+  disableFeatures?: string[];
+  /** Extra feature names appended to --enable-features (one per entry). */
+  enableFeatures?: string[];
+  /**
+   * Freeform additional switches, one per line. Each line is either
+   * `switch-name` or `switch-name=value` (no leading `--`).
+   */
+  customSwitches?: string;
+}
+
+export const DEFAULT_CHROMIUM_FLAGS: ChromiumFlagsType = {
+  disableNativeWinOcclusion: false,
+  angleBackend: 'default',
+  disableDirectComposition: false,
+  disableFeatures: [],
+  enableFeatures: [],
+  customSwitches: '',
+};
+
+/** Bridge methods exposed to the renderer for chromium flag management */
+export interface ChromiumFlagsBridge {
+  getFlags: () => Promise<ChromiumFlagsType>;
+  saveFlags: (flags: ChromiumFlagsType) => Promise<ChromiumFlagsType>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,3 +12,4 @@ export * from './widgetConfigs';
 export * from './defaultDashboard';
 export * from './logBridge';
 export * from './keybindings';
+export * from './chromiumFlags';

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -631,7 +631,8 @@ export type SettingsTabType =
   | 'footer'
   | 'history'
   | 'telemetry'
-  | 'dashboard';
+  | 'dashboard'
+  | 'chromium';
 
 /** Available widgets for the Fuel Calculator */
 export type FuelWidgetType =


### PR DESCRIPTION
## Description

Adds a new **Chromium** tab in Advanced Settings for configuring Chromium command-line switches at startup. The motivation is that some users (e.g. RTX 50-series with transparent always-on-top overlays) get black flickering that's only fixable by disabling hardware acceleration entirely — which is very CPU intensive. This gives users finer-grained switches to flip without that perf hit.

**Recommended fixes (presets):**
- Disable native window occlusion (`--disable-features=CalculateNativeWinOcclusion`) — most common fix for transparent overlay black flicker
- ANGLE backend selector (`--use-angle=gl|d3d11|d3d9|vulkan|metal`)
- Disable Direct Composition (`--disable-direct-composition`)

**Power-user controls:**
- Freeform `--disable-features` and `--enable-features` lists
- Custom switches textarea (one per line, supports `name=value` and `#` comments)

**Storage:** Flags are persisted in `userData/config.json` under a separate `chromiumFlags` key (same pattern as keybindings) — **not** in `dashboard.json` — because they're machine-specific (driver/GPU dependent) and shouldn't travel with dashboard import/export. Loaded synchronously in `setupChromiumFlags()` before `app.whenReady()` and applied via `app.commandLine.appendSwitch`.

Defaults preserve existing behavior (no flags applied unless the user opts in).

Tested by toggling settings and verifying they round-trip through `userData/config.json`. Have not yet validated the actual flicker fix on the target RTX 5070 hardware.

## Screenshots

### Before
No Chromium flag controls — only an all-or-nothing **Hardware Acceleration** toggle in General Settings.

### After
New **Chromium** tab under **Advanced** with three sections (Recommended fixes, Additional features, Custom switches) plus a Reset button.

<img width="958" height="1012" alt="image" src="https://github.com/user-attachments/assets/a9ddceba-a7b3-44d9-b77f-1e128bfe8de6" />


## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via \`npm test\` (750 passed)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run \`npm run lint\` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (n/a — flags live outside dashboard.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chromium settings tab in Advanced Settings for GPU/Chromium startup flags.
  * UI controls to toggle native window occlusion, select ANGLE backend, and disable DirectComposition.
  * Fields to enable/disable specific features and enter custom command-line switches (one per line).
  * Settings persist across restarts and are applied at startup; includes a Reset button to restore defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->