### PR TITLE
fix: setup comparison unavailable in settings window

### DIFF
--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -476,11 +476,7 @@ export class OverlayManager {
    * Send a message to the container window and settings window
    */
   // High-frequency messages that only the overlay container needs
-  private static readonly OVERLAY_ONLY_MESSAGES = new Set([
-    'telemetry',
-    'sessionData',
-    'runningState',
-  ]);
+  private static readonly OVERLAY_ONLY_MESSAGES = new Set(['telemetry']);
 
   public publishMessage(key: string, value: unknown): void {
     // Send to all display overlay windows

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -28,11 +28,14 @@ const isSettingsWindow = () => {
  */
 const SettingsApp = () => {
   return (
-    <HashRouter>
-      <Routes>
-        <Route path="/settings/*" element={<Settings />} />
-      </Routes>
-    </HashRouter>
+    <RunningStateProvider bridge={window.irsdkBridge}>
+      <SessionProvider bridge={window.irsdkBridge} />
+      <HashRouter>
+        <Routes>
+          <Route path="/settings/*" element={<Settings />} />
+        </Routes>
+      </HashRouter>
+    </RunningStateProvider>
   );
 };
 

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -28,11 +28,14 @@ const isSettingsWindow = () => {
  */
 const SettingsApp = () => {
   return (
-    <HashRouter>
-      <Routes>
-        <Route path="/settings/*" element={<Settings />} />
-      </Routes>
-    </HashRouter>
+    <>
+      <SessionProvider bridge={window.irsdkBridge} />
+      <HashRouter>
+        <Routes>
+          <Route path="/settings/*" element={<Settings />} />
+        </Routes>
+      </HashRouter>
+    </>
   );
 };
 


### PR DESCRIPTION
Add SessionProvider/RunningStateProvider to the settings window React tree, and remove sessionData/runningState from the overlay-only message blocklist so the settings window receives session updates.

## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

### After
<!-- Screenshot or description of the new behaviour -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [X] I have tested this in iRacing (either in an online session or with AI)
- [X] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have run `npm run lint` and fixed any issues
- [ ] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings UI now initializes with live session context from the host app, improving access to current session info.

* **Bug Fixes**
  * Settings window now receives session and running-state updates in real time (previously filtered out), improving synchronization of status and controls.
  * Other high-frequency overlay-only messages remain filtered to limit noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->