### PR TITLE
chore: simplify reference lap logic & store reactivity

### DIFF
--- a/src/frontend/components/SectorDelta/SectorDelta.stories.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.stories.tsx
@@ -168,7 +168,6 @@ function GhostLapSeeder() {
     const ghostLap = buildMockGhostLap(GHOST_BOUNDARIES, GHOST_SECTOR_TIMES);
 
     useReferenceLapStore.setState({
-      seriesId: 1,
       trackId: 1,
       pointsCount: ghostLap.pointsCount,
       interval: ghostLap.interval,

--- a/src/frontend/components/SectorDelta/SectorDelta.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.tsx
@@ -90,9 +90,9 @@ export const SectorDelta = ({
     currentSectorIdx,
   } = useSectorDeltas();
   const isOnTrack = useTelemetryValue('IsOnTrack');
-  const { refSectorTimes, hasGhostLap } = useReferenceLapSectorTimes();
+  const { refSectorTimes, hasReferenceLap } = useReferenceLapSectorTimes();
 
-  const useGhost = ghostComparison === 'prefer-ghost' && hasGhostLap;
+  const useGhost = ghostComparison === 'prefer-ghost' && hasReferenceLap;
 
   const currentSectorStart = sectors[currentSectorIdx]?.SectorStartPct ?? 0;
   const currentSectorEnd = sectors[currentSectorIdx + 1]?.SectorStartPct ?? 1;
@@ -190,11 +190,7 @@ export const SectorDelta = ({
           ].join(' ')}
         >
           <span>
-            {isCurrent ? (
-              <LiveDelta useGhost={useGhost} dp={dp} fallback={fallback} />
-            ) : (
-              fallback
-            )}
+            {isCurrent ? <LiveDelta dp={dp} fallback={fallback} /> : fallback}
           </span>
           {isUnclean && (
             <WarningIcon

--- a/src/frontend/components/SectorDelta/components/LiveDelta.tsx
+++ b/src/frontend/components/SectorDelta/components/LiveDelta.tsx
@@ -5,15 +5,13 @@ import { useLiveSectorDelta } from '../hooks/useLiveSectorDelta';
  * don't re-render the whole widget.
  */
 export const LiveDelta = ({
-  useGhost,
   dp,
   fallback,
 }: {
-  useGhost: boolean;
   dp: number;
   fallback: string;
 }) => {
-  const liveSectorDelta = useLiveSectorDelta(useGhost);
+  const liveSectorDelta = useLiveSectorDelta();
   if (liveSectorDelta === null) return <>{fallback}</>;
   const sign = liveSectorDelta >= 0 ? '+' : '';
   return <>{`${sign}${liveSectorDelta.toFixed(dp)}`}</>;

--- a/src/frontend/components/SectorDelta/hooks/useLiveSectorDelta.ts
+++ b/src/frontend/components/SectorDelta/hooks/useLiveSectorDelta.ts
@@ -2,9 +2,9 @@ import { useMemo } from 'react';
 import {
   useSectorTimingStore,
   useSessionStore,
-  useDriverCarIdx,
   useReferenceLapStore,
   useTelemetryValueRounded,
+  useDriverCarIdx,
 } from '@irdashies/context';
 import { calculateReferenceDelta } from '../../Standings/relativeGapHelpers';
 
@@ -15,14 +15,13 @@ import { calculateReferenceDelta } from '../../Standings/relativeGapHelpers';
  * lap's interpolated elapsed time at the same track position. Positive = behind
  * the reference, negative = ahead.
  *
- * When `useGhostFile` is true, compares against the file-loaded ghost lap.
- * Otherwise compares against the player's in-session personal best only —
- * returns null until a personal best lap has been completed.
+ * Automatically selects the best available reference lap: prefers the player's
+ * in-session personal best, falling back to the class-best (ghost) lap.
  *
  * Returns null when no reference data is available or the current sector entry
  * is invalid (reset/teleport).
  */
-export const useLiveSectorDelta = (useGhostFile: boolean): number | null => {
+export const useLiveSectorDelta = (): number | null => {
   // 4dp matches the reference-lap interpolation step (REFERENCE_INTERVAL = 0.0025);
   // 2dp on SessionTime gives 10ms resolution which exceeds the 0.1s display.
   const lapDistPct = useTelemetryValueRounded('LapDistPct', 4) ?? 0;
@@ -32,6 +31,7 @@ export const useLiveSectorDelta = (useGhostFile: boolean): number | null => {
   const sectorEntryValid = useSectorTimingStore((s) => s.sectorEntryValid);
   const currentSectorIdx = useSectorTimingStore((s) => s.currentSectorIdx);
   const sectors = useSectorTimingStore((s) => s.sectors);
+  const getReferenceLap = useReferenceLapStore((s) => s.getReferenceLap);
 
   const playerCarIdx = useDriverCarIdx();
   const playerClassId = useSessionStore((s) => {
@@ -40,21 +40,11 @@ export const useLiveSectorDelta = (useGhostFile: boolean): number | null => {
     return drivers?.find((d) => d.CarIdx === carIdx)?.CarClassID ?? null;
   });
 
-  // Subscribe to these so the memo re-runs when a ghost lap is loaded or the
-  // session resets — the actual lap data is accessed via getState() below.
-  const persistedLapsVersion = useReferenceLapStore(
-    (s) => s.persistedLapsVersion
-  );
-  const seriesId = useReferenceLapStore((s) => s.seriesId);
-
   return useMemo(() => {
     if (!sectorEntryValid) return null;
     if (playerCarIdx == null || playerClassId == null) return null;
 
-    const state = useReferenceLapStore.getState();
-    const refLap = useGhostFile
-      ? state.getReferenceLap(playerCarIdx, playerClassId, true)
-      : state.bestLaps.get(playerCarIdx);
+    const refLap = getReferenceLap(playerCarIdx, playerClassId, false);
 
     if (!refLap || refLap.finishTime < 0) return null;
 
@@ -67,21 +57,15 @@ export const useLiveSectorDelta = (useGhostFile: boolean): number | null => {
     const playerElapsed = sessionTime - sectorEntryTime;
 
     return playerElapsed - ghostElapsed;
-    // persistedLapsVersion and seriesId are intentionally included as deps even
-    // though they're not used directly — they trigger re-computation when ghost
-    // lap data changes or the session resets.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    sectorEntryValid,
+    playerCarIdx,
+    playerClassId,
+    getReferenceLap,
+    sectors,
+    currentSectorIdx,
     lapDistPct,
     sessionTime,
     sectorEntryTime,
-    sectorEntryValid,
-    currentSectorIdx,
-    sectors,
-    playerCarIdx,
-    playerClassId,
-    persistedLapsVersion,
-    seriesId,
-    useGhostFile,
   ]);
 };

--- a/src/frontend/components/TrackMap/hooks/useGhostSectorColors.tsx
+++ b/src/frontend/components/TrackMap/hooks/useGhostSectorColors.tsx
@@ -19,7 +19,7 @@ export const useGhostSectorColors = (): SectorColor[] | null => {
     (w) => w.id === 'sectordelta'
   )?.config as SectorDeltaConfig | undefined;
 
-  const { refSectorTimes, hasGhostLap } = useReferenceLapSectorTimes();
+  const { refSectorTimes, hasReferenceLap } = useReferenceLapSectorTimes();
   const sectors = useSectorTimingStore((s) => s.sectors);
   const currentSectorIdx = useSectorTimingStore((s) => s.currentSectorIdx);
   const currentLapSectorTimes = useSectorTimingStore(
@@ -33,7 +33,7 @@ export const useGhostSectorColors = (): SectorColor[] | null => {
     if (
       (sectorDeltaConfig?.ghostComparison ?? 'prefer-ghost') !==
         'prefer-ghost' ||
-      !hasGhostLap
+      !hasReferenceLap
     ) {
       return null;
     }
@@ -51,7 +51,7 @@ export const useGhostSectorColors = (): SectorColor[] | null => {
   }, [
     sectorDeltaConfig?.ghostComparison,
     sectorDeltaConfig?.thresholds,
-    hasGhostLap,
+    hasReferenceLap,
     sectors,
     currentSectorIdx,
     currentLapSectorTimes,

--- a/src/frontend/context/ReferenceLapStore/ReferenceLapStore.bench.spec.ts
+++ b/src/frontend/context/ReferenceLapStore/ReferenceLapStore.bench.spec.ts
@@ -14,13 +14,10 @@ describe('ReferenceLapStore Benchmark', () => {
     // We only need to serialize the metadata keys as completeSession() handles clearing maps.
     const state = useReferenceLapStore.getState();
     initialState = {
-      seriesId: state.seriesId,
       trackId: state.trackId,
       trackLength: state.trackLength,
       pointsCount: state.pointsCount,
       interval: state.interval,
-      persistedLapsVersion: state.persistedLapsVersion,
-      fileLoadedClassIds: new Set(state.fileLoadedClassIds),
     } as ReferenceRegistryState;
   });
 
@@ -45,7 +42,6 @@ describe('ReferenceLapStore Benchmark', () => {
     useReferenceLapStore.setState({
       pointsCount,
       interval,
-      seriesId: 1,
       trackId: 1,
     });
 
@@ -71,6 +67,7 @@ describe('ReferenceLapStore Benchmark', () => {
         .getState()
         .collectBulkData(
           bridge,
+          1,
           drivers,
           carIdxLapDistPct,
           carIdxOnPitRoad,

--- a/src/frontend/context/ReferenceLapStore/ReferenceLapStore.spec.tsx
+++ b/src/frontend/context/ReferenceLapStore/ReferenceLapStore.spec.tsx
@@ -64,7 +64,6 @@ describe('ReferenceLapStore', () => {
         .initialize(mockBridge as ReferenceLapBridge, 100, 200, 1000, [1]);
 
       const state = useReferenceLapStore.getState();
-      expect(state.seriesId).toBe(100);
       expect(state.trackId).toBe(200);
       expect(state.persistedLaps.get(1)).toEqual(mockLap);
     });
@@ -73,6 +72,7 @@ describe('ReferenceLapStore', () => {
   describe('collectBulkData', () => {
     const carIdx = 5;
     const classId = 1;
+    const seriesId = 100;
     const drivers = [{ CarIdx: carIdx, CarClassID: classId }];
 
     beforeEach(() => {
@@ -93,6 +93,7 @@ describe('ReferenceLapStore', () => {
 
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists,
         pits,
@@ -117,6 +118,7 @@ describe('ReferenceLapStore', () => {
       // 1. First call initializes
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists,
         pits,
@@ -126,6 +128,7 @@ describe('ReferenceLapStore', () => {
       // 2. Second call (same bucket) should store if clean
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists,
         pits,
@@ -142,7 +145,7 @@ describe('ReferenceLapStore', () => {
     });
 
     it('should populate pointPos for the initial bucket when a lap is completed and a new one starts', () => {
-      useReferenceLapStore.setState({ seriesId: 1, trackId: 1 });
+      useReferenceLapStore.setState({ trackId: 1 });
       const store = useReferenceLapStore.getState();
 
       const dists1 = [];
@@ -157,6 +160,7 @@ describe('ReferenceLapStore', () => {
       // 1. Start a lap
       store.collectBulkData(
         mockBridge as unknown as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists1,
         pits,
@@ -174,6 +178,7 @@ describe('ReferenceLapStore', () => {
       // 2. Cross the line
       store.collectBulkData(
         mockBridge as unknown as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists2,
         pits,
@@ -181,6 +186,7 @@ describe('ReferenceLapStore', () => {
       );
       store.collectBulkData(
         mockBridge as unknown as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists3,
         pits,
@@ -206,6 +212,7 @@ describe('ReferenceLapStore', () => {
         .getState()
         .collectBulkData(
           mockBridge as ReferenceLapBridge,
+          seriesId,
           drivers,
           dists,
           pits,
@@ -233,6 +240,7 @@ describe('ReferenceLapStore', () => {
       expect(() => {
         store.collectBulkData(
           mockBridge as ReferenceLapBridge,
+          seriesId,
           sparseDrivers as { CarIdx: number; CarClassID: number }[],
           dists,
           pits,
@@ -256,6 +264,7 @@ describe('ReferenceLapStore', () => {
       // 1. Initial point
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists1,
         pits,
@@ -265,6 +274,7 @@ describe('ReferenceLapStore', () => {
       // 2. Point with a gap
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists2,
         pits,
@@ -290,6 +300,7 @@ describe('ReferenceLapStore', () => {
         .getState()
         .collectBulkData(
           mockBridge as ReferenceLapBridge,
+          seriesId,
           drivers,
           dists1,
           pits1,
@@ -301,6 +312,7 @@ describe('ReferenceLapStore', () => {
         .getState()
         .collectBulkData(
           mockBridge as ReferenceLapBridge,
+          seriesId,
           drivers,
           dists2,
           pits2,
@@ -312,7 +324,7 @@ describe('ReferenceLapStore', () => {
     });
 
     it('should complete a lap and save it if it is the new best clean lap', async () => {
-      useReferenceLapStore.setState({ seriesId: 1, trackId: 1 });
+      useReferenceLapStore.setState({ trackId: 1 });
       const store = useReferenceLapStore.getState();
 
       const dists1 = [];
@@ -327,6 +339,7 @@ describe('ReferenceLapStore', () => {
       // 1. Start a lap near the start
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists1,
         pits,
@@ -346,6 +359,7 @@ describe('ReferenceLapStore', () => {
       // 2. Get near the end
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists2,
         pits,
@@ -355,6 +369,7 @@ describe('ReferenceLapStore', () => {
       // 3. Cross the line (0.96 -> 0.01)
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists3,
         pits,
@@ -383,6 +398,7 @@ describe('ReferenceLapStore', () => {
       // Start dirty (far from start line)
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists1,
         pits,
@@ -392,6 +408,7 @@ describe('ReferenceLapStore', () => {
       // Get near the end
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists2,
         pits,
@@ -401,6 +418,7 @@ describe('ReferenceLapStore', () => {
       // Complete lap
       store.collectBulkData(
         mockBridge as ReferenceLapBridge,
+        seriesId,
         drivers,
         dists3,
         pits,
@@ -415,13 +433,13 @@ describe('ReferenceLapStore', () => {
   describe('completeSession', () => {
     it('should reset all maps and IDs', () => {
       useReferenceLapStore.getState().activeLaps.set(1, {} as ReferenceLap);
-      useReferenceLapStore.setState({ seriesId: 50 });
+      useReferenceLapStore.setState({ trackId: 50 });
 
       useReferenceLapStore.getState().completeSession();
 
       const state = useReferenceLapStore.getState();
       expect(state.activeLaps.size).toBe(0);
-      expect(state.seriesId).toBeNull();
+      expect(state.trackId).toBeNull();
       expect(state.bestLaps.size).toBe(0);
     });
   });

--- a/src/frontend/context/ReferenceLapStore/ReferenceLapStore.tsx
+++ b/src/frontend/context/ReferenceLapStore/ReferenceLapStore.tsx
@@ -73,20 +73,10 @@ export interface ReferenceRegistryState {
   activeLaps: Map<number, ReferenceLap>;
   bestLaps: Map<number, ReferenceLap>;
   persistedLaps: Map<number, ReferenceLap>;
-  seriesId: number | null;
   trackId: number | null;
   trackLength: number | null;
   interval: number;
   pointsCount: number;
-  /** Incremented each time persisted laps finish loading so subscribers re-run. */
-  persistedLapsVersion: number;
-  /**
-   * Class IDs for which a ghost lap was loaded from disk during initialize().
-   * In-session laps promoted to persistedLaps are NOT included here. Used by
-   * useReferenceLapSectorTimes to show the ghost icon only when a saved file
-   * is present, not for newly-completed in-session laps.
-   */
-  fileLoadedClassIds: Set<number>;
 
   /**
    * Bootstraps the store at the start of a session by loading previously saved
@@ -106,6 +96,7 @@ export interface ReferenceRegistryState {
    */
   collectBulkData: (
     bridge: ReferenceLapBridge,
+    seriesId: number,
     drivers: { CarIdx: number; CarClassID: number }[],
     carIdxLapDistPct: number[],
     carIdxOnPitRoad: boolean[],
@@ -140,20 +131,14 @@ export const useReferenceLapStore = create<ReferenceRegistryState>(
     activeLaps: new Map<number, ReferenceLap>(),
     bestLaps: new Map<number, ReferenceLap>(),
     persistedLaps: new Map<number, ReferenceLap>(),
-    seriesId: null,
     trackId: null,
     trackLength: null,
     interval: 0,
     pointsCount: 0,
-    persistedLapsVersion: 0,
-    fileLoadedClassIds: new Set<number>(),
 
     initialize: async (bridge, seriesId, trackId, trackLength, classList) => {
       const pointsCount = Math.ceil(trackLength / TARGET_SPACING_METERS);
       const interval = parseFloat((1 / pointsCount).toFixed(6));
-
-      set({ seriesId, trackId, trackLength, pointsCount, interval });
-      const { persistedLaps } = get();
 
       const results = await Promise.all(
         classList.map(async (classId) => {
@@ -175,25 +160,27 @@ export const useReferenceLapStore = create<ReferenceRegistryState>(
         })
       );
 
-      // Mutate persistedLaps in place to avoid triggering Zustand subscriptions
-      // on each lap, then fire a single notification so hooks re-run once all
-      // laps are ready. Build a new Set for fileLoadedClassIds so selectors
-      // that depend on it re-run after initialization completes.
-      const newFileLoadedClassIds = new Set<number>();
+      const newPersistedLaps = new Map<number, ReferenceLap>();
       results.forEach(({ classId, lap }) => {
         if (lap) {
-          persistedLaps.set(classId, lap);
-          newFileLoadedClassIds.add(classId);
+          newPersistedLaps.set(classId, lap);
         }
       });
-      set((s) => ({
-        persistedLapsVersion: s.persistedLapsVersion + 1,
-        fileLoadedClassIds: newFileLoadedClassIds,
-      }));
+
+      set({
+        trackId,
+        trackLength,
+        pointsCount,
+        interval,
+        persistedLaps: newPersistedLaps,
+        activeLaps: new Map<number, ReferenceLap>(),
+        bestLaps: new Map<number, ReferenceLap>(),
+      });
     },
 
     collectBulkData: (
       bridge,
+      seriesId,
       drivers,
       carIdxLapDistPct,
       carIdxOnPitRoad,
@@ -204,7 +191,6 @@ export const useReferenceLapStore = create<ReferenceRegistryState>(
         activeLaps,
         bestLaps,
         persistedLaps,
-        seriesId,
         trackId,
         pointsCount,
         interval,
@@ -294,7 +280,7 @@ export const useReferenceLapStore = create<ReferenceRegistryState>(
 
                 persistedLaps.set(classId, refLap);
 
-                if (seriesId !== null && trackId !== null) {
+                if (seriesId !== -1 && trackId !== null) {
                   bridge
                     .saveReferenceLap(seriesId, trackId, classId, refLap)
                     .catch((err: Error) => {
@@ -376,12 +362,10 @@ export const useReferenceLapStore = create<ReferenceRegistryState>(
         activeLaps: new Map<number, ReferenceLap>(),
         bestLaps: new Map<number, ReferenceLap>(),
         persistedLaps: new Map<number, ReferenceLap>(),
-        seriesId: null,
         trackId: null,
         trackLength: null,
         interval: 0,
         pointsCount: 0,
-        fileLoadedClassIds: new Set<number>(),
       });
     },
   })

--- a/src/frontend/context/ReferenceLapStore/ReferenceLapStoreUpdater.spec.tsx
+++ b/src/frontend/context/ReferenceLapStore/ReferenceLapStoreUpdater.spec.tsx
@@ -17,7 +17,6 @@ describe('useReferenceLapStoreUpdater', () => {
     useReferenceLapStore.getState().completeSession();
     // Initialize store state
     useReferenceLapStore.setState({
-      seriesId: -1,
       trackId: -1,
     });
   });

--- a/src/frontend/context/ReferenceLapStore/ReferenceLapStoreUpdater.tsx
+++ b/src/frontend/context/ReferenceLapStore/ReferenceLapStoreUpdater.tsx
@@ -113,7 +113,7 @@ export const useReferenceLapStoreUpdater = (bridge: ReferenceLapBridge) => {
         time > -1 &&
         s.drivers.length > 0
       ) {
-        collectBulkData(bridge, s.drivers, dists, pits, time);
+        collectBulkData(bridge, s.seriesId, s.drivers, dists, pits, time);
       }
     });
 

--- a/src/frontend/context/SectorTimingStore/SectorTimingStore.tsx
+++ b/src/frontend/context/SectorTimingStore/SectorTimingStore.tsx
@@ -501,7 +501,10 @@ export const useSectorTimingStore = create<SectorTimingState>((set, get) => ({
     });
   },
 
-  setTrackIncidentSectors: (v: boolean) => set({ trackIncidentSectors: v }),
+  setTrackIncidentSectors: (v: boolean) => {
+    if (get().trackIncidentSectors === v) return;
+    set({ trackIncidentSectors: v });
+  },
 
   reset: () =>
     set((state) => ({

--- a/src/frontend/context/shared/useReferenceLapSectorTimes.ts
+++ b/src/frontend/context/shared/useReferenceLapSectorTimes.ts
@@ -7,11 +7,10 @@ import { interpolateAtPoint } from '../../components/Standings/interpolation';
 /**
  * Derives per-sector times from the persisted (ghost) reference lap for the
  * player's car class.  Returns the sector times and a flag indicating whether a
- * ghost file is actually loaded from disk.
+ * valid reference lap is available.
  *
- * hasGhostLap is only true when initialize() found and loaded a saved ghost
- * file for the player's class. In-session laps promoted to persistedLaps are
- * NOT counted — use the ghost icon only for file-backed reference laps.
+ * hasReferenceLap is true when a valid reference lap (either loaded from disk
+ * or created in-session) is available for comparison.
  *
  * Sector times are computed by interpolating the reference lap's
  * timeElapsedSinceStart at each sector-boundary trackPct, then diffing
@@ -19,7 +18,7 @@ import { interpolateAtPoint } from '../../components/Standings/interpolation';
  */
 export const useReferenceLapSectorTimes = (): {
   refSectorTimes: (number | null)[];
-  hasGhostLap: boolean;
+  hasReferenceLap: boolean;
 } => {
   const playerCarIdx = useDriverCarIdx();
 
@@ -32,35 +31,30 @@ export const useReferenceLapSectorTimes = (): {
   const sectors = useSectorTimingStore((s) => s.sectors);
 
   // Subscribe so we recompute once persisted laps finish loading asynchronously.
-  // seriesId is also included to clear the ghost row when a session resets.
-  const seriesId = useReferenceLapStore((s) => s.seriesId);
-  const persistedLapsVersion = useReferenceLapStore(
-    (s) => s.persistedLapsVersion
+  // We use a selector for the lap itself so we re-run when the lap object
+  // reference changes (e.g. after async load or in-session promotion).
+  const refLap = useReferenceLapStore((s) =>
+    playerCarIdx != null && playerClassId != null
+      ? s.getReferenceLap(playerCarIdx, playerClassId, true)
+      : null
   );
 
-  // Only classes that had a ghost file loaded from disk — not in-session laps.
-  const fileLoadedClassIds = useReferenceLapStore((s) => s.fileLoadedClassIds);
-
   return useMemo(() => {
-    if (playerCarIdx == null || playerClassId == null || sectors.length === 0) {
-      return { refSectorTimes: [], hasGhostLap: false };
+    if (
+      playerCarIdx == null ||
+      playerClassId == null ||
+      sectors.length === 0 ||
+      !refLap
+    ) {
+      return { refSectorTimes: [], hasReferenceLap: false };
     }
-
-    // Only show ghost comparison when a file was explicitly loaded from disk.
-    if (!fileLoadedClassIds.has(playerClassId)) {
-      return { refSectorTimes: [], hasGhostLap: false };
-    }
-
-    const refLap = useReferenceLapStore
-      .getState()
-      .getReferenceLap(playerCarIdx, playerClassId, true);
 
     if (refLap.startTime < 0 || refLap.pointsCount === 0) {
-      return { refSectorTimes: [], hasGhostLap: false };
+      return { refSectorTimes: [], hasReferenceLap: false };
     }
 
     const lapTime = refLap.finishTime - refLap.startTime;
-    if (lapTime <= 0) return { refSectorTimes: [], hasGhostLap: false };
+    if (lapTime <= 0) return { refSectorTimes: [], hasReferenceLap: false };
 
     // Time elapsed at each sector's start boundary.
     // Sector 0 always begins at the S/F line (elapsed = 0).
@@ -76,18 +70,7 @@ export const useReferenceLapSectorTimes = (): {
       return end - start;
     });
 
-    return { refSectorTimes, hasGhostLap: true };
-    // seriesId clears the ghost row when the session resets.
-    // persistedLapsVersion increments after the async load in initialize()
-    // completes, ensuring the memo re-runs once laps are actually available.
-    // fileLoadedClassIds changes when initialize() finds a file lap.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    playerCarIdx,
-    playerClassId,
-    sectors,
-    seriesId,
-    persistedLapsVersion,
-    fileLoadedClassIds,
-  ]);
+    return { refSectorTimes, hasReferenceLap: true };
+    // refLap selector triggers re-run if the reference lap object changes.
+  }, [playerCarIdx, playerClassId, sectors, refLap]);
 };


### PR DESCRIPTION
## Description

Refactored the SectorDelta widget and ReferenceLapStore to simplify reference lap selection and improve store reactivity.

- Automatic Reference Selection: useLiveSectorDelta now automatically picks the best reference lap (Session Best -> Class Best/Ghost).
- Store Refactoring: Simplified ReferenceLapStore by removing redundant state (seriesId, persistedLapsVersion, fileLoadedClassIds).
- Performance & Reactivity: Replaced manual getState calls with proper Zustand selectors.
- Optimization: Prevented unnecessary re-renders in SectorTimingStore.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Performance improvement
- [x] Refactoring

## Checklist

- [x] I have tested this in iRacing
- [x] All tests pass locally via npm test
- [x] I have run npm run lint
- [x] I have performed a self-review
- [x] I have added/updated Storybook stories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified ghost lap reference selection to automatically choose the best available comparison lap.
  * Refined reference lap comparison logic to improve lap timing calculations and consistency across sectors.
  * Enhanced sector timing updates to prevent redundant state changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->