### PR TITLE
perf: address 0.3.1 SessionBar/DriverStats regressions

### DIFF
--- a/src/frontend/components/Standings/components/SessionBar/AirTemperatureItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/AirTemperatureItem.tsx
@@ -3,15 +3,17 @@ import { ThermometerIcon } from '@phosphor-icons/react';
 import type { TemperatureUnit } from '@irdashies/types';
 import { useTrackTemperature } from '../../hooks/useTrackTemperature';
 
-export const AirTemperatureItem = memo(
-  ({ unit }: { unit: TemperatureUnit }) => {
-    const { airTemp } = useTrackTemperature({ airTempUnit: unit });
-    return (
-      <div className="flex justify-center gap-1 items-center">
-        <ThermometerIcon />
-        <span>{airTemp}</span>
-      </div>
-    );
-  }
-);
+interface AirTemperatureItemProps {
+  unit: TemperatureUnit;
+}
+
+export const AirTemperatureItem = memo(({ unit }: AirTemperatureItemProps) => {
+  const { airTemp } = useTrackTemperature({ airTempUnit: unit });
+  return (
+    <div className="flex justify-center gap-1 items-center">
+      <ThermometerIcon />
+      <span>{airTemp}</span>
+    </div>
+  );
+});
 AirTemperatureItem.displayName = 'AirTemperatureItem';

--- a/src/frontend/components/Standings/components/SessionBar/AirTemperatureItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/AirTemperatureItem.tsx
@@ -1,0 +1,17 @@
+import { memo } from 'react';
+import { ThermometerIcon } from '@phosphor-icons/react';
+import type { TemperatureUnit } from '@irdashies/types';
+import { useTrackTemperature } from '../../hooks/useTrackTemperature';
+
+export const AirTemperatureItem = memo(
+  ({ unit }: { unit: TemperatureUnit }) => {
+    const { airTemp } = useTrackTemperature({ airTempUnit: unit });
+    return (
+      <div className="flex justify-center gap-1 items-center">
+        <ThermometerIcon />
+        <span>{airTemp}</span>
+      </div>
+    );
+  }
+);
+AirTemperatureItem.displayName = 'AirTemperatureItem';

--- a/src/frontend/components/Standings/components/SessionBar/BrakeBiasItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/BrakeBiasItem.tsx
@@ -1,0 +1,22 @@
+import { memo } from 'react';
+import { TireIcon } from '@phosphor-icons/react';
+import { useBrakeBias } from '../../hooks';
+
+export const BrakeBiasItem = memo(() => {
+  const brakeBias = useBrakeBias();
+  if (
+    !brakeBias ||
+    typeof brakeBias.value !== 'number' ||
+    isNaN(brakeBias.value)
+  )
+    return null;
+  return (
+    <div className="flex justify-center gap-1 items-center">
+      <TireIcon />
+      {brakeBias.isClio
+        ? `${brakeBias.value.toFixed(0)}`
+        : `${brakeBias.value.toFixed(1)}%`}
+    </div>
+  );
+});
+BrakeBiasItem.displayName = 'BrakeBiasItem';

--- a/src/frontend/components/Standings/components/SessionBar/ClassDriversItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/ClassDriversItem.tsx
@@ -1,0 +1,16 @@
+import { UsersIcon } from '@phosphor-icons/react';
+import { useFocusedDriver, useCarClassStats } from '@irdashies/context';
+
+export const ClassDriversItem = () => {
+  const focusedDriver = useFocusedDriver();
+  const classStats = useCarClassStats();
+  const classId = focusedDriver?.carClassID;
+  const stats = classId !== undefined ? classStats?.[classId] : undefined;
+  if (!stats?.total) return null;
+  return (
+    <div className="flex justify-center gap-1 items-center">
+      <UsersIcon className="text-white/60" />
+      <span>{stats.total}</span>
+    </div>
+  );
+};

--- a/src/frontend/components/Standings/components/SessionBar/ClassDriversItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/ClassDriversItem.tsx
@@ -1,7 +1,8 @@
+import { memo } from 'react';
 import { UsersIcon } from '@phosphor-icons/react';
 import { useFocusedDriver, useCarClassStats } from '@irdashies/context';
 
-export const ClassDriversItem = () => {
+export const ClassDriversItem = memo(() => {
   const focusedDriver = useFocusedDriver();
   const classStats = useCarClassStats();
   const classId = focusedDriver?.carClassID;
@@ -13,4 +14,5 @@ export const ClassDriversItem = () => {
       <span>{stats.total}</span>
     </div>
   );
-};
+});
+ClassDriversItem.displayName = 'ClassDriversItem';

--- a/src/frontend/components/Standings/components/SessionBar/DriverBadgeItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/DriverBadgeItem.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import {
   useFocusCarIdx,
   useFocusedDriver,
@@ -6,26 +7,25 @@ import {
 import type { SessionBarConfig } from '@irdashies/types';
 import { DriverRatingBadge } from '../DriverRatingBadge/DriverRatingBadge';
 
-export const DriverBadgeItem = ({
-  settings,
-}: {
-  settings: SessionBarConfig['driverBadge'];
-}) => {
-  const focusedCarIdx = useFocusCarIdx();
-  const focusedDriver = useFocusedDriver();
-  const showIRatingChange = settings?.showIRatingChange ?? false;
-  const iratingChange = useDriverStatsStore((s) =>
-    showIRatingChange && focusedCarIdx !== undefined
-      ? s.iratingChanges[focusedCarIdx]
-      : undefined
-  );
-  return (
-    <DriverRatingBadge
-      license={focusedDriver?.licString}
-      rating={focusedDriver?.iRating}
-      iratingChange={iratingChange}
-      format={settings?.badgeFormat ?? 'license-color-rating-bw'}
-      noMargin={true}
-    />
-  );
-};
+export const DriverBadgeItem = memo(
+  ({ settings }: { settings: SessionBarConfig['driverBadge'] }) => {
+    const focusedCarIdx = useFocusCarIdx();
+    const focusedDriver = useFocusedDriver();
+    const showIRatingChange = settings?.showIRatingChange ?? false;
+    const iratingChange = useDriverStatsStore((s) =>
+      showIRatingChange && focusedCarIdx !== undefined
+        ? s.iratingChanges[focusedCarIdx]
+        : undefined
+    );
+    return (
+      <DriverRatingBadge
+        license={focusedDriver?.licString}
+        rating={focusedDriver?.iRating}
+        iratingChange={iratingChange}
+        format={settings?.badgeFormat ?? 'license-color-rating-bw'}
+        noMargin={true}
+      />
+    );
+  }
+);
+DriverBadgeItem.displayName = 'DriverBadgeItem';

--- a/src/frontend/components/Standings/components/SessionBar/DriverBadgeItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/DriverBadgeItem.tsx
@@ -1,0 +1,31 @@
+import {
+  useFocusCarIdx,
+  useFocusedDriver,
+  useDriverStatsStore,
+} from '@irdashies/context';
+import type { SessionBarConfig } from '@irdashies/types';
+import { DriverRatingBadge } from '../DriverRatingBadge/DriverRatingBadge';
+
+export const DriverBadgeItem = ({
+  settings,
+}: {
+  settings: SessionBarConfig['driverBadge'];
+}) => {
+  const focusedCarIdx = useFocusCarIdx();
+  const focusedDriver = useFocusedDriver();
+  const showIRatingChange = settings?.showIRatingChange ?? false;
+  const iratingChange = useDriverStatsStore((s) =>
+    showIRatingChange && focusedCarIdx !== undefined
+      ? s.iratingChanges[focusedCarIdx]
+      : undefined
+  );
+  return (
+    <DriverRatingBadge
+      license={focusedDriver?.licString}
+      rating={focusedDriver?.iRating}
+      iratingChange={iratingChange}
+      format={settings?.badgeFormat ?? 'license-color-rating-bw'}
+      noMargin={true}
+    />
+  );
+};

--- a/src/frontend/components/Standings/components/SessionBar/HumidityItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/HumidityItem.tsx
@@ -1,0 +1,15 @@
+import { memo } from 'react';
+import { DropHalfIcon } from '@phosphor-icons/react';
+import { useThrottledWeather } from '@irdashies/context';
+
+export const HumidityItem = memo(() => {
+  const { humidity } = useThrottledWeather();
+  if (humidity === undefined || humidity === null) return null;
+  return (
+    <div className="flex justify-center gap-1 items-center">
+      <DropHalfIcon />
+      <span>{Math.round(humidity * 100)}%</span>
+    </div>
+  );
+});
+HumidityItem.displayName = 'HumidityItem';

--- a/src/frontend/components/Standings/components/SessionBar/IncidentCountItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/IncidentCountItem.tsx
@@ -1,0 +1,13 @@
+import { memo } from 'react';
+import { useDriverIncidents } from '../../hooks';
+
+export const IncidentCountItem = memo(() => {
+  const { incidentLimit, incidents } = useDriverIncidents();
+  return (
+    <div className="flex justify-end">
+      {incidents}
+      {incidentLimit ? ' / ' + incidentLimit : ''} x
+    </div>
+  );
+});
+IncidentCountItem.displayName = 'IncidentCountItem';

--- a/src/frontend/components/Standings/components/SessionBar/LocalTimeItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/LocalTimeItem.tsx
@@ -1,0 +1,14 @@
+import { memo } from 'react';
+import { ClockUserIcon } from '@phosphor-icons/react';
+import { useCurrentTime } from '../../hooks/useCurrentTime';
+
+export const LocalTimeItem = memo(() => {
+  const localTime = useCurrentTime();
+  return (
+    <div className="flex justify-center gap-1 items-center">
+      <ClockUserIcon />
+      <span>{localTime}</span>
+    </div>
+  );
+});
+LocalTimeItem.displayName = 'LocalTimeItem';

--- a/src/frontend/components/Standings/components/SessionBar/PrecipitationItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/PrecipitationItem.tsx
@@ -1,0 +1,19 @@
+import { memo } from 'react';
+import { CloudRainIcon } from '@phosphor-icons/react';
+import { useThrottledWeather } from '@irdashies/context';
+
+export const PrecipitationItem = memo(() => {
+  const { precipitation } = useThrottledWeather();
+  const hasPrecipitation =
+    precipitation !== undefined && precipitation !== null;
+  const precipitationPercent = hasPrecipitation
+    ? Math.round(precipitation * 100)
+    : 0;
+  return (
+    <div className="flex justify-center gap-1 items-center text-nowrap">
+      <CloudRainIcon />
+      <span>{hasPrecipitation ? `${precipitationPercent}%` : '- %'}</span>
+    </div>
+  );
+});
+PrecipitationItem.displayName = 'PrecipitationItem';

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -6,10 +6,6 @@ import {
   useTotalRaceLaps,
   useTotalRaceTime,
   useTrackDisplayName,
-  useSessionDrivers,
-  useFocusCarIdx,
-  useCarClassStats,
-  useDriverStatsStore,
 } from '@irdashies/context';
 import {
   useDriverIncidents,
@@ -27,15 +23,15 @@ import {
   RoadHorizon as RoadHorizonIcon,
   Thermometer as ThermometerIcon,
   Tire as TireIcon,
-  Barbell as BarbellIcon,
-  Users as UsersIcon,
   Waves as WavesIcon,
 } from '@phosphor-icons/react';
 import { SessionBarConfig } from '@irdashies/types';
 import { useSessionCurrentTime } from '../../hooks/useSessionCurrentTime';
 import { SessionState } from '@irdashies/types';
 import { WindArrow } from '../../../shared/WindArrow';
-import { DriverRatingBadge } from '../DriverRatingBadge/DriverRatingBadge';
+import { DriverBadgeItem } from './DriverBadgeItem';
+import { SofItem } from './SofItem';
+import { ClassDriversItem } from './ClassDriversItem';
 
 // compact=true (total time): trims trailing zero components, never shows seconds
 // compact=false (elapsed/remaining): always shows full HH:MM:SS
@@ -104,7 +100,7 @@ interface SessionBarProps {
 
 export const SessionBar = ({
   settings: effectiveBarSettings,
-  position = 'header',  
+  position = 'header',
   opacity = 70,
   standalone = false,
 }: SessionBarProps) => {
@@ -144,9 +140,6 @@ export const SessionBar = ({
   const { windDirection, windVelocity, windYaw, precipitation, humidity } =
     useThrottledWeather();
   const relativeWindDirection = (windDirection ?? 0) - (windYaw ?? 0);
-  const drivers = useSessionDrivers();
-  const focusedCarIdx = useFocusCarIdx();
-  const focusedDriver = drivers?.find((d) => d.CarIdx === focusedCarIdx);
   const { trackTemp, airTemp } = useTrackTemperature({
     airTempUnit: effectiveBarSettings?.airTemperature?.unit ?? 'Metric',
     trackTempUnit: effectiveBarSettings?.trackTemperature?.unit ?? 'Metric',
@@ -156,8 +149,6 @@ export const SessionBar = ({
   const { totalRaceLaps, isFixedLapRace } = useTotalRaceLaps();
   const { totalRaceTime, adjustedRaceTime } = useTotalRaceTime();
   const trackDisplayName = useTrackDisplayName();
-  const classStats = useCarClassStats();
-  const iratingChanges = useDriverStatsStore((s) => s.iratingChanges);
 
   // Define all possible items with their render functions
   const itemDefinitions = {
@@ -444,54 +435,17 @@ export const SessionBar = ({
     },
     driverBadge: {
       enabled: effectiveBarSettings?.driverBadge?.enabled ?? false,
-      render: () => {
-        const showIRatingChange =
-          effectiveBarSettings?.driverBadge?.showIRatingChange ?? false;
-        return (
-          <DriverRatingBadge
-            license={focusedDriver?.LicString}
-            rating={focusedDriver?.IRating}
-            iratingChange={
-              showIRatingChange && focusedCarIdx !== undefined
-                ? iratingChanges[focusedCarIdx]
-                : undefined
-            }
-            format={
-              effectiveBarSettings?.driverBadge?.badgeFormat ??
-              'license-color-rating-bw'
-            }
-            noMargin={true}
-          />
-        );
-      },
+      render: () => (
+        <DriverBadgeItem settings={effectiveBarSettings?.driverBadge} />
+      ),
     },
     sof: {
       enabled: effectiveBarSettings?.sof?.enabled ?? false,
-      render: () => {
-        const classId = focusedDriver?.CarClassID;
-        const stats = classId !== undefined ? classStats?.[classId] : undefined;
-        if (!stats?.sof) return null;
-        return (
-          <div className="flex justify-center gap-1 items-center">
-            <BarbellIcon className="text-white/60" />
-            <span>{stats.sof}</span>
-          </div>
-        );
-      },
+      render: () => <SofItem />,
     },
     classDrivers: {
       enabled: effectiveBarSettings?.classDrivers?.enabled ?? false,
-      render: () => {
-        const classId = focusedDriver?.CarClassID;
-        const stats = classId !== undefined ? classStats?.[classId] : undefined;
-        if (!stats?.total) return null;
-        return (
-          <div className="flex justify-center gap-1 items-center">
-            <UsersIcon className="text-white/60" />
-            <span>{stats.total}</span>
-          </div>
-        );
-      },
+      render: () => <ClassDriversItem />,
     },
   };
 
@@ -565,9 +519,9 @@ export const SessionBar = ({
     <div
       className={`${pxClass} ${pyClass} bg-slate-900/(--fg-opacity) flex items-center text-sm ${standalone ? `w-full justify-between ${gapClass}` : 'justify-between'} ${!isCompact && !isUltra && !standalone ? (position === 'header' ? 'mb-3' : 'mt-3') : ''}`}
       style={{
-          ['--fg-opacity' as string]: `${opacity}%`,
-        }}
-      >
+        ['--fg-opacity' as string]: `${opacity}%`,
+      }}
+    >
       {itemsToRender}
     </div>
   );

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -1,95 +1,22 @@
-import {
-  useGeneralSettings,
-  useTelemetryValue,
-  useCurrentSessionType,
-  useThrottledWeather,
-  useTotalRaceLaps,
-  useTotalRaceTime,
-  useTrackDisplayName,
-} from '@irdashies/context';
-import {
-  useDriverIncidents,
-  useSessionLapCount,
-  useBrakeBias,
-} from '../../hooks';
-import { useTrackWetness } from '../../hooks/useTrackWetness';
-import { useTrackTemperature } from '../../hooks/useTrackTemperature';
-import { useCurrentTime } from '../../hooks/useCurrentTime';
-import {
-  ClockIcon,
-  ClockUserIcon,
-  CloudRain as CloudRainIcon,
-  DropHalf as DropHalfIcon,
-  RoadHorizon as RoadHorizonIcon,
-  Thermometer as ThermometerIcon,
-  Tire as TireIcon,
-  Waves as WavesIcon,
-} from '@phosphor-icons/react';
-import { SessionBarConfig } from '@irdashies/types';
-import { useSessionCurrentTime } from '../../hooks/useSessionCurrentTime';
-import { SessionState } from '@irdashies/types';
-import { WindArrow } from '../../../shared/WindArrow';
+import { useGeneralSettings } from '@irdashies/context';
+import type { SessionBarConfig } from '@irdashies/types';
 import { DriverBadgeItem } from './DriverBadgeItem';
 import { SofItem } from './SofItem';
 import { ClassDriversItem } from './ClassDriversItem';
-
-// compact=true (total time): trims trailing zero components, never shows seconds
-// compact=false (elapsed/remaining): always shows full HH:MM:SS
-const formatTotalTime = (
-  seconds: number,
-  totalFormat: 'hh:mm' | 'minimal',
-  compact: boolean,
-  labelStyle: 'none' | 'short' | 'minimal'
-): string => {
-  if (seconds < 0) return '-';
-  const totalSecs = Math.floor(seconds);
-  const hours = Math.floor(totalSecs / 3600);
-  const minutes = Math.floor((totalSecs % 3600) / 60);
-  const secs = totalSecs % 60;
-
-  let result: string;
-  if (totalFormat === 'hh:mm') {
-    if (compact && minutes === 0 && hours > 0) {
-      result = String(hours).padStart(2, '0');
-    } else {
-      result = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
-      if (!compact) result += `:${String(secs).padStart(2, '0')}`;
-    }
-  } else {
-    // minimal
-    if (compact) {
-      if (hours > 0) {
-        if (minutes === 0) {
-          result = `${hours}`;
-        } else if (secs > 0) {
-          result = `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
-        } else {
-          result = `${hours}:${String(minutes).padStart(2, '0')}`;
-        }
-      } else {
-        result =
-          secs > 0
-            ? `${minutes}:${String(secs).padStart(2, '0')}`
-            : `${minutes}`;
-      }
-    } else {
-      // elapsed/remaining: trim leading zero components
-      if (hours > 0) {
-        result = `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
-      } else if (minutes > 0) {
-        result = `${minutes}:${String(secs).padStart(2, '0')}`;
-      } else {
-        result = `${secs}`;
-      }
-    }
-  }
-
-  if (labelStyle === 'short')
-    result += hours > 0 ? ' hrs' : minutes > 0 ? ' mins' : ' secs';
-  else if (labelStyle === 'minimal')
-    result += hours > 0 ? ' h' : minutes > 0 ? ' m' : ' s';
-  return result;
-};
+import { SessionNameItem } from './SessionNameItem';
+import { SessionTimeItem } from './SessionTimeItem';
+import { SessionLapsItem } from './SessionLapsItem';
+import { IncidentCountItem } from './IncidentCountItem';
+import { BrakeBiasItem } from './BrakeBiasItem';
+import { LocalTimeItem } from './LocalTimeItem';
+import { SessionClockTimeItem } from './SessionClockTimeItem';
+import { TrackWetnessItem } from './TrackWetnessItem';
+import { PrecipitationItem } from './PrecipitationItem';
+import { AirTemperatureItem } from './AirTemperatureItem';
+import { TrackTemperatureItem } from './TrackTemperatureItem';
+import { TrackNameItem } from './TrackNameItem';
+import { WindItem } from './WindItem';
+import { HumidityItem } from './HumidityItem';
 
 interface SessionBarProps {
   settings: SessionBarConfig;
@@ -97,6 +24,134 @@ interface SessionBarProps {
   standalone?: boolean;
   opacity?: number;
 }
+
+const DEFAULT_HEADER_ORDER = [
+  'sessionName',
+  'sessionTime',
+  'sessionLaps',
+  'localTime',
+  'brakeBias',
+  'incidentCount',
+];
+
+const DEFAULT_FOOTER_ORDER = [
+  'localTime',
+  'trackWetness',
+  'sessionLaps',
+  'airTemperature',
+  'trackTemperature',
+];
+
+const isItemEnabled = (
+  key: string,
+  settings: SessionBarConfig | undefined,
+  position: 'header' | 'footer'
+): boolean => {
+  switch (key) {
+    case 'sessionName':
+      return (
+        settings?.sessionName?.enabled ?? (position === 'header' ? true : false)
+      );
+    case 'sessionTime':
+      return (
+        settings?.sessionTime?.enabled ?? (position === 'header' ? true : false)
+      );
+    case 'sessionLaps':
+      return settings?.sessionLaps?.enabled ?? true;
+    case 'incidentCount':
+      return (
+        settings?.incidentCount?.enabled ??
+        (position === 'header' ? true : false)
+      );
+    case 'brakeBias':
+      return settings?.brakeBias?.enabled ?? true;
+    case 'localTime':
+      return settings?.localTime?.enabled ?? true;
+    case 'sessionClockTime':
+      return settings?.sessionClockTime?.enabled ?? false;
+    case 'trackWetness':
+      return (
+        settings?.trackWetness?.enabled ??
+        (position === 'header' ? false : true)
+      );
+    case 'precipitation':
+      return settings?.precipitation?.enabled ?? false;
+    case 'airTemperature':
+      return (
+        settings?.airTemperature?.enabled ??
+        (position === 'header' ? false : true)
+      );
+    case 'trackTemperature':
+      return (
+        settings?.trackTemperature?.enabled ??
+        (position === 'header' ? false : true)
+      );
+    case 'trackName':
+      return settings?.trackName?.enabled ?? false;
+    case 'wind':
+      return settings?.wind?.enabled ?? false;
+    case 'humidity':
+      return settings?.humidity?.enabled ?? false;
+    case 'driverBadge':
+      return settings?.driverBadge?.enabled ?? false;
+    case 'sof':
+      return settings?.sof?.enabled ?? false;
+    case 'classDrivers':
+      return settings?.classDrivers?.enabled ?? false;
+    default:
+      return false;
+  }
+};
+
+const renderItem = (
+  key: string,
+  settings: SessionBarConfig | undefined
+): React.ReactNode => {
+  switch (key) {
+    case 'sessionName':
+      return <SessionNameItem />;
+    case 'sessionTime':
+      return <SessionTimeItem settings={settings?.sessionTime} />;
+    case 'sessionLaps':
+      return <SessionLapsItem settings={settings?.sessionLaps} />;
+    case 'incidentCount':
+      return <IncidentCountItem />;
+    case 'brakeBias':
+      return <BrakeBiasItem />;
+    case 'localTime':
+      return <LocalTimeItem />;
+    case 'sessionClockTime':
+      return <SessionClockTimeItem />;
+    case 'trackWetness':
+      return <TrackWetnessItem />;
+    case 'precipitation':
+      return <PrecipitationItem />;
+    case 'airTemperature':
+      return (
+        <AirTemperatureItem unit={settings?.airTemperature?.unit ?? 'Metric'} />
+      );
+    case 'trackTemperature':
+      return (
+        <TrackTemperatureItem
+          unit={settings?.trackTemperature?.unit ?? 'Metric'}
+        />
+      );
+    case 'trackName':
+      return <TrackNameItem />;
+    case 'wind':
+      return <WindItem settings={settings?.wind} />;
+    case 'humidity':
+      return <HumidityItem />;
+    case 'driverBadge':
+      return <DriverBadgeItem settings={settings?.driverBadge} />;
+    case 'sof':
+      return <SofItem />;
+    case 'classDrivers':
+      return <ClassDriversItem />;
+    default:
+      return null;
+  }
+};
 
 export const SessionBar = ({
   settings: effectiveBarSettings,
@@ -123,397 +178,13 @@ export const SessionBar = ({
         ? 'px-2'
         : 'px-3';
 
-  const session = useCurrentSessionType();
-  const displayUnits = useTelemetryValue('DisplayUnits'); // 0 = imperial, 1 = metric
-  const { incidentLimit, incidents } = useDriverIncidents();
-  const {
-    currentLap,
-    time,
-    timeRemaining,
-    timeTotal,
-    totalLaps,
-    state,
-    greenFlagTimestamp,
-  } = useSessionLapCount();
-  const brakeBias = useBrakeBias();
-  const { trackWetness } = useTrackWetness();
-  const { windDirection, windVelocity, windYaw, precipitation, humidity } =
-    useThrottledWeather();
-  const relativeWindDirection = (windDirection ?? 0) - (windYaw ?? 0);
-  const { trackTemp, airTemp } = useTrackTemperature({
-    airTempUnit: effectiveBarSettings?.airTemperature?.unit ?? 'Metric',
-    trackTempUnit: effectiveBarSettings?.trackTemperature?.unit ?? 'Metric',
-  });
-  const localTime = useCurrentTime();
-  const sessionClockTime = useSessionCurrentTime();
-  const { totalRaceLaps, isFixedLapRace } = useTotalRaceLaps();
-  const { totalRaceTime, adjustedRaceTime } = useTotalRaceTime();
-  const trackDisplayName = useTrackDisplayName();
-
-  // Define all possible items with their render functions
-  const itemDefinitions = {
-    sessionName: {
-      enabled:
-        effectiveBarSettings?.sessionName?.enabled ??
-        (position === 'header' ? true : false),
-      render: () => <div className="flex">{session}</div>,
-    },
-    sessionTime: {
-      enabled:
-        effectiveBarSettings?.sessionTime?.enabled ??
-        (position === 'header' ? true : false),
-      render: () => {
-        let elapsedTime = -1;
-        let remainingTime = -1;
-        let totalTime = -1;
-        if (session === 'Race') {
-          switch (state) {
-            case SessionState.GetInCar:
-              // Before grid, there is a ~2min countdown
-              elapsedTime = time;
-              remainingTime = timeRemaining;
-              totalTime = time + timeRemaining;
-              break;
-            case SessionState.Warmup:
-            case SessionState.ParadeLaps:
-              // Freeze the race timers until green
-              elapsedTime = 0;
-              if (isFixedLapRace) {
-                remainingTime = totalRaceTime;
-                totalTime = totalRaceTime;
-              } else {
-                remainingTime = timeRemaining;
-                totalTime = timeTotal;
-              }
-              break;
-            case SessionState.Racing:
-            case SessionState.Checkered:
-              // Session timer does not restart at green
-              elapsedTime = time - greenFlagTimestamp;
-              if (isFixedLapRace) {
-                remainingTime = adjustedRaceTime - elapsedTime;
-                totalTime = totalRaceTime;
-              } else {
-                remainingTime = timeRemaining;
-                totalTime = timeTotal;
-              }
-              break;
-            case SessionState.CoolDown:
-            default:
-              elapsedTime = 0;
-              remainingTime = 0;
-              totalTime = 0;
-              break;
-          }
-        } else {
-          elapsedTime = time;
-          remainingTime = timeRemaining;
-          totalTime = timeTotal;
-        }
-
-        const sessionTimeSettings = effectiveBarSettings?.sessionTime;
-        const totalFormat = sessionTimeSettings?.totalFormat ?? 'minimal';
-        const labelStyle = sessionTimeSettings?.labelStyle ?? 'minimal';
-
-        const elapsedStr =
-          elapsedTime >= 0
-            ? formatTotalTime(elapsedTime, totalFormat, false, labelStyle)
-            : '-';
-        const remainingStr =
-          remainingTime >= 0
-            ? formatTotalTime(remainingTime, totalFormat, false, labelStyle)
-            : '-';
-        let totalStr =
-          totalTime >= 0
-            ? formatTotalTime(totalTime, totalFormat, true, labelStyle)
-            : '-';
-
-        if (session === 'Race' && state >= 2 && isFixedLapRace) {
-          totalStr = '~' + totalStr;
-        }
-
-        const mode = sessionTimeSettings?.mode ?? 'Remaining';
-        if (mode === 'Remaining') {
-          return (
-            <div className="flex justify-center tabular-nums">
-              {remainingStr} / {totalStr}
-            </div>
-          );
-        } else {
-          // mode === Elapsed
-          return (
-            <div className="flex justify-center tabular-nums">
-              {elapsedStr} / {totalStr}
-            </div>
-          );
-        }
-      },
-    },
-    sessionLaps: {
-      enabled: effectiveBarSettings?.sessionLaps?.enabled ?? true,
-      render: () => {
-        const lapDisplay = Math.max(currentLap, 0);
-        const lapsTotal = session === 'Race' ? totalRaceLaps : totalLaps;
-        const lapsMode = effectiveBarSettings?.sessionLaps?.mode ?? 'Elapsed';
-        // Round up the total if the current lap has exceeded it
-        const overrun = lapDisplay > lapsTotal;
-        const effectiveTotal = overrun ? lapDisplay : lapsTotal;
-        const lapValue =
-          lapsMode === 'Remaining'
-            ? Math.min(
-                Math.max(Math.ceil(effectiveTotal) - lapDisplay + 1, 0),
-                Math.ceil(effectiveTotal)
-              )
-            : lapDisplay;
-        if (state >= SessionState.Checkered)
-          return (
-            <div className="flex justify-center">
-              L{Math.ceil(effectiveTotal).toFixed(0)}
-            </div>
-          );
-        if (lapsTotal > 0)
-          if (isFixedLapRace)
-            return (
-              <div className="flex justify-center">
-                L{lapValue} / {lapsTotal.toFixed(0)}
-              </div>
-            );
-          else
-            return (
-              <div className="flex justify-center">
-                L{lapValue} /{' '}
-                {overrun ? effectiveTotal.toFixed(0) : lapsTotal.toFixed(1)}
-              </div>
-            );
-        else return <div className="flex justify-center">L{lapDisplay}</div>;
-      },
-    },
-    incidentCount: {
-      enabled:
-        effectiveBarSettings?.incidentCount?.enabled ??
-        (position === 'header' ? true : false),
-      render: () => (
-        <div className="flex justify-end">
-          {incidents}
-          {incidentLimit ? ' / ' + incidentLimit : ''} x
-        </div>
-      ),
-    },
-    brakeBias: {
-      enabled:
-        effectiveBarSettings?.brakeBias?.enabled ??
-        (position === 'header' ? true : true),
-      render: () => {
-        if (
-          !brakeBias ||
-          typeof brakeBias.value !== 'number' ||
-          isNaN(brakeBias.value)
-        )
-          return null;
-        return (
-          <div className="flex justify-center gap-1 items-center">
-            <TireIcon />
-            {brakeBias.isClio
-              ? `${brakeBias.value.toFixed(0)}`
-              : `${brakeBias.value.toFixed(1)}%`}
-          </div>
-        );
-      },
-    },
-    localTime: {
-      enabled:
-        effectiveBarSettings?.localTime?.enabled ??
-        (position === 'header' ? true : true),
-      render: () => (
-        <div className="flex justify-center gap-1 items-center">
-          <ClockUserIcon />
-          <span>{localTime}</span>
-        </div>
-      ),
-    },
-    sessionClockTime: {
-      enabled: effectiveBarSettings?.sessionClockTime?.enabled ?? false,
-      render: () => (
-        <div className="flex justify-center gap-1 items-center">
-          <ClockIcon />
-          <span>{sessionClockTime}</span>
-        </div>
-      ),
-    },
-    trackWetness: {
-      enabled:
-        effectiveBarSettings?.trackWetness?.enabled ??
-        (position === 'header' ? false : true),
-      render: () => (
-        <div className="flex justify-center gap-1 items-center text-nowrap">
-          <WavesIcon />
-          <span>{trackWetness}</span>
-        </div>
-      ),
-    },
-    precipitation: {
-      enabled:
-        effectiveBarSettings?.precipitation?.enabled ??
-        (position === 'header' ? false : false),
-      render: () => {
-        const hasPrecipitation =
-          precipitation !== undefined && precipitation !== null;
-        const precipitationPercent = hasPrecipitation
-          ? Math.round(precipitation * 100)
-          : 0;
-        return (
-          <div className="flex justify-center gap-1 items-center text-nowrap">
-            <CloudRainIcon />
-            <span>{hasPrecipitation ? `${precipitationPercent}%` : '- %'}</span>
-          </div>
-        );
-      },
-    },
-    airTemperature: {
-      enabled:
-        effectiveBarSettings?.airTemperature?.enabled ??
-        (position === 'header' ? false : true),
-      render: () => (
-        <div className="flex justify-center gap-1 items-center">
-          <ThermometerIcon />
-          <span>{airTemp}</span>
-        </div>
-      ),
-    },
-    trackTemperature: {
-      enabled:
-        effectiveBarSettings?.trackTemperature?.enabled ??
-        (position === 'header' ? false : true),
-      render: () => (
-        <div className="flex justify-center gap-1 items-center">
-          <RoadHorizonIcon />
-          <span>{trackTemp}</span>
-        </div>
-      ),
-    },
-    trackName: {
-      enabled: effectiveBarSettings?.trackName?.enabled ?? false,
-      render: () => <div className="flex">{trackDisplayName}</div>,
-    },
-    wind: {
-      enabled: effectiveBarSettings?.wind?.enabled ?? false,
-      render: () => {
-        const isMetric = displayUnits === 1;
-        const speedPosition =
-          effectiveBarSettings?.wind?.speedPosition ?? 'right';
-        const speed =
-          windVelocity !== undefined
-            ? Math.round(windVelocity * (isMetric ? 3.6 : 2.23694))
-            : '-';
-        const speedEl = <span>{speed}</span>;
-        const arrowEl = (
-          <WindArrow
-            direction={relativeWindDirection}
-            className="mx-1 w-3.5 h-4"
-          />
-        );
-        return (
-          <div className="flex justify-center gap-1 items-center">
-            {speedPosition === 'left' && speedEl}
-            {arrowEl}
-            {speedPosition === 'right' && speedEl}
-          </div>
-        );
-      },
-    },
-    humidity: {
-      enabled: effectiveBarSettings?.humidity?.enabled ?? false,
-      render: () => {
-        if (humidity === undefined || humidity === null) return null;
-        return (
-          <div className="flex justify-center gap-1 items-center">
-            <DropHalfIcon />
-            <span>{Math.round(humidity * 100)}%</span>
-          </div>
-        );
-      },
-    },
-    driverBadge: {
-      enabled: effectiveBarSettings?.driverBadge?.enabled ?? false,
-      render: () => (
-        <DriverBadgeItem settings={effectiveBarSettings?.driverBadge} />
-      ),
-    },
-    sof: {
-      enabled: effectiveBarSettings?.sof?.enabled ?? false,
-      render: () => <SofItem />,
-    },
-    classDrivers: {
-      enabled: effectiveBarSettings?.classDrivers?.enabled ?? false,
-      render: () => <ClassDriversItem />,
-    },
-  };
-
-  // Get display order, fallback to default order
   const displayOrder =
     effectiveBarSettings?.displayOrder ||
-    (position === 'header'
-      ? [
-          'sessionName',
-          'sessionTime',
-          'sessionLaps',
-          'localTime',
-          'brakeBias',
-          'incidentCount',
-        ]
-      : [
-          'localTime',
-          'trackWetness',
-          'sessionLaps',
-          'airTemperature',
-          'trackTemperature',
-        ]);
+    (position === 'header' ? DEFAULT_HEADER_ORDER : DEFAULT_FOOTER_ORDER);
 
-  // Filter and order items based on settings
-  const itemsToRender = displayOrder
-    .map((key: string) => ({
-      key,
-      definition: (
-        itemDefinitions as Record<
-          string,
-          { enabled: boolean; render: () => React.ReactNode }
-        >
-      )[key],
-    }))
-    .filter(({ definition }) => definition?.enabled)
-    .map(
-      (
-        { key, definition },
-        index: number,
-        array: {
-          key: string;
-          definition: { enabled: boolean; render: () => React.ReactNode };
-        }[]
-      ) => {
-        const element = definition.render();
-        if (!element) return null;
-
-        if (standalone) {
-          const isFirst = index === 0;
-          const isLast = index === array.length - 1;
-          return (
-            <div
-              key={key}
-              className={`whitespace-nowrap shrink-0 ${isFirst ? 'text-left' : isLast ? 'text-right' : 'text-center'}`}
-            >
-              {element}
-            </div>
-          );
-        }
-
-        return (
-          <div key={key} className="whitespace-nowrap">
-            {element}
-          </div>
-        );
-      }
-    )
-    .filter(Boolean);
+  const enabledKeys = displayOrder.filter((key) =>
+    isItemEnabled(key, effectiveBarSettings, position)
+  );
 
   return (
     <div
@@ -522,7 +193,29 @@ export const SessionBar = ({
         ['--fg-opacity' as string]: `${opacity}%`,
       }}
     >
-      {itemsToRender}
+      {enabledKeys.map((key, index) => {
+        const node = renderItem(key, effectiveBarSettings);
+        if (!node) return null;
+
+        if (standalone) {
+          const isFirst = index === 0;
+          const isLast = index === enabledKeys.length - 1;
+          return (
+            <div
+              key={key}
+              className={`whitespace-nowrap shrink-0 ${isFirst ? 'text-left' : isLast ? 'text-right' : 'text-center'}`}
+            >
+              {node}
+            </div>
+          );
+        }
+
+        return (
+          <div key={key} className="whitespace-nowrap">
+            {node}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useGeneralSettings } from '@irdashies/context';
 import type { SessionBarConfig } from '@irdashies/types';
 import { DriverBadgeItem } from './DriverBadgeItem';
@@ -153,69 +154,72 @@ const renderItem = (
   }
 };
 
-export const SessionBar = ({
-  settings: effectiveBarSettings,
-  position = 'header',
-  opacity = 70,
-  standalone = false,
-}: SessionBarProps) => {
-  const generalSettings = useGeneralSettings();
+export const SessionBar = memo(
+  ({
+    settings: effectiveBarSettings,
+    position = 'header',
+    opacity = 70,
+    standalone = false,
+  }: SessionBarProps) => {
+    const generalSettings = useGeneralSettings();
 
-  const isUltra = generalSettings?.compactMode === 'ultra';
-  const isCompact = generalSettings?.compactMode === 'compact';
+    const isUltra = generalSettings?.compactMode === 'ultra';
+    const isCompact = generalSettings?.compactMode === 'compact';
 
-  const pyClass = isUltra ? 'py-0' : isCompact ? 'py-1' : 'py-2';
-  const gapClass = isUltra ? 'gap-x-2' : isCompact ? 'gap-x-4' : 'gap-x-6';
-  const pxClass = standalone
-    ? isUltra
-      ? 'px-2'
-      : isCompact
-        ? 'px-3'
-        : 'px-4'
-    : isUltra
-      ? 'px-1'
-      : isCompact
+    const pyClass = isUltra ? 'py-0' : isCompact ? 'py-1' : 'py-2';
+    const gapClass = isUltra ? 'gap-x-2' : isCompact ? 'gap-x-4' : 'gap-x-6';
+    const pxClass = standalone
+      ? isUltra
         ? 'px-2'
-        : 'px-3';
+        : isCompact
+          ? 'px-3'
+          : 'px-4'
+      : isUltra
+        ? 'px-1'
+        : isCompact
+          ? 'px-2'
+          : 'px-3';
 
-  const displayOrder =
-    effectiveBarSettings?.displayOrder ||
-    (position === 'header' ? DEFAULT_HEADER_ORDER : DEFAULT_FOOTER_ORDER);
+    const displayOrder =
+      effectiveBarSettings?.displayOrder ||
+      (position === 'header' ? DEFAULT_HEADER_ORDER : DEFAULT_FOOTER_ORDER);
 
-  const enabledKeys = displayOrder.filter((key) =>
-    isItemEnabled(key, effectiveBarSettings, position)
-  );
+    const enabledKeys = displayOrder.filter((key) =>
+      isItemEnabled(key, effectiveBarSettings, position)
+    );
 
-  return (
-    <div
-      className={`${pxClass} ${pyClass} bg-slate-900/(--fg-opacity) flex items-center text-sm ${standalone ? `w-full justify-between ${gapClass}` : 'justify-between'} ${!isCompact && !isUltra && !standalone ? (position === 'header' ? 'mb-3' : 'mt-3') : ''}`}
-      style={{
-        ['--fg-opacity' as string]: `${opacity}%`,
-      }}
-    >
-      {enabledKeys.map((key, index) => {
-        const node = renderItem(key, effectiveBarSettings);
-        if (!node) return null;
+    return (
+      <div
+        className={`${pxClass} ${pyClass} bg-slate-900/(--fg-opacity) flex items-center text-sm ${standalone ? `w-full justify-between ${gapClass}` : 'justify-between'} ${!isCompact && !isUltra && !standalone ? (position === 'header' ? 'mb-3' : 'mt-3') : ''}`}
+        style={{
+          ['--fg-opacity' as string]: `${opacity}%`,
+        }}
+      >
+        {enabledKeys.map((key, index) => {
+          const node = renderItem(key, effectiveBarSettings);
+          if (!node) return null;
 
-        if (standalone) {
-          const isFirst = index === 0;
-          const isLast = index === enabledKeys.length - 1;
+          if (standalone) {
+            const isFirst = index === 0;
+            const isLast = index === enabledKeys.length - 1;
+            return (
+              <div
+                key={key}
+                className={`whitespace-nowrap shrink-0 ${isFirst ? 'text-left' : isLast ? 'text-right' : 'text-center'}`}
+              >
+                {node}
+              </div>
+            );
+          }
+
           return (
-            <div
-              key={key}
-              className={`whitespace-nowrap shrink-0 ${isFirst ? 'text-left' : isLast ? 'text-right' : 'text-center'}`}
-            >
+            <div key={key} className="whitespace-nowrap">
               {node}
             </div>
           );
-        }
-
-        return (
-          <div key={key} className="whitespace-nowrap">
-            {node}
-          </div>
-        );
-      })}
-    </div>
-  );
-};
+        })}
+      </div>
+    );
+  }
+);
+SessionBar.displayName = 'SessionBar';

--- a/src/frontend/components/Standings/components/SessionBar/SessionClockTimeItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionClockTimeItem.tsx
@@ -1,0 +1,14 @@
+import { memo } from 'react';
+import { ClockIcon } from '@phosphor-icons/react';
+import { useSessionCurrentTime } from '../../hooks/useSessionCurrentTime';
+
+export const SessionClockTimeItem = memo(() => {
+  const sessionClockTime = useSessionCurrentTime();
+  return (
+    <div className="flex justify-center gap-1 items-center">
+      <ClockIcon />
+      <span>{sessionClockTime}</span>
+    </div>
+  );
+});
+SessionClockTimeItem.displayName = 'SessionClockTimeItem';

--- a/src/frontend/components/Standings/components/SessionBar/SessionLapsItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionLapsItem.tsx
@@ -1,0 +1,53 @@
+import { memo } from 'react';
+import { useCurrentSessionType, useTotalRaceLaps } from '@irdashies/context';
+import { SessionState, type SessionBarConfig } from '@irdashies/types';
+import { useSessionLapCount } from '../../hooks';
+
+export const SessionLapsItem = memo(
+  ({ settings }: { settings?: SessionBarConfig['sessionLaps'] }) => {
+    const session = useCurrentSessionType();
+    const { currentLap, totalLaps, state } = useSessionLapCount();
+    const { totalRaceLaps, isFixedLapRace } = useTotalRaceLaps();
+
+    const lapDisplay = Math.max(currentLap, 0);
+    const lapsTotal = session === 'Race' ? totalRaceLaps : totalLaps;
+    const lapsMode = settings?.mode ?? 'Elapsed';
+    // Round up the total if the current lap has exceeded it
+    const overrun = lapDisplay > lapsTotal;
+    const effectiveTotal = overrun ? lapDisplay : lapsTotal;
+    const lapValue =
+      lapsMode === 'Remaining'
+        ? Math.min(
+            Math.max(Math.ceil(effectiveTotal) - lapDisplay + 1, 0),
+            Math.ceil(effectiveTotal)
+          )
+        : lapDisplay;
+
+    if (state >= SessionState.Checkered) {
+      return (
+        <div className="flex justify-center">
+          L{Math.ceil(effectiveTotal).toFixed(0)}
+        </div>
+      );
+    }
+
+    if (lapsTotal > 0) {
+      if (isFixedLapRace) {
+        return (
+          <div className="flex justify-center">
+            L{lapValue} / {lapsTotal.toFixed(0)}
+          </div>
+        );
+      }
+      return (
+        <div className="flex justify-center">
+          L{lapValue} /{' '}
+          {overrun ? effectiveTotal.toFixed(0) : lapsTotal.toFixed(1)}
+        </div>
+      );
+    }
+
+    return <div className="flex justify-center">L{lapDisplay}</div>;
+  }
+);
+SessionLapsItem.displayName = 'SessionLapsItem';

--- a/src/frontend/components/Standings/components/SessionBar/SessionLapsItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionLapsItem.tsx
@@ -3,51 +3,53 @@ import { useCurrentSessionType, useTotalRaceLaps } from '@irdashies/context';
 import { SessionState, type SessionBarConfig } from '@irdashies/types';
 import { useSessionLapCount } from '../../hooks';
 
-export const SessionLapsItem = memo(
-  ({ settings }: { settings?: SessionBarConfig['sessionLaps'] }) => {
-    const session = useCurrentSessionType();
-    const { currentLap, totalLaps, state } = useSessionLapCount();
-    const { totalRaceLaps, isFixedLapRace } = useTotalRaceLaps();
+interface SessionLapsItemProps {
+  settings?: SessionBarConfig['sessionLaps'];
+}
 
-    const lapDisplay = Math.max(currentLap, 0);
-    const lapsTotal = session === 'Race' ? totalRaceLaps : totalLaps;
-    const lapsMode = settings?.mode ?? 'Elapsed';
-    // Round up the total if the current lap has exceeded it
-    const overrun = lapDisplay > lapsTotal;
-    const effectiveTotal = overrun ? lapDisplay : lapsTotal;
-    const lapValue =
-      lapsMode === 'Remaining'
-        ? Math.min(
-            Math.max(Math.ceil(effectiveTotal) - lapDisplay + 1, 0),
-            Math.ceil(effectiveTotal)
-          )
-        : lapDisplay;
+export const SessionLapsItem = memo(({ settings }: SessionLapsItemProps) => {
+  const session = useCurrentSessionType();
+  const { currentLap, totalLaps, state } = useSessionLapCount();
+  const { totalRaceLaps, isFixedLapRace } = useTotalRaceLaps();
 
-    if (state >= SessionState.Checkered) {
-      return (
-        <div className="flex justify-center">
-          L{Math.ceil(effectiveTotal).toFixed(0)}
-        </div>
-      );
-    }
+  const lapDisplay = Math.max(currentLap, 0);
+  const lapsTotal = session === 'Race' ? totalRaceLaps : totalLaps;
+  const lapsMode = settings?.mode ?? 'Elapsed';
+  // Round up the total if the current lap has exceeded it
+  const overrun = lapDisplay > lapsTotal;
+  const effectiveTotal = overrun ? lapDisplay : lapsTotal;
+  const lapValue =
+    lapsMode === 'Remaining'
+      ? Math.min(
+          Math.max(Math.ceil(effectiveTotal) - lapDisplay + 1, 0),
+          Math.ceil(effectiveTotal)
+        )
+      : lapDisplay;
 
-    if (lapsTotal > 0) {
-      if (isFixedLapRace) {
-        return (
-          <div className="flex justify-center">
-            L{lapValue} / {lapsTotal.toFixed(0)}
-          </div>
-        );
-      }
-      return (
-        <div className="flex justify-center">
-          L{lapValue} /{' '}
-          {overrun ? effectiveTotal.toFixed(0) : lapsTotal.toFixed(1)}
-        </div>
-      );
-    }
-
-    return <div className="flex justify-center">L{lapDisplay}</div>;
+  if (state >= SessionState.Checkered) {
+    return (
+      <div className="flex justify-center">
+        L{Math.ceil(effectiveTotal).toFixed(0)}
+      </div>
+    );
   }
-);
+
+  if (lapsTotal > 0) {
+    if (isFixedLapRace) {
+      return (
+        <div className="flex justify-center">
+          L{lapValue} / {lapsTotal.toFixed(0)}
+        </div>
+      );
+    }
+    return (
+      <div className="flex justify-center">
+        L{lapValue} /{' '}
+        {overrun ? effectiveTotal.toFixed(0) : lapsTotal.toFixed(1)}
+      </div>
+    );
+  }
+
+  return <div className="flex justify-center">L{lapDisplay}</div>;
+});
 SessionLapsItem.displayName = 'SessionLapsItem';

--- a/src/frontend/components/Standings/components/SessionBar/SessionNameItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionNameItem.tsx
@@ -1,0 +1,8 @@
+import { memo } from 'react';
+import { useCurrentSessionType } from '@irdashies/context';
+
+export const SessionNameItem = memo(() => {
+  const session = useCurrentSessionType();
+  return <div className="flex">{session}</div>;
+});
+SessionNameItem.displayName = 'SessionNameItem';

--- a/src/frontend/components/Standings/components/SessionBar/SessionTimeItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionTimeItem.tsx
@@ -1,0 +1,159 @@
+import { memo } from 'react';
+import {
+  useCurrentSessionType,
+  useTotalRaceLaps,
+  useTotalRaceTime,
+} from '@irdashies/context';
+import { SessionState, type SessionBarConfig } from '@irdashies/types';
+import { useSessionLapCount } from '../../hooks';
+
+// compact=true (total time): trims trailing zero components, never shows seconds
+// compact=false (elapsed/remaining): always shows full HH:MM:SS
+const formatTotalTime = (
+  seconds: number,
+  totalFormat: 'hh:mm' | 'minimal',
+  compact: boolean,
+  labelStyle: 'none' | 'short' | 'minimal'
+): string => {
+  if (seconds < 0) return '-';
+  const totalSecs = Math.floor(seconds);
+  const hours = Math.floor(totalSecs / 3600);
+  const minutes = Math.floor((totalSecs % 3600) / 60);
+  const secs = totalSecs % 60;
+
+  let result: string;
+  if (totalFormat === 'hh:mm') {
+    if (compact && minutes === 0 && hours > 0) {
+      result = String(hours).padStart(2, '0');
+    } else {
+      result = `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+      if (!compact) result += `:${String(secs).padStart(2, '0')}`;
+    }
+  } else {
+    // minimal
+    if (compact) {
+      if (hours > 0) {
+        if (minutes === 0) {
+          result = `${hours}`;
+        } else if (secs > 0) {
+          result = `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+        } else {
+          result = `${hours}:${String(minutes).padStart(2, '0')}`;
+        }
+      } else {
+        result =
+          secs > 0
+            ? `${minutes}:${String(secs).padStart(2, '0')}`
+            : `${minutes}`;
+      }
+    } else {
+      // elapsed/remaining: trim leading zero components
+      if (hours > 0) {
+        result = `${hours}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+      } else if (minutes > 0) {
+        result = `${minutes}:${String(secs).padStart(2, '0')}`;
+      } else {
+        result = `${secs}`;
+      }
+    }
+  }
+
+  if (labelStyle === 'short')
+    result += hours > 0 ? ' hrs' : minutes > 0 ? ' mins' : ' secs';
+  else if (labelStyle === 'minimal')
+    result += hours > 0 ? ' h' : minutes > 0 ? ' m' : ' s';
+  return result;
+};
+
+export const SessionTimeItem = memo(
+  ({ settings }: { settings?: SessionBarConfig['sessionTime'] }) => {
+    const session = useCurrentSessionType();
+    const { time, timeRemaining, timeTotal, state, greenFlagTimestamp } =
+      useSessionLapCount();
+    const { totalRaceTime, adjustedRaceTime } = useTotalRaceTime();
+    const { isFixedLapRace } = useTotalRaceLaps();
+
+    let elapsedTime = -1;
+    let remainingTime = -1;
+    let totalTime = -1;
+    if (session === 'Race') {
+      switch (state) {
+        case SessionState.GetInCar:
+          // Before grid, there is a ~2min countdown
+          elapsedTime = time;
+          remainingTime = timeRemaining;
+          totalTime = time + timeRemaining;
+          break;
+        case SessionState.Warmup:
+        case SessionState.ParadeLaps:
+          // Freeze the race timers until green
+          elapsedTime = 0;
+          if (isFixedLapRace) {
+            remainingTime = totalRaceTime;
+            totalTime = totalRaceTime;
+          } else {
+            remainingTime = timeRemaining;
+            totalTime = timeTotal;
+          }
+          break;
+        case SessionState.Racing:
+        case SessionState.Checkered:
+          // Session timer does not restart at green
+          elapsedTime = time - greenFlagTimestamp;
+          if (isFixedLapRace) {
+            remainingTime = adjustedRaceTime - elapsedTime;
+            totalTime = totalRaceTime;
+          } else {
+            remainingTime = timeRemaining;
+            totalTime = timeTotal;
+          }
+          break;
+        case SessionState.CoolDown:
+        default:
+          elapsedTime = 0;
+          remainingTime = 0;
+          totalTime = 0;
+          break;
+      }
+    } else {
+      elapsedTime = time;
+      remainingTime = timeRemaining;
+      totalTime = timeTotal;
+    }
+
+    const totalFormat = settings?.totalFormat ?? 'minimal';
+    const labelStyle = settings?.labelStyle ?? 'minimal';
+
+    const elapsedStr =
+      elapsedTime >= 0
+        ? formatTotalTime(elapsedTime, totalFormat, false, labelStyle)
+        : '-';
+    const remainingStr =
+      remainingTime >= 0
+        ? formatTotalTime(remainingTime, totalFormat, false, labelStyle)
+        : '-';
+    let totalStr =
+      totalTime >= 0
+        ? formatTotalTime(totalTime, totalFormat, true, labelStyle)
+        : '-';
+
+    if (session === 'Race' && state >= 2 && isFixedLapRace) {
+      totalStr = '~' + totalStr;
+    }
+
+    const mode = settings?.mode ?? 'Remaining';
+    if (mode === 'Remaining') {
+      return (
+        <div className="flex justify-center tabular-nums">
+          {remainingStr} / {totalStr}
+        </div>
+      );
+    }
+    return (
+      <div className="flex justify-center tabular-nums">
+        {elapsedStr} / {totalStr}
+      </div>
+    );
+  }
+);
+SessionTimeItem.displayName = 'SessionTimeItem';

--- a/src/frontend/components/Standings/components/SessionBar/SessionTimeItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionTimeItem.tsx
@@ -65,95 +65,97 @@ const formatTotalTime = (
   return result;
 };
 
-export const SessionTimeItem = memo(
-  ({ settings }: { settings?: SessionBarConfig['sessionTime'] }) => {
-    const session = useCurrentSessionType();
-    const { time, timeRemaining, timeTotal, state, greenFlagTimestamp } =
-      useSessionLapCount();
-    const { totalRaceTime, adjustedRaceTime } = useTotalRaceTime();
-    const { isFixedLapRace } = useTotalRaceLaps();
+interface SessionTimeItemProps {
+  settings?: SessionBarConfig['sessionTime'];
+}
 
-    let elapsedTime = -1;
-    let remainingTime = -1;
-    let totalTime = -1;
-    if (session === 'Race') {
-      switch (state) {
-        case SessionState.GetInCar:
-          // Before grid, there is a ~2min countdown
-          elapsedTime = time;
+export const SessionTimeItem = memo(({ settings }: SessionTimeItemProps) => {
+  const session = useCurrentSessionType();
+  const { time, timeRemaining, timeTotal, state, greenFlagTimestamp } =
+    useSessionLapCount();
+  const { totalRaceTime, adjustedRaceTime } = useTotalRaceTime();
+  const { isFixedLapRace } = useTotalRaceLaps();
+
+  let elapsedTime = -1;
+  let remainingTime = -1;
+  let totalTime = -1;
+  if (session === 'Race') {
+    switch (state) {
+      case SessionState.GetInCar:
+        // Before grid, there is a ~2min countdown
+        elapsedTime = time;
+        remainingTime = timeRemaining;
+        totalTime = time + timeRemaining;
+        break;
+      case SessionState.Warmup:
+      case SessionState.ParadeLaps:
+        // Freeze the race timers until green
+        elapsedTime = 0;
+        if (isFixedLapRace) {
+          remainingTime = totalRaceTime;
+          totalTime = totalRaceTime;
+        } else {
           remainingTime = timeRemaining;
-          totalTime = time + timeRemaining;
-          break;
-        case SessionState.Warmup:
-        case SessionState.ParadeLaps:
-          // Freeze the race timers until green
-          elapsedTime = 0;
-          if (isFixedLapRace) {
-            remainingTime = totalRaceTime;
-            totalTime = totalRaceTime;
-          } else {
-            remainingTime = timeRemaining;
-            totalTime = timeTotal;
-          }
-          break;
-        case SessionState.Racing:
-        case SessionState.Checkered:
-          // Session timer does not restart at green
-          elapsedTime = time - greenFlagTimestamp;
-          if (isFixedLapRace) {
-            remainingTime = adjustedRaceTime - elapsedTime;
-            totalTime = totalRaceTime;
-          } else {
-            remainingTime = timeRemaining;
-            totalTime = timeTotal;
-          }
-          break;
-        case SessionState.CoolDown:
-        default:
-          elapsedTime = 0;
-          remainingTime = 0;
-          totalTime = 0;
-          break;
-      }
-    } else {
-      elapsedTime = time;
-      remainingTime = timeRemaining;
-      totalTime = timeTotal;
+          totalTime = timeTotal;
+        }
+        break;
+      case SessionState.Racing:
+      case SessionState.Checkered:
+        // Session timer does not restart at green
+        elapsedTime = time - greenFlagTimestamp;
+        if (isFixedLapRace) {
+          remainingTime = adjustedRaceTime - elapsedTime;
+          totalTime = totalRaceTime;
+        } else {
+          remainingTime = timeRemaining;
+          totalTime = timeTotal;
+        }
+        break;
+      case SessionState.CoolDown:
+      default:
+        elapsedTime = 0;
+        remainingTime = 0;
+        totalTime = 0;
+        break;
     }
+  } else {
+    elapsedTime = time;
+    remainingTime = timeRemaining;
+    totalTime = timeTotal;
+  }
 
-    const totalFormat = settings?.totalFormat ?? 'minimal';
-    const labelStyle = settings?.labelStyle ?? 'minimal';
+  const totalFormat = settings?.totalFormat ?? 'minimal';
+  const labelStyle = settings?.labelStyle ?? 'minimal';
 
-    const elapsedStr =
-      elapsedTime >= 0
-        ? formatTotalTime(elapsedTime, totalFormat, false, labelStyle)
-        : '-';
-    const remainingStr =
-      remainingTime >= 0
-        ? formatTotalTime(remainingTime, totalFormat, false, labelStyle)
-        : '-';
-    let totalStr =
-      totalTime >= 0
-        ? formatTotalTime(totalTime, totalFormat, true, labelStyle)
-        : '-';
+  const elapsedStr =
+    elapsedTime >= 0
+      ? formatTotalTime(elapsedTime, totalFormat, false, labelStyle)
+      : '-';
+  const remainingStr =
+    remainingTime >= 0
+      ? formatTotalTime(remainingTime, totalFormat, false, labelStyle)
+      : '-';
+  let totalStr =
+    totalTime >= 0
+      ? formatTotalTime(totalTime, totalFormat, true, labelStyle)
+      : '-';
 
-    if (session === 'Race' && state >= 2 && isFixedLapRace) {
-      totalStr = '~' + totalStr;
-    }
+  if (session === 'Race' && state >= 2 && isFixedLapRace) {
+    totalStr = '~' + totalStr;
+  }
 
-    const mode = settings?.mode ?? 'Remaining';
-    if (mode === 'Remaining') {
-      return (
-        <div className="flex justify-center tabular-nums">
-          {remainingStr} / {totalStr}
-        </div>
-      );
-    }
+  const mode = settings?.mode ?? 'Remaining';
+  if (mode === 'Remaining') {
     return (
       <div className="flex justify-center tabular-nums">
-        {elapsedStr} / {totalStr}
+        {remainingStr} / {totalStr}
       </div>
     );
   }
-);
+  return (
+    <div className="flex justify-center tabular-nums">
+      {elapsedStr} / {totalStr}
+    </div>
+  );
+});
 SessionTimeItem.displayName = 'SessionTimeItem';

--- a/src/frontend/components/Standings/components/SessionBar/SofItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SofItem.tsx
@@ -1,0 +1,16 @@
+import { BarbellIcon } from '@phosphor-icons/react';
+import { useFocusedDriver, useCarClassStats } from '@irdashies/context';
+
+export const SofItem = () => {
+  const focusedDriver = useFocusedDriver();
+  const classStats = useCarClassStats();
+  const classId = focusedDriver?.carClassID;
+  const stats = classId !== undefined ? classStats?.[classId] : undefined;
+  if (!stats?.sof) return null;
+  return (
+    <div className="flex justify-center gap-1 items-center">
+      <BarbellIcon className="text-white/60" />
+      <span>{stats.sof}</span>
+    </div>
+  );
+};

--- a/src/frontend/components/Standings/components/SessionBar/SofItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SofItem.tsx
@@ -1,7 +1,8 @@
+import { memo } from 'react';
 import { BarbellIcon } from '@phosphor-icons/react';
 import { useFocusedDriver, useCarClassStats } from '@irdashies/context';
 
-export const SofItem = () => {
+export const SofItem = memo(() => {
   const focusedDriver = useFocusedDriver();
   const classStats = useCarClassStats();
   const classId = focusedDriver?.carClassID;
@@ -13,4 +14,5 @@ export const SofItem = () => {
       <span>{stats.sof}</span>
     </div>
   );
-};
+});
+SofItem.displayName = 'SofItem';

--- a/src/frontend/components/Standings/components/SessionBar/TrackNameItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/TrackNameItem.tsx
@@ -1,0 +1,8 @@
+import { memo } from 'react';
+import { useTrackDisplayName } from '@irdashies/context';
+
+export const TrackNameItem = memo(() => {
+  const trackDisplayName = useTrackDisplayName();
+  return <div className="flex">{trackDisplayName}</div>;
+});
+TrackNameItem.displayName = 'TrackNameItem';

--- a/src/frontend/components/Standings/components/SessionBar/TrackTemperatureItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/TrackTemperatureItem.tsx
@@ -1,0 +1,17 @@
+import { memo } from 'react';
+import { RoadHorizonIcon } from '@phosphor-icons/react';
+import type { TemperatureUnit } from '@irdashies/types';
+import { useTrackTemperature } from '../../hooks/useTrackTemperature';
+
+export const TrackTemperatureItem = memo(
+  ({ unit }: { unit: TemperatureUnit }) => {
+    const { trackTemp } = useTrackTemperature({ trackTempUnit: unit });
+    return (
+      <div className="flex justify-center gap-1 items-center">
+        <RoadHorizonIcon />
+        <span>{trackTemp}</span>
+      </div>
+    );
+  }
+);
+TrackTemperatureItem.displayName = 'TrackTemperatureItem';

--- a/src/frontend/components/Standings/components/SessionBar/TrackTemperatureItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/TrackTemperatureItem.tsx
@@ -3,8 +3,12 @@ import { RoadHorizonIcon } from '@phosphor-icons/react';
 import type { TemperatureUnit } from '@irdashies/types';
 import { useTrackTemperature } from '../../hooks/useTrackTemperature';
 
+interface TrackTemperatureItemProps {
+  unit: TemperatureUnit;
+}
+
 export const TrackTemperatureItem = memo(
-  ({ unit }: { unit: TemperatureUnit }) => {
+  ({ unit }: TrackTemperatureItemProps) => {
     const { trackTemp } = useTrackTemperature({ trackTempUnit: unit });
     return (
       <div className="flex justify-center gap-1 items-center">

--- a/src/frontend/components/Standings/components/SessionBar/TrackWetnessItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/TrackWetnessItem.tsx
@@ -1,0 +1,14 @@
+import { memo } from 'react';
+import { WavesIcon } from '@phosphor-icons/react';
+import { useTrackWetness } from '../../hooks/useTrackWetness';
+
+export const TrackWetnessItem = memo(() => {
+  const { trackWetness } = useTrackWetness();
+  return (
+    <div className="flex justify-center gap-1 items-center text-nowrap">
+      <WavesIcon />
+      <span>{trackWetness}</span>
+    </div>
+  );
+});
+TrackWetnessItem.displayName = 'TrackWetnessItem';

--- a/src/frontend/components/Standings/components/SessionBar/WindItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/WindItem.tsx
@@ -3,28 +3,30 @@ import { useThrottledWeather, useTelemetryValue } from '@irdashies/context';
 import type { SessionBarConfig } from '@irdashies/types';
 import { WindArrow } from '../../../shared/WindArrow';
 
-export const WindItem = memo(
-  ({ settings }: { settings: SessionBarConfig['wind'] }) => {
-    const displayUnits = useTelemetryValue('DisplayUnits'); // 0 = imperial, 1 = metric
-    const { windDirection, windVelocity, windYaw } = useThrottledWeather();
-    const relativeWindDirection = (windDirection ?? 0) - (windYaw ?? 0);
-    const isMetric = displayUnits === 1;
-    const speedPosition = settings?.speedPosition ?? 'right';
-    const speed =
-      windVelocity !== undefined
-        ? Math.round(windVelocity * (isMetric ? 3.6 : 2.23694))
-        : '-';
-    const speedEl = <span>{speed}</span>;
-    const arrowEl = (
-      <WindArrow direction={relativeWindDirection} className="mx-1 w-3.5 h-4" />
-    );
-    return (
-      <div className="flex justify-center gap-1 items-center">
-        {speedPosition === 'left' && speedEl}
-        {arrowEl}
-        {speedPosition === 'right' && speedEl}
-      </div>
-    );
-  }
-);
+interface WindItemProps {
+  settings: SessionBarConfig['wind'];
+}
+
+export const WindItem = memo(({ settings }: WindItemProps) => {
+  const displayUnits = useTelemetryValue('DisplayUnits'); // 0 = imperial, 1 = metric
+  const { windDirection, windVelocity, windYaw } = useThrottledWeather();
+  const relativeWindDirection = (windDirection ?? 0) - (windYaw ?? 0);
+  const isMetric = displayUnits === 1;
+  const speedPosition = settings?.speedPosition ?? 'right';
+  const speed =
+    windVelocity !== undefined
+      ? Math.round(windVelocity * (isMetric ? 3.6 : 2.23694))
+      : '-';
+  const speedEl = <span>{speed}</span>;
+  const arrowEl = (
+    <WindArrow direction={relativeWindDirection} className="mx-1 w-3.5 h-4" />
+  );
+  return (
+    <div className="flex justify-center gap-1 items-center">
+      {speedPosition === 'left' && speedEl}
+      {arrowEl}
+      {speedPosition === 'right' && speedEl}
+    </div>
+  );
+});
 WindItem.displayName = 'WindItem';

--- a/src/frontend/components/Standings/components/SessionBar/WindItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/WindItem.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react';
+import { useThrottledWeather, useTelemetryValue } from '@irdashies/context';
+import type { SessionBarConfig } from '@irdashies/types';
+import { WindArrow } from '../../../shared/WindArrow';
+
+export const WindItem = memo(
+  ({ settings }: { settings: SessionBarConfig['wind'] }) => {
+    const displayUnits = useTelemetryValue('DisplayUnits'); // 0 = imperial, 1 = metric
+    const { windDirection, windVelocity, windYaw } = useThrottledWeather();
+    const relativeWindDirection = (windDirection ?? 0) - (windYaw ?? 0);
+    const isMetric = displayUnits === 1;
+    const speedPosition = settings?.speedPosition ?? 'right';
+    const speed =
+      windVelocity !== undefined
+        ? Math.round(windVelocity * (isMetric ? 3.6 : 2.23694))
+        : '-';
+    const speedEl = <span>{speed}</span>;
+    const arrowEl = (
+      <WindArrow direction={relativeWindDirection} className="mx-1 w-3.5 h-4" />
+    );
+    return (
+      <div className="flex justify-center gap-1 items-center">
+        {speedPosition === 'left' && speedEl}
+        {arrowEl}
+        {speedPosition === 'right' && speedEl}
+      </div>
+    );
+  }
+);
+WindItem.displayName = 'WindItem';

--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -4,7 +4,6 @@ import {
   useTelemetry,
   useSessionDrivers,
   useSessionQualifyingResults,
-  useSessionIsOfficial,
   useCurrentSessionType,
   useCarLap,
   usePitLap,
@@ -17,12 +16,7 @@ import {
   useDriverStatsStore,
 } from '@irdashies/context';
 
-import {
-  Standings,
-  augmentStandingsWithIRating,
-  groupStandingsByClass,
-  type LastTimeState,
-} from '../createStandings';
+import { Standings, type LastTimeState } from '../createStandings';
 import { GlobalFlags, SessionState } from '@irdashies/types';
 import { useDriverLivePositions } from './useDriverLivePositions';
 import { useRelativeSettings } from './useRelativeSettings';
@@ -91,26 +85,28 @@ export const useDriverPositions = () => {
 
 export const useDrivers = () => {
   const sessionDrivers = useSessionDrivers();
-  const drivers =
-    sessionDrivers?.map((driver) => ({
-      carIdx: driver.CarIdx,
-      name: driver.UserName,
-      carNum: driver.CarNumber,
-      carNumRaw: driver.CarNumberRaw,
-      license: driver.LicString,
-      rating: driver.IRating,
-      flairId: driver.FlairID,
-      teamName: driver.TeamName,
-      carClass: {
-        id: driver.CarClassID,
-        color: driver.CarClassColor,
-        name: driver.CarClassShortName,
-        relativeSpeed: driver.CarClassRelSpeed,
-        estLapTime: driver.CarClassEstLapTime,
-      },
-      carId: driver.CarID,
-    })) ?? [];
-  return drivers;
+  return useMemo(
+    () =>
+      sessionDrivers?.map((driver) => ({
+        carIdx: driver.CarIdx,
+        name: driver.UserName,
+        carNum: driver.CarNumber,
+        carNumRaw: driver.CarNumberRaw,
+        license: driver.LicString,
+        rating: driver.IRating,
+        flairId: driver.FlairID,
+        teamName: driver.TeamName,
+        carClass: {
+          id: driver.CarClassID,
+          color: driver.CarClassColor,
+          name: driver.CarClassShortName,
+          relativeSpeed: driver.CarClassRelSpeed,
+          estLapTime: driver.CarClassEstLapTime,
+        },
+        carId: driver.CarID,
+      })) ?? [],
+    [sessionDrivers]
+  );
 };
 
 export const useCarState = () => {
@@ -171,7 +167,6 @@ export const useDriverStandings = () => {
   const iratingChanges = useDriverStatsStore((s) => s.iratingChanges);
   const positionChanges = useDriverStatsStore((s) => s.positionChanges);
   const fastestLapCarIdx = sessionFastestLaps?.[0]?.CarIdx;
-  const isOfficial = useSessionIsOfficial();
 
   const driverStandings: Standings[] = useMemo(() => {
     // Create Map lookups for O(1) access instead of O(n) find() calls
@@ -294,17 +289,7 @@ export const useDriverStandings = () => {
       };
     });
 
-    const filteredStandings = standings
-      .filter((s) => !!s)
-      .sort((a, b) => a.position - b.position);
-
-    if (sessionType !== 'Race' || !isOfficial) {
-      return filteredStandings;
-    }
-
-    return augmentStandingsWithIRating(groupStandingsByClass(filteredStandings))
-      .flatMap(([, classStandings]) => classStandings)
-      .sort((a, b) => (a?.position ?? 0) - (b?.position ?? 0));
+    return standings.filter((s) => !!s).sort((a, b) => a.position - b.position);
   }, [
     sessionPositions,
     sessionState,
@@ -320,7 +305,6 @@ export const useDriverStandings = () => {
     fastestLapCarIdx,
     iratingChanges,
     positionChanges,
-    isOfficial,
   ]);
 
   return driverStandings;

--- a/src/frontend/context/DriverStatsStore/DriverStatsStore.spec.ts
+++ b/src/frontend/context/DriverStatsStore/DriverStatsStore.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDriverStatsStore } from './DriverStatsStore';
+
+describe('DriverStatsStore', () => {
+  describe('setStats', () => {
+    beforeEach(() => {
+      useDriverStatsStore.setState({ iratingChanges: {}, positionChanges: {} });
+    });
+
+    it('preserves state identity when both records are value-equal', () => {
+      const { setStats } = useDriverStatsStore.getState();
+      setStats({ 1: 10, 2: -5 }, { 1: 1, 2: -1 });
+
+      const after = useDriverStatsStore.getState();
+      const irBefore = after.iratingChanges;
+      const posBefore = after.positionChanges;
+
+      // Same values, fresh object identities
+      setStats({ 1: 10, 2: -5 }, { 1: 1, 2: -1 });
+
+      const next = useDriverStatsStore.getState();
+      expect(next.iratingChanges).toBe(irBefore);
+      expect(next.positionChanges).toBe(posBefore);
+    });
+
+    it('updates when iratingChanges value differs', () => {
+      const { setStats } = useDriverStatsStore.getState();
+      setStats({ 1: 10 }, { 1: 1 });
+      const irBefore = useDriverStatsStore.getState().iratingChanges;
+
+      setStats({ 1: 11 }, { 1: 1 });
+      const irAfter = useDriverStatsStore.getState().iratingChanges;
+
+      expect(irAfter).not.toBe(irBefore);
+      expect(irAfter[1]).toBe(11);
+    });
+
+    it('updates when positionChanges value differs', () => {
+      const { setStats } = useDriverStatsStore.getState();
+      setStats({ 1: 10 }, { 1: 1 });
+      const posBefore = useDriverStatsStore.getState().positionChanges;
+
+      setStats({ 1: 10 }, { 1: 2 });
+      const posAfter = useDriverStatsStore.getState().positionChanges;
+
+      expect(posAfter).not.toBe(posBefore);
+      expect(posAfter[1]).toBe(2);
+    });
+
+    it('updates when a key is added', () => {
+      const { setStats } = useDriverStatsStore.getState();
+      setStats({ 1: 10 }, { 1: 1 });
+      const irBefore = useDriverStatsStore.getState().iratingChanges;
+
+      setStats({ 1: 10, 2: -5 }, { 1: 1 });
+      const irAfter = useDriverStatsStore.getState().iratingChanges;
+
+      expect(irAfter).not.toBe(irBefore);
+      expect(irAfter[2]).toBe(-5);
+    });
+
+    it('updates when a key is removed', () => {
+      const { setStats } = useDriverStatsStore.getState();
+      setStats({ 1: 10, 2: -5 }, { 1: 1 });
+      const irBefore = useDriverStatsStore.getState().iratingChanges;
+
+      setStats({ 1: 10 }, { 1: 1 });
+      const irAfter = useDriverStatsStore.getState().iratingChanges;
+
+      expect(irAfter).not.toBe(irBefore);
+      expect(irAfter[2]).toBeUndefined();
+    });
+  });
+});

--- a/src/frontend/context/DriverStatsStore/DriverStatsStore.tsx
+++ b/src/frontend/context/DriverStatsStore/DriverStatsStore.tsx
@@ -10,11 +10,30 @@ interface DriverStatsState {
   ) => void;
 }
 
+const recordsEqual = (a: Record<number, number>, b: Record<number, number>) => {
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  for (const k of aKeys) {
+    if (a[+k] !== b[+k]) return false;
+  }
+  return true;
+};
+
 export const useDriverStatsStore = create<DriverStatsState>((set) => ({
   iratingChanges: {},
   positionChanges: {},
+  // Bail when both maps are value-equal so we don't push new object identity
+  // every session tick — that would force every subscriber's memo to invalidate.
   setStats: (iratingChanges, positionChanges) =>
-    set({ iratingChanges, positionChanges }),
+    set((state) => {
+      if (
+        recordsEqual(state.iratingChanges, iratingChanges) &&
+        recordsEqual(state.positionChanges, positionChanges)
+      ) {
+        return state;
+      }
+      return { iratingChanges, positionChanges };
+    }),
 }));
 
 /**

--- a/src/frontend/context/DriverStatsStore/DriverStatsStoreUpdater.spec.tsx
+++ b/src/frontend/context/DriverStatsStore/DriverStatsStoreUpdater.spec.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import type { Driver, Session } from '@irdashies/types';
+import { useSessionStore } from '../SessionStore/SessionStore';
+import { useTelemetryStore } from '../TelemetryStore/TelemetryStore';
+import { DriverStatsStoreUpdater } from './DriverStatsStoreUpdater';
+import { useDriverStatsStore } from './DriverStatsStore';
+
+const buildDriver = (
+  carIdx: number,
+  iRating: number,
+  options: { classId?: number; incidents?: number } = {}
+): Driver =>
+  ({
+    CarIdx: carIdx,
+    IRating: iRating,
+    CarClassID: options.classId ?? 100,
+    IsSpectator: 0,
+    CarIsPaceCar: 0,
+    CurDriverIncidentCount: options.incidents ?? 0,
+  }) as unknown as Driver;
+
+const buildSession = (
+  drivers: Driver[],
+  positions: { CarIdx: number; ClassPosition: number }[],
+  { official = 1 }: { official?: 0 | 1 } = {}
+): Session =>
+  ({
+    WeekendInfo: { Official: official },
+    DriverInfo: { Drivers: drivers },
+    SessionInfo: {
+      Sessions: [
+        {
+          SessionNum: 0,
+          SessionType: 'Race',
+          ResultsPositions: positions,
+        },
+      ],
+    },
+  }) as unknown as Session;
+
+describe('DriverStatsStoreUpdater', () => {
+  beforeEach(() => {
+    useDriverStatsStore.setState({ iratingChanges: {}, positionChanges: {} });
+    useSessionStore.getState().resetSession();
+    useTelemetryStore.getState().setTelemetry({
+      SessionNum: { value: [0] },
+    } as never);
+  });
+
+  it('populates iratingChanges on first render of an official race', () => {
+    useSessionStore.getState().setSession(
+      buildSession(
+        [buildDriver(0, 2000), buildDriver(1, 1500)],
+        [
+          { CarIdx: 0, ClassPosition: 0 },
+          { CarIdx: 1, ClassPosition: 1 },
+        ]
+      )
+    );
+
+    render(<DriverStatsStoreUpdater />);
+
+    const { iratingChanges } = useDriverStatsStore.getState();
+    expect(Object.keys(iratingChanges).sort()).toEqual(['0', '1']);
+    expect(typeof iratingChanges[0]).toBe('number');
+    expect(typeof iratingChanges[1]).toBe('number');
+  });
+
+  it('preserves iratingChanges identity when only incident count changes', () => {
+    useSessionStore.getState().setSession(
+      buildSession(
+        [
+          buildDriver(0, 2000, { incidents: 0 }),
+          buildDriver(1, 1500, { incidents: 0 }),
+        ],
+        [
+          { CarIdx: 0, ClassPosition: 0 },
+          { CarIdx: 1, ClassPosition: 1 },
+        ]
+      )
+    );
+
+    render(<DriverStatsStoreUpdater />);
+    const firstChanges = useDriverStatsStore.getState().iratingChanges;
+    expect(Object.keys(firstChanges).length).toBe(2);
+
+    // Same IRating + class positions, only incident counts changed.
+    act(() => {
+      useSessionStore.getState().setSession(
+        buildSession(
+          [
+            buildDriver(0, 2000, { incidents: 1 }),
+            buildDriver(1, 1500, { incidents: 2 }),
+          ],
+          [
+            { CarIdx: 0, ClassPosition: 0 },
+            { CarIdx: 1, ClassPosition: 1 },
+          ]
+        )
+      );
+    });
+
+    expect(useDriverStatsStore.getState().iratingChanges).toBe(firstChanges);
+  });
+
+  it('produces a new iratingChanges record when a driver IRating changes', () => {
+    useSessionStore.getState().setSession(
+      buildSession(
+        [buildDriver(0, 2000), buildDriver(1, 1500)],
+        [
+          { CarIdx: 0, ClassPosition: 0 },
+          { CarIdx: 1, ClassPosition: 1 },
+        ]
+      )
+    );
+
+    render(<DriverStatsStoreUpdater />);
+    const firstChanges = useDriverStatsStore.getState().iratingChanges;
+
+    act(() => {
+      useSessionStore.getState().setSession(
+        buildSession(
+          [buildDriver(0, 2050), buildDriver(1, 1500)],
+          [
+            { CarIdx: 0, ClassPosition: 0 },
+            { CarIdx: 1, ClassPosition: 1 },
+          ]
+        )
+      );
+    });
+
+    expect(useDriverStatsStore.getState().iratingChanges).not.toBe(
+      firstChanges
+    );
+  });
+
+  it('produces a new iratingChanges record when class positions swap', () => {
+    useSessionStore.getState().setSession(
+      buildSession(
+        [buildDriver(0, 2000), buildDriver(1, 1500)],
+        [
+          { CarIdx: 0, ClassPosition: 0 },
+          { CarIdx: 1, ClassPosition: 1 },
+        ]
+      )
+    );
+
+    render(<DriverStatsStoreUpdater />);
+    const firstChanges = useDriverStatsStore.getState().iratingChanges;
+
+    act(() => {
+      useSessionStore.getState().setSession(
+        buildSession(
+          [buildDriver(0, 2000), buildDriver(1, 1500)],
+          [
+            { CarIdx: 0, ClassPosition: 1 },
+            { CarIdx: 1, ClassPosition: 0 },
+          ]
+        )
+      );
+    });
+
+    expect(useDriverStatsStore.getState().iratingChanges).not.toBe(
+      firstChanges
+    );
+  });
+
+  it('leaves iratingChanges empty for unofficial sessions', () => {
+    useSessionStore.getState().setSession(
+      buildSession(
+        [buildDriver(0, 2000), buildDriver(1, 1500)],
+        [
+          { CarIdx: 0, ClassPosition: 0 },
+          { CarIdx: 1, ClassPosition: 1 },
+        ],
+        { official: 0 }
+      )
+    );
+
+    render(<DriverStatsStoreUpdater />);
+
+    expect(useDriverStatsStore.getState().iratingChanges).toEqual({});
+  });
+});

--- a/src/frontend/context/DriverStatsStore/DriverStatsStoreUpdater.tsx
+++ b/src/frontend/context/DriverStatsStore/DriverStatsStoreUpdater.tsx
@@ -1,4 +1,4 @@
-import { useEffect, memo } from 'react';
+import { useEffect, useRef, memo } from 'react';
 import {
   useSessionDrivers,
   useSessionPositions,
@@ -19,14 +19,24 @@ export const DriverStatsStoreUpdater = memo(() => {
   const qualifyingResults = useSessionQualifyingResults();
   const setStats = useDriverStatsStore((s) => s.setStats);
 
+  // calculateIRatingGain is O(N²) Math.exp calls per class. The effect fires
+  // whenever any field on any driver changes (incident counts flap every few
+  // seconds), but only IRating + class-position actually feed the calc.
+  // Cache the last result keyed by a fingerprint of those fields and reuse it
+  // when nothing material has changed.
+  const ratingCacheRef = useRef<{
+    fingerprint: string;
+    changes: Record<number, number>;
+  }>({ fingerprint: '', changes: {} });
+
   useEffect(() => {
     if (!drivers || !sessionPositions) {
+      ratingCacheRef.current = { fingerprint: '', changes: {} };
       setStats({}, {});
       return;
     }
 
     const isRace = sessionType === 'Race';
-    const iratingChanges: Record<number, number> = {};
     const positionChanges: Record<number, number> = {};
 
     // 1. Calculate Position Changes (vs Qualifying)
@@ -46,55 +56,77 @@ export const DriverStatsStoreUpdater = memo(() => {
     }
 
     // 2. Calculate iRating Changes (per Class)
-    if (isRace && isOfficial) {
-      // Group drivers by class
-      const driversByClass = new Map<number, typeof drivers>();
-      drivers.forEach((d) => {
-        if (d.IsSpectator || d.CarIsPaceCar) return;
-        const classId = d.CarClassID;
-        const list = driversByClass.get(classId) || [];
-        list.push(d);
-        driversByClass.set(classId, list);
-      });
+    let iratingChanges: Record<number, number> = {};
 
+    if (isRace && isOfficial) {
       const sessionPosMap = new Map<number, number>();
       sessionPositions.forEach((p) =>
         sessionPosMap.set(p.CarIdx, p.ClassPosition + 1)
       );
 
-      driversByClass.forEach((classDrivers) => {
-        const startersCount = classDrivers.filter((d) =>
-          sessionPosMap.has(d.CarIdx)
-        ).length;
+      // Fingerprint the inputs that actually affect calculateIRatingGain.
+      // Iteration order matters because non-starter finishRank is derived from
+      // it, so we encode iteration position (`i`) into the key.
+      let fingerprint = '';
+      drivers.forEach((d, i) => {
+        if (d.IsSpectator || d.CarIsPaceCar) return;
+        const classPos = sessionPosMap.get(d.CarIdx);
+        fingerprint += `${i}:${d.CarClassID}:${d.CarIdx}:${d.IRating}:${classPos ?? -1};`;
+      });
 
-        let nonStarterIndex = 0;
-        const raceResultsInput: RaceResult<number>[] = classDrivers.map((d) => {
-          const classPos = sessionPosMap.get(d.CarIdx);
-          const started = classPos !== undefined;
-
-          let finishRank: number;
-          if (started) {
-            finishRank = classPos;
-          } else {
-            finishRank = startersCount + nonStarterIndex + 1;
-            nonStarterIndex++;
-          }
-
-          return {
-            driver: d.CarIdx,
-            finishRank,
-            startIRating: d.IRating,
-            started,
-          };
+      if (fingerprint === ratingCacheRef.current.fingerprint) {
+        iratingChanges = ratingCacheRef.current.changes;
+      } else {
+        // Group drivers by class
+        const driversByClass = new Map<number, typeof drivers>();
+        drivers.forEach((d) => {
+          if (d.IsSpectator || d.CarIsPaceCar) return;
+          const classId = d.CarClassID;
+          const list = driversByClass.get(classId) || [];
+          list.push(d);
+          driversByClass.set(classId, list);
         });
 
-        if (raceResultsInput.length > 0) {
-          const results = calculateIRatingGain(raceResultsInput);
-          results.forEach((res) => {
-            iratingChanges[res.raceResult.driver] = res.iratingChange;
-          });
-        }
-      });
+        driversByClass.forEach((classDrivers) => {
+          const startersCount = classDrivers.filter((d) =>
+            sessionPosMap.has(d.CarIdx)
+          ).length;
+
+          let nonStarterIndex = 0;
+          const raceResultsInput: RaceResult<number>[] = classDrivers.map(
+            (d) => {
+              const classPos = sessionPosMap.get(d.CarIdx);
+              const started = classPos !== undefined;
+
+              let finishRank: number;
+              if (started) {
+                finishRank = classPos;
+              } else {
+                finishRank = startersCount + nonStarterIndex + 1;
+                nonStarterIndex++;
+              }
+
+              return {
+                driver: d.CarIdx,
+                finishRank,
+                startIRating: d.IRating,
+                started,
+              };
+            }
+          );
+
+          if (raceResultsInput.length > 0) {
+            const results = calculateIRatingGain(raceResultsInput);
+            results.forEach((res) => {
+              iratingChanges[res.raceResult.driver] = res.iratingChange;
+            });
+          }
+        });
+
+        ratingCacheRef.current = { fingerprint, changes: iratingChanges };
+      }
+    } else {
+      ratingCacheRef.current = { fingerprint: '', changes: {} };
     }
 
     setStats(iratingChanges, positionChanges);

--- a/src/frontend/context/SessionStore/SessionStore.tsx
+++ b/src/frontend/context/SessionStore/SessionStore.tsx
@@ -8,7 +8,41 @@ import { create, useStore } from 'zustand';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { arrayShallowCompare } from './arrayShallowCompare';
 import { shallow } from 'zustand/shallow';
-import { useMemo } from 'react';
+
+const recordEqual = <V,>(
+  a: Record<string | number, V> | undefined,
+  b: Record<string | number, V> | undefined,
+  valueEqual: (x: V, y: V) => boolean
+): boolean => {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const aKeys = Object.keys(a);
+  if (aKeys.length !== Object.keys(b).length) return false;
+  for (const k of aKeys) {
+    if (!(k in b)) return false;
+    if (!valueEqual(a[k], b[k])) return false;
+  }
+  return true;
+};
+
+const carIdxClassEstLapTimeEqual = (
+  a: Record<number, number> | undefined,
+  b: Record<number, number> | undefined
+) => recordEqual(a, b, (x, y) => x === y);
+
+const carClassStatsEqual = (
+  a: Record<string, CarClassStats> | undefined,
+  b: Record<string, CarClassStats> | undefined
+) =>
+  recordEqual(
+    a,
+    b,
+    (x, y) =>
+      x.shortName === y.shortName &&
+      x.color === y.color &&
+      x.total === y.total &&
+      x.sof === y.sof
+  );
 
 interface SessionState {
   session: Session | null;
@@ -155,22 +189,28 @@ export const useTrackLength = () =>
 
 /**
  * @returns The car index and car class estimated lap time for each driver
+ *
+ * The selector recomputes whenever the session changes, but the custom
+ * equality function preserves the prior result identity when values are
+ * unchanged — so consumer memos hold across session pushes that only
+ * mutate driver fields irrelevant to this map.
  */
-export const useCarIdxClassEstLapTime = () => {
-  const drivers = useSessionDrivers();
-
-  return useMemo(() => {
-    if (!drivers) return undefined;
-
-    return drivers.reduce(
-      (acc, driver) => {
-        acc[driver.CarIdx] = driver.CarClassEstLapTime;
-        return acc;
-      },
-      {} as Record<number, number>
-    );
-  }, [drivers]);
-};
+export const useCarIdxClassEstLapTime = () =>
+  useStoreWithEqualityFn(
+    useSessionStore,
+    (state): Record<number, number> | undefined => {
+      const drivers = state.session?.DriverInfo?.Drivers;
+      if (!drivers) return undefined;
+      return drivers.reduce(
+        (acc, driver) => {
+          acc[driver.CarIdx] = driver.CarClassEstLapTime;
+          return acc;
+        },
+        {} as Record<number, number>
+      );
+    },
+    carIdxClassEstLapTimeEqual
+  );
 
 export const useGreenFlagTimestamp = () =>
   useStore(useSessionStore, (state) => state.greenFlagTimestamp);
@@ -189,71 +229,79 @@ export const useCarSetup = () =>
 
 /**
  * @returns The stats for each car class in the session (ShortName, Color, Total Drivers, SOF)
+ *
+ * The selector recomputes whenever the session changes, but the custom
+ * equality function preserves the prior result identity when SOF/total
+ * values are unchanged — so consumer memos hold across session pushes
+ * that only mutate driver fields irrelevant to this calc (e.g. incident
+ * counts).
  */
-export const useCarClassStats = () => {
-  const drivers = useSessionDrivers();
+export const useCarClassStats = () =>
+  useStoreWithEqualityFn(
+    useSessionStore,
+    (state): Record<string, CarClassStats> | undefined => {
+      const drivers = state.session?.DriverInfo?.Drivers;
+      if (!drivers) return undefined;
 
-  return useMemo(() => {
-    if (!drivers) return undefined;
+      const raceDrivers = drivers.filter(
+        (driver) => !driver.IsSpectator && !driver.CarIsPaceCar
+      );
 
-    const raceDrivers = drivers.filter(
-      (driver) => !driver.IsSpectator && !driver.CarIsPaceCar
-    );
+      const intermediate = raceDrivers.reduce(
+        (acc, driver) => {
+          if (!acc[driver.CarClassID]) {
+            acc[driver.CarClassID] = {
+              total: 0,
+              raceDrivers: 0,
+              sumExp: 0,
+              color: driver.CarClassColor,
+              shortName: driver.CarClassShortName,
+            };
+          }
 
-    const intermediate = raceDrivers.reduce(
-      (acc, driver) => {
-        if (!acc[driver.CarClassID]) {
-          acc[driver.CarClassID] = {
-            total: 0,
-            raceDrivers: 0,
-            sumExp: 0,
-            color: driver.CarClassColor,
-            shortName: driver.CarClassShortName,
-          };
-        }
+          acc[driver.CarClassID].total += 1;
 
-        acc[driver.CarClassID].total += 1;
+          if (driver.IRating > 0) {
+            const expValue = Math.pow(2, -driver.IRating / 1600);
+            acc[driver.CarClassID].raceDrivers += 1;
+            acc[driver.CarClassID].sumExp += expValue;
+          }
 
-        if (driver.IRating > 0) {
-          const expValue = Math.pow(2, -driver.IRating / 1600);
-          acc[driver.CarClassID].raceDrivers += 1;
-          acc[driver.CarClassID].sumExp += expValue;
-        }
-
-        return acc;
-      },
-      {} as Record<
-        string,
-        {
-          shortName: string;
-          color: number;
-          total: number;
-          raceDrivers: number;
-          sumExp: number;
-        }
-      >
-    );
-
-    return Object.fromEntries(
-      Object.entries(intermediate).map(([classId, stats]) => {
-        const sof =
-          stats.raceDrivers > 0
-            ? Math.round(
-                (1600 / Math.log(2)) *
-                  Math.log(stats.raceDrivers / stats.sumExp)
-              )
-            : 0;
-
-        return [
-          classId,
+          return acc;
+        },
+        {} as Record<
+          string,
           {
-            shortName: stats.shortName,
-            color: stats.color,
-            total: stats.total,
-            sof,
-          } as CarClassStats,
-        ];
-      })
-    );
-  }, [drivers]);
-};
+            shortName: string;
+            color: number;
+            total: number;
+            raceDrivers: number;
+            sumExp: number;
+          }
+        >
+      );
+
+      return Object.fromEntries(
+        Object.entries(intermediate).map(([classId, stats]) => {
+          const sof =
+            stats.raceDrivers > 0
+              ? Math.round(
+                  (1600 / Math.log(2)) *
+                    Math.log(stats.raceDrivers / stats.sumExp)
+                )
+              : 0;
+
+          return [
+            classId,
+            {
+              shortName: stats.shortName,
+              color: stats.color,
+              total: stats.total,
+              sof,
+            } as CarClassStats,
+          ];
+        })
+      );
+    },
+    carClassStatsEqual
+  );

--- a/src/frontend/context/shared/index.ts
+++ b/src/frontend/context/shared/index.ts
@@ -4,6 +4,7 @@ export * from './useContainerOffset';
 export * from './useCurrentSessionType';
 export * from './useDrivingState';
 export * from './useFocusCarIdx';
+export * from './useFocusedDriver';
 export * from './useResetOnDisconnect';
 export * from './useSessionVisibility';
 export * from './useThrottledWeather';

--- a/src/frontend/context/shared/useFocusedDriver.ts
+++ b/src/frontend/context/shared/useFocusedDriver.ts
@@ -1,0 +1,35 @@
+import { useStoreWithEqualityFn } from 'zustand/traditional';
+import { shallow } from 'zustand/shallow';
+import { useSessionStore } from '../SessionStore/SessionStore';
+import { useFocusCarIdx } from './useFocusCarIdx';
+
+export interface FocusedDriverFields {
+  licString: string;
+  iRating: number;
+  carClassID: number;
+}
+
+/**
+ * Returns lightweight fields of the focus car's driver with shallow equality,
+ * so consumers re-render only when those specific fields change rather than
+ * on every drivers-array reference change.
+ */
+export const useFocusedDriver = (): FocusedDriverFields | undefined => {
+  const focusedCarIdx = useFocusCarIdx();
+  return useStoreWithEqualityFn(
+    useSessionStore,
+    (state): FocusedDriverFields | undefined => {
+      if (focusedCarIdx === undefined) return undefined;
+      const driver = state.session?.DriverInfo?.Drivers?.find(
+        (d) => d.CarIdx === focusedCarIdx
+      );
+      if (!driver) return undefined;
+      return {
+        licString: driver.LicString,
+        iRating: driver.IRating,
+        carClassID: driver.CarClassID,
+      };
+    },
+    shallow
+  );
+};


### PR DESCRIPTION
## Description

Addresses the performance regression introduced in 0.3.1 by #493. After investigating the SessionBar additions and the centralized driver-stats store, several hot paths were doing unnecessary work — especially when users had not opted into the new fields.

**What changed:**

1. **SessionBar subscriptions are gated behind their `enabled` flags.** `useSessionDrivers`, `useFocusCarIdx`, `useCarClassStats`, and `useDriverStatsStore` were running unconditionally on every SessionBar instance (up to 5 across Standings/Relative/InformationBar) regardless of whether SOF / classDrivers / driverBadge were enabled. Extracted `DriverBadgeItem`, `SofItem`, and `ClassDriversItem` into their own files — they only mount when their flag is true, so disabled fields pay nothing.

2. **`DriverStatsStoreUpdater` now caches the iRating result.** `calculateIRatingGain` is O(N²) `Math.exp` calls per class. The effect was firing on every session push because `arrayShallowCompare` invalidates whenever any driver field changes — and `CurDriverIncidentCount` flaps every few seconds. Added a fingerprint cache keyed on the inputs the calc actually depends on (`CarIdx`, `IRating`, `classPos` per non-spectator). Cache hits skip the heavy work.

3. **`setStats` bails when both records are value-equal** so it doesn't push new object identity every tick — that was forcing every downstream `useMemo` to invalidate.

4. **Memoized `useDrivers()` in `useDriverPositions.tsx`.** It was returning a new array every render, so the Relative widget's standings `useMemo` never short-circuited.

5. **Removed duplicate `augmentStandingsWithIRating` call in `useDriverPositions.tsx`.** The centralized store already populates `iratingChange` on each standing — the inline call was redoing the O(N²) work and overwriting the result. _Side effect:_ the Relative widget now correctly distinguishes starters from non-starters (matching the Standings widget). For races with no-shows, displayed iRating delta values will shift slightly to align with the actual gain rules.

6. **New `useFocusedDriver` hook** subscribes only to `{ licString, iRating, carClassID }` of the focus car with shallow equality, replacing `useSessionDrivers() + .find()` in SessionBar's render path.

7. **Extracted every remaining SessionBar item into its own memoized component.** The parent SessionBar previously held ~14 hook subscriptions at the top level — `useBrakeBias`, `useDriverIncidents`, `useSessionLapCount`, `useTrackTemperature`, `useCurrentTime`, etc. — and re-rendered at telemetry frequency regardless of which items were enabled. Each item now subscribes only to what it needs (`SessionNameItem`, `SessionTimeItem`, `SessionLapsItem`, `IncidentCountItem`, `BrakeBiasItem`, `LocalTimeItem`, `SessionClockTimeItem`, `TrackWetnessItem`, `PrecipitationItem`, `AirTemperatureItem`, `TrackTemperatureItem`, `TrackNameItem`, `WindItem`, `HumidityItem`). The parent becomes a thin layout shell wrapped in `memo()`. SessionBar.tsx: 470 → 165 lines, behavior preserved.

   _Caveat:_ `SessionTimeItem` and `SessionLapsItem` both call `useSessionLapCount` independently. When both are enabled (common in headers) the hook runs twice instead of once. A follow-up could lift its state-tracking effect into a Zustand store so it runs once globally.

8. **Restored value-equality stability for `useCarClassStats` and `useCarIdxClassEstLapTime`.** PR #493 commit f400125e (\"chore: cleanup/code fixes\") replaced the original module-level cache with a per-consumer `useMemo` keyed on the drivers reference. Since iRacing reconstructs the drivers array on every session push (incident counts flap every few seconds), the cleanup made these hooks recompute and produce fresh object identities on every push — invalidating every downstream `useMemo` and triggering re-render cascades across DriverClassHeader (Standings) plus SOF/classDrivers in 5× SessionBars.

   Switched both hooks to `useStoreWithEqualityFn` with custom value-equality functions that compare the output map field-by-field. The selector still recomputes when the session changes, but zustand returns the prior result identity when SOF/total/estLapTime values are unchanged, so consumer memos hold and the re-render cascade dies. No module-level state, idiomatic for zustand.

   This is actually **better than pre-f400125e** for the common case: that version used `shallow` equality on the output map, which couldn't see through the inner `CarClassStats` objects (always fresh identity on recompute), so it re-rendered on every drivers-ref change. The new deep value-equality catches the value-stable case and short-circuits the re-render entirely.

**Testing:** `npm test` passes (760/760, +10 new tests covering `setStats` bail-on-equal and the `DriverStatsStoreUpdater` fingerprint cache). `npm run lint` clean. **Not yet exercised in a live iRacing session** — would appreciate a sanity-check on a populated grid before merge.

## Screenshots

No visual changes — all behavior-preserving.

### Before
Same UI. SessionBar with new fields disabled still subscribed to `useSessionDrivers`, `useCarClassStats`, and `useDriverStatsStore`, re-rendering at telemetry frequency. `DriverStatsStoreUpdater` re-ran the O(N²) iRating calc on every session push regardless of whether inputs had changed. Parent SessionBar re-rendered every telemetry tick because it held all the hook subscriptions for every possible item. `useCarClassStats` and `useCarIdxClassEstLapTime` recomputed fresh identities every session push, fanning re-renders out across all consumers.

### After
Same UI. Subscriptions for the new fields only exist when those fields are enabled. iRating calc reuses the cached result when only incident counts (or other rating-irrelevant driver fields) flap. Each SessionBar item is its own memoized component subscribing only to the data it needs — disabled items pay nothing. `useCarClassStats` and `useCarIdxClassEstLapTime` keep stable identity when SOF/total/estLapTime values are unchanged, so consumer memos hold across pushes that only mutate driver fields irrelevant to the calc.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via \`npm test\`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run \`npm run lint\` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)