### PR TITLE
fix: sanitize standings/relative display order on init

### DIFF
--- a/src/frontend/components/Settings/sections/RelativeSettings.tsx
+++ b/src/frontend/components/Settings/sections/RelativeSettings.tsx
@@ -415,7 +415,16 @@ export const RelativeSettings = () => {
       (savedSettings?.config as RelativeWidgetSettings['config']) ??
       defaultConfig,
   });
-  const [itemsOrder, setItemsOrder] = useState(settings.config.displayOrder);
+  const [itemsOrder, setItemsOrder] = useState(() => {
+    const validIds = new Set(sortableSettings.map((s) => s.id));
+    const saved = settings.config.displayOrder ?? [];
+    const filtered = saved.filter((id) => validIds.has(id));
+    const present = new Set(filtered);
+    const missing = sortableSettings
+      .filter((s) => !present.has(s.id))
+      .map((s) => s.id);
+    return [...filtered, ...missing];
+  });
 
   // Tab state with persistence
   const [activeTab, setActiveTab] = useState<SettingsTabType>(

--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -525,7 +525,16 @@ export const StandingsSettings = () => {
       (savedSettings?.config as StandingsWidgetSettings['config']) ??
       defaultConfig,
   });
-  const [itemsOrder, setItemsOrder] = useState(settings.config.displayOrder);
+  const [itemsOrder, setItemsOrder] = useState(() => {
+    const validIds = new Set(sortableSettings.map((s) => s.id));
+    const saved = settings.config.displayOrder ?? [];
+    const filtered = saved.filter((id) => validIds.has(id));
+    const present = new Set(filtered);
+    const missing = sortableSettings
+      .filter((s) => !present.has(s.id))
+      .map((s) => s.id);
+    return [...filtered, ...missing];
+  });
 
   // Tab state with persistence
   const [activeTab, setActiveTab] = useState<SettingsTabType>(


### PR DESCRIPTION
## Description

When settings are added to or removed from `sortableSettings` in `StandingsSettings` / `RelativeSettings`, the saved `displayOrder` could fall out of sync with the actual options:

- **Removed** entries lingered in saved data — visually filtered at render time, but still persisted.
- **Newly added** entries never appeared in the reorderable list at all (the user had to click "Reset to Default Order" to surface them).

This change normalizes `itemsOrder` on `useState` init: filters out IDs not in `sortableSettings`, and appends any new IDs that aren't yet in the saved order. The next reorder/reset persists the cleaned list to disk.

Tested locally by running `npm run lint` on the two modified files.

## Screenshots

N/A — no visual changes.

### Before
Newly-added display settings (e.g. a future `something`) wouldn't show up in the reorderable list for users who already had a saved `displayOrder`.

### After
The reorderable list always reflects the current `sortableSettings` — old entries are dropped, new ones are appended.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display order initialization in settings to validate and normalize persisted configurations, filtering out unknown items and ensuring all expected items are included. This prevents inconsistencies and ensures the settings UI always renders a complete, valid ordering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/542)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->