### PR TITLE
feat: show edge distance labels in widget edit mode

### DIFF
--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -20,6 +20,7 @@ import { SlowCarAhead } from './components/SlowCarAhead/SlowCarAhead';
 import { SectorDelta } from './components/SectorDelta/SectorDelta';
 import { Wind } from './components/Wind';
 import { WeatherHorizontal } from './components/WeatherHorizontal';
+import { InputTrace } from './components/InputTrace';
 import type { WidgetConfigMap } from '@irdashies/types';
 
 export {
@@ -45,6 +46,7 @@ export {
   SectorDelta,
   Wind,
   WeatherHorizontal,
+  InputTrace,
 };
 
 // TODO: type this better, right now the config comes from settings
@@ -76,6 +78,7 @@ export const WIDGET_MAP: Record<
   sectordelta: SectorDelta,
   wind: Wind,
   weatherhorizontal: WeatherHorizontal,
+  inputtrace: InputTrace,
 };
 
 export type WidgetId = keyof WidgetConfigMap;

--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -18,6 +18,8 @@ import { LapTimeLog } from './components/LapTimeLog/LapTimeLog';
 import { InformationBar } from './components/InformationBar/InformationBar';
 import { SlowCarAhead } from './components/SlowCarAhead/SlowCarAhead';
 import { SectorDelta } from './components/SectorDelta/SectorDelta';
+import { Wind } from './components/Wind';
+import { WeatherHorizontal } from './components/WeatherHorizontal';
 import type { WidgetConfigMap } from '@irdashies/types';
 
 export {
@@ -41,6 +43,8 @@ export {
   InformationBar,
   SlowCarAhead,
   SectorDelta,
+  Wind,
+  WeatherHorizontal,
 };
 
 // TODO: type this better, right now the config comes from settings
@@ -70,6 +74,8 @@ export const WIDGET_MAP: Record<
   infobar: InformationBar,
   slowcarahead: SlowCarAhead,
   sectordelta: SectorDelta,
+  wind: Wind,
+  weatherhorizontal: WeatherHorizontal,
 };
 
 export type WidgetId = keyof WidgetConfigMap;

--- a/src/frontend/components/InputTrace/InputTrace.stories.tsx
+++ b/src/frontend/components/InputTrace/InputTrace.stories.tsx
@@ -1,0 +1,28 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { InputTrace } from './InputTrace';
+import { TelemetryDecorator } from '@irdashies/storybook';
+
+const meta: Meta<typeof InputTrace> = {
+  component: InputTrace,
+  title: 'widgets/InputTrace',
+  decorators: [TelemetryDecorator()],
+};
+export default meta;
+
+type Story = StoryObj<typeof InputTrace>;
+
+export const Primary: Story = {
+  render: () => (
+    <div className="h-[70px] w-[396px]">
+      <InputTrace />
+    </div>
+  ),
+};
+
+export const Tall: Story = {
+  render: () => (
+    <div className="h-[120px] w-[600px]">
+      <InputTrace />
+    </div>
+  ),
+};

--- a/src/frontend/components/InputTrace/InputTrace.tsx
+++ b/src/frontend/components/InputTrace/InputTrace.tsx
@@ -1,0 +1,36 @@
+import { useDrivingState, useSessionVisibility } from '@irdashies/context';
+import { useInputs } from '../Input/hooks/useInputs';
+import { InputTrace as InputTraceViz } from '../Input/InputTrace/InputTrace';
+import { useInputTraceSettings } from './hooks/useInputTraceSettings';
+
+export const InputTrace = () => {
+  const settings = useInputTraceSettings();
+  const inputs = useInputs(settings?.useRawValues ?? false);
+  const { isDriving } = useDrivingState();
+
+  if (!useSessionVisibility(settings?.sessionVisibility)) return <></>;
+
+  if (!settings) return <></>;
+
+  if (settings.showOnlyWhenOnTrack && !isDriving) return <></>;
+
+  return (
+    <div
+      className="w-full h-full p-2 rounded-md bg-slate-800/(--bg-opacity) [&_svg]:h-full [&_svg]:w-full"
+      style={{
+        ['--bg-opacity' as string]: `${settings.background?.opacity ?? 80}%`,
+      }}
+    >
+      <InputTraceViz
+        input={{
+          brake: inputs.brake,
+          throttle: inputs.throttle,
+          clutch: inputs.clutch,
+          brakeAbsActive: inputs.brakeAbsActive,
+          steer: inputs.steer,
+        }}
+        settings={settings.trace}
+      />
+    </div>
+  );
+};

--- a/src/frontend/components/InputTrace/hooks/useInputTraceSettings.tsx
+++ b/src/frontend/components/InputTrace/hooks/useInputTraceSettings.tsx
@@ -1,0 +1,21 @@
+import { useDashboard } from '@irdashies/context';
+import { InputTraceWidgetSettings } from '@irdashies/types';
+
+export const useInputTraceSettings = () => {
+  const { currentDashboard } = useDashboard();
+
+  const settings = currentDashboard?.widgets.find(
+    (widget) => widget.id === 'inputtrace'
+  )?.config;
+
+  if (
+    settings &&
+    typeof settings === 'object' &&
+    'trace' in settings &&
+    typeof settings.trace === 'object'
+  ) {
+    return settings as unknown as InputTraceWidgetSettings['config'];
+  }
+
+  return undefined;
+};

--- a/src/frontend/components/InputTrace/index.tsx
+++ b/src/frontend/components/InputTrace/index.tsx
@@ -1,0 +1,1 @@
+export { InputTrace } from './InputTrace';

--- a/src/frontend/components/Settings/SettingsLoader.tsx
+++ b/src/frontend/components/Settings/SettingsLoader.tsx
@@ -28,6 +28,7 @@ import { SlowCarAheadSettings } from './sections/SlowCarAheadSettings';
 import { SectorDeltaSettings } from './sections/SectorDeltaSettings';
 import { WindSettings } from './sections/WindSettings';
 import { WeatherHorizontalSettings } from './sections/WeatherHorizontalSettings';
+import { InputTraceSettings } from './sections/InputTraceSettings';
 
 interface SettingsLoaderProps {
   previewMode?: boolean;
@@ -94,6 +95,8 @@ export const SettingsLoader = ({ previewMode }: SettingsLoaderProps = {}) => {
       return <WindSettings />;
     case 'weatherhorizontal':
       return <WeatherHorizontalSettings />;
+    case 'inputtrace':
+      return <InputTraceSettings />;
     default:
       return widget ? (
         <div className="text-red-400">No settings available for {type}</div>

--- a/src/frontend/components/Settings/SettingsLoader.tsx
+++ b/src/frontend/components/Settings/SettingsLoader.tsx
@@ -26,6 +26,8 @@ import { InformationBarSettings } from './sections/InformationBarSettings';
 import { useDashboard } from '@irdashies/context';
 import { SlowCarAheadSettings } from './sections/SlowCarAheadSettings';
 import { SectorDeltaSettings } from './sections/SectorDeltaSettings';
+import { WindSettings } from './sections/WindSettings';
+import { WeatherHorizontalSettings } from './sections/WeatherHorizontalSettings';
 
 interface SettingsLoaderProps {
   previewMode?: boolean;
@@ -88,6 +90,10 @@ export const SettingsLoader = ({ previewMode }: SettingsLoaderProps = {}) => {
       return <SlowCarAheadSettings />;
     case 'sectordelta':
       return <SectorDeltaSettings />;
+    case 'wind':
+      return <WindSettings />;
+    case 'weatherhorizontal':
+      return <WeatherHorizontalSettings />;
     default:
       return widget ? (
         <div className="text-red-400">No settings available for {type}</div>

--- a/src/frontend/components/Settings/SettingsMenu.tsx
+++ b/src/frontend/components/Settings/SettingsMenu.tsx
@@ -97,6 +97,12 @@ const widgetItems: MenuItem[] = [
     widgetType: 'input',
   },
   {
+    to: '/settings/inputtrace',
+    path: '/inputtrace',
+    label: 'Input Trace',
+    widgetType: 'inputtrace',
+  },
+  {
     to: '/settings/laptimelog',
     path: '/laptimelog',
     label: 'Lap Timer',
@@ -192,7 +198,9 @@ const MenuLink = ({
   showIcon?: boolean;
   isEnabled?: boolean;
 }) => {
-  const isActive = pathname.startsWith(`/settings${item.path}`);
+  const isActive =
+    pathname === `/settings${item.path}` ||
+    pathname.startsWith(`/settings${item.path}/`);
   return (
     <li>
       <Link

--- a/src/frontend/components/Settings/SettingsMenu.tsx
+++ b/src/frontend/components/Settings/SettingsMenu.tsx
@@ -157,6 +157,18 @@ const widgetItems: MenuItem[] = [
     label: 'Weather',
     widgetType: 'weather',
   },
+  {
+    to: '/settings/weatherhorizontal',
+    path: '/weatherhorizontal',
+    label: 'Weather (Horizontal)',
+    widgetType: 'weatherhorizontal',
+  },
+  {
+    to: '/settings/wind',
+    path: '/wind',
+    label: 'Wind',
+    widgetType: 'wind',
+  },
 ];
 
 const bottomItems: MenuItem[] = [

--- a/src/frontend/components/Settings/sections/InputTraceSettings.tsx
+++ b/src/frontend/components/Settings/sections/InputTraceSettings.tsx
@@ -112,6 +112,13 @@ export const InputTraceSettings = () => {
                 handleConfigChange({ background: { opacity: v } })
               }
             />
+            <SettingDivider />
+            <SettingToggleRow
+              title="Use Raw Inputs"
+              description="Disables iRacing's automated input processing, showing direct pedal telemetry without assists like auto-clutch or anti-stall."
+              enabled={settings.config.useRawValues}
+              onToggle={(v) => handleConfigChange({ useRawValues: v })}
+            />
           </SettingsSection>
 
           <SettingsSection title="Visibility">

--- a/src/frontend/components/Settings/sections/InputTraceSettings.tsx
+++ b/src/frontend/components/Settings/sections/InputTraceSettings.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import { BaseSettingsSection } from '../components/BaseSettingsSection';
+import {
+  getWidgetDefaultConfig,
+  type InputTraceWidgetSettings,
+} from '@irdashies/types';
+import { useDashboard } from '@irdashies/context';
+import { SessionVisibility } from '../components/SessionVisibility';
+import { SettingToggleRow } from '../components/SettingToggleRow';
+import { SettingDivider } from '../components/SettingDivider';
+import { SettingsSection } from '../components/SettingSection';
+import { SettingSliderRow } from '../components/SettingSliderRow';
+
+const SETTING_ID = 'inputtrace';
+const defaultConfig = getWidgetDefaultConfig('inputtrace');
+
+export const InputTraceSettings = () => {
+  const { currentDashboard } = useDashboard();
+  const savedSettings = currentDashboard?.widgets.find(
+    (w) => w.id === SETTING_ID
+  ) as InputTraceWidgetSettings | undefined;
+  const [settings, setSettings] = useState<InputTraceWidgetSettings>({
+    enabled: savedSettings?.enabled ?? false,
+    config:
+      (savedSettings?.config as InputTraceWidgetSettings['config']) ??
+      defaultConfig,
+  });
+
+  if (!currentDashboard) {
+    return <>Loading...</>;
+  }
+
+  return (
+    <BaseSettingsSection
+      title="Input Trace"
+      description="Standalone pedal and steering trace visualization."
+      settings={settings}
+      onSettingsChange={(s) => setSettings(s)}
+      widgetId={SETTING_ID}
+    >
+      {(handleConfigChange) => (
+        <div className="space-y-4">
+          <SettingsSection title="Traces">
+            <SettingToggleRow
+              title="Throttle"
+              enabled={settings.config.trace.includeThrottle}
+              onToggle={(v) =>
+                handleConfigChange({
+                  trace: { ...settings.config.trace, includeThrottle: v },
+                })
+              }
+            />
+            <SettingToggleRow
+              title="Brake"
+              enabled={settings.config.trace.includeBrake}
+              onToggle={(v) =>
+                handleConfigChange({
+                  trace: { ...settings.config.trace, includeBrake: v },
+                })
+              }
+            />
+            <SettingToggleRow
+              title="Clutch"
+              enabled={settings.config.trace.includeClutch}
+              onToggle={(v) =>
+                handleConfigChange({
+                  trace: { ...settings.config.trace, includeClutch: v },
+                })
+              }
+            />
+            <SettingToggleRow
+              title="ABS overlay"
+              enabled={settings.config.trace.includeAbs}
+              onToggle={(v) =>
+                handleConfigChange({
+                  trace: { ...settings.config.trace, includeAbs: v },
+                })
+              }
+            />
+            <SettingToggleRow
+              title="Steering"
+              enabled={settings.config.trace.includeSteer ?? true}
+              onToggle={(v) =>
+                handleConfigChange({
+                  trace: { ...settings.config.trace, includeSteer: v },
+                })
+              }
+            />
+            <SettingDivider />
+            <SettingSliderRow
+              title="Stroke width"
+              value={settings.config.trace.strokeWidth ?? 3}
+              min={1}
+              max={8}
+              step={1}
+              onChange={(v) =>
+                handleConfigChange({
+                  trace: { ...settings.config.trace, strokeWidth: v },
+                })
+              }
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Display">
+            <SettingSliderRow
+              title="Background opacity"
+              value={settings.config.background.opacity}
+              min={0}
+              max={100}
+              step={5}
+              onChange={(v) =>
+                handleConfigChange({ background: { opacity: v } })
+              }
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Visibility">
+            <SessionVisibility
+              sessionVisibility={settings.config.sessionVisibility}
+              handleConfigChange={handleConfigChange}
+            />
+
+            <SettingDivider />
+
+            <SettingToggleRow
+              title="Show only when on track"
+              description="Hide the widget when not driving"
+              enabled={settings.config.showOnlyWhenOnTrack}
+              onToggle={(v) => handleConfigChange({ showOnlyWhenOnTrack: v })}
+            />
+          </SettingsSection>
+        </div>
+      )}
+    </BaseSettingsSection>
+  );
+};

--- a/src/frontend/components/Settings/sections/WeatherHorizontalSettings.tsx
+++ b/src/frontend/components/Settings/sections/WeatherHorizontalSettings.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { BaseSettingsSection } from '../components/BaseSettingsSection';
+import {
+  getWidgetDefaultConfig,
+  type WeatherHorizontalWidgetSettings,
+} from '@irdashies/types';
+import { useDashboard } from '@irdashies/context';
+import { SessionVisibility } from '../components/SessionVisibility';
+import { SettingToggleRow } from '../components/SettingToggleRow';
+import { SettingDivider } from '../components/SettingDivider';
+import { SettingsSection } from '../components/SettingSection';
+import { SettingSliderRow } from '../components/SettingSliderRow';
+import { SettingButtonGroupRow } from '../components/SettingButtonGroupRow';
+
+const SETTING_ID = 'weatherhorizontal';
+const defaultConfig = getWidgetDefaultConfig('weatherhorizontal');
+
+export const WeatherHorizontalSettings = () => {
+  const { currentDashboard } = useDashboard();
+  const savedSettings = currentDashboard?.widgets.find(
+    (w) => w.id === SETTING_ID
+  ) as WeatherHorizontalWidgetSettings | undefined;
+  const [settings, setSettings] = useState<WeatherHorizontalWidgetSettings>({
+    enabled: savedSettings?.enabled ?? false,
+    config:
+      (savedSettings?.config as WeatherHorizontalWidgetSettings['config']) ??
+      defaultConfig,
+  });
+
+  if (!currentDashboard) {
+    return <>Loading...</>;
+  }
+
+  return (
+    <BaseSettingsSection
+      title="Weather (Horizontal)"
+      description="Two-row horizontal layout showing temperatures, track wetness, and rubber state."
+      settings={settings}
+      onSettingsChange={(s) => setSettings(s)}
+      widgetId={SETTING_ID}
+    >
+      {(handleConfigChange) => (
+        <div className="space-y-4">
+          <SettingsSection title="Options">
+            <SettingSliderRow
+              title="Background Opacity"
+              value={settings.config.background.opacity ?? 80}
+              units="%"
+              min={0}
+              max={100}
+              step={1}
+              onChange={(v) =>
+                handleConfigChange({ background: { opacity: v } })
+              }
+            />
+
+            <SettingButtonGroupRow<'auto' | 'Metric' | 'Imperial'>
+              title="Temperature Units"
+              value={settings.config.units ?? 'auto'}
+              options={[
+                { label: 'Auto', value: 'auto' },
+                { label: '°C', value: 'Metric' },
+                { label: '°F', value: 'Imperial' },
+              ]}
+              onChange={(v) => handleConfigChange({ units: v })}
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Visibility">
+            <SessionVisibility
+              sessionVisibility={settings.config.sessionVisibility}
+              handleConfigChange={handleConfigChange}
+            />
+
+            <SettingDivider />
+
+            <SettingToggleRow
+              title="Show only when on track"
+              description="If enabled, the widget will only be shown when driving"
+              enabled={settings.config.showOnlyWhenOnTrack ?? false}
+              onToggle={(newValue) =>
+                handleConfigChange({ showOnlyWhenOnTrack: newValue })
+              }
+            />
+          </SettingsSection>
+        </div>
+      )}
+    </BaseSettingsSection>
+  );
+};

--- a/src/frontend/components/Settings/sections/WindSettings.tsx
+++ b/src/frontend/components/Settings/sections/WindSettings.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { BaseSettingsSection } from '../components/BaseSettingsSection';
+import {
+  getWidgetDefaultConfig,
+  type WindWidgetSettings,
+} from '@irdashies/types';
+import { useDashboard } from '@irdashies/context';
+import { SessionVisibility } from '../components/SessionVisibility';
+import { SettingToggleRow } from '../components/SettingToggleRow';
+import { SettingDivider } from '../components/SettingDivider';
+import { SettingsSection } from '../components/SettingSection';
+import { SettingButtonGroupRow } from '../components/SettingButtonGroupRow';
+
+const SETTING_ID = 'wind';
+const defaultConfig = getWidgetDefaultConfig('wind');
+
+export const WindSettings = () => {
+  const { currentDashboard } = useDashboard();
+  const savedSettings = currentDashboard?.widgets.find(
+    (w) => w.id === SETTING_ID
+  ) as WindWidgetSettings | undefined;
+  const [settings, setSettings] = useState<WindWidgetSettings>({
+    enabled: savedSettings?.enabled ?? false,
+    config:
+      (savedSettings?.config as WindWidgetSettings['config']) ?? defaultConfig,
+  });
+
+  if (!currentDashboard) {
+    return <>Loading...</>;
+  }
+
+  return (
+    <BaseSettingsSection
+      title="Wind"
+      description="Show wind direction and speed."
+      settings={settings}
+      onSettingsChange={(s) => setSettings(s)}
+      widgetId={SETTING_ID}
+    >
+      {(handleConfigChange) => (
+        <div className="space-y-4">
+          <SettingsSection title="Options">
+            <SettingButtonGroupRow<'auto' | 'Metric' | 'Imperial'>
+              title="Speed Units"
+              value={settings.config.units ?? 'auto'}
+              options={[
+                { label: 'Auto', value: 'auto' },
+                { label: 'km/h', value: 'Metric' },
+                { label: 'mph', value: 'Imperial' },
+              ]}
+              onChange={(v) => handleConfigChange({ units: v })}
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Visibility">
+            <SessionVisibility
+              sessionVisibility={settings.config.sessionVisibility}
+              handleConfigChange={handleConfigChange}
+            />
+
+            <SettingDivider />
+
+            <SettingToggleRow
+              title="Show only when on track"
+              description="If enabled, the wind widget will only be shown when driving"
+              enabled={settings.config.showOnlyWhenOnTrack ?? false}
+              onToggle={(newValue) =>
+                handleConfigChange({ showOnlyWhenOnTrack: newValue })
+              }
+            />
+          </SettingsSection>
+        </div>
+      )}
+    </BaseSettingsSection>
+  );
+};

--- a/src/frontend/components/WeatherHorizontal/WeatherHorizontal.stories.tsx
+++ b/src/frontend/components/WeatherHorizontal/WeatherHorizontal.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TelemetryDecorator } from '@irdashies/storybook';
+import { WeatherHorizontal } from './WeatherHorizontal';
+
+export default {
+  component: WeatherHorizontal,
+  title: 'widgets/WeatherHorizontal',
+  decorators: [TelemetryDecorator()],
+} as Meta;
+
+type Story = StoryObj<typeof WeatherHorizontal>;
+
+export const Primary: Story = {};

--- a/src/frontend/components/WeatherHorizontal/WeatherHorizontal.tsx
+++ b/src/frontend/components/WeatherHorizontal/WeatherHorizontal.tsx
@@ -1,0 +1,58 @@
+import {
+  useTelemetryValue,
+  useSessionVisibility,
+  useThrottledWeather,
+} from '@irdashies/context';
+import { RoadHorizonIcon, ThermometerIcon } from '@phosphor-icons/react';
+import { useWeatherHorizontalSettings } from './hooks/useWeatherHorizontalSettings';
+import { useTrackTemperature } from './hooks/useTrackTemperature';
+import { useTrackRubberedState } from './hooks/useTrackRubberedState';
+import { WeatherTemp } from './WeatherTemp/WeatherTemp';
+import { WeatherTrackWetness } from './WeatherTrackWetness/WeatherTrackWetness';
+import { WeatherTrackRubbered } from './WeatherTrackRubbered/WeatherTrackRubbered';
+
+export const WeatherHorizontal = () => {
+  const settings = useWeatherHorizontalSettings();
+  const displayUnits = useTelemetryValue('DisplayUnits');
+  const isOnTrack = useTelemetryValue('IsOnTrack');
+  const isSessionVisible = useSessionVisibility(settings?.sessionVisibility);
+
+  const unitSetting = settings?.units ?? 'auto';
+  const isMetric =
+    unitSetting === 'auto' ? displayUnits === 1 : unitSetting === 'Metric';
+  const actualUnit = isMetric ? 'Metric' : 'Imperial';
+
+  const { trackTemp, airTemp } = useTrackTemperature({
+    airTempUnit: actualUnit,
+    trackTempUnit: actualUnit,
+  });
+
+  const weather = useThrottledWeather();
+  const trackRubbered = useTrackRubberedState();
+
+  if (settings?.showOnlyWhenOnTrack && !isOnTrack) {
+    return null;
+  }
+
+  if (!isSessionVisible) return <></>;
+
+  return (
+    <div
+      className="@container w-full rounded-sm p-2 bg-slate-800/(--bg-opacity)"
+      style={{
+        ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
+      }}
+    >
+      <div className="flex flex-col gap-2">
+        <div className="grid grid-cols-2 gap-2">
+          <WeatherTemp title="Track" value={trackTemp} icon={RoadHorizonIcon} />
+          <WeatherTemp title="Air" value={airTemp} icon={ThermometerIcon} />
+        </div>
+        <div className="grid grid-cols-2 gap-2">
+          <WeatherTrackWetness trackMoisture={weather.trackMoisture} />
+          <WeatherTrackRubbered trackRubbered={trackRubbered} />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/frontend/components/WeatherHorizontal/WeatherHorizontal.tsx
+++ b/src/frontend/components/WeatherHorizontal/WeatherHorizontal.tsx
@@ -38,20 +38,16 @@ export const WeatherHorizontal = () => {
 
   return (
     <div
-      className="@container w-full rounded-sm p-2 bg-slate-800/(--bg-opacity)"
+      className="w-fit rounded-sm p-2 bg-slate-800/(--bg-opacity)"
       style={{
         ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
       }}
     >
-      <div className="flex flex-col gap-2">
-        <div className="grid grid-cols-2 gap-2">
-          <WeatherTemp title="Track" value={trackTemp} icon={RoadHorizonIcon} />
-          <WeatherTemp title="Air" value={airTemp} icon={ThermometerIcon} />
-        </div>
-        <div className="grid grid-cols-2 gap-2">
-          <WeatherTrackWetness trackMoisture={weather.trackMoisture} />
-          <WeatherTrackRubbered trackRubbered={trackRubbered} />
-        </div>
+      <div className="grid grid-cols-[auto_auto_auto_auto]">
+        <WeatherTemp value={trackTemp} icon={RoadHorizonIcon} />
+        <WeatherTemp value={airTemp} icon={ThermometerIcon} />
+        <WeatherTrackWetness trackMoisture={weather.trackMoisture} />
+        <WeatherTrackRubbered trackRubbered={trackRubbered} />
       </div>
     </div>
   );

--- a/src/frontend/components/WeatherHorizontal/WeatherTemp/WeatherTemp.tsx
+++ b/src/frontend/components/WeatherHorizontal/WeatherTemp/WeatherTemp.tsx
@@ -1,22 +1,18 @@
 import { memo } from 'react';
 
 export interface WeatherTempProps {
-  title: string;
   value: string;
   icon: React.ElementType;
 }
 
-export const WeatherTemp = memo(
-  ({ title, value, icon: Icon }: WeatherTempProps) => {
-    return (
-      <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
-        <div className="flex flex-row gap-x-2 items-center text-sm">
-          <Icon className="flex-none" />
-          <span className="truncate min-w-0 flex-1">{title}</span>
-          <div className="flex-none whitespace-nowrap text-right">{value}</div>
-        </div>
+export const WeatherTemp = memo(({ value, icon: Icon }: WeatherTempProps) => {
+  return (
+    <div className="bg-slate-800/70 px-2 py-1 w-full min-w-0">
+      <div className="flex items-center gap-x-1.5">
+        <Icon size={12} className="flex-none text-white/50" />
+        <div className="text-sm font-medium truncate">{value}</div>
       </div>
-    );
-  }
-);
+    </div>
+  );
+});
 WeatherTemp.displayName = 'WeatherTemp';

--- a/src/frontend/components/WeatherHorizontal/WeatherTemp/WeatherTemp.tsx
+++ b/src/frontend/components/WeatherHorizontal/WeatherTemp/WeatherTemp.tsx
@@ -1,0 +1,22 @@
+import { memo } from 'react';
+
+export interface WeatherTempProps {
+  title: string;
+  value: string;
+  icon: React.ElementType;
+}
+
+export const WeatherTemp = memo(
+  ({ title, value, icon: Icon }: WeatherTempProps) => {
+    return (
+      <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
+        <div className="flex flex-row gap-x-2 items-center text-sm">
+          <Icon className="flex-none" />
+          <span className="truncate min-w-0 flex-1">{title}</span>
+          <div className="flex-none whitespace-nowrap text-right">{value}</div>
+        </div>
+      </div>
+    );
+  }
+);
+WeatherTemp.displayName = 'WeatherTemp';

--- a/src/frontend/components/WeatherHorizontal/WeatherTrackRubbered/WeatherTrackRubbered.tsx
+++ b/src/frontend/components/WeatherHorizontal/WeatherTrackRubbered/WeatherTrackRubbered.tsx
@@ -1,0 +1,24 @@
+import { memo } from 'react';
+import { PathIcon } from '@phosphor-icons/react';
+
+interface Props {
+  trackRubbered: string | undefined;
+}
+
+export const WeatherTrackRubbered = memo(({ trackRubbered }: Props) => {
+  return (
+    <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
+      <div className="flex flex-row gap-x-2 items-center text-sm">
+        <PathIcon className="flex-none" />
+        <span className="truncate min-w-0 flex-1">Rubber</span>
+        <div
+          className="flex-none truncate text-right capitalize"
+          title={trackRubbered ?? 'N/A'}
+        >
+          {trackRubbered ?? 'N/A'}
+        </div>
+      </div>
+    </div>
+  );
+});
+WeatherTrackRubbered.displayName = 'WeatherTrackRubbered';

--- a/src/frontend/components/WeatherHorizontal/WeatherTrackRubbered/WeatherTrackRubbered.tsx
+++ b/src/frontend/components/WeatherHorizontal/WeatherTrackRubbered/WeatherTrackRubbered.tsx
@@ -7,12 +7,11 @@ interface Props {
 
 export const WeatherTrackRubbered = memo(({ trackRubbered }: Props) => {
   return (
-    <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
-      <div className="flex flex-row gap-x-2 items-center text-sm">
-        <PathIcon className="flex-none" />
-        <span className="truncate min-w-0 flex-1">Rubber</span>
+    <div className="bg-slate-800/70 px-2 py-1 w-full min-w-0">
+      <div className="flex items-center gap-x-1.5">
+        <PathIcon size={12} className="flex-none text-white/50" />
         <div
-          className="flex-none truncate text-right capitalize"
+          className="text-sm font-medium capitalize truncate"
           title={trackRubbered ?? 'N/A'}
         >
           {trackRubbered ?? 'N/A'}

--- a/src/frontend/components/WeatherHorizontal/WeatherTrackWetness/WeatherTrackWetness.tsx
+++ b/src/frontend/components/WeatherHorizontal/WeatherTrackWetness/WeatherTrackWetness.tsx
@@ -1,8 +1,6 @@
-import { DropIcon, SunIcon, WavesIcon } from '@phosphor-icons/react';
+import { WavesIcon } from '@phosphor-icons/react';
 import { memo } from 'react';
 
-const MIN_WETNESS = 1;
-const MAX_WETNESS = 7;
 const DEFAULT_WETNESS = 0;
 const WETNESS_LEVELS: Record<number, string> = {
   0: '',
@@ -21,39 +19,25 @@ export interface WeatherTrackWetnessProps {
 
 export const WeatherTrackWetness = memo(
   ({ trackMoisture }: WeatherTrackWetnessProps) => {
-    const normalizedMoisture = trackMoisture || MIN_WETNESS;
-    const wetnessScale = MAX_WETNESS - MIN_WETNESS;
-    const trackWetnessPct =
-      ((normalizedMoisture - MIN_WETNESS) / wetnessScale) * 100;
-
     const safeTrackMoisture = trackMoisture ?? DEFAULT_WETNESS;
-    const trackState =
+    const label =
       safeTrackMoisture in WETNESS_LEVELS
         ? WETNESS_LEVELS[safeTrackMoisture]
         : 'Unknown';
-
     return (
-      <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
-        <div className="flex flex-row gap-x-2 items-center text-sm mb-2">
-          <WavesIcon className="flex-none" />
-          <span className="truncate min-w-0 flex-1">Wetness</span>
-          <div className="flex-none whitespace-nowrap text-right capitalize">
-            {trackState}
+      <div className="bg-slate-800/70 px-2 py-1 w-full min-w-0">
+        <div className="flex items-center gap-x-1.5">
+          <WavesIcon size={12} className="flex-none text-white/50" />
+          <div className="flex items-center gap-x-1.5 min-w-0">
+            <span className="text-sm font-medium capitalize truncate">
+              {label}
+            </span>
+            {safeTrackMoisture > 0 && (
+              <span className="flex-none text-xs text-white/50 bg-white/10 rounded px-1 py-px">
+                {safeTrackMoisture}/7
+              </span>
+            )}
           </div>
-        </div>
-        <div className="flex items-center flex-row gap-x-2 px-1">
-          <SunIcon size={14} className="text-gray-400 flex-none" />
-          <div className="grow bg-gray-700/50 rounded-full h-2">
-            <div
-              role="progressbar"
-              aria-valuenow={trackWetnessPct}
-              aria-valuemin={0}
-              aria-valuemax={100}
-              style={{ width: `${trackWetnessPct}%` }}
-              className="bg-blue-500 h-2 rounded-full transition-all duration-1000 ease-in-out shadow-[0_0_8px_rgba(59,130,246,0.5)]"
-            />
-          </div>
-          <DropIcon size={14} className="text-blue-400 flex-none" />
         </div>
       </div>
     );

--- a/src/frontend/components/WeatherHorizontal/WeatherTrackWetness/WeatherTrackWetness.tsx
+++ b/src/frontend/components/WeatherHorizontal/WeatherTrackWetness/WeatherTrackWetness.tsx
@@ -1,0 +1,62 @@
+import { DropIcon, SunIcon, WavesIcon } from '@phosphor-icons/react';
+import { memo } from 'react';
+
+const MIN_WETNESS = 1;
+const MAX_WETNESS = 7;
+const DEFAULT_WETNESS = 0;
+const WETNESS_LEVELS: Record<number, string> = {
+  0: '',
+  1: 'Dry',
+  2: 'Mostly Dry',
+  3: 'Very Lightly Wet',
+  4: 'Lightly Wet',
+  5: 'Moderately Wet',
+  6: 'Very Wet',
+  7: 'Extremely Wet',
+};
+
+export interface WeatherTrackWetnessProps {
+  trackMoisture?: number;
+}
+
+export const WeatherTrackWetness = memo(
+  ({ trackMoisture }: WeatherTrackWetnessProps) => {
+    const normalizedMoisture = trackMoisture || MIN_WETNESS;
+    const wetnessScale = MAX_WETNESS - MIN_WETNESS;
+    const trackWetnessPct =
+      ((normalizedMoisture - MIN_WETNESS) / wetnessScale) * 100;
+
+    const safeTrackMoisture = trackMoisture ?? DEFAULT_WETNESS;
+    const trackState =
+      safeTrackMoisture in WETNESS_LEVELS
+        ? WETNESS_LEVELS[safeTrackMoisture]
+        : 'Unknown';
+
+    return (
+      <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
+        <div className="flex flex-row gap-x-2 items-center text-sm mb-2">
+          <WavesIcon className="flex-none" />
+          <span className="truncate min-w-0 flex-1">Wetness</span>
+          <div className="flex-none whitespace-nowrap text-right capitalize">
+            {trackState}
+          </div>
+        </div>
+        <div className="flex items-center flex-row gap-x-2 px-1">
+          <SunIcon size={14} className="text-gray-400 flex-none" />
+          <div className="grow bg-gray-700/50 rounded-full h-2">
+            <div
+              role="progressbar"
+              aria-valuenow={trackWetnessPct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              style={{ width: `${trackWetnessPct}%` }}
+              className="bg-blue-500 h-2 rounded-full transition-all duration-1000 ease-in-out shadow-[0_0_8px_rgba(59,130,246,0.5)]"
+            />
+          </div>
+          <DropIcon size={14} className="text-blue-400 flex-none" />
+        </div>
+      </div>
+    );
+  }
+);
+WeatherTrackWetness.displayName = 'WeatherTrackWetness';

--- a/src/frontend/components/WeatherHorizontal/hooks/useTrackRubberedState.tsx
+++ b/src/frontend/components/WeatherHorizontal/hooks/useTrackRubberedState.tsx
@@ -1,0 +1,12 @@
+import { useSessionStore } from '@irdashies/context';
+import { useStore } from 'zustand';
+
+export const useTrackRubberedState = () => {
+  return useStore(
+    useSessionStore,
+    (state) =>
+      state.session?.SessionInfo?.Sessions?.findLast(
+        (session) => session.SessionTrackRubberState !== 'carry over'
+      )?.SessionTrackRubberState
+  );
+};

--- a/src/frontend/components/WeatherHorizontal/hooks/useTrackTemperature.tsx
+++ b/src/frontend/components/WeatherHorizontal/hooks/useTrackTemperature.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import { useTelemetry } from '@irdashies/context';
+
+interface UseTrackTemperatureOptions {
+  airTempUnit?: 'Metric' | 'Imperial';
+  trackTempUnit?: 'Metric' | 'Imperial';
+}
+
+export const useTrackTemperature = (
+  options: UseTrackTemperatureOptions = {}
+) => {
+  const { airTempUnit = 'Metric', trackTempUnit = 'Metric' } = options;
+  const trackTempVal = useTelemetry('TrackTempCrew');
+  const airTempVal = useTelemetry('AirTemp');
+
+  const trackTemp = useMemo(() => {
+    const temp = trackTempVal?.value[0] ?? 0;
+    if (temp === null || temp === undefined) return '';
+    const displayTemp =
+      trackTempUnit === 'Imperial' ? (temp * 9) / 5 + 32 : temp;
+    const unit = trackTempUnit === 'Imperial' ? 'F' : 'C';
+    return `${displayTemp.toFixed(0)}°${unit}`;
+  }, [trackTempVal?.value, trackTempUnit]);
+
+  const airTemp = useMemo(() => {
+    const temp = airTempVal?.value[0] ?? 0;
+    if (temp === null || temp === undefined) return '';
+    const displayTemp = airTempUnit === 'Imperial' ? (temp * 9) / 5 + 32 : temp;
+    const unit = airTempUnit === 'Imperial' ? 'F' : 'C';
+    return `${displayTemp.toFixed(0)}°${unit}`;
+  }, [airTempVal?.value, airTempUnit]);
+
+  return { trackTemp, airTemp };
+};

--- a/src/frontend/components/WeatherHorizontal/hooks/useWeatherHorizontalSettings.tsx
+++ b/src/frontend/components/WeatherHorizontal/hooks/useWeatherHorizontalSettings.tsx
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { useDashboard } from '@irdashies/context';
+import type { WeatherHorizontalWidgetSettings } from '@irdashies/types';
+
+export const useWeatherHorizontalSettings = () => {
+  const { currentDashboard } = useDashboard();
+
+  return useMemo(
+    () =>
+      currentDashboard?.widgets.find((w) => w.id === 'weatherhorizontal')
+        ?.config as unknown as WeatherHorizontalWidgetSettings['config'],
+    [currentDashboard]
+  );
+};

--- a/src/frontend/components/WeatherHorizontal/index.tsx
+++ b/src/frontend/components/WeatherHorizontal/index.tsx
@@ -1,0 +1,1 @@
+export * from './WeatherHorizontal';

--- a/src/frontend/components/WidgetContainer/EdgeDistanceLabels.stories.tsx
+++ b/src/frontend/components/WidgetContainer/EdgeDistanceLabels.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { EdgeDistanceLabels } from './EdgeDistanceLabels';
+
+const meta: Meta<typeof EdgeDistanceLabels> = {
+  title: 'WidgetContainer/EdgeDistanceLabels',
+  component: EdgeDistanceLabels,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const WidgetFrame = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      position: 'relative',
+      width: 220,
+      height: 100,
+      border: '2px solid #38bdf8',
+      background: 'rgba(15,23,42,0.8)',
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const MidScreen: Story = {
+  render: (args) => (
+    <WidgetFrame>
+      <EdgeDistanceLabels {...args} />
+    </WidgetFrame>
+  ),
+  args: {
+    distances: { left: 340, top: 180, right: 820, bottom: 620 },
+  },
+};
+
+export const NearTopLeft: Story = {
+  render: (args) => (
+    <WidgetFrame>
+      <EdgeDistanceLabels {...args} />
+    </WidgetFrame>
+  ),
+  args: {
+    distances: { left: 8, top: 8, right: 1692, bottom: 1072 },
+  },
+};
+
+export const AtEdge: Story = {
+  render: (args) => (
+    <WidgetFrame>
+      <EdgeDistanceLabels {...args} />
+    </WidgetFrame>
+  ),
+  args: {
+    distances: { left: 0, top: 0, right: 0, bottom: 0 },
+  },
+};

--- a/src/frontend/components/WidgetContainer/EdgeDistanceLabels.tsx
+++ b/src/frontend/components/WidgetContainer/EdgeDistanceLabels.tsx
@@ -1,0 +1,68 @@
+import type { CSSProperties } from 'react';
+import type { EdgeDistances } from './useEdgeDistances';
+
+interface Props {
+  distances: EdgeDistances;
+}
+
+const labelStyle: CSSProperties = {
+  position: 'absolute',
+  pointerEvents: 'none',
+  userSelect: 'none',
+};
+
+const cls =
+  'text-xs font-mono bg-slate-900/90 text-sky-400 px-1.5 py-0.5 rounded leading-none';
+
+export const EdgeDistanceLabels = ({ distances }: Props) => {
+  return (
+    <>
+      <div
+        className={cls}
+        style={{
+          ...labelStyle,
+          top: 4,
+          left: '50%',
+          transform: 'translateX(-50%)',
+        }}
+      >
+        {Math.round(distances.top)}
+      </div>
+      <div
+        className={cls}
+        style={{
+          ...labelStyle,
+          bottom: 4,
+          left: '50%',
+          transform: 'translateX(-50%)',
+        }}
+      >
+        {Math.round(distances.bottom)}
+      </div>
+      <div
+        className={cls}
+        style={{
+          ...labelStyle,
+          left: 4,
+          top: '50%',
+          transform: 'translateY(-50%)',
+        }}
+      >
+        {Math.round(distances.left)}
+      </div>
+      <div
+        className={cls}
+        style={{
+          ...labelStyle,
+          right: 4,
+          top: '50%',
+          transform: 'translateY(-50%)',
+        }}
+      >
+        {Math.round(distances.right)}
+      </div>
+    </>
+  );
+};
+
+EdgeDistanceLabels.displayName = 'EdgeDistanceLabels';

--- a/src/frontend/components/WidgetContainer/WidgetContainer.tsx
+++ b/src/frontend/components/WidgetContainer/WidgetContainer.tsx
@@ -10,6 +10,8 @@ import type { DashboardWidget, WidgetLayout } from '@irdashies/types';
 import { useDragWidget } from './useDragWidget';
 import { useResizeWidget } from './useResizeWidget';
 import { ResizeHandles } from './ResizeHandle';
+import { EdgeDistanceLabels } from './EdgeDistanceLabels';
+import { useEdgeDistances } from './useEdgeDistances';
 import { getWidgetName } from '../../constants/widgetNames';
 import { ResizeIcon, GearIcon, XIcon } from '@phosphor-icons/react';
 import { useContainerOffset } from '@irdashies/context';
@@ -127,6 +129,7 @@ export const WidgetContainer = memo(
 
     // Always use localLayout for display
     const displayedLayout = localLayout;
+    const edgeDistances = useEdgeDistances(displayedLayout);
 
     // Transform widget coordinates from screen space to container space
     // Widget coords assume primary display at (0,0), but container may span multiple displays
@@ -195,6 +198,9 @@ export const WidgetContainer = memo(
 
             {/* Resize handles */}
             <ResizeHandles getResizeHandleProps={getResizeHandleProps} />
+
+            {/* Edge distance indicators */}
+            {edgeDistances && <EdgeDistanceLabels distances={edgeDistances} />}
           </>
         )}
       </div>

--- a/src/frontend/components/WidgetContainer/useEdgeDistances.ts
+++ b/src/frontend/components/WidgetContainer/useEdgeDistances.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import type { WidgetLayout } from '@irdashies/types';
+import { useDashboard } from '@irdashies/context';
+
+export interface EdgeDistances {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Computes pixel distances from each widget edge to the corresponding display edge.
+ * Returns null when displayBounds isn't available (e.g., before the first IPC message arrives).
+ */
+export const useEdgeDistances = (
+  layout: WidgetLayout
+): EdgeDistances | null => {
+  const { containerBoundsInfo } = useDashboard();
+
+  return useMemo(() => {
+    const displayBounds = containerBoundsInfo?.displayBounds;
+    if (!displayBounds) return null;
+
+    return {
+      left: layout.x - displayBounds.x,
+      top: layout.y - displayBounds.y,
+      right: displayBounds.x + displayBounds.width - (layout.x + layout.width),
+      bottom:
+        displayBounds.y + displayBounds.height - (layout.y + layout.height),
+    };
+  }, [layout, containerBoundsInfo]);
+};

--- a/src/frontend/components/Wind/Wind.stories.tsx
+++ b/src/frontend/components/Wind/Wind.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TelemetryDecorator } from '@irdashies/storybook';
+import { Wind } from './Wind';
+
+export default {
+  component: Wind,
+  title: 'widgets/Wind',
+  decorators: [TelemetryDecorator()],
+} as Meta;
+
+type Story = StoryObj<typeof Wind>;
+
+export const Primary: Story = {};

--- a/src/frontend/components/Wind/Wind.tsx
+++ b/src/frontend/components/Wind/Wind.tsx
@@ -1,0 +1,36 @@
+import {
+  useTelemetryValue,
+  useSessionVisibility,
+  useThrottledWeather,
+} from '@irdashies/context';
+import { useWindSettings } from './hooks/useWindSettings';
+import { WindDirection } from './WindDirection/WindDirection';
+
+export const Wind = () => {
+  const settings = useWindSettings();
+  const displayUnits = useTelemetryValue('DisplayUnits');
+  const isOnTrack = useTelemetryValue('IsOnTrack');
+  const isSessionVisible = useSessionVisibility(settings?.sessionVisibility);
+
+  const unitSetting = settings?.units ?? 'auto';
+  const isMetric =
+    unitSetting === 'auto' ? displayUnits === 1 : unitSetting === 'Metric';
+
+  const weather = useThrottledWeather();
+  const relativeWindDirection =
+    (weather.windDirection ?? 0) - (weather.windYaw ?? 0);
+
+  if (settings?.showOnlyWhenOnTrack && !isOnTrack) {
+    return null;
+  }
+
+  if (!isSessionVisible) return <></>;
+
+  return (
+    <WindDirection
+      speedMs={weather.windVelocity}
+      direction={relativeWindDirection}
+      metric={isMetric}
+    />
+  );
+};

--- a/src/frontend/components/Wind/WindDirection/WindDirection.tsx
+++ b/src/frontend/components/Wind/WindDirection/WindDirection.tsx
@@ -1,0 +1,59 @@
+import { memo, useRef, useEffect, useState } from 'react';
+
+export interface WindDirectionProps {
+  speedMs?: number;
+  direction?: number;
+  metric?: boolean;
+}
+
+export const WindDirection = memo(
+  ({ speedMs, direction, metric = true }: WindDirectionProps) => {
+    const speed =
+      speedMs !== undefined
+        ? speedMs * (metric ? 3.6 : 2.23694) // km/h or mph
+        : undefined;
+
+    const [normalizedAngle, setNormalizedAngle] = useState<number>(0);
+    const prevAngleRef = useRef<number>(0);
+
+    useEffect(() => {
+      if (direction === undefined) return;
+
+      const currentAngle = direction;
+      const prevAngle = prevAngleRef.current;
+
+      let diff = currentAngle - prevAngle;
+
+      while (diff > Math.PI) diff -= 2 * Math.PI;
+      while (diff < -Math.PI) diff += 2 * Math.PI;
+
+      setNormalizedAngle((prev) => prev + diff);
+      prevAngleRef.current = currentAngle;
+    }, [direction]);
+
+    return (
+      <div className="flex justify-center">
+        <div
+          id="wind"
+          className="flex aspect-square relative w-full max-w-[120px] mx-auto items-center justify-center"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 60 60"
+            className="absolute stroke-current stroke-[3] w-full h-full box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out"
+            style={{
+              rotate: `calc(${normalizedAngle} * 1rad + 0.5turn)`,
+            }}
+          >
+            <path d="M48 8A28 28 90 0158 30c0 15.464-12.536 28-28 28S2 45.464 2 30A28 28 90 0112 8M22 9 30 1l8 8" />
+          </svg>
+
+          <div className="absolute w-full h-full flex justify-center items-center text-[32px]">
+            {speed !== undefined ? Math.round(speed) : '-'}
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+WindDirection.displayName = 'WindDirection';

--- a/src/frontend/components/Wind/hooks/useWindSettings.tsx
+++ b/src/frontend/components/Wind/hooks/useWindSettings.tsx
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { useDashboard } from '@irdashies/context';
+import type { WindWidgetSettings } from '@irdashies/types';
+
+export const useWindSettings = () => {
+  const { currentDashboard } = useDashboard();
+
+  return useMemo(
+    () =>
+      currentDashboard?.widgets.find((w) => w.id === 'wind')
+        ?.config as unknown as WindWidgetSettings['config'],
+    [currentDashboard]
+  );
+};

--- a/src/frontend/components/Wind/index.tsx
+++ b/src/frontend/components/Wind/index.tsx
@@ -1,0 +1,1 @@
+export * from './Wind';

--- a/src/frontend/constants/widgetNames.ts
+++ b/src/frontend/constants/widgetNames.ts
@@ -25,6 +25,8 @@ export const WIDGET_NAMES: Record<WidgetId, string> = {
   infobar: 'Information Bar',
   slowcarahead: 'Slow Car Ahead',
   sectordelta: 'Sector Delta',
+  wind: 'Wind',
+  weatherhorizontal: 'Weather (Horizontal)',
 };
 
 /**

--- a/src/frontend/constants/widgetNames.ts
+++ b/src/frontend/constants/widgetNames.ts
@@ -6,7 +6,7 @@ import type { WidgetId } from '../WidgetIndex';
  */
 export const WIDGET_NAMES: Record<WidgetId, string> = {
   standings: 'Standings',
-  input: 'Input Traces',
+  input: 'Input',
   relative: 'Relative',
   map: 'Track Map',
   flatmap: 'Flat Track Map',
@@ -27,6 +27,7 @@ export const WIDGET_NAMES: Record<WidgetId, string> = {
   sectordelta: 'Sector Delta',
   wind: 'Wind',
   weatherhorizontal: 'Weather (Horizontal)',
+  inputtrace: 'Input Trace',
 };
 
 /**

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1186,6 +1186,39 @@ export const defaultDashboard: {
       },
     },
     {
+      id: 'inputtrace',
+      enabled: false,
+      layout: {
+        x: 622,
+        y: 810,
+        width: 396,
+        height: 70,
+      },
+      config: {
+        useRawValues: false,
+        trace: {
+          includeThrottle: true,
+          includeBrake: true,
+          includeClutch: false,
+          includeAbs: true,
+          includeSteer: true,
+          strokeWidth: 3,
+          maxSamples: 400,
+        },
+        background: {
+          opacity: 80,
+        },
+        showOnlyWhenOnTrack: true,
+        sessionVisibility: {
+          race: true,
+          loneQualify: true,
+          openQualify: true,
+          practice: true,
+          offlineTesting: true,
+        },
+      },
+    },
+    {
       id: 'sectordelta',
       enabled: false,
       layout: {

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -49,8 +49,8 @@ export const defaultDashboard: {
         background: {
           opacity: 80,
         },
-        foreground: { 
-          opacity: 70, 
+        foreground: {
+          opacity: 70,
         },
         countryFlags: {
           enabled: true,
@@ -386,8 +386,8 @@ export const defaultDashboard: {
         background: {
           opacity: 80,
         },
-        foreground: { 
-          opacity: 70, 
+        foreground: {
+          opacity: 70,
         },
         position: {
           enabled: true,
@@ -1138,6 +1138,51 @@ export const defaultDashboard: {
           'wind',
           'trackName',
         ],
+      },
+    },
+    {
+      id: 'weatherhorizontal',
+      enabled: false,
+      layout: {
+        x: 1334,
+        y: 271,
+        width: 360,
+        height: 110,
+      },
+      config: {
+        background: {
+          opacity: 80,
+        },
+        units: 'auto',
+        showOnlyWhenOnTrack: false,
+        sessionVisibility: {
+          race: true,
+          loneQualify: true,
+          openQualify: true,
+          practice: true,
+          offlineTesting: true,
+        },
+      },
+    },
+    {
+      id: 'wind',
+      enabled: false,
+      layout: {
+        x: 1334,
+        y: 471,
+        width: 174,
+        height: 200,
+      },
+      config: {
+        units: 'auto',
+        showOnlyWhenOnTrack: false,
+        sessionVisibility: {
+          race: true,
+          loneQualify: true,
+          openQualify: true,
+          practice: true,
+          offlineTesting: true,
+        },
       },
     },
     {

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -443,6 +443,22 @@ export interface WeatherHorizontalConfig {
   sessionVisibility: SessionVisibilitySettings;
 }
 
+export interface InputTraceConfig {
+  useRawValues: boolean;
+  trace: {
+    includeThrottle: boolean;
+    includeBrake: boolean;
+    includeClutch: boolean;
+    includeAbs: boolean;
+    includeSteer?: boolean;
+    strokeWidth?: number;
+    maxSamples?: number;
+  };
+  background: { opacity: number };
+  showOnlyWhenOnTrack: boolean;
+  sessionVisibility: SessionVisibilitySettings;
+}
+
 export interface WindConfig {
   units: 'auto' | 'Metric' | 'Imperial';
   showOnlyWhenOnTrack: boolean;
@@ -609,6 +625,7 @@ export interface WidgetConfigMap {
   sectordelta: SectorDeltaConfig;
   wind: WindConfig;
   weatherhorizontal: WeatherHorizontalConfig;
+  inputtrace: InputTraceConfig;
 }
 
 export type TypedDashboardWidget<
@@ -709,3 +726,4 @@ export type SectorDeltaWidgetSettings = BaseWidgetSettings<SectorDeltaConfig>;
 export type WindWidgetSettings = BaseWidgetSettings<WindConfig>;
 export type WeatherHorizontalWidgetSettings =
   BaseWidgetSettings<WeatherHorizontalConfig>;
+export type InputTraceWidgetSettings = BaseWidgetSettings<InputTraceConfig>;

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -436,6 +436,19 @@ export interface GarageCoverConfig {
   imageFilename: string;
 }
 
+export interface WeatherHorizontalConfig {
+  background: { opacity: number };
+  units: 'auto' | 'Metric' | 'Imperial';
+  showOnlyWhenOnTrack: boolean;
+  sessionVisibility: SessionVisibilitySettings;
+}
+
+export interface WindConfig {
+  units: 'auto' | 'Metric' | 'Imperial';
+  showOnlyWhenOnTrack: boolean;
+  sessionVisibility: SessionVisibilitySettings;
+}
+
 export interface TelemetryInspectorConfig {
   background?: { opacity: number };
   properties?: {
@@ -594,6 +607,8 @@ export interface WidgetConfigMap {
   infobar: InformationBarConfig;
   slowcarahead: SlowCarAheadConfig;
   sectordelta: SectorDeltaConfig;
+  wind: WindConfig;
+  weatherhorizontal: WeatherHorizontalConfig;
 }
 
 export type TypedDashboardWidget<
@@ -691,3 +706,6 @@ export type InformationBarWidgetSettings =
   BaseWidgetSettings<InformationBarConfig>;
 export type SlowCarAheadWidgetSettings = BaseWidgetSettings<SlowCarAheadConfig>;
 export type SectorDeltaWidgetSettings = BaseWidgetSettings<SectorDeltaConfig>;
+export type WindWidgetSettings = BaseWidgetSettings<WindConfig>;
+export type WeatherHorizontalWidgetSettings =
+  BaseWidgetSettings<WeatherHorizontalConfig>;


### PR DESCRIPTION
## Description

Adds pixel-distance indicators on all four sides of a widget when edit mode is active. Each label shows how many pixels that edge is from the corresponding display boundary (e.g. `0` on the left means the widget is flush with the left edge of the monitor). The numbers update live during drag and resize.

Implementation:
- `useEdgeDistances` hook reads `containerBoundsInfo.displayBounds` from `DashboardContext` and computes the four distances in screen space. Returns `null` until Electron sends the bounds info, so nothing renders on load.
- `EdgeDistanceLabels` is a pure presentational component — four small monospace pill labels positioned 4px inside each edge of the widget.
- Labels are only rendered when `editMode` is true and distances are available.

Not tested in iRacing directly, verified in the running Electron app.

## Screenshots

<img width="624" height="194" alt="CleanShot 2026-05-25 at 14 40 14@2x" src="https://github.com/user-attachments/assets/4957b8ad-c014-4a6a-81bf-6195db0e2752" />


### Before
Edit mode shows the widget border and resize handles with no positional reference.

### After
Edit mode additionally shows four distance labels inside the widget, one per side, indicating the pixel distance to the nearest display edge.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] All tests pass locally via `npm test`
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Wind widget with configurable speed units and track visibility controls
  * Added Weather (Horizontal) widget displaying track temperature, air conditions, track wetness, and surface state
  * Added Input Trace widget showing driver inputs (throttle, brake, steering, clutch, ABS) with customizable display options
  * All new widgets include settings panels for background opacity, session visibility, and on-track display preferences

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->