### PR TITLE
perf: drive SectorDelta strip imperatively, fix carousel highlight

### DIFF
--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -73,3 +73,11 @@ export const WIDGET_MAP: Record<
 };
 
 export type WidgetId = keyof WidgetConfigMap;
+
+/**
+ * Looks up a widget component by id. Accepts a raw string because dashboard
+ * config is user-supplied and may contain unknown ids; returns undefined
+ * when no widget is registered for that id.
+ */
+export const getWidget = (id: string) =>
+  WIDGET_MAP[id as WidgetId] as (typeof WIDGET_MAP)[WidgetId] | undefined;

--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -18,6 +18,7 @@ import { LapTimeLog } from './components/LapTimeLog/LapTimeLog';
 import { InformationBar } from './components/InformationBar/InformationBar';
 import { SlowCarAhead } from './components/SlowCarAhead/SlowCarAhead';
 import { SectorDelta } from './components/SectorDelta/SectorDelta';
+import type { WidgetConfigMap } from '@irdashies/types';
 
 export {
   Standings,
@@ -45,7 +46,7 @@ export {
 // TODO: type this better, right now the config comes from settings
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const WIDGET_MAP: Record<
-  string,
+  keyof WidgetConfigMap,
   (config?: any) => React.JSX.Element | null
 > = {
   /* eslint-enable @typescript-eslint/no-explicit-any */
@@ -71,4 +72,4 @@ export const WIDGET_MAP: Record<
   sectordelta: SectorDelta,
 };
 
-export type WidgetId = keyof typeof WIDGET_MAP;
+export type WidgetId = keyof WidgetConfigMap;

--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -78,6 +78,11 @@ export type WidgetId = keyof WidgetConfigMap;
  * Looks up a widget component by id. Accepts a raw string because dashboard
  * config is user-supplied and may contain unknown ids; returns undefined
  * when no widget is registered for that id.
+ *
+ * Uses Object.hasOwn so prototype-chain keys (e.g. "__proto__", "toString")
+ * never resolve to truthy non-component values that React would try to render.
  */
 export const getWidget = (id: string) =>
-  WIDGET_MAP[id as WidgetId] as (typeof WIDGET_MAP)[WidgetId] | undefined;
+  Object.hasOwn(WIDGET_MAP, id)
+    ? (WIDGET_MAP[id as WidgetId] as (typeof WIDGET_MAP)[WidgetId])
+    : undefined;

--- a/src/frontend/components/DashboardView/DashboardView.tsx
+++ b/src/frontend/components/DashboardView/DashboardView.tsx
@@ -8,7 +8,7 @@ import {
   CSSProperties,
 } from 'react';
 import { useDashboard } from '@irdashies/context';
-import { WIDGET_MAP } from '../../WidgetIndex';
+import { WIDGET_MAP, type WidgetId } from '../../WidgetIndex';
 import { getWidgetName } from '../../constants/widgetNames';
 import { ResizeIcon, XIcon } from '@phosphor-icons/react';
 import type { DashboardWidget } from '@irdashies/types';
@@ -106,7 +106,7 @@ const DashboardWidgetItem = memo(
       };
     }, []);
 
-    const WidgetComponent = WIDGET_MAP[widget.type || widget.id];
+    const WidgetComponent = WIDGET_MAP[(widget.type || widget.id) as WidgetId];
     if (!WidgetComponent) {
       return null;
     }

--- a/src/frontend/components/DashboardView/DashboardView.tsx
+++ b/src/frontend/components/DashboardView/DashboardView.tsx
@@ -8,7 +8,7 @@ import {
   CSSProperties,
 } from 'react';
 import { useDashboard } from '@irdashies/context';
-import { WIDGET_MAP, type WidgetId } from '../../WidgetIndex';
+import { getWidget } from '../../WidgetIndex';
 import { getWidgetName } from '../../constants/widgetNames';
 import { ResizeIcon, XIcon } from '@phosphor-icons/react';
 import type { DashboardWidget } from '@irdashies/types';
@@ -106,7 +106,7 @@ const DashboardWidgetItem = memo(
       };
     }, []);
 
-    const WidgetComponent = WIDGET_MAP[(widget.type || widget.id) as WidgetId];
+    const WidgetComponent = getWidget(widget.type || widget.id);
     if (!WidgetComponent) {
       return null;
     }

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useRef } from 'react';
 import { useDashboard, useRunningState } from '@irdashies/context';
 import type { WidgetLayout } from '@irdashies/types';
 import { WidgetContainer } from '../WidgetContainer';
-import { WIDGET_MAP } from '../../WidgetIndex';
+import { WIDGET_MAP, type WidgetId } from '../../WidgetIndex';
 import { XIcon } from '@phosphor-icons/react';
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 import { SectorTimingUpdater } from './SectorTimingUpdater';
@@ -108,7 +108,8 @@ export const OverlayContainer = memo(() => {
     >
       <SectorTimingUpdater />
       {widgetsForThisDisplay.map((widget, index) => {
-        const WidgetComponent = WIDGET_MAP[widget.type || widget.id];
+        const WidgetComponent =
+          WIDGET_MAP[(widget.type || widget.id) as WidgetId];
         if (!WidgetComponent) {
           return null;
         }

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useEffect, useRef } from 'react';
 import { useDashboard, useRunningState } from '@irdashies/context';
 import type { WidgetLayout } from '@irdashies/types';
 import { WidgetContainer } from '../WidgetContainer';
-import { WIDGET_MAP, type WidgetId } from '../../WidgetIndex';
+import { getWidget } from '../../WidgetIndex';
 import { XIcon } from '@phosphor-icons/react';
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 import { SectorTimingUpdater } from './SectorTimingUpdater';
@@ -108,8 +108,7 @@ export const OverlayContainer = memo(() => {
     >
       <SectorTimingUpdater />
       {widgetsForThisDisplay.map((widget, index) => {
-        const WidgetComponent =
-          WIDGET_MAP[(widget.type || widget.id) as WidgetId];
+        const WidgetComponent = getWidget(widget.type || widget.id);
         if (!WidgetComponent) {
           return null;
         }

--- a/src/frontend/components/SectorDelta/SectorDelta.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.tsx
@@ -94,6 +94,9 @@ export const SectorDelta = ({
 
   const useGhost = ghostComparison === 'prefer-ghost' && hasGhostLap;
 
+  const currentSectorStart = sectors[currentSectorIdx]?.SectorStartPct ?? 0;
+  const currentSectorEnd = sectors[currentSectorIdx + 1]?.SectorStartPct ?? 1;
+
   const setThresholds = useSectorTimingStore((s) => s.setThresholds);
   useEffect(() => {
     const { green, yellow } = getSectorDeltaThresholdFractions(thresholds);
@@ -116,7 +119,8 @@ export const SectorDelta = ({
     centerSlot,
   } = useCarouselWindow(
     currentSectorIdx,
-    sectors,
+    currentSectorStart,
+    currentSectorEnd,
     sectors.length,
     maxSectorsShown,
     alwaysScroll
@@ -164,9 +168,6 @@ export const SectorDelta = ({
     const fallback = formatDelta(displayTime, refTime, timeFormat);
     const cardStyle = SECTOR_CARD[colorKey];
 
-    const sectorStart = sector.SectorStartPct;
-    const sectorEnd = sectors[i + 1]?.SectorStartPct ?? 1;
-
     return (
       <div
         key={cardKey}
@@ -205,8 +206,8 @@ export const SectorDelta = ({
         </span>
         {isCurrent && (
           <SectorProgressIndicator
-            sectorStart={sectorStart}
-            sectorEnd={sectorEnd}
+            sectorStart={currentSectorStart}
+            sectorEnd={currentSectorEnd}
             isWindowed={isWindowed}
           />
         )}

--- a/src/frontend/components/SectorDelta/SectorDelta.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.tsx
@@ -122,14 +122,20 @@ export const SectorDelta = ({
     setTrackIncidentSectors(trackIncidentSectors);
   }, [trackIncidentSectors, setTrackIncidentSectors]);
 
-  const { isWindowed, extendedIndices, slotWidth, containerRef, stripStyle } =
-    useCarouselWindow(
-      currentSectorIdx,
-      sectorProgress,
-      sectors.length,
-      maxSectorsShown,
-      alwaysScroll
-    );
+  const {
+    isWindowed,
+    extendedIndices,
+    slotWidth,
+    containerRef,
+    stripStyle,
+    centerSlot,
+  } = useCarouselWindow(
+    currentSectorIdx,
+    sectorProgress,
+    sectors.length,
+    maxSectorsShown,
+    alwaysScroll
+  );
 
   if (!useSessionVisibility(sessionVisibility)) return null;
   if (showOnlyWhenOnTrack && !isOnTrack) return null;
@@ -138,11 +144,14 @@ export const SectorDelta = ({
   const opacity = (background?.opacity ?? 80) / 100;
 
   /** Renders the card content for a given sector index. */
-  const renderCard = (i: number, cardKey: string | number) => {
+  const renderCard = (
+    i: number,
+    cardKey: string | number,
+    isCurrent: boolean
+  ) => {
     const sector = sectors[i];
     if (!sector) return null;
 
-    const isCurrent = i === currentSectorIdx;
     const displayTime = isCurrent
       ? (previousLapSectorTimes[i] ?? null)
       : (currentLapSectorTimes[i] ?? previousLapSectorTimes[i] ?? null);
@@ -253,14 +262,16 @@ export const SectorDelta = ({
         <div ref={containerRef} className="flex-1 overflow-hidden relative">
           <div className="flex flex-row gap-1" style={stripStyle}>
             {extendedIndices.map((sectorIdx, slotPosition) =>
-              renderCard(sectorIdx, slotPosition)
+              renderCard(sectorIdx, slotPosition, slotPosition === centerSlot)
             )}
           </div>
           <div className="absolute inset-y-0 left-1/2 w-px bg-sky-400/60 pointer-events-none" />
         </div>
       ) : (
         // Normal mode: all sectors visible, each card expands to fill width
-        sectors.map((sector, i) => renderCard(i, sector.SectorNum))
+        sectors.map((sector, i) =>
+          renderCard(i, sector.SectorNum, i === currentSectorIdx)
+        )
       )}
     </div>
   );

--- a/src/frontend/components/SectorDelta/SectorDelta.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.tsx
@@ -1,17 +1,14 @@
 import { useEffect } from 'react';
 import { GhostIcon, WarningIcon } from '@phosphor-icons/react';
 import { useSectorDeltas, useSectorTimingStore } from '@irdashies/context';
-import {
-  useSessionVisibility,
-  useTelemetryValue,
-  useTelemetryValueRounded,
-} from '@irdashies/context';
+import { useSessionVisibility, useTelemetryValue } from '@irdashies/context';
 import { useReferenceLapSectorTimes } from '@irdashies/context';
 import type { SectorDeltaConfig } from '@irdashies/types';
 import type { TimeFormat } from '@irdashies/types';
 import type { SectorColor } from '@irdashies/context';
-import { useLiveSectorDelta } from './hooks/useLiveSectorDelta';
 import { useCarouselWindow } from './hooks/useCarouselWindow';
+import { LiveDelta } from './components/LiveDelta';
+import { SectorProgressIndicator } from './components/SectorProgressIndicator';
 import {
   computeGhostSectorColor,
   getSectorDeltaThresholdFractions,
@@ -93,21 +90,9 @@ export const SectorDelta = ({
     currentSectorIdx,
   } = useSectorDeltas();
   const isOnTrack = useTelemetryValue('IsOnTrack');
-  const lapDistPct = useTelemetryValueRounded('LapDistPct', 3) ?? 0;
   const { refSectorTimes, hasGhostLap } = useReferenceLapSectorTimes();
 
   const useGhost = ghostComparison === 'prefer-ghost' && hasGhostLap;
-  const liveSectorDelta = useLiveSectorDelta(useGhost);
-
-  const sectorStart = sectors[currentSectorIdx]?.SectorStartPct ?? 0;
-  const sectorEnd = sectors[currentSectorIdx + 1]?.SectorStartPct ?? 1;
-  const sectorProgress =
-    sectorEnd > sectorStart
-      ? Math.max(
-          0,
-          Math.min(1, (lapDistPct - sectorStart) / (sectorEnd - sectorStart))
-        )
-      : 0;
 
   const setThresholds = useSectorTimingStore((s) => s.setThresholds);
   useEffect(() => {
@@ -127,11 +112,11 @@ export const SectorDelta = ({
     extendedIndices,
     slotWidth,
     containerRef,
-    stripStyle,
+    stripRef,
     centerSlot,
   } = useCarouselWindow(
     currentSectorIdx,
-    sectorProgress,
+    sectors,
     sectors.length,
     maxSectorsShown,
     alwaysScroll
@@ -142,8 +127,9 @@ export const SectorDelta = ({
   if (sectors.length === 0) return null;
 
   const opacity = (background?.opacity ?? 80) / 100;
+  const dp = timeFormatToDecimalPlaces(timeFormat);
 
-  /** Renders the card content for a given sector index. */
+  /** Renders a sector card. */
   const renderCard = (
     i: number,
     cardKey: string | number,
@@ -175,12 +161,11 @@ export const SectorDelta = ({
         ? (previousSessionBestSectorTimes[i] ?? null)
         : (sessionBestSectorTimes[i] ?? null);
 
-    const dp = timeFormatToDecimalPlaces(timeFormat);
-    const delta =
-      isCurrent && liveSectorDelta !== null
-        ? `${liveSectorDelta >= 0 ? '+' : ''}${liveSectorDelta.toFixed(dp)}`
-        : formatDelta(displayTime, refTime, timeFormat);
+    const fallback = formatDelta(displayTime, refTime, timeFormat);
     const cardStyle = SECTOR_CARD[colorKey];
+
+    const sectorStart = sector.SectorStartPct;
+    const sectorEnd = sectors[i + 1]?.SectorStartPct ?? 1;
 
     return (
       <div
@@ -203,7 +188,13 @@ export const SectorDelta = ({
             isCurrent ? 'opacity-70' : '',
           ].join(' ')}
         >
-          <span>{delta}</span>
+          <span>
+            {isCurrent ? (
+              <LiveDelta useGhost={useGhost} dp={dp} fallback={fallback} />
+            ) : (
+              fallback
+            )}
+          </span>
           {isUnclean && (
             <WarningIcon
               size={10}
@@ -213,32 +204,11 @@ export const SectorDelta = ({
           )}
         </span>
         {isCurrent && (
-          <>
-            <div
-              className={
-                isWindowed
-                  ? 'absolute top-0 left-0 bottom-0'
-                  : 'absolute top-0 left-0 bottom-0 transition-[width] duration-200 ease-linear'
-              }
-              style={{
-                width: `${sectorProgress * 100}%`,
-                backgroundColor: 'rgba(56, 189, 248, 0.4)',
-              }}
-            />
-            {!isWindowed && (
-              <>
-                <div className="absolute top-0 left-0 bottom-0 w-[2px] bg-sky-400" />
-                <div
-                  className="absolute top-0 left-0 h-[2px] bg-sky-400 transition-[width] duration-200 ease-linear"
-                  style={{ width: `${sectorProgress * 100}%` }}
-                />
-                <div
-                  className="absolute bottom-0 left-0 h-[2px] bg-sky-400 transition-[width] duration-200 ease-linear"
-                  style={{ width: `${sectorProgress * 100}%` }}
-                />
-              </>
-            )}
-          </>
+          <SectorProgressIndicator
+            sectorStart={sectorStart}
+            sectorEnd={sectorEnd}
+            isWindowed={isWindowed}
+          />
         )}
       </div>
     );
@@ -256,11 +226,8 @@ export const SectorDelta = ({
       )}
 
       {isWindowed ? (
-        // Continuous scroll mode: strip translates every frame to keep the
-        // player's exact track position pinned to the horizontal center.
-        // Partial cards are visible on both edges.
         <div ref={containerRef} className="flex-1 overflow-hidden relative">
-          <div className="flex flex-row gap-1" style={stripStyle}>
+          <div ref={stripRef} className="flex flex-row gap-1">
             {extendedIndices.map((sectorIdx, slotPosition) =>
               renderCard(sectorIdx, slotPosition, slotPosition === centerSlot)
             )}
@@ -268,7 +235,6 @@ export const SectorDelta = ({
           <div className="absolute inset-y-0 left-1/2 w-px bg-sky-400/60 pointer-events-none" />
         </div>
       ) : (
-        // Normal mode: all sectors visible, each card expands to fill width
         sectors.map((sector, i) =>
           renderCard(i, sector.SectorNum, i === currentSectorIdx)
         )

--- a/src/frontend/components/SectorDelta/components/LiveDelta.tsx
+++ b/src/frontend/components/SectorDelta/components/LiveDelta.tsx
@@ -1,0 +1,20 @@
+import { useLiveSectorDelta } from '../hooks/useLiveSectorDelta';
+
+/**
+ * Live numeric delta on the active sector card. Isolated so its 60Hz updates
+ * don't re-render the whole widget.
+ */
+export const LiveDelta = ({
+  useGhost,
+  dp,
+  fallback,
+}: {
+  useGhost: boolean;
+  dp: number;
+  fallback: string;
+}) => {
+  const liveSectorDelta = useLiveSectorDelta(useGhost);
+  if (liveSectorDelta === null) return <>{fallback}</>;
+  const sign = liveSectorDelta >= 0 ? '+' : '';
+  return <>{`${sign}${liveSectorDelta.toFixed(dp)}`}</>;
+};

--- a/src/frontend/components/SectorDelta/components/SectorProgressIndicator.tsx
+++ b/src/frontend/components/SectorDelta/components/SectorProgressIndicator.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react';
+import { useTelemetryStore } from '@irdashies/context';
+
+/**
+ * Track-progress overlay for the active card. Subscribes to LapDistPct
+ * directly and mutates style.width on its own elements — no React renders
+ * per frame.
+ */
+export const SectorProgressIndicator = ({
+  sectorStart,
+  sectorEnd,
+  isWindowed,
+}: {
+  sectorStart: number;
+  sectorEnd: number;
+  isWindowed: boolean;
+}) => {
+  const fillRef = useRef<HTMLDivElement>(null);
+  const topBarRef = useRef<HTMLDivElement>(null);
+  const bottomBarRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const apply = () => {
+      const lapDistPct =
+        useTelemetryStore.getState().telemetry?.LapDistPct?.value?.[0] ?? 0;
+      const progress =
+        sectorEnd > sectorStart
+          ? Math.max(
+              0,
+              Math.min(
+                1,
+                (lapDistPct - sectorStart) / (sectorEnd - sectorStart)
+              )
+            )
+          : 0;
+      const w = `${progress * 100}%`;
+      if (fillRef.current) fillRef.current.style.width = w;
+      if (topBarRef.current) topBarRef.current.style.width = w;
+      if (bottomBarRef.current) bottomBarRef.current.style.width = w;
+    };
+
+    apply();
+    return useTelemetryStore.subscribe(apply);
+  }, [sectorStart, sectorEnd]);
+
+  return (
+    <>
+      <div
+        ref={fillRef}
+        className="absolute top-0 left-0 bottom-0"
+        style={{ backgroundColor: 'rgba(56, 189, 248, 0.4)', width: 0 }}
+      />
+      {!isWindowed && (
+        <>
+          <div className="absolute top-0 left-0 bottom-0 w-0.5 bg-sky-400" />
+          <div
+            ref={topBarRef}
+            className="absolute top-0 left-0 h-0.5 bg-sky-400"
+            style={{ width: 0 }}
+          />
+          <div
+            ref={bottomBarRef}
+            className="absolute bottom-0 left-0 h-0.5 bg-sky-400"
+            style={{ width: 0 }}
+          />
+        </>
+      )}
+    </>
+  );
+};

--- a/src/frontend/components/SectorDelta/components/SectorProgressIndicator.tsx
+++ b/src/frontend/components/SectorDelta/components/SectorProgressIndicator.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useRef } from 'react';
+import { useLayoutEffect, useRef } from 'react';
 import { useTelemetryStore } from '@irdashies/context';
 
 /**
  * Track-progress overlay for the active card. Subscribes to LapDistPct
  * directly and mutates style.width on its own elements — no React renders
  * per frame.
+ *
+ * useLayoutEffect ensures the initial width is applied before paint, so the
+ * bars don't flash at 0% on mount.
  */
 export const SectorProgressIndicator = ({
   sectorStart,
@@ -19,19 +22,14 @@ export const SectorProgressIndicator = ({
   const topBarRef = useRef<HTMLDivElement>(null);
   const bottomBarRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const apply = () => {
       const lapDistPct =
         useTelemetryStore.getState().telemetry?.LapDistPct?.value?.[0] ?? 0;
+      const span = sectorEnd - sectorStart;
       const progress =
-        sectorEnd > sectorStart
-          ? Math.max(
-              0,
-              Math.min(
-                1,
-                (lapDistPct - sectorStart) / (sectorEnd - sectorStart)
-              )
-            )
+        span > 0
+          ? Math.max(0, Math.min(1, (lapDistPct - sectorStart) / span))
           : 0;
       const w = `${progress * 100}%`;
       if (fillRef.current) fillRef.current.style.width = w;
@@ -47,21 +45,19 @@ export const SectorProgressIndicator = ({
     <>
       <div
         ref={fillRef}
-        className="absolute top-0 left-0 bottom-0"
-        style={{ backgroundColor: 'rgba(56, 189, 248, 0.4)', width: 0 }}
+        className="absolute top-0 left-0 bottom-0 w-0"
+        style={{ backgroundColor: 'rgba(56, 189, 248, 0.4)' }}
       />
       {!isWindowed && (
         <>
           <div className="absolute top-0 left-0 bottom-0 w-0.5 bg-sky-400" />
           <div
             ref={topBarRef}
-            className="absolute top-0 left-0 h-0.5 bg-sky-400"
-            style={{ width: 0 }}
+            className="absolute top-0 left-0 h-0.5 w-0 bg-sky-400"
           />
           <div
             ref={bottomBarRef}
-            className="absolute bottom-0 left-0 h-0.5 bg-sky-400"
-            style={{ width: 0 }}
+            className="absolute bottom-0 left-0 h-0.5 w-0 bg-sky-400"
           />
         </>
       )}

--- a/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
+++ b/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
@@ -32,11 +32,13 @@ export function useCarouselWindow(
   currentSectorIdx: number,
   sectorProgress: number,
   totalSectors: number,
-  maxSectorsShown: number | undefined,
-  alwaysScroll = false
+  maxSectorsShown: number | null | undefined,
+  alwaysScroll: boolean | null | undefined = false
 ) {
+  const effectiveAlwaysScroll = alwaysScroll ?? false;
   const isWindowed =
-    alwaysScroll || (maxSectorsShown != null && totalSectors > maxSectorsShown);
+    effectiveAlwaysScroll ||
+    (maxSectorsShown != null && totalSectors > maxSectorsShown);
 
   const [slotWidth, setSlotWidth] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -89,11 +91,17 @@ export function useCarouselWindow(
     ? { transform: `translateX(${containerWidth / 2 - stripPosition}px)` }
     : {};
 
+  // Slot position in extendedIndices that represents the player's current
+  // sector for *this* cycle. Buffer copies of the same sectorIdx are not
+  // current — they represent past/future cycles and should not show progress.
+  const centerSlot = isWindowed ? bufferExtra + currentSectorIdx : -1;
+
   return {
     isWindowed,
     extendedIndices,
     slotWidth,
     containerRef,
     stripStyle,
+    centerSlot,
   };
 }

--- a/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
+++ b/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
@@ -1,11 +1,7 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTelemetryStore } from '@irdashies/context';
 
 const GAP = 4; // gap-1 = 4px
-
-interface SectorLike {
-  SectorStartPct: number;
-}
 
 /**
  * Builds an extended sector index list with buffer sectors on each side:
@@ -34,7 +30,8 @@ function buildExtendedIndices(
  */
 export function useCarouselWindow(
   currentSectorIdx: number,
-  sectors: SectorLike[],
+  currentSectorStart: number,
+  currentSectorEnd: number,
   totalSectors: number,
   maxSectorsShown: number | null | undefined,
   alwaysScroll: boolean | null | undefined = false
@@ -48,6 +45,7 @@ export function useCarouselWindow(
   const containerRef = useRef<HTMLDivElement>(null);
   const stripRef = useRef<HTMLDivElement>(null);
 
+  // When alwaysScroll is on but maxSectorsShown is unset, fit all sectors.
   const effectiveMaxShown =
     maxSectorsShown ?? (isWindowed ? totalSectors : undefined);
 
@@ -68,6 +66,8 @@ export function useCarouselWindow(
     return () => ro.disconnect();
   }, [isWindowed, effectiveMaxShown]);
 
+  // Extra sectors rendered before sector 0 and after the last sector.
+  // Enough to fill half the visible window so the edges are always covered.
   const bufferExtra =
     isWindowed && effectiveMaxShown ? Math.ceil(effectiveMaxShown / 2) + 1 : 0;
 
@@ -79,11 +79,15 @@ export function useCarouselWindow(
     [isWindowed, effectiveMaxShown, totalSectors, bufferExtra]
   );
 
+  // Pixel width of one slot (card + trailing gap), and total container width.
   const step = slotWidth + GAP;
   const containerWidth = effectiveMaxShown ? effectiveMaxShown * step - GAP : 0;
   const centerSlot = isWindowed ? bufferExtra + currentSectorIdx : -1;
 
-  useEffect(() => {
+  // Drive the strip transform imperatively. useLayoutEffect so the initial
+  // apply runs before paint — avoids a one-frame flash at translateX(0) on
+  // mount or whenever the layout (slotWidth, currentSectorIdx) changes.
+  useLayoutEffect(() => {
     if (!isWindowed || slotWidth === 0) return;
 
     const apply = () => {
@@ -91,18 +95,13 @@ export function useCarouselWindow(
       if (!node) return;
       const lapDistPct =
         useTelemetryStore.getState().telemetry?.LapDistPct?.value?.[0] ?? 0;
-      const sectorStart = sectors[currentSectorIdx]?.SectorStartPct ?? 0;
-      const sectorEnd = sectors[currentSectorIdx + 1]?.SectorStartPct ?? 1;
+      const span = currentSectorEnd - currentSectorStart;
       const progress =
-        sectorEnd > sectorStart
-          ? Math.max(
-              0,
-              Math.min(
-                1,
-                (lapDistPct - sectorStart) / (sectorEnd - sectorStart)
-              )
-            )
+        span > 0
+          ? Math.max(0, Math.min(1, (lapDistPct - currentSectorStart) / span))
           : 0;
+      // Whole-card steps for completed sectors, then fractional slotWidth
+      // within the current card (gap is not traversed mid-card).
       const stripPosition =
         (bufferExtra + currentSectorIdx) * step + progress * slotWidth;
       node.style.transform = `translateX(${containerWidth / 2 - stripPosition}px)`;
@@ -117,7 +116,8 @@ export function useCarouselWindow(
     bufferExtra,
     containerWidth,
     currentSectorIdx,
-    sectors,
+    currentSectorStart,
+    currentSectorEnd,
   ]);
 
   return {

--- a/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
+++ b/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
@@ -1,7 +1,11 @@
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
-import type React from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useTelemetryStore } from '@irdashies/context';
 
 const GAP = 4; // gap-1 = 4px
+
+interface SectorLike {
+  SectorStartPct: number;
+}
 
 /**
  * Builds an extended sector index list with buffer sectors on each side:
@@ -22,15 +26,15 @@ function buildExtendedIndices(
 
 /**
  * Drives a continuously scrolling sector strip centered on the player's
- * exact track position. The strip translates every time sectorProgress
- * changes (i.e. every lapDistPct update), so the current position is
- * always pinned to the horizontal center of the viewport.
+ * exact track position.
  *
- * Partial sector cards are visible on both edges at all times.
+ * The strip transform is updated imperatively from the telemetry store
+ * (~60×/sec) so the React tree does not re-render every frame — only the
+ * `style.transform` of the strip element mutates.
  */
 export function useCarouselWindow(
   currentSectorIdx: number,
-  sectorProgress: number,
+  sectors: SectorLike[],
   totalSectors: number,
   maxSectorsShown: number | null | undefined,
   alwaysScroll: boolean | null | undefined = false
@@ -42,8 +46,8 @@ export function useCarouselWindow(
 
   const [slotWidth, setSlotWidth] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
+  const stripRef = useRef<HTMLDivElement>(null);
 
-  // When alwaysScroll is on but maxSectorsShown is unset, fit all sectors.
   const effectiveMaxShown =
     maxSectorsShown ?? (isWindowed ? totalSectors : undefined);
 
@@ -64,8 +68,6 @@ export function useCarouselWindow(
     return () => ro.disconnect();
   }, [isWindowed, effectiveMaxShown]);
 
-  // Extra sectors rendered before sector 0 and after the last sector.
-  // Enough to fill half the visible window so the edges are always covered.
   const bufferExtra =
     isWindowed && effectiveMaxShown ? Math.ceil(effectiveMaxShown / 2) + 1 : 0;
 
@@ -77,31 +79,53 @@ export function useCarouselWindow(
     [isWindowed, effectiveMaxShown, totalSectors, bufferExtra]
   );
 
-  // Pixel width of one slot (card + trailing gap), and total container width
   const step = slotWidth + GAP;
   const containerWidth = effectiveMaxShown ? effectiveMaxShown * step - GAP : 0;
-
-  // Position in the strip of the player's exact track point.
-  // Uses whole-card steps for completed sectors, then fractional slotWidth
-  // within the current card (gap is not traversed mid-card).
-  const stripPosition =
-    (bufferExtra + currentSectorIdx) * step + sectorProgress * slotWidth;
-
-  const stripStyle: React.CSSProperties = isWindowed
-    ? { transform: `translateX(${containerWidth / 2 - stripPosition}px)` }
-    : {};
-
-  // Slot position in extendedIndices that represents the player's current
-  // sector for *this* cycle. Buffer copies of the same sectorIdx are not
-  // current — they represent past/future cycles and should not show progress.
   const centerSlot = isWindowed ? bufferExtra + currentSectorIdx : -1;
+
+  useEffect(() => {
+    if (!isWindowed || slotWidth === 0) return;
+
+    const apply = () => {
+      const node = stripRef.current;
+      if (!node) return;
+      const lapDistPct =
+        useTelemetryStore.getState().telemetry?.LapDistPct?.value?.[0] ?? 0;
+      const sectorStart = sectors[currentSectorIdx]?.SectorStartPct ?? 0;
+      const sectorEnd = sectors[currentSectorIdx + 1]?.SectorStartPct ?? 1;
+      const progress =
+        sectorEnd > sectorStart
+          ? Math.max(
+              0,
+              Math.min(
+                1,
+                (lapDistPct - sectorStart) / (sectorEnd - sectorStart)
+              )
+            )
+          : 0;
+      const stripPosition =
+        (bufferExtra + currentSectorIdx) * step + progress * slotWidth;
+      node.style.transform = `translateX(${containerWidth / 2 - stripPosition}px)`;
+    };
+
+    apply();
+    return useTelemetryStore.subscribe(apply);
+  }, [
+    isWindowed,
+    slotWidth,
+    step,
+    bufferExtra,
+    containerWidth,
+    currentSectorIdx,
+    sectors,
+  ]);
 
   return {
     isWindowed,
     extendedIndices,
     slotWidth,
     containerRef,
-    stripStyle,
+    stripRef,
     centerSlot,
   };
 }

--- a/src/frontend/components/Settings/SettingsMenu.tsx
+++ b/src/frontend/components/Settings/SettingsMenu.tsx
@@ -121,6 +121,12 @@ const widgetItems: MenuItem[] = [
     widgetType: 'relative',
   },
   {
+    to: '/settings/sectordelta',
+    path: '/sectordelta',
+    label: 'Sector Delta',
+    widgetType: 'sectordelta',
+  },
+  {
     to: '/settings/slowcarahead',
     path: '/slowcarahead',
     label: 'Slow Car Ahead',
@@ -139,12 +145,6 @@ const widgetItems: MenuItem[] = [
     widgetType: 'tachometer',
   },
   { to: '/settings/map', path: '/map', label: 'Track Map', widgetType: 'map' },
-  {
-    to: '/settings/sectordelta',
-    path: '/sectordelta',
-    label: 'Sector Delta',
-    widgetType: 'sectordelta',
-  },
   {
     to: '/settings/twitchchat',
     path: '/twitchchat',

--- a/src/frontend/constants/widgetNames.ts
+++ b/src/frontend/constants/widgetNames.ts
@@ -22,6 +22,9 @@ export const WIDGET_NAMES: Record<WidgetId, string> = {
   flag: 'Flag',
   twitchchat: 'Twitch Chat',
   laptimelog: 'Lap Timer',
+  infobar: 'Information Bar',
+  slowcarahead: 'Slow Car Ahead',
+  sectordelta: 'Sector Delta',
 };
 
 /**
@@ -30,5 +33,5 @@ export const WIDGET_NAMES: Record<WidgetId, string> = {
  * @returns The friendly display name, or the ID itself if not found
  */
 export function getWidgetName(widgetId: string): string {
-  return WIDGET_NAMES[widgetId] || widgetId;
+  return WIDGET_NAMES[widgetId as WidgetId] || widgetId;
 }

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1194,6 +1194,9 @@ export const defaultDashboard: {
         timeFormat: 'seconds-full',
         ghostComparison: 'prefer-ghost',
         trackIncidentSectors: true,
+        alwaysScroll: false,
+        maxSectorsShown: null,
+        thresholds: null,
         showOnlyWhenOnTrack: true,
         sessionVisibility: {
           race: true,

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -546,18 +546,18 @@ export interface SectorDeltaConfig {
   sessionVisibility: SessionVisibilitySettings;
   /**
    * Custom color thresholds as percentages of session best.
-   * Omit to use defaults (green: 0.5%, yellow: 1.0%).
+   * Set to null to use defaults (green: 0.5%, yellow: 1.0%).
    */
   thresholds?: {
     green: number; // e.g. 0.5 means within 0.5% → green
     yellow: number; // e.g. 1.0 means within 1.0% → yellow; above = red
-  };
+  } | null;
   /**
    * Maximum number of sector cards to show at once. When the track has more
    * sectors than this, the widget becomes a sliding carousel centered on the
-   * current sector. Omit (or undefined) to always show all sectors.
+   * current sector. Set to null to always show all sectors.
    */
-  maxSectorsShown?: number;
+  maxSectorsShown?: number | null;
   /**
    * Always use the continuous-scroll mode, even when all sectors fit in the
    * widget. The center line stays pinned to your exact track position.


### PR DESCRIPTION
## Description

Two related fixes to the SectorDelta widget added in #525.

### Carousel current-slot highlighting

In windowed/scroll mode the strip renders buffer copies of the same sector index for past/future cycles. The renderer was treating every slot whose index matched `currentSectorIdx` as "current", so buffer copies showed the live progress bar and previous-lap time alongside the real one. The hook now exposes the single `centerSlot` position; the component passes that through `renderCard` so only the actual center cycle is highlighted.

### Performance: stop re-rendering at 60Hz

The widget was subscribing to `LapDistPct` directly in render and feeding it into `useCarouselWindow` as `sectorProgress`, which produced a new `stripStyle` object every frame. With ~13–20 cards in the windowed strip, the entire widget tree (and every card subtree) was reconciling ~60×/sec.

After this PR:

- `useCarouselWindow` returns a `stripRef` and subscribes to `useTelemetryStore` once. Each tick reads `LapDistPct` and mutates `stripRef.current.style.transform` directly — no React render.
- A new `SectorProgressIndicator` leaf owns the active-card progress fill and the top/bottom edge bars, mutating their `style.width` on the same subscription. The CSS `transition-[width]` (which existed to smooth React-driven jitter) is gone — at native 60Hz it isn't needed.
- A new `LiveDelta` leaf owns `useLiveSectorDelta`, so its 60Hz numeric updates re-render only that one `<span>` instead of the whole widget.
- The parent `SectorDelta` no longer subscribes to `LapDistPct` at all, and re-renders only when actual sector data changes (~3×/lap).

Visual output is identical. Verified locally with `npm test` (750 passed) and `npm run lint`; not yet exercised in an iRacing session.

### Bundled cleanups

- **Widget type-safety**: `WIDGET_MAP` and `WidgetId` are keyed off `WidgetConfigMap`, so a widget defined in config but missing from the map (or vice versa) becomes a type error instead of a silent runtime miss.
- **Friendly names**: `widgetNames.ts` was missing entries for `infobar`, `slowcarahead`, and `sectordelta` — they now resolve to their proper labels instead of falling back to the raw id.
- **Settings menu**: Sector Delta moved into alphabetical position in the widget list.
- **Nullable config**: `SectorDeltaConfig.thresholds` and `maxSectorsShown` now explicitly accept `null` (the form returns `null` when cleared), with matching defaults in `defaultDashboard.ts`.

## Screenshots

### Before
Carousel mode: every buffer copy of the current sector showed the live progress overlay and the "previous lap" time, stacking duplicate highlights across the strip. The widget was also reconciling the full card tree every frame.

### After
Only the true center slot shows the live progress; buffer copies render as normal past/future sector cards. Strip transform and progress fills are mutated directly on the DOM, so the React tree only re-renders on real sector data changes.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sector Delta widget: live delta display and sector progress indicators; improved carousel positioning and rendering
  * New configurable options for Sector Delta: scrolling behavior, visible-sector limits, and delta thresholds
  * Widget menu reordered for improved discoverability

* **Refactor**
  * More robust widget lookup/registration mechanism for safer component resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->