### PR TITLE
fix: SectorDelta sectors squished/repeating on new session

### DIFF
--- a/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
+++ b/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTelemetryStore } from '@irdashies/context';
 
 const GAP = 4; // gap-1 = 4px
@@ -42,7 +42,14 @@ export function useCarouselWindow(
     (maxSectorsShown != null && totalSectors > maxSectorsShown);
 
   const [slotWidth, setSlotWidth] = useState(0);
-  const containerRef = useRef<HTMLDivElement>(null);
+  // Callback ref so the measure effect re-runs when the container element
+  // actually attaches. The parent returns null while sectors are empty, so
+  // a plain useRef would still be null on the first render where layout
+  // params (isWindowed, effectiveMaxShown) are stable, leaving slotWidth=0.
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    setContainer(node);
+  }, []);
   const stripRef = useRef<HTMLDivElement>(null);
 
   // When alwaysScroll is on but maxSectorsShown is unset, fit all sectors.
@@ -50,21 +57,20 @@ export function useCarouselWindow(
     maxSectorsShown ?? (isWindowed ? totalSectors : undefined);
 
   useLayoutEffect(() => {
-    if (!isWindowed || !effectiveMaxShown || !containerRef.current) return;
+    if (!isWindowed || !effectiveMaxShown || !container) return;
 
     const measure = () => {
-      if (!containerRef.current) return;
       setSlotWidth(
-        (containerRef.current.offsetWidth - (effectiveMaxShown - 1) * GAP) /
+        (container.offsetWidth - (effectiveMaxShown - 1) * GAP) /
           effectiveMaxShown
       );
     };
 
     measure();
     const ro = new ResizeObserver(measure);
-    ro.observe(containerRef.current);
+    ro.observe(container);
     return () => ro.disconnect();
-  }, [isWindowed, effectiveMaxShown]);
+  }, [isWindowed, effectiveMaxShown, container]);
 
   // Extra sectors rendered before sector 0 and after the last sector.
   // Enough to fill half the visible window so the edges are always covered.


### PR DESCRIPTION
## Description

On a new session (or app restart) the SectorDelta strip rendered with all sector cards squished and repeating until the user toggled "limit visible sectors", which forced a re-measure.

Root cause: `SectorDelta` calls `useCarouselWindow` unconditionally but returns `null` while `sectors.length === 0`, so the windowed `<div ref={containerRef}>` is not mounted on first render. The measure `useLayoutEffect` only depends on `[isWindowed, effectiveMaxShown]`. When sectors arrive, those values are typically unchanged (e.g. `alwaysScroll=true` keeps `isWindowed` true and `maxSectorsShown` is stable), so the effect never re-runs and `slotWidth` stays at 0. With `slotWidth=0` plus `flex-none`, every card collapses to its `px-2` padding and the strip transform is gated on `slotWidth !== 0`, so all buffer + sectors + buffer cards render at `translateX(0)` — the squished/repeating pattern.

Fix: use a callback ref for the container so the effect re-runs the moment the DOM node attaches. Toggle no longer required.

## Screenshots

### Before
Sectors squished and repeating immediately after joining a session / restarting the app:

<img width="331" height="79" alt="image" src="https://github.com/user-attachments/assets/bfdf33cc-7af0-4c2b-9c61-585f1731103b" />

### After
Carousel sized correctly on initial render, no toggle needed.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Carousel responsiveness enhancement: Improved internal handling of container dimension changes with real-time detection and adaptation. The carousel component now dynamically recalculates display properties and automatically adjusts item positioning when the container resizes. This ensures accurate rendering, proper alignment, and consistent visual presentation across all viewport sizes and responsive design configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/546)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->