### PR TITLE
fix: throttle posthog log transport to avoid event floods

### DIFF
--- a/src/app/analytics.spec.ts
+++ b/src/app/analytics.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { LogMessage } from 'electron-log';
+import type { EventMessage, IdentifyMessage } from 'posthog-node';
+
+vi.mock('electron', () => ({
+  screen: {
+    getAllDisplays: vi.fn().mockReturnValue([]),
+    getPrimaryDisplay: vi
+      .fn()
+      .mockReturnValue({ size: { width: 0, height: 0 } }),
+  },
+}));
+
+const { loggerStub } = vi.hoisted(() => ({
+  loggerStub: {
+    transports: {
+      file: { level: 'info', maxSize: 0 },
+      console: { level: 'debug' },
+    } as Record<string, unknown>,
+    initialize: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('electron-log/main', () => ({
+  default: loggerStub,
+}));
+
+vi.mock('./storage/storage', () => ({
+  readData: vi.fn(),
+  writeData: vi.fn(),
+}));
+
+vi.mock('./storage/analytics', () => ({
+  getAnalyticsOptOut: vi.fn().mockReturnValue(true),
+}));
+
+import { Analytics, type AnalyticsProvider } from './analytics';
+import logger from './logger';
+
+const makeProvider = () => ({
+  capture: vi.fn<(event: EventMessage) => void>(),
+  identify: vi.fn<(message: IdentifyMessage) => void>(),
+  shutdown: vi.fn<(shutdownTimeoutMs?: number) => void>(),
+});
+
+const emit = (level: LogMessage['level'], ...data: unknown[]): void => {
+  const transport = logger.transports.posthog as unknown as (
+    msg: LogMessage
+  ) => void;
+  transport({ level, data, date: new Date() } as LogMessage);
+};
+
+describe('Analytics.setupLogTransport', () => {
+  let provider: ReturnType<typeof makeProvider>;
+  let analytics: Analytics;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    provider = makeProvider();
+    analytics = new Analytics(provider);
+    analytics.setupLogTransport();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete logger.transports.posthog;
+  });
+
+  it('forwards a log message to the provider', () => {
+    emit('warn', 'something went wrong');
+    expect(provider.capture).toHaveBeenCalledWith({
+      event: 'log_message',
+      properties: { level: 'warn', message: 'something went wrong' },
+    });
+  });
+
+  it('suppresses identical messages within the dedup window', () => {
+    emit('warn', 'flooded message');
+    vi.advanceTimersByTime(30 * 60 * 1000);
+    emit('warn', 'flooded message');
+    expect(provider.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-emits an identical message after the dedup window elapses', () => {
+    emit('warn', 'flooded message');
+    vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+    emit('warn', 'flooded message');
+    expect(provider.capture).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats the same text at different levels as distinct', () => {
+    emit('warn', 'same text');
+    emit('error', 'same text');
+    expect(provider.capture).toHaveBeenCalledTimes(2);
+  });
+
+  it('keys on the first 30 characters — messages sharing that prefix collide', () => {
+    const prefix = 'a'.repeat(30);
+    emit('warn', `${prefix}-foo`);
+    emit('warn', `${prefix}-bar`);
+    expect(provider.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('stringifies non-string log data', () => {
+    emit('warn', 'context:', { code: 42 });
+    expect(provider.capture).toHaveBeenCalledWith({
+      event: 'log_message',
+      properties: { level: 'warn', message: 'context: {"code":42}' },
+    });
+  });
+
+  it('does nothing when the provider is absent', () => {
+    const noopAnalytics = new Analytics(provider);
+    // Force provider to null by going through the public surface
+    (
+      noopAnalytics as unknown as { provider: AnalyticsProvider | null }
+    ).provider = null;
+    delete logger.transports.posthog;
+    noopAnalytics.setupLogTransport();
+    expect(logger.transports.posthog).toBeUndefined();
+  });
+});

--- a/src/app/analytics.ts
+++ b/src/app/analytics.ts
@@ -99,10 +99,20 @@ export class Analytics {
   setupLogTransport(): void {
     if (!this.provider) return;
 
+    const DEDUP_WINDOW_MS = 60 * 60 * 1000;
+    const DEDUP_KEY_LENGTH = 30;
+    const lastSent = new Map<string, number>();
+
     const transport = ((message: LogMessage) => {
       const text = message.data
         .map((d: unknown) => (typeof d === 'string' ? d : JSON.stringify(d)))
         .join(' ');
+
+      const key = `${message.level}:${text.slice(0, DEDUP_KEY_LENGTH)}`;
+      const now = Date.now();
+      const last = lastSent.get(key);
+      if (last !== undefined && now - last < DEDUP_WINDOW_MS) return;
+      lastSent.set(key, now);
 
       // Not the nicest way to do this, but avoids having to implement OTEL to get logging in posthog
       this.capture({

--- a/src/app/analytics.ts
+++ b/src/app/analytics.ts
@@ -12,6 +12,10 @@ import type { LogMessage } from 'electron-log';
 
 declare const POSTHOG_KEY: string;
 
+const DEDUP_WINDOW_MS = 60 * 60 * 1000;
+const DEDUP_KEY_LENGTH = 30;
+const DEDUP_MAX_ENTRIES = 5000;
+
 export interface AnalyticsProvider {
   capture(event: EventMessage): void;
   identify(message: IdentifyMessage): void;
@@ -99,8 +103,6 @@ export class Analytics {
   setupLogTransport(): void {
     if (!this.provider) return;
 
-    const DEDUP_WINDOW_MS = 60 * 60 * 1000;
-    const DEDUP_KEY_LENGTH = 30;
     const lastSent = new Map<string, number>();
 
     const transport = ((message: LogMessage) => {
@@ -113,6 +115,12 @@ export class Analytics {
       const last = lastSent.get(key);
       if (last !== undefined && now - last < DEDUP_WINDOW_MS) return;
       lastSent.set(key, now);
+
+      if (lastSent.size > DEDUP_MAX_ENTRIES) {
+        for (const [k, t] of lastSent) {
+          if (now - t >= DEDUP_WINDOW_MS) lastSent.delete(k);
+        }
+      }
 
       // Not the nicest way to do this, but avoids having to implement OTEL to get logging in posthog
       this.capture({


### PR DESCRIPTION
## Description

`Analytics.setupLogTransport` forwards every `warn`/`error` log to PostHog with no rate limiting. Errors that fire on every retry (e.g. `getSessionData` failing to parse the iRacing session YAML — the `YAMLException` carries the full ~70KB buffer as part of its serialized payload) can flood PostHog with massive duplicate events.

This adds a simple dedup-with-cooldown inside the transport:

- Key = `level` + first 30 chars of the joined message
- Drops any matching event seen within the last 1 hour
- Full message is still sent on the first occurrence — no call-site changes needed

For the session YAML case the key becomes `error:There was an error getting s`, so the same error caps at one event per hour regardless of how varied the embedded YAML buffer is.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic de-duplication of log messages in analytics to reduce redundant event logging within a configured time window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/555?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->