### PR TITLE
fix: site download button points to latest release

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
     paths:
       - 'site/**'
-      - 'src/frontend/utils/**'
-      - 'src/frontend/context/**'
-      - 'src/types/**'
   workflow_dispatch:
 
 permissions:

--- a/site/src/sections/Hero.tsx
+++ b/site/src/sections/Hero.tsx
@@ -1,10 +1,52 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { DownloadSimple, CaretDown } from '@phosphor-icons/react';
 
 const SPEED_LINE_WIDTHS = [112, 167, 93, 185, 140, 158];
 
+const RELEASES_PAGE_URL = 'https://github.com/tariknz/irdashies/releases';
+const LATEST_RELEASE_API_URL =
+  'https://api.github.com/repos/tariknz/irdashies/releases/latest';
+const DOWNLOAD_URL_CACHE_KEY = 'irdashies:latest-setup-url';
+
+function useLatestSetupUrl() {
+  const [url, setUrl] = useState<string>(() => {
+    if (typeof window === 'undefined') return RELEASES_PAGE_URL;
+    return (
+      window.sessionStorage.getItem(DOWNLOAD_URL_CACHE_KEY) ?? RELEASES_PAGE_URL
+    );
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(LATEST_RELEASE_API_URL);
+        if (!res.ok) return;
+        const data: {
+          assets?: { name: string; browser_download_url: string }[];
+        } = await res.json();
+        const setup = data.assets?.find((a) => a.name.endsWith('.Setup.exe'));
+        if (!setup || cancelled) return;
+        setUrl(setup.browser_download_url);
+        window.sessionStorage.setItem(
+          DOWNLOAD_URL_CACHE_KEY,
+          setup.browser_download_url
+        );
+      } catch {
+        // Keep fallback URL.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return url;
+}
+
 export function Hero() {
   const speedLineWidths = useMemo(() => SPEED_LINE_WIDTHS, []);
+  const downloadUrl = useLatestSetupUrl();
 
   return (
     <section className="relative min-h-[90vh] flex items-center justify-center overflow-hidden">
@@ -66,7 +108,7 @@ export function Hero() {
         <div className="flex flex-col items-center gap-2">
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
-              href="https://github.com/tariknz/irdashies/releases/download/v0.3.0/irdashies-0.3.0.Setup.exe"
+              href={downloadUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 px-8 py-3 bg-red-600 hover:bg-red-700 text-white font-bold uppercase tracking-wide text-sm rounded-sm transition-colors"
@@ -83,7 +125,7 @@ export function Hero() {
             </a>
           </div>
           <a
-            href="https://github.com/tariknz/irdashies/releases"
+            href={RELEASES_PAGE_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-slate-500 hover:text-slate-300 underline transition-colors"


### PR DESCRIPTION
## Description

The Hero download button on the marketing site was hardcoded to `v0.3.0/irdashies-0.3.0.Setup.exe` and went stale every time we ship a new version (currently `v0.3.3`). Since `deploy-site.yml` only runs on `site/**` changes, a release alone doesn't refresh it.

Hero now fetches `releases/latest` from the GitHub API on mount, picks the `.Setup.exe` asset, and uses its `browser_download_url`. The URL is cached in `sessionStorage` so repeated visits within a session skip the API call. If the fetch fails or hasn't returned yet, the button falls back to `/releases` (instead of a dead versioned link).

Also dropped `src/frontend/utils/**`, `src/frontend/context/**`, and `src/types/**` from `deploy-site.yml`'s trigger paths — the site doesn't import from those locations, so changes there shouldn't trigger a Pages redeploy.

## Screenshots

### Before
Download button → `releases/download/v0.3.0/irdashies-0.3.0.Setup.exe` (stale).

### After
Download button → latest release's `.Setup.exe` resolved at runtime; falls back to `/releases` page.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Download link now dynamically retrieves and points to the latest release installer, ensuring users always access the most recent version.

* **Bug Fixes**
  * Improved robustness with fallback to releases page when latest installer cannot be determined.

* **Chores**
  * Updated deployment workflow configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->