### PR TITLE
fix: coerce driver UserName to string before trim

### DIFF
--- a/src/frontend/components/Standings/components/DriverName/DriverName.spec.tsx
+++ b/src/frontend/components/Standings/components/DriverName/DriverName.spec.tsx
@@ -1,6 +1,35 @@
 import { render } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { DriverNameView } from './DriverNameView';
+import { extractDriverName } from './DriverName';
+
+describe('extractDriverName', () => {
+  it('handles non-string fullName (numeric YAML scalar)', () => {
+    // iRacing session YAML can parse an all-digit handle as a number
+    expect(() => extractDriverName(12345 as unknown as string)).not.toThrow();
+    expect(extractDriverName(12345 as unknown as string)).toEqual({
+      firstName: '12345',
+      middleName: null,
+      surname: '',
+    });
+  });
+
+  it('handles null fullName', () => {
+    expect(extractDriverName(null as unknown as string)).toEqual({
+      firstName: '',
+      middleName: null,
+      surname: '',
+    });
+  });
+
+  it('handles non-Latin names with a digit suffix', () => {
+    expect(extractDriverName('畅 谭2')).toEqual({
+      firstName: '畅',
+      middleName: null,
+      surname: '谭2',
+    });
+  });
+});
 
 describe('DriverNameView', () => {
   it('renders name-surname format', () => {
@@ -22,9 +51,7 @@ describe('DriverNameView', () => {
       />
     );
 
-    expect(container.textContent).toBe(
-      'Charles Marc Hervé Perceval Leclerc'
-    );
+    expect(container.textContent).toBe('Charles Marc Hervé Perceval Leclerc');
   });
 
   it('renders name-m.-surname format', () => {
@@ -60,27 +87,21 @@ describe('DriverNameView', () => {
     expect(container.textContent).toBe('Leclerc');
   });
 
-// every driver should have a name but you never know. Delete it if you think it's useless
+  // every driver should have a name but you never know. Delete it if you think it's useless
 
   it('handles empty fullName', () => {
     const { container } = render(
-      <DriverNameView
-        fullName=""
-        format="name-surname"
-      />
+      <DriverNameView fullName="" format="name-surname" />
     );
 
     expect(container.textContent).toBe('');
   });
 
-// tests for drivers with single name
+  // tests for drivers with single name
 
   it('renders single name, name-surname format', () => {
     const { container } = render(
-      <DriverNameView
-        fullName="Max"
-        format="name-surname"
-      />
+      <DriverNameView fullName="Max" format="name-surname" />
     );
 
     expect(container.textContent).toBe('Max');
@@ -88,21 +109,15 @@ describe('DriverNameView', () => {
 
   it('renders single name, name-middlename-surname format', () => {
     const { container } = render(
-      <DriverNameView
-        fullName="Max"
-        format="name-middlename-surname"
-      />
+      <DriverNameView fullName="Max" format="name-middlename-surname" />
     );
 
     expect(container.textContent).toBe('Max');
   });
 
- it('renders single name, name-m.-surname format', () => {
+  it('renders single name, name-m.-surname format', () => {
     const { container } = render(
-      <DriverNameView
-        fullName="Max"
-        format="name-m.-surname"
-      />
+      <DriverNameView fullName="Max" format="name-m.-surname" />
     );
 
     expect(container.textContent).toBe('Max');
@@ -110,32 +125,23 @@ describe('DriverNameView', () => {
 
   it('renders single name, n.-surname format', () => {
     const { container } = render(
-      <DriverNameView
-        fullName="Max"
-        format="n.-surname"
-      />
+      <DriverNameView fullName="Max" format="n.-surname" />
     );
 
     expect(container.textContent).toBe('Max');
   });
 
- it('renders single name, surname-n. format', () => {
+  it('renders single name, surname-n. format', () => {
     const { container } = render(
-      <DriverNameView
-        fullName="Max"
-        format="surname-n."
-      />
+      <DriverNameView fullName="Max" format="surname-n." />
     );
 
     expect(container.textContent).toBe('Max');
   });
 
- it('renders single name, surname format', () => {
+  it('renders single name, surname format', () => {
     const { container } = render(
-      <DriverNameView
-        fullName="Max"
-        format="surname"
-      />
+      <DriverNameView fullName="Max" format="surname" />
     );
 
     expect(container.textContent).toBe('Max');

--- a/src/frontend/components/Standings/components/DriverName/DriverName.tsx
+++ b/src/frontend/components/Standings/components/DriverName/DriverName.tsx
@@ -5,10 +5,12 @@ export interface DriverNameParts {
 }
 
 export const extractDriverName = (
-  fullName = '',
+  fullName: string | number | null | undefined = '',
   removeNumbersFromName = false
 ): DriverNameParts => {
-  const parts = fullName
+  // iRacing session YAML can yield non-string values for UserName (e.g. an
+  // all-digit handle parses as a number), so coerce before string ops.
+  const parts = String(fullName ?? '')
     .trim()
     .split(/\s+/)
     .filter(Boolean)

--- a/src/frontend/components/Standings/hooks/useDriverTagMap.ts
+++ b/src/frontend/components/Standings/hooks/useDriverTagMap.ts
@@ -136,7 +136,7 @@ export const useDriverTagMap = (
     const tagMap = new Map<number, ResolvedDriverTag>();
     for (const driver of drivers) {
       const userId = driver.UserID != null ? String(driver.UserID) : undefined;
-      const name = (driver.UserName ?? '').trim();
+      const name = String(driver.UserName ?? '').trim();
       const tag = resolveTag(userId, name, tagSettings, lcMapping, groupsById);
       if (tag) tagMap.set(driver.CarIdx, tag);
     }


### PR DESCRIPTION
## Description

Fixes #562.

iRacing's session-string YAML is typed — an all-digit handle (e.g. `UserName: 12345`) parses as a JavaScript **number**, not a string. The standings widget then crashes inside `extractDriverName` / `useDriverTagMap` with `TypeError: y.trim is not a function`, which the ErrorBoundary surfaces after 3 retries.

The reporter associated the crash with a Chinese-named driver in the lobby (`畅 谭2`), but that name itself parses fine as a string — I verified by feeding it through `js-yaml` directly. The actual trigger is a *different* driver in the same session whose handle happens to be all digits; the Chinese-named row was just the visually unusual one that drew the eye.

Defensive fix at the two consumption sites:

- `extractDriverName` (`DriverName.tsx`) — coerce with `String(fullName ?? '')` before `.trim()`, and widen the param type to reflect what can actually arrive at runtime (`string | number | null | undefined`).
- `useDriverTagMap.ts:139` — same coercion on `driver.UserName`. The existing `?? ''` doesn't help when the value is a number, since `2 ?? ''` is `2`.

### Verification

I temporarily reverted the source fix and re-ran the new tests; both new cases failed with the exact production error (`TypeError: fullName.trim is not a function`). Restored the fix and all 15 tests pass.

## Screenshots

### Before
ErrorBoundary in the standings widget after 3 retries:
```
[error] [renderer] [ErrorBoundary:widget:standings] y.trim is not a function (attempt 3/3)
TypeError: y.trim is not a function
  at file:///.../WidgetIndex-DQXBKy8Y.js:1:5767162
```

### After
Standings widget renders the all-digit handle as a normal name (e.g. `12345`), no crash. Existing Latin / non-Latin / mixed names continue to render correctly.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced driver name handling to support various input formats and edge cases in standings display
  * Improved driver name normalization for consistency across components

* **Tests**
  * Added comprehensive test coverage for driver name extraction with different input types
  * Expanded test cases for driver name rendering scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->