### PR TITLE
fix: align local time hook to wall-clock minute boundary

### DIFF
--- a/src/frontend/components/Standings/hooks/useCurrentTime.spec.tsx
+++ b/src/frontend/components/Standings/hooks/useCurrentTime.spec.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCurrentTime } from './useCurrentTime';
+
+const formatHHMM = (date: Date) =>
+  date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+
+describe('useCurrentTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the current wall-clock time on mount', () => {
+    const mountAt = new Date(2026, 4, 8, 12, 0, 30, 500);
+    vi.setSystemTime(mountAt);
+
+    const { result } = renderHook(() => useCurrentTime());
+
+    expect(result.current).toBe(formatHHMM(mountAt));
+  });
+
+  it('updates exactly at the next wall-clock minute boundary, not 60s after mount', () => {
+    // mount 30.5s into the minute — naive setInterval(60s) would tick at 12:01:30.5
+    // and only show "12:01" then, almost a full minute stale.
+    const mountAt = new Date(2026, 4, 8, 12, 0, 30, 500);
+    vi.setSystemTime(mountAt);
+
+    const { result } = renderHook(() => useCurrentTime());
+    expect(result.current).toBe(formatHHMM(mountAt));
+
+    // 1ms before the minute boundary — should still show 12:00.
+    act(() => {
+      vi.advanceTimersByTime(60_000 - 30_500 - 1);
+    });
+    expect(result.current).toBe(
+      formatHHMM(new Date(2026, 4, 8, 12, 0, 59, 999))
+    );
+
+    // crossing the boundary — should flip to 12:01 immediately.
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(formatHHMM(new Date(2026, 4, 8, 12, 1, 0, 0)));
+  });
+
+  it('continues to align to subsequent minute boundaries', () => {
+    const mountAt = new Date(2026, 4, 8, 12, 0, 45, 0);
+    vi.setSystemTime(mountAt);
+
+    const { result } = renderHook(() => useCurrentTime());
+
+    // 12:00 -> 12:01 at 15s elapsed
+    act(() => {
+      vi.advanceTimersByTime(15_000);
+    });
+    expect(result.current).toBe(formatHHMM(new Date(2026, 4, 8, 12, 1, 0, 0)));
+
+    // 12:01 -> 12:02 at 60s after that
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe(formatHHMM(new Date(2026, 4, 8, 12, 2, 0, 0)));
+
+    // 12:02 -> 12:03 at another 60s
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe(formatHHMM(new Date(2026, 4, 8, 12, 3, 0, 0)));
+  });
+
+  it('handles mount exactly on a minute boundary', () => {
+    const mountAt = new Date(2026, 4, 8, 12, 0, 0, 0);
+    vi.setSystemTime(mountAt);
+
+    const { result } = renderHook(() => useCurrentTime());
+    expect(result.current).toBe(formatHHMM(mountAt));
+
+    // 60_000 % 60_000 === 0, so the hook schedules the next tick 60s out.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe(formatHHMM(new Date(2026, 4, 8, 12, 1, 0, 0)));
+  });
+
+  it('clears its timeout on unmount', () => {
+    vi.setSystemTime(new Date(2026, 4, 8, 12, 0, 30, 0));
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout');
+
+    const { unmount } = renderHook(() => useCurrentTime());
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+    // After unmount, no further timers should fire — advancing time should not throw or update state.
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(5 * 60_000);
+      });
+    }).not.toThrow();
+  });
+});

--- a/src/frontend/components/Standings/hooks/useCurrentTime.tsx
+++ b/src/frontend/components/Standings/hooks/useCurrentTime.tsx
@@ -13,12 +13,17 @@ export const useCurrentTime = () => {
   );
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      // only hour / minutes
-      setTime(new Date().toLocaleTimeString([], options));
-    }, 60000);
+    let timeoutId: ReturnType<typeof setTimeout>;
 
-    return () => clearInterval(interval);
+    const tick = () => {
+      setTime(new Date().toLocaleTimeString([], options));
+      // align next tick to the next wall-clock minute boundary
+      timeoutId = setTimeout(tick, 60_000 - (Date.now() % 60_000));
+    };
+
+    timeoutId = setTimeout(tick, 60_000 - (Date.now() % 60_000));
+
+    return () => clearTimeout(timeoutId);
   }, [options]);
 
   return time;


### PR DESCRIPTION
## Description

The `useCurrentTime` hook (used by the Session Bar's "Local Time" item) ticked on a `setInterval(..., 60000)` started at mount, so the displayed minute could be up to ~60s stale. If the component mounted at e.g. `12:00:30.500`, it would only flip from `12:00` to `12:01` at `12:01:30.500` — almost a full minute behind the wall clock.

Replaced with a chained `setTimeout` that schedules the next update for `60_000 - (Date.now() % 60_000)` ms, so each tick lands on the wall-clock minute boundary.

`useSessionCurrentTime` was checked and is unaffected — it derives from `SessionTimeOfDay` telemetry that updates at 60fps.

`backgroundThrottling: false` is already set on overlay windows (`overlayManager.ts:168`, `:809`), so no visibility-change re-sync is needed.

## Screenshots

### Before
Session Bar local time could lag the system clock by up to ~60 seconds depending on when the overlay opened.

### After
Local time flips at the same instant the system clock does.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed time display to update at exact minute boundaries rather than fixed intervals, ensuring accurate hour and minute transitions
* Improved cleanup behavior to properly clear scheduled updates on component unmount

## Tests
* Added comprehensive test coverage for time synchronization, boundary conditions, and alignment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->