### PR TITLE
feat: Add edit mode snapping and distance labels

### DIFF
--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -264,6 +264,10 @@ export class OverlayManager {
         y: actualBounds.y - expectedBounds.y,
       };
 
+      const allDisplayBounds = screen
+        .getAllDisplays()
+        .map((d) => ({ ...d.bounds }));
+
       const boundsInfo: ContainerBoundsInfo = {
         expected: expectedBounds,
         actual: actualBounds,
@@ -271,6 +275,7 @@ export class OverlayManager {
         displayId: display.id,
         isPrimary,
         displayBounds: { ...expectedBounds },
+        allDisplayBounds,
       };
 
       this.displayBoundsInfo.set(display.id, boundsInfo);

--- a/src/frontend/components/EditMode/EditMode.stories.tsx
+++ b/src/frontend/components/EditMode/EditMode.stories.tsx
@@ -1,10 +1,18 @@
 import { Meta } from '@storybook/react-vite';
 import { EditMode } from './EditMode';
 import { DashboardProvider } from '@irdashies/context';
-import type { DashboardBridge, DashboardLayout } from '@irdashies/types';
+import type {
+  DashboardBridge,
+  DashboardLayout,
+  DashboardWidget,
+  GeneralSettingsType,
+} from '@irdashies/types';
 import { Input } from '../Input';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import { TelemetryDecorator, mockDashboardBridge } from '@irdashies/storybook';
 import { Standings } from '../Standings/Standings';
+import { WidgetContainer } from '../WidgetContainer';
+import { useCallback, useState } from 'react';
+import type { WidgetLayout } from '@irdashies/types';
 
 const meta: Meta<typeof EditMode> = {
   component: EditMode,
@@ -18,86 +26,140 @@ const mockDashboard: DashboardLayout = {
 };
 
 const mockBridge: (editMode: boolean) => DashboardBridge = (editMode) => ({
-  getAnalyticsOptOut: () => Promise.resolve(false),
-  setAnalyticsOptOut: () => Promise.resolve(),
-  saveDashboard: () => {
-    // noop
-  },
+  ...mockDashboardBridge,
   dashboardUpdated: () => {
     return undefined;
-  },
-  reloadDashboard: () => {
-    // noop
   },
   resetDashboard: () => Promise.resolve(mockDashboard),
   onEditModeToggled: (callback) => {
     callback(editMode);
     return undefined;
   },
-  toggleLockOverlays: () => Promise.resolve(true),
-  getAppVersion: () => Promise.resolve('1.0.0'),
-  toggleDemoMode: () => {
-    return;
-  },
-  onDemoModeChanged: (callback) => {
-    callback(false);
-    return () => {
-      return;
-    };
-  },
-  getCurrentDashboard: () => {
-    return null;
-  },
-  stop: () => {
-    return;
-  },
-  saveGarageCoverImage: () => Promise.resolve(''),
-  getGarageCoverImage: () => Promise.resolve(null),
-  getGarageCoverImageAsDataUrl: () => Promise.resolve(null),
-  savePlayerIconImage: () => Promise.resolve(''),
-  getPlayerIconImageAsDataUrl: () => Promise.resolve(null),
-  // Profile management methods
-  listProfiles: () =>
-    Promise.resolve([
-      {
-        id: 'default',
-        name: 'Default',
-        createdAt: new Date().toISOString(),
-        lastModified: new Date().toISOString(),
-      },
-    ]),
-  createProfile: (name: string) =>
-    Promise.resolve({
-      id: 'mock-id',
-      name,
-      createdAt: new Date().toISOString(),
-      lastModified: new Date().toISOString(),
-    }),
-  cloneProfile: (profileId: string) =>
-    Promise.resolve({
-      id: 'mock-clone-id',
-      name: `${profileId} - cloned`,
-      createdAt: new Date().toISOString(),
-      lastModified: new Date().toISOString(),
-    }),
-  deleteProfile: () => Promise.resolve(),
-  renameProfile: () => Promise.resolve(),
-  switchProfile: () => Promise.resolve(),
-  getCurrentProfile: () =>
-    Promise.resolve({
-      id: 'default',
-      name: 'Default',
-      createdAt: new Date().toISOString(),
-      lastModified: new Date().toISOString(),
-    }),
-  updateProfileTheme: async () => undefined,
-  getDashboardForProfile: async () => null,
-  exportDashboardToFile: async () => false,
-  importDashboardFromFile: async () => null,
-  setAutoStart: () => Promise.resolve(),
-  openLogFolder: async () => undefined,
-  exportLogFile: async () => false,
 });
+
+const VIEWPORT = { x: 0, y: 0, width: 1200, height: 700 };
+
+const sampleWidgets: DashboardWidget[] = [
+  {
+    id: 'standings',
+    enabled: true,
+    layout: { x: 24, y: 24, width: 280, height: 360 },
+  },
+  {
+    id: 'input',
+    enabled: true,
+    layout: { x: 380, y: 24, width: 340, height: 100 },
+  },
+  {
+    id: 'fuel',
+    enabled: true,
+    layout: { x: 380, y: 180, width: 340, height: 300 },
+  },
+];
+
+const createEditModeBridge = (
+  generalSettings: Partial<GeneralSettingsType>
+): DashboardBridge => {
+  const dashboard: DashboardLayout = {
+    widgets: sampleWidgets,
+    generalSettings: {
+      showEditModePixelDistances: true,
+      snapEditModeWidgetsToGrid: true,
+      ...generalSettings,
+    },
+  };
+  return {
+    ...mockDashboardBridge,
+    dashboardUpdated: (callback) => {
+      callback(dashboard, undefined);
+      return () => undefined;
+    },
+    resetDashboard: async () => dashboard,
+    onEditModeToggled: (callback) => {
+      callback(true);
+      return () => undefined;
+    },
+    onContainerBoundsInfo: (callback) => {
+      callback({
+        expected: VIEWPORT,
+        actual: VIEWPORT,
+        offset: { x: 0, y: 0 },
+        isPrimary: true,
+        displayBounds: VIEWPORT,
+      });
+      return () => undefined;
+    },
+  };
+};
+
+const WidgetPlaceholder = ({
+  label,
+  color,
+}: {
+  label: string;
+  color: string;
+}) => (
+  <div
+    className={`w-full h-full ${color} flex items-center justify-center text-white/80 text-sm`}
+  >
+    {label}
+  </div>
+);
+
+const widgetContent: Record<string, { label: string; color: string }> = {
+  standings: { label: 'Standings', color: 'bg-slate-800/80' },
+  input: { label: 'Input Trace', color: 'bg-slate-700/80' },
+  fuel: { label: 'Fuel Calculator', color: 'bg-slate-800/80' },
+};
+
+const MultiWidgetScene = ({
+  generalSettings,
+}: {
+  generalSettings: Partial<GeneralSettingsType>;
+}) => {
+  const bridge = createEditModeBridge(generalSettings);
+  const [widgets, setWidgets] = useState(sampleWidgets);
+
+  const handleLayoutChange = useCallback(
+    (widgetId: string, layout: WidgetLayout) => {
+      setWidgets((prev) =>
+        prev.map((w) => (w.id === widgetId ? { ...w, layout } : w))
+      );
+    },
+    []
+  );
+
+  return (
+    <DashboardProvider bridge={bridge}>
+      <div
+        className="relative bg-blue-900/20 overflow-hidden"
+        style={{ width: VIEWPORT.width, height: VIEWPORT.height }}
+      >
+        {widgets.map((widget, i) => {
+          const content = widgetContent[widget.id];
+          const siblingLayouts = widgets
+            .filter((w) => w.id !== widget.id)
+            .map((w) => w.layout);
+          return (
+            <WidgetContainer
+              key={widget.id}
+              widget={widget}
+              siblingLayouts={siblingLayouts}
+              editMode={true}
+              zIndex={i + 1}
+              onLayoutChange={handleLayoutChange}
+            >
+              <WidgetPlaceholder
+                label={content?.label ?? widget.id}
+                color={content?.color ?? 'bg-slate-800/80'}
+              />
+            </WidgetContainer>
+          );
+        })}
+      </div>
+    </DashboardProvider>
+  );
+};
 
 export const Primary = {
   render: (args: { editMode: boolean }) => {
@@ -144,4 +206,84 @@ export const WithStandings = {
   args: {
     editMode: true,
   } as { editMode: boolean },
+};
+
+export const DistanceLabelsVisible = {
+  render: () => (
+    <MultiWidgetScene
+      generalSettings={{
+        showEditModePixelDistances: true,
+        snapEditModeWidgetsToGrid: true,
+      }}
+    />
+  ),
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Three widgets in edit mode with pixel distance labels visible on each edge. Drag widgets to see labels update live.',
+      },
+    },
+  },
+};
+
+export const DistanceLabelsHidden = {
+  render: () => (
+    <MultiWidgetScene
+      generalSettings={{
+        showEditModePixelDistances: false,
+        snapEditModeWidgetsToGrid: true,
+      }}
+    />
+  ),
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Same layout with pixel distance labels turned off. Widget edit chrome is still visible but without the edge distance readouts.',
+      },
+    },
+  },
+};
+
+export const SnappingEnabled = {
+  render: () => (
+    <MultiWidgetScene
+      generalSettings={{
+        showEditModePixelDistances: true,
+        snapEditModeWidgetsToGrid: true,
+      }}
+    />
+  ),
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Grid snapping is active. Drag or resize a widget and it will snap to the viewport grid and lock to nearby sibling edges. Hold Shift to bypass snapping temporarily.',
+      },
+    },
+  },
+};
+
+export const SnappingDisabled = {
+  render: () => (
+    <MultiWidgetScene
+      generalSettings={{
+        showEditModePixelDistances: true,
+        snapEditModeWidgetsToGrid: false,
+      }}
+    />
+  ),
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        story:
+          'Grid snapping is turned off. Widgets move and resize freely with pixel-level precision. Distance labels are still visible.',
+      },
+    },
+  },
 };

--- a/src/frontend/components/EditMode/EditMode.stories.tsx
+++ b/src/frontend/components/EditMode/EditMode.stories.tsx
@@ -63,9 +63,12 @@ const createEditModeBridge = (
   const dashboard: DashboardLayout = {
     widgets: sampleWidgets,
     generalSettings: {
-      showEditModePixelDistances: true,
-      snapEditModeWidgetsToGrid: true,
       ...generalSettings,
+      editMode: {
+        pixelDistances: true,
+        snapToGrid: true,
+        ...generalSettings.editMode,
+      },
     },
   };
   return {
@@ -214,8 +217,10 @@ export const DistanceLabelsVisible = {
   render: () => (
     <MultiWidgetScene
       generalSettings={{
-        showEditModePixelDistances: true,
-        snapEditModeWidgetsToGrid: true,
+        editMode: {
+          pixelDistances: true,
+          snapToGrid: true,
+        },
       }}
     />
   ),
@@ -234,8 +239,10 @@ export const DistanceLabelsHidden = {
   render: () => (
     <MultiWidgetScene
       generalSettings={{
-        showEditModePixelDistances: false,
-        snapEditModeWidgetsToGrid: true,
+        editMode: {
+          pixelDistances: false,
+          snapToGrid: true,
+        },
       }}
     />
   ),
@@ -254,8 +261,10 @@ export const SnappingEnabled = {
   render: () => (
     <MultiWidgetScene
       generalSettings={{
-        showEditModePixelDistances: true,
-        snapEditModeWidgetsToGrid: true,
+        editMode: {
+          pixelDistances: true,
+          snapToGrid: true,
+        },
       }}
     />
   ),
@@ -274,8 +283,10 @@ export const SnappingDisabled = {
   render: () => (
     <MultiWidgetScene
       generalSettings={{
-        showEditModePixelDistances: true,
-        snapEditModeWidgetsToGrid: false,
+        editMode: {
+          pixelDistances: true,
+          snapToGrid: false,
+        },
       }}
     />
   ),

--- a/src/frontend/components/EditMode/EditMode.stories.tsx
+++ b/src/frontend/components/EditMode/EditMode.stories.tsx
@@ -11,7 +11,7 @@ import { Input } from '../Input';
 import { TelemetryDecorator, mockDashboardBridge } from '@irdashies/storybook';
 import { Standings } from '../Standings/Standings';
 import { WidgetContainer } from '../WidgetContainer';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import type { WidgetLayout } from '@irdashies/types';
 
 const meta: Meta<typeof EditMode> = {
@@ -92,13 +92,12 @@ const createEditModeBridge = (
   };
 };
 
-const WidgetPlaceholder = ({
-  label,
-  color,
-}: {
+interface WidgetPlaceholderProps {
   label: string;
   color: string;
-}) => (
+}
+
+const WidgetPlaceholder = ({ label, color }: WidgetPlaceholderProps) => (
   <div
     className={`w-full h-full ${color} flex items-center justify-center text-white/80 text-sm`}
   >
@@ -112,12 +111,15 @@ const widgetContent: Record<string, { label: string; color: string }> = {
   fuel: { label: 'Fuel Calculator', color: 'bg-slate-800/80' },
 };
 
-const MultiWidgetScene = ({
-  generalSettings,
-}: {
+interface MultiWidgetSceneProps {
   generalSettings: Partial<GeneralSettingsType>;
-}) => {
-  const bridge = createEditModeBridge(generalSettings);
+}
+
+const MultiWidgetScene = ({ generalSettings }: MultiWidgetSceneProps) => {
+  const bridge = useMemo(
+    () => createEditModeBridge(generalSettings),
+    [generalSettings]
+  );
   const [widgets, setWidgets] = useState(sampleWidgets);
 
   const handleLayoutChange = useCallback(

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   useDashboard,
   useRunningState,
@@ -76,33 +76,47 @@ export const OverlayContainer = memo(() => {
     []
   );
 
-  if (!currentDashboard) {
-    return null;
-  }
-
-  const enabledWidgets = currentDashboard.widgets.filter(
-    (widget) => widget.enabled
+  const enabledWidgets = useMemo(
+    () => currentDashboard?.widgets.filter((widget) => widget.enabled) ?? [],
+    [currentDashboard?.widgets]
   );
 
   // When running per-display windows, each window only renders its own widgets.
   // A widget belongs to a display if its center point falls within that display's bounds.
   // Unmatched widgets (e.g. default positions that fall in no display) render on the primary.
-  const widgetsForThisDisplay = containerBoundsInfo?.displayId
-    ? enabledWidgets.filter((widget) => {
-        const displayBounds =
-          containerBoundsInfo.displayBounds ?? containerBoundsInfo.expected;
-        const centerX = widget.layout.x + widget.layout.width / 2;
-        const centerY = widget.layout.y + widget.layout.height / 2;
-        const inThisDisplay =
-          centerX >= displayBounds.x &&
-          centerX < displayBounds.x + displayBounds.width &&
-          centerY >= displayBounds.y &&
-          centerY < displayBounds.y + displayBounds.height;
-        return (
-          inThisDisplay || (!inThisDisplay && containerBoundsInfo.isPrimary)
-        );
-      })
-    : enabledWidgets;
+  const widgetsForThisDisplay = useMemo(() => {
+    if (!containerBoundsInfo?.displayId) {
+      return enabledWidgets;
+    }
+
+    return enabledWidgets.filter((widget) => {
+      const displayBounds =
+        containerBoundsInfo.displayBounds ?? containerBoundsInfo.expected;
+      const centerX = widget.layout.x + widget.layout.width / 2;
+      const centerY = widget.layout.y + widget.layout.height / 2;
+      const inThisDisplay =
+        centerX >= displayBounds.x &&
+        centerX < displayBounds.x + displayBounds.width &&
+        centerY >= displayBounds.y &&
+        centerY < displayBounds.y + displayBounds.height;
+      return inThisDisplay || (!inThisDisplay && containerBoundsInfo.isPrimary);
+    });
+  }, [containerBoundsInfo, enabledWidgets]);
+
+  const siblingLayoutsByWidgetId = useMemo(() => {
+    return new Map(
+      widgetsForThisDisplay.map((widget) => [
+        widget.id,
+        widgetsForThisDisplay
+          .filter((otherWidget) => otherWidget.id !== widget.id)
+          .map((otherWidget) => otherWidget.layout),
+      ])
+    );
+  }, [widgetsForThisDisplay]);
+
+  if (!currentDashboard) {
+    return null;
+  }
 
   return (
     <div
@@ -122,6 +136,7 @@ export const OverlayContainer = memo(() => {
           <WidgetContainer
             key={widget.id}
             widget={widget}
+            siblingLayouts={siblingLayoutsByWidgetId.get(widget.id)}
             editMode={editMode}
             zIndex={index + 1}
             onLayoutChange={handleLayoutChange}

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -94,12 +94,20 @@ export const OverlayContainer = memo(() => {
         containerBoundsInfo.displayBounds ?? containerBoundsInfo.expected;
       const centerX = widget.layout.x + widget.layout.width / 2;
       const centerY = widget.layout.y + widget.layout.height / 2;
-      const inThisDisplay =
-        centerX >= displayBounds.x &&
-        centerX < displayBounds.x + displayBounds.width &&
-        centerY >= displayBounds.y &&
-        centerY < displayBounds.y + displayBounds.height;
-      return inThisDisplay || (!inThisDisplay && containerBoundsInfo.isPrimary);
+      const inBounds = (b: {
+        x: number;
+        y: number;
+        width: number;
+        height: number;
+      }) =>
+        centerX >= b.x &&
+        centerX < b.x + b.width &&
+        centerY >= b.y &&
+        centerY < b.y + b.height;
+      const inThisDisplay = inBounds(displayBounds);
+      const inAnyDisplay =
+        containerBoundsInfo.allDisplayBounds?.some(inBounds) ?? inThisDisplay;
+      return inThisDisplay || (containerBoundsInfo.isPrimary && !inAnyDisplay);
     });
   }, [containerBoundsInfo, enabledWidgets]);
 

--- a/src/frontend/components/Settings/components/BaseSettingsSection.tsx
+++ b/src/frontend/components/Settings/components/BaseSettingsSection.tsx
@@ -6,9 +6,9 @@ import { useDashboard } from '@irdashies/context';
 interface BaseSettingsSectionProps<T> {
   title: string;
   description: string;
-  settings: BaseWidgetSettings<T>;
-  onSettingsChange: (settings: BaseWidgetSettings<T>) => void;
-  widgetId: string;
+  settings?: BaseWidgetSettings<T>;
+  onSettingsChange?: (settings: BaseWidgetSettings<T>) => void;
+  widgetId?: string;
   children?:
     | ((handleConfigChange: (config: Partial<T>) => void) => ReactNode)
     | ReactNode;
@@ -27,8 +27,9 @@ export const BaseSettingsSection = <T,>({
   disableInternalScroll = false,
 }: BaseSettingsSectionProps<T>) => {
   const { currentDashboard, onDashboardUpdated } = useDashboard();
-  const [localSettings, setLocalSettings] =
-    useState<BaseWidgetSettings<T>>(settings);
+  const [localSettings, setLocalSettings] = useState<BaseWidgetSettings<T>>(
+    settings ?? { enabled: false, config: {} as T }
+  );
 
   // Clean synchronization pattern: track what we last synced to detect external changes
   const updatedWidget = currentDashboard?.widgets.find(
@@ -50,7 +51,7 @@ export const BaseSettingsSection = <T,>({
 
   const handleSettingsChange = (newSettings: BaseWidgetSettings<T>) => {
     setLocalSettings(newSettings);
-    onSettingsChange(newSettings);
+    onSettingsChange?.(newSettings);
     updateDashboard(newSettings);
   };
 
@@ -64,7 +65,7 @@ export const BaseSettingsSection = <T,>({
     };
 
     setLocalSettings(updatedSettings);
-    onSettingsChange(updatedSettings);
+    onSettingsChange?.(updatedSettings);
     updateDashboard(updatedSettings);
     onConfigChange?.(newConfig);
   };
@@ -104,7 +105,7 @@ export const BaseSettingsSection = <T,>({
   };
 
   const updateDashboard = (newSettings: BaseWidgetSettings<T>) => {
-    if (currentDashboard && onDashboardUpdated) {
+    if (currentDashboard && onDashboardUpdated && widgetId) {
       const widgetExists = currentDashboard.widgets.some(
         (w) => w.id === widgetId
       );
@@ -137,6 +138,21 @@ export const BaseSettingsSection = <T,>({
       onDashboardUpdated(updatedDashboard);
     }
   };
+
+  if (!settings || !onSettingsChange || !widgetId) {
+    return (
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-lg font-medium text-slate-200">{title}</h3>
+          <p className="text-sm text-slate-400">{description}</p>
+        </div>
+        {children &&
+          (typeof children === 'function'
+            ? children(() => undefined)
+            : children)}
+      </div>
+    );
+  }
 
   return (
     <div className={`flex flex-col ${disableInternalScroll ? '' : 'h-full'}`}>

--- a/src/frontend/components/Settings/sections/GeneralSettings.tsx
+++ b/src/frontend/components/Settings/sections/GeneralSettings.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useDashboard } from '@irdashies/context';
 import type { GeneralSettingsType } from '@irdashies/types';
+import { BaseSettingsSection } from '../components/BaseSettingsSection';
 
 const FONT_PRESETS = {
   lato: 'Lato',
@@ -416,15 +417,10 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
         </div>
 
         {/* Edit Mode Settings */}
-        <div className="space-y-4">
-          <div>
-            <h3 className="text-lg font-medium text-slate-200">Edit Mode</h3>
-            <p className="text-sm text-slate-400">
-              Controls for positioning and sizing widgets while editing the
-              overlay layout.
-            </p>
-          </div>
-
+        <BaseSettingsSection
+          title="Edit Mode"
+          description="Controls for positioning and sizing widgets while editing the overlay layout."
+        >
           <div className="flex items-center justify-between gap-4">
             <div>
               <h4
@@ -479,7 +475,7 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
               <div className="w-11 h-6 bg-slate-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
             </label>
           </div>
-        </div>
+        </BaseSettingsSection>
 
         {/* Color Theme Settings */}
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/GeneralSettings.tsx
+++ b/src/frontend/components/Settings/sections/GeneralSettings.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useDashboard } from '@irdashies/context';
-import { GeneralSettingsType } from '@irdashies/types';
+import type { GeneralSettingsType } from '@irdashies/types';
 
 const FONT_PRESETS = {
   lato: 'Lato',
@@ -99,6 +99,10 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
       currentDashboard?.generalSettings?.overlayAlwaysOnTop ?? true,
     enableNetworkAccess:
       currentDashboard?.generalSettings?.enableNetworkAccess ?? false,
+    showEditModePixelDistances:
+      currentDashboard?.generalSettings?.showEditModePixelDistances ?? true,
+    snapEditModeWidgetsToGrid:
+      currentDashboard?.generalSettings?.snapEditModeWidgetsToGrid ?? true,
   });
 
   if (!currentDashboard || !onDashboardUpdated) {
@@ -274,6 +278,18 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
     updateDashboard(newSettings);
   };
 
+  const handleShowEditModePixelDistancesChange = (enabled: boolean) => {
+    const newSettings = { ...settings, showEditModePixelDistances: enabled };
+    setSettings(newSettings);
+    updateDashboard(newSettings);
+  };
+
+  const handleSnapEditModeWidgetsToGridChange = (enabled: boolean) => {
+    const newSettings = { ...settings, snapEditModeWidgetsToGrid: enabled };
+    setSettings(newSettings);
+    updateDashboard(newSettings);
+  };
+
   return (
     <div className="flex flex-col h-full">
       <div className="flex-none p-4 bg-slate-700 rounded">
@@ -382,6 +398,64 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
               <option value="compact">Compact</option>
               <option value="ultra">Ultra</option>
             </select>
+          </div>
+        </div>
+
+        {/* Edit Mode Settings */}
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-lg font-medium text-slate-200">Edit Mode</h3>
+            <p className="text-sm text-slate-400">
+              Controls for positioning and sizing widgets while editing the
+              overlay layout.
+            </p>
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h4 className="text-md font-medium text-slate-300">
+                Show Pixel Distances
+              </h4>
+              <p className="text-sm text-slate-500 pr-8">
+                Shows the pixel distance from widgets to each edge of the
+                viewport.
+              </p>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={settings.showEditModePixelDistances ?? true}
+                onChange={(e) =>
+                  handleShowEditModePixelDistancesChange(e.target.checked)
+                }
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-slate-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+            </label>
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h4 className="text-md font-medium text-slate-300">
+                Snap Widgets to Grid
+              </h4>
+              <p className="text-sm text-slate-500 pr-8">
+                Snaps widget movement and resizing to the pixel grid. Hold
+                &apos;Shift&apos; while dragging or resizing to temporarily
+                disable snapping.
+              </p>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={settings.snapEditModeWidgetsToGrid ?? true}
+                onChange={(e) =>
+                  handleSnapEditModeWidgetsToGridChange(e.target.checked)
+                }
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-slate-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+            </label>
           </div>
         </div>
 

--- a/src/frontend/components/Settings/sections/GeneralSettings.tsx
+++ b/src/frontend/components/Settings/sections/GeneralSettings.tsx
@@ -413,7 +413,10 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
 
           <div className="flex items-center justify-between gap-4">
             <div>
-              <h4 className="text-md font-medium text-slate-300">
+              <h4
+                id="show-edit-mode-pixel-distances-label"
+                className="text-md font-medium text-slate-300"
+              >
                 Show Pixel Distances
               </h4>
               <p className="text-sm text-slate-500 pr-8">
@@ -428,6 +431,7 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
                 onChange={(e) =>
                   handleShowEditModePixelDistancesChange(e.target.checked)
                 }
+                aria-labelledby="show-edit-mode-pixel-distances-label"
                 className="sr-only peer"
               />
               <div className="w-11 h-6 bg-slate-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
@@ -436,7 +440,10 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
 
           <div className="flex items-center justify-between gap-4">
             <div>
-              <h4 className="text-md font-medium text-slate-300">
+              <h4
+                id="snap-edit-mode-widgets-to-grid-label"
+                className="text-md font-medium text-slate-300"
+              >
                 Snap Widgets to Grid
               </h4>
               <p className="text-sm text-slate-500 pr-8">
@@ -452,6 +459,7 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
                 onChange={(e) =>
                   handleSnapEditModeWidgetsToGridChange(e.target.checked)
                 }
+                aria-labelledby="snap-edit-mode-widgets-to-grid-label"
                 className="sr-only peer"
               />
               <div className="w-11 h-6 bg-slate-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>

--- a/src/frontend/components/Settings/sections/GeneralSettings.tsx
+++ b/src/frontend/components/Settings/sections/GeneralSettings.tsx
@@ -99,10 +99,12 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
       currentDashboard?.generalSettings?.overlayAlwaysOnTop ?? true,
     enableNetworkAccess:
       currentDashboard?.generalSettings?.enableNetworkAccess ?? false,
-    showEditModePixelDistances:
-      currentDashboard?.generalSettings?.showEditModePixelDistances ?? true,
-    snapEditModeWidgetsToGrid:
-      currentDashboard?.generalSettings?.snapEditModeWidgetsToGrid ?? true,
+    editMode: {
+      pixelDistances:
+        currentDashboard?.generalSettings?.editMode?.pixelDistances ?? false,
+      snapToGrid:
+        currentDashboard?.generalSettings?.editMode?.snapToGrid ?? false,
+    },
   });
 
   if (!currentDashboard || !onDashboardUpdated) {
@@ -279,13 +281,25 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
   };
 
   const handleShowEditModePixelDistancesChange = (enabled: boolean) => {
-    const newSettings = { ...settings, showEditModePixelDistances: enabled };
+    const newSettings = {
+      ...settings,
+      editMode: {
+        ...settings.editMode,
+        pixelDistances: enabled,
+      },
+    };
     setSettings(newSettings);
     updateDashboard(newSettings);
   };
 
   const handleSnapEditModeWidgetsToGridChange = (enabled: boolean) => {
-    const newSettings = { ...settings, snapEditModeWidgetsToGrid: enabled };
+    const newSettings = {
+      ...settings,
+      editMode: {
+        ...settings.editMode,
+        snapToGrid: enabled,
+      },
+    };
     setSettings(newSettings);
     updateDashboard(newSettings);
   };
@@ -427,7 +441,7 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
             <label className="relative inline-flex items-center cursor-pointer">
               <input
                 type="checkbox"
-                checked={settings.showEditModePixelDistances ?? true}
+                checked={settings.editMode?.pixelDistances ?? false}
                 onChange={(e) =>
                   handleShowEditModePixelDistancesChange(e.target.checked)
                 }
@@ -455,7 +469,7 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
             <label className="relative inline-flex items-center cursor-pointer">
               <input
                 type="checkbox"
-                checked={settings.snapEditModeWidgetsToGrid ?? true}
+                checked={settings.editMode?.snapToGrid ?? false}
                 onChange={(e) =>
                   handleSnapEditModeWidgetsToGridChange(e.target.checked)
                 }

--- a/src/frontend/components/WidgetContainer/EdgeDistanceLabels.tsx
+++ b/src/frontend/components/WidgetContainer/EdgeDistanceLabels.tsx
@@ -14,6 +14,7 @@ const labelStyle: CSSProperties = {
 const cls =
   'text-xs font-mono bg-slate-900/90 text-sky-400 px-1.5 py-0.5 rounded leading-none';
 
+/** Renders four floating labels showing pixel distances from a widget to each viewport edge. */
 export const EdgeDistanceLabels = ({ distances }: Props) => {
   return (
     <>

--- a/src/frontend/components/WidgetContainer/EdgeDistanceLabels.tsx
+++ b/src/frontend/components/WidgetContainer/EdgeDistanceLabels.tsx
@@ -1,0 +1,68 @@
+import type { CSSProperties } from 'react';
+import type { EdgeDistances } from './useEdgeDistances';
+
+interface Props {
+  distances: EdgeDistances;
+}
+
+const labelStyle: CSSProperties = {
+  position: 'absolute',
+  pointerEvents: 'none',
+  userSelect: 'none',
+};
+
+const cls =
+  'text-xs font-mono bg-slate-900/90 text-sky-400 px-1.5 py-0.5 rounded leading-none';
+
+export const EdgeDistanceLabels = ({ distances }: Props) => {
+  return (
+    <>
+      <div
+        className={cls}
+        style={{
+          ...labelStyle,
+          top: 4,
+          left: '50%',
+          transform: 'translateX(-50%)',
+        }}
+      >
+        {Math.round(distances.top)}
+      </div>
+      <div
+        className={cls}
+        style={{
+          ...labelStyle,
+          bottom: 4,
+          left: '50%',
+          transform: 'translateX(-50%)',
+        }}
+      >
+        {Math.round(distances.bottom)}
+      </div>
+      <div
+        className={cls}
+        style={{
+          ...labelStyle,
+          left: 4,
+          top: '50%',
+          transform: 'translateY(-50%)',
+        }}
+      >
+        {Math.round(distances.left)}
+      </div>
+      <div
+        className={cls}
+        style={{
+          ...labelStyle,
+          right: 4,
+          top: '50%',
+          transform: 'translateY(-50%)',
+        }}
+      >
+        {Math.round(distances.right)}
+      </div>
+    </>
+  );
+};
+
+EdgeDistanceLabels.displayName = 'EdgeDistanceLabels';

--- a/src/frontend/components/WidgetContainer/WidgetContainer.tsx
+++ b/src/frontend/components/WidgetContainer/WidgetContainer.tsx
@@ -4,18 +4,22 @@ import {
   useRef,
   useState,
   useEffect,
+  useMemo,
   CSSProperties,
 } from 'react';
 import type { DashboardWidget, WidgetLayout } from '@irdashies/types';
 import { useDragWidget } from './useDragWidget';
 import { useResizeWidget } from './useResizeWidget';
 import { ResizeHandles } from './ResizeHandle';
+import { EdgeDistanceLabels } from './EdgeDistanceLabels';
+import { useEdgeDistances } from './useEdgeDistances';
 import { getWidgetName } from '../../constants/widgetNames';
 import { ResizeIcon, GearIcon, XIcon } from '@phosphor-icons/react';
-import { useContainerOffset } from '@irdashies/context';
+import { useContainerOffset, useDashboard } from '@irdashies/context';
 
 export interface WidgetContainerProps {
   widget: DashboardWidget;
+  siblingLayouts?: WidgetLayout[];
   editMode: boolean;
   zIndex: number;
   onLayoutChange: (widgetId: string, layout: WidgetLayout) => void;
@@ -27,6 +31,7 @@ export interface WidgetContainerProps {
 export const WidgetContainer = memo(
   ({
     widget,
+    siblingLayouts = [],
     editMode,
     zIndex,
     onLayoutChange,
@@ -41,6 +46,23 @@ export const WidgetContainer = memo(
     );
     const pendingLayoutRef = useRef<WidgetLayout | null>(null);
     const containerOffset = useContainerOffset();
+    const { containerBoundsInfo, currentDashboard } = useDashboard();
+    const showEditModePixelDistances =
+      currentDashboard?.generalSettings?.showEditModePixelDistances ?? true;
+    const snapEditModeWidgetsToGrid =
+      currentDashboard?.generalSettings?.snapEditModeWidgetsToGrid ?? true;
+    const snapBounds =
+      containerBoundsInfo?.displayBounds ?? containerBoundsInfo?.expected;
+    const gridSnapOptions = useMemo(
+      () =>
+        snapEditModeWidgetsToGrid
+          ? {
+              bounds: snapBounds,
+              siblingLayouts,
+            }
+          : undefined,
+      [snapEditModeWidgetsToGrid, siblingLayouts, snapBounds]
+    );
 
     const handleLayoutChange = useCallback(
       (newLayout: WidgetLayout) => {
@@ -75,12 +97,14 @@ export const WidgetContainer = memo(
       layout: localLayout,
       onLayoutChange: handleLayoutChange,
       enabled: editMode,
+      snapOptions: gridSnapOptions,
     });
 
     const { isResizing, getResizeHandleProps } = useResizeWidget({
       layout: localLayout,
       onLayoutChange: handleLayoutChange,
       enabled: editMode,
+      snapOptions: gridSnapOptions,
     });
 
     // Use local state during interaction, otherwise use prop
@@ -127,6 +151,10 @@ export const WidgetContainer = memo(
 
     // Always use localLayout for display
     const displayedLayout = localLayout;
+    const edgeDistances = useEdgeDistances(
+      displayedLayout,
+      editMode && showEditModePixelDistances
+    );
 
     // Transform widget coordinates from screen space to container space
     // Widget coords assume primary display at (0,0), but container may span multiple displays
@@ -195,6 +223,11 @@ export const WidgetContainer = memo(
 
             {/* Resize handles */}
             <ResizeHandles getResizeHandleProps={getResizeHandleProps} />
+
+            {/* Edge distance indicators */}
+            {showEditModePixelDistances && edgeDistances && (
+              <EdgeDistanceLabels distances={edgeDistances} />
+            )}
           </>
         )}
       </div>

--- a/src/frontend/components/WidgetContainer/WidgetContainer.tsx
+++ b/src/frontend/components/WidgetContainer/WidgetContainer.tsx
@@ -47,21 +47,21 @@ export const WidgetContainer = memo(
     const pendingLayoutRef = useRef<WidgetLayout | null>(null);
     const containerOffset = useContainerOffset();
     const { containerBoundsInfo, currentDashboard } = useDashboard();
-    const showEditModePixelDistances =
-      currentDashboard?.generalSettings?.showEditModePixelDistances ?? true;
-    const snapEditModeWidgetsToGrid =
-      currentDashboard?.generalSettings?.snapEditModeWidgetsToGrid ?? true;
+    const pixelDistances =
+      currentDashboard?.generalSettings?.editMode?.pixelDistances ?? false;
+    const snapToGrid =
+      currentDashboard?.generalSettings?.editMode?.snapToGrid ?? false;
     const snapBounds =
       containerBoundsInfo?.displayBounds ?? containerBoundsInfo?.expected;
     const gridSnapOptions = useMemo(
       () =>
-        snapEditModeWidgetsToGrid
+        snapToGrid
           ? {
               bounds: snapBounds,
               siblingLayouts,
             }
           : undefined,
-      [snapEditModeWidgetsToGrid, siblingLayouts, snapBounds]
+      [snapToGrid, siblingLayouts, snapBounds]
     );
 
     const handleLayoutChange = useCallback(
@@ -153,7 +153,7 @@ export const WidgetContainer = memo(
     const displayedLayout = localLayout;
     const edgeDistances = useEdgeDistances(
       displayedLayout,
-      editMode && showEditModePixelDistances
+      editMode && pixelDistances
     );
 
     // Transform widget coordinates from screen space to container space
@@ -225,7 +225,7 @@ export const WidgetContainer = memo(
             <ResizeHandles getResizeHandleProps={getResizeHandleProps} />
 
             {/* Edge distance indicators */}
-            {showEditModePixelDistances && edgeDistances && (
+            {pixelDistances && edgeDistances && (
               <EdgeDistanceLabels distances={edgeDistances} />
             )}
           </>

--- a/src/frontend/components/WidgetContainer/snapToViewportGrid.spec.ts
+++ b/src/frontend/components/WidgetContainer/snapToViewportGrid.spec.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from 'vitest';
+import {
+  snapLayoutPositionToViewportGrid,
+  snapLayoutResizeToViewportGrid,
+} from './snapToViewportGrid';
+
+const bounds = {
+  x: -1920,
+  y: 0,
+  width: 1920,
+  height: 1080,
+};
+
+const options = { bounds };
+
+describe('snapToViewportGrid', () => {
+  it('snaps widget position to a viewport-derived grid', () => {
+    expect(
+      snapLayoutPositionToViewportGrid(
+        { x: -1906, y: 17, width: 240, height: 120 },
+        options
+      ).layout
+    ).toEqual({ x: -1910, y: 15, width: 240, height: 120 });
+  });
+
+  it('returns the original layout when display bounds are unavailable', () => {
+    const layout = { x: 103, y: 56, width: 240, height: 120 };
+
+    expect(snapLayoutPositionToViewportGrid(layout).layout).toBe(layout);
+    expect(
+      snapLayoutResizeToViewportGrid(layout, 'se', {}, 100, 50).layout
+    ).toBe(layout);
+  });
+
+  it('returns the original layout when snapping is disabled', () => {
+    const layout = { x: 103, y: 56, width: 240, height: 120 };
+
+    expect(
+      snapLayoutPositionToViewportGrid(layout, {
+        bounds,
+        disabled: true,
+      }).layout
+    ).toBe(layout);
+    expect(
+      snapLayoutResizeToViewportGrid(
+        layout,
+        'se',
+        { bounds, disabled: true },
+        100,
+        50
+      ).layout
+    ).toBe(layout);
+  });
+
+  it('snaps east and south resize edges to the grid', () => {
+    expect(
+      snapLayoutResizeToViewportGrid(
+        { x: -1800, y: 20, width: 157, height: 83 },
+        'se',
+        options,
+        100,
+        50
+      ).layout
+    ).toEqual({ x: -1800, y: 20, width: 160, height: 85 });
+  });
+
+  it('snaps west and north resize edges while preserving the far edge', () => {
+    expect(
+      snapLayoutResizeToViewportGrid(
+        { x: -1813, y: 13, width: 253, height: 127 },
+        'nw',
+        options,
+        100,
+        50
+      ).layout
+    ).toEqual({ x: -1810, y: 15, width: 250, height: 125 });
+  });
+
+  it('honors minimum dimensions when a snapped resize edge crosses the limit', () => {
+    expect(
+      snapLayoutResizeToViewportGrid(
+        { x: -1813, y: 13, width: 95, height: 43 },
+        'nw',
+        options,
+        100,
+        50
+      ).layout
+    ).toEqual({ x: -1818, y: 6, width: 100, height: 50 });
+  });
+
+  it('locks a dragged widget to the display edge after snapping to zero distance', () => {
+    const first = snapLayoutPositionToViewportGrid(
+      { x: -1916, y: 120, width: 240, height: 120 },
+      options,
+      {},
+      1000
+    );
+    const second = snapLayoutPositionToViewportGrid(
+      { x: -1912, y: 120, width: 240, height: 120 },
+      options,
+      first.state,
+      1300
+    );
+
+    expect(first.layout.x).toBe(-1920);
+    expect(second.layout.x).toBe(-1920);
+  });
+
+  it('does not edge-lock when the widget is outside the tight edge threshold', () => {
+    const result = snapLayoutPositionToViewportGrid(
+      { x: -1915, y: 120, width: 240, height: 120 },
+      options,
+      {},
+      1000
+    );
+
+    expect(result.layout.x).toBe(-1910);
+  });
+
+  it('releases an edge lock when the widget keeps moving past the display edge', () => {
+    const first = snapLayoutPositionToViewportGrid(
+      { x: -1916, y: 120, width: 240, height: 120 },
+      options,
+      {},
+      1000
+    );
+    const second = snapLayoutPositionToViewportGrid(
+      { x: -1940, y: 120, width: 240, height: 120 },
+      options,
+      first.state,
+      1100
+    );
+
+    expect(first.layout.x).toBe(-1920);
+    expect(second.layout.x).toBe(-1940);
+  });
+
+  it('releases an edge lock after a small continued move past the display edge', () => {
+    const first = snapLayoutPositionToViewportGrid(
+      { x: -1916, y: 120, width: 240, height: 120 },
+      options,
+      {},
+      1000
+    );
+    const second = snapLayoutPositionToViewportGrid(
+      { x: -1927, y: 120, width: 240, height: 120 },
+      options,
+      first.state,
+      1100
+    );
+
+    expect(first.layout.x).toBe(-1920);
+    expect(second.layout.x).toBe(-1927);
+  });
+
+  it('temporarily bypasses vertical grid snapping after releasing an edge lock', () => {
+    const first = snapLayoutPositionToViewportGrid(
+      { x: -1800, y: 4, width: 240, height: 120 },
+      options,
+      {},
+      1000
+    );
+    const second = snapLayoutPositionToViewportGrid(
+      { x: -1800, y: -7, width: 240, height: 120 },
+      options,
+      first.state,
+      1100
+    );
+
+    expect(first.layout.y).toBe(0);
+    expect(second.layout.y).toBe(-7);
+  });
+
+  it('resumes grid snapping after the release bypass window', () => {
+    const first = snapLayoutPositionToViewportGrid(
+      { x: -1916, y: 120, width: 240, height: 120 },
+      options,
+      {},
+      1000
+    );
+    const second = snapLayoutPositionToViewportGrid(
+      { x: -1927, y: 120, width: 240, height: 120 },
+      options,
+      first.state,
+      1100
+    );
+    const third = snapLayoutPositionToViewportGrid(
+      { x: -1927, y: 120, width: 240, height: 120 },
+      options,
+      second.state,
+      1400
+    );
+
+    expect(second.layout.x).toBe(-1927);
+    expect(third.layout.x).toBe(-1930);
+  });
+
+  it('releases an edge lock after 400ms', () => {
+    const first = snapLayoutPositionToViewportGrid(
+      { x: -1916, y: 120, width: 240, height: 120 },
+      options,
+      {},
+      1000
+    );
+    const second = snapLayoutPositionToViewportGrid(
+      { x: -1912, y: 120, width: 240, height: 120 },
+      options,
+      first.state,
+      1400
+    );
+
+    expect(first.layout.x).toBe(-1920);
+    expect(second.layout.x).toBe(-1912);
+  });
+
+  it('locks a resized widget edge to zero distance', () => {
+    const first = snapLayoutResizeToViewportGrid(
+      { x: -1800, y: 120, width: 1797, height: 120 },
+      'e',
+      options,
+      100,
+      50,
+      {},
+      1000
+    );
+    const second = snapLayoutResizeToViewportGrid(
+      { x: -1800, y: 120, width: 1792, height: 120 },
+      'e',
+      options,
+      100,
+      50,
+      first.state,
+      1300
+    );
+
+    expect(first.layout.width).toBe(1800);
+    expect(second.layout.width).toBe(1800);
+  });
+
+  it('locks a dragged widget edge to a sibling widget edge', () => {
+    const siblingLayouts = [{ x: -1500, y: 300, width: 300, height: 120 }];
+    const first = snapLayoutPositionToViewportGrid(
+      { x: -1743, y: 300, width: 240, height: 120 },
+      { bounds, siblingLayouts },
+      {},
+      1000
+    );
+    const second = snapLayoutPositionToViewportGrid(
+      { x: -1748, y: 300, width: 240, height: 120 },
+      { bounds, siblingLayouts },
+      first.state,
+      1300
+    );
+
+    expect(first.layout.x + first.layout.width).toBe(-1500);
+    expect(second.layout.x + second.layout.width).toBe(-1500);
+  });
+
+  it('does not lock to a sibling edge when the widgets are in different rows', () => {
+    const siblingLayouts = [{ x: -1500, y: 700, width: 300, height: 120 }];
+    const result = snapLayoutPositionToViewportGrid(
+      { x: -1748, y: 300, width: 240, height: 120 },
+      { bounds, siblingLayouts },
+      {},
+      1000
+    );
+
+    expect(result.layout.x + result.layout.width).toBe(-1510);
+  });
+
+  it('locks a resized widget edge to a sibling widget edge', () => {
+    const siblingLayouts = [{ x: -1500, y: 300, width: 300, height: 120 }];
+    const first = snapLayoutResizeToViewportGrid(
+      { x: -1800, y: 300, width: 297, height: 120 },
+      'e',
+      { bounds, siblingLayouts },
+      100,
+      50,
+      {},
+      1000
+    );
+    const second = snapLayoutResizeToViewportGrid(
+      { x: -1800, y: 300, width: 292, height: 120 },
+      'e',
+      { bounds, siblingLayouts },
+      100,
+      50,
+      first.state,
+      1300
+    );
+
+    expect(first.layout.x + first.layout.width).toBe(-1500);
+    expect(second.layout.x + second.layout.width).toBe(-1500);
+  });
+
+  it('honors minimum width after locking a resized west edge', () => {
+    const result = snapLayoutResizeToViewportGrid(
+      { x: -1817, y: 300, width: 97, height: 120 },
+      'w',
+      options,
+      100,
+      50,
+      {},
+      1000
+    );
+
+    expect(result.layout).toEqual({
+      x: -1820,
+      y: 300,
+      width: 100,
+      height: 120,
+    });
+  });
+
+  it('honors minimum height after locking a resized north edge', () => {
+    const result = snapLayoutResizeToViewportGrid(
+      { x: -1800, y: 3, width: 240, height: 47 },
+      'n',
+      options,
+      100,
+      50,
+      {},
+      1000
+    );
+
+    expect(result.layout).toEqual({
+      x: -1800,
+      y: 0,
+      width: 240,
+      height: 50,
+    });
+  });
+});

--- a/src/frontend/components/WidgetContainer/snapToViewportGrid.ts
+++ b/src/frontend/components/WidgetContainer/snapToViewportGrid.ts
@@ -36,15 +36,19 @@ const EDGE_ESCAPE_PX = 6;
 const EDGE_LOCK_THRESHOLD_PX = 4;
 const EDGE_RELEASE_FREE_MS = 250;
 
+/** Computes the pixel size of one grid cell for a given viewport dimension. */
 const getGridSize = (length: number) =>
   Math.max(1, Math.round(length / VIEWPORT_GRID_DIVISIONS));
 
+/** Snaps a value to the nearest grid cell relative to an origin. */
 const snapToGrid = (value: number, origin: number, gridSize: number) =>
   origin + Math.round((value - origin) / gridSize) * gridSize;
 
+/** Returns true when value is within threshold pixels of edge. */
 const isNearEdge = (value: number, edge: number, threshold: number) =>
   Math.abs(value - edge) <= threshold;
 
+/** Returns true when two inclusive ranges overlap. */
 const rangesOverlap = (
   firstStart: number,
   firstEnd: number,
@@ -52,6 +56,10 @@ const rangesOverlap = (
   secondEnd: number
 ) => firstStart <= secondEnd && secondStart <= firstEnd;
 
+/**
+ * Returns horizontal snap targets: viewport left/right edges plus the left and right
+ * edges of any sibling widgets whose vertical extent overlaps the current layout.
+ */
 const getHorizontalTargets = (
   bounds: SnapBounds,
   siblingLayouts: WidgetLayout[],
@@ -74,6 +82,10 @@ const getHorizontalTargets = (
     ]),
 ];
 
+/**
+ * Returns vertical snap targets: viewport top/bottom edges plus the top and bottom
+ * edges of any sibling widgets whose horizontal extent overlaps the current layout.
+ */
 const getVerticalTargets = (
   bounds: SnapBounds,
   siblingLayouts: WidgetLayout[],
@@ -96,6 +108,7 @@ const getVerticalTargets = (
     ]),
 ];
 
+/** Returns the closest target within threshold, or undefined if none qualify. */
 const findNearestTarget = (
   value: number,
   targets: number[],
@@ -111,6 +124,10 @@ const findNearestTarget = (
   }, undefined);
 };
 
+/**
+ * Returns true while the lock should hold: the edge hasn't exceeded EDGE_ESCAPE_PX
+ * from the snap target and the lock hasn't expired after EDGE_LOCK_MS.
+ */
 const shouldKeepEdgeLock = (
   edge: SnapEdge,
   layout: WidgetLayout,
@@ -129,6 +146,10 @@ const shouldKeepEdgeLock = (
   return layout.y + layout.height <= target + EDGE_ESCAPE_PX;
 };
 
+/**
+ * Snaps the given edge to target. When preserveOppositeEdge is true (resize mode)
+ * the opposite edge stays fixed and size adjusts accordingly.
+ */
 const applyEdgeLock = (
   layout: WidgetLayout,
   edge: SnapEdge,
@@ -168,6 +189,10 @@ const applyEdgeLock = (
   return { ...layout, y: target - layout.height };
 };
 
+/**
+ * Restores the unsnapped (raw) position for the given edge, used when releasing
+ * a lock so the widget tracks the pointer again instead of staying snapped.
+ */
 const applyRawEdge = (
   layout: WidgetLayout,
   edge: SnapEdge,
@@ -205,6 +230,7 @@ const applyRawEdge = (
   return { ...layout, y: rawLayout.y };
 };
 
+/** Returns a new state object with the given edge entry removed. */
 const omitEdgeState = (
   state: ViewportGridSnapState,
   edge: SnapEdge
@@ -214,6 +240,12 @@ const omitEdgeState = (
   ) as ViewportGridSnapState;
 };
 
+/**
+ * Core snap-lock state machine for a single edge. Acquires a lock when the raw edge
+ * crosses within threshold of a target, holds it for EDGE_LOCK_MS, then releases
+ * into a free period (EDGE_RELEASE_FREE_MS) before allowing re-lock. The suppressed
+ * state prevents immediate re-lock after the user escapes back to the same target.
+ */
 const lockEdgeIfNear = (
   layout: WidgetLayout,
   edge: SnapEdge,
@@ -301,6 +333,11 @@ const lockEdgeIfNear = (
   };
 };
 
+/**
+ * Snaps a dragged widget position to the viewport grid and to sibling/boundary edges.
+ * Pass shift-key state via options.disabled to temporarily bypass snapping.
+ * The returned state must be threaded back in on subsequent calls for lock continuity.
+ */
 export const snapLayoutPositionToViewportGrid = (
   layout: WidgetLayout,
   options: ViewportGridSnapOptions = {},
@@ -361,6 +398,10 @@ export const snapLayoutPositionToViewportGrid = (
   return { layout: result, state: nextState };
 };
 
+/**
+ * Clamps width/height to minimums after snapping, anchoring to the stationary edge
+ * so the fixed side of the widget doesn't shift when the minimum kicks in.
+ */
 const enforceResizeMinimums = (
   layout: WidgetLayout,
   direction: ResizeDirection,
@@ -388,6 +429,11 @@ const enforceResizeMinimums = (
   return nextLayout;
 };
 
+/**
+ * Snaps a resize operation to the viewport grid and to sibling/boundary edges.
+ * Only the edges active in `direction` are snapped; opposite edges are preserved.
+ * Minimum dimensions are enforced after snapping to avoid zero-size widgets.
+ */
 export const snapLayoutResizeToViewportGrid = (
   layout: WidgetLayout,
   direction: ResizeDirection,

--- a/src/frontend/components/WidgetContainer/snapToViewportGrid.ts
+++ b/src/frontend/components/WidgetContainer/snapToViewportGrid.ts
@@ -1,0 +1,468 @@
+import type { WidgetLayout } from '@irdashies/types';
+import type { ResizeDirection } from './useResizeWidget';
+
+export interface SnapBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type SnapEdge = 'left' | 'top' | 'right' | 'bottom';
+
+export interface ViewportGridSnapOptions {
+  bounds?: SnapBounds;
+  siblingLayouts?: WidgetLayout[];
+  disabled?: boolean;
+}
+
+interface SnapEdgeLock {
+  target?: number;
+  lockedAt?: number;
+  freeUntil?: number;
+  suppressed?: boolean;
+}
+
+export type ViewportGridSnapState = Partial<Record<SnapEdge, SnapEdgeLock>>;
+
+export interface ViewportGridSnapResult {
+  layout: WidgetLayout;
+  state: ViewportGridSnapState;
+}
+
+const VIEWPORT_GRID_DIVISIONS = 200;
+const EDGE_LOCK_MS = 400;
+const EDGE_ESCAPE_PX = 6;
+const EDGE_LOCK_THRESHOLD_PX = 4;
+const EDGE_RELEASE_FREE_MS = 250;
+
+const getGridSize = (length: number) =>
+  Math.max(1, Math.round(length / VIEWPORT_GRID_DIVISIONS));
+
+const snapToGrid = (value: number, origin: number, gridSize: number) =>
+  origin + Math.round((value - origin) / gridSize) * gridSize;
+
+const isNearEdge = (value: number, edge: number, threshold: number) =>
+  Math.abs(value - edge) <= threshold;
+
+const rangesOverlap = (
+  firstStart: number,
+  firstEnd: number,
+  secondStart: number,
+  secondEnd: number
+) => firstStart <= secondEnd && secondStart <= firstEnd;
+
+const getHorizontalTargets = (
+  bounds: SnapBounds,
+  siblingLayouts: WidgetLayout[],
+  layout: WidgetLayout
+) => [
+  bounds.x,
+  bounds.x + bounds.width,
+  ...siblingLayouts
+    .filter((siblingLayout) =>
+      rangesOverlap(
+        layout.y,
+        layout.y + layout.height,
+        siblingLayout.y,
+        siblingLayout.y + siblingLayout.height
+      )
+    )
+    .flatMap((siblingLayout) => [
+      siblingLayout.x,
+      siblingLayout.x + siblingLayout.width,
+    ]),
+];
+
+const getVerticalTargets = (
+  bounds: SnapBounds,
+  siblingLayouts: WidgetLayout[],
+  layout: WidgetLayout
+) => [
+  bounds.y,
+  bounds.y + bounds.height,
+  ...siblingLayouts
+    .filter((siblingLayout) =>
+      rangesOverlap(
+        layout.x,
+        layout.x + layout.width,
+        siblingLayout.x,
+        siblingLayout.x + siblingLayout.width
+      )
+    )
+    .flatMap((siblingLayout) => [
+      siblingLayout.y,
+      siblingLayout.y + siblingLayout.height,
+    ]),
+];
+
+const findNearestTarget = (
+  value: number,
+  targets: number[],
+  threshold: number
+) => {
+  return targets.reduce<number | undefined>((nearest, target) => {
+    if (!isNearEdge(value, target, threshold)) return nearest;
+    if (nearest === undefined) return target;
+
+    return Math.abs(value - target) < Math.abs(value - nearest)
+      ? target
+      : nearest;
+  }, undefined);
+};
+
+const shouldKeepEdgeLock = (
+  edge: SnapEdge,
+  layout: WidgetLayout,
+  target: number,
+  lockedAt: number,
+  now: number
+) => {
+  if (now - lockedAt >= EDGE_LOCK_MS) return false;
+
+  if (edge === 'left') return layout.x >= target - EDGE_ESCAPE_PX;
+  if (edge === 'top') return layout.y >= target - EDGE_ESCAPE_PX;
+  if (edge === 'right') {
+    return layout.x + layout.width <= target + EDGE_ESCAPE_PX;
+  }
+
+  return layout.y + layout.height <= target + EDGE_ESCAPE_PX;
+};
+
+const applyEdgeLock = (
+  layout: WidgetLayout,
+  edge: SnapEdge,
+  target: number,
+  preserveOppositeEdge: boolean
+) => {
+  if (edge === 'left') {
+    if (preserveOppositeEdge) {
+      const rightEdge = layout.x + layout.width;
+      return { ...layout, x: target, width: rightEdge - target };
+    }
+
+    return { ...layout, x: target };
+  }
+
+  if (edge === 'top') {
+    if (preserveOppositeEdge) {
+      const bottomEdge = layout.y + layout.height;
+      return { ...layout, y: target, height: bottomEdge - target };
+    }
+
+    return { ...layout, y: target };
+  }
+
+  if (edge === 'right') {
+    if (preserveOppositeEdge) {
+      return { ...layout, width: target - layout.x };
+    }
+
+    return { ...layout, x: target - layout.width };
+  }
+
+  if (preserveOppositeEdge) {
+    return { ...layout, height: target - layout.y };
+  }
+
+  return { ...layout, y: target - layout.height };
+};
+
+const applyRawEdge = (
+  layout: WidgetLayout,
+  edge: SnapEdge,
+  rawLayout: WidgetLayout,
+  preserveOppositeEdge: boolean
+) => {
+  if (edge === 'left') {
+    if (preserveOppositeEdge) {
+      return { ...layout, x: rawLayout.x, width: rawLayout.width };
+    }
+
+    return { ...layout, x: rawLayout.x };
+  }
+
+  if (edge === 'top') {
+    if (preserveOppositeEdge) {
+      return { ...layout, y: rawLayout.y, height: rawLayout.height };
+    }
+
+    return { ...layout, y: rawLayout.y };
+  }
+
+  if (edge === 'right') {
+    if (preserveOppositeEdge) {
+      return { ...layout, width: rawLayout.width };
+    }
+
+    return { ...layout, x: rawLayout.x };
+  }
+
+  if (preserveOppositeEdge) {
+    return { ...layout, height: rawLayout.height };
+  }
+
+  return { ...layout, y: rawLayout.y };
+};
+
+const omitEdgeState = (
+  state: ViewportGridSnapState,
+  edge: SnapEdge
+): ViewportGridSnapState => {
+  return Object.fromEntries(
+    Object.entries(state).filter(([stateEdge]) => stateEdge !== edge)
+  ) as ViewportGridSnapState;
+};
+
+const lockEdgeIfNear = (
+  layout: WidgetLayout,
+  edge: SnapEdge,
+  rawLayout: WidgetLayout,
+  targets: number[],
+  threshold: number,
+  state: ViewportGridSnapState,
+  now: number,
+  preserveOppositeEdge: boolean
+) => {
+  let nextState = { ...state };
+  const edgeState = nextState[edge];
+  const lockedAt = edgeState?.lockedAt;
+  const freeUntil = edgeState?.freeUntil;
+
+  const edgeValue =
+    edge === 'left'
+      ? rawLayout.x
+      : edge === 'top'
+        ? rawLayout.y
+        : edge === 'right'
+          ? rawLayout.x + rawLayout.width
+          : rawLayout.y + rawLayout.height;
+  const nearestTarget = findNearestTarget(edgeValue, targets, threshold);
+  const nearLockedTarget =
+    edgeState?.target !== undefined &&
+    isNearEdge(edgeValue, edgeState.target, EDGE_LOCK_THRESHOLD_PX);
+
+  const lockedTarget = edgeState?.target;
+  if (freeUntil !== undefined && now < freeUntil) {
+    return {
+      layout: applyRawEdge(layout, edge, rawLayout, preserveOppositeEdge),
+      state: nextState,
+    };
+  }
+
+  if (
+    lockedAt !== undefined &&
+    lockedTarget !== undefined &&
+    shouldKeepEdgeLock(edge, rawLayout, lockedTarget, lockedAt, now)
+  ) {
+    return {
+      layout: applyEdgeLock(layout, edge, lockedTarget, preserveOppositeEdge),
+      state: nextState,
+    };
+  }
+
+  if (edgeState?.suppressed && nearLockedTarget) {
+    return { layout, state: nextState };
+  }
+
+  nextState = omitEdgeState(nextState, edge);
+
+  if (lockedAt !== undefined || edgeState?.suppressed) {
+    if (lockedAt !== undefined && !nearLockedTarget) {
+      nextState[edge] = {
+        target: edgeState?.target,
+        freeUntil: now + EDGE_RELEASE_FREE_MS,
+      };
+      return {
+        layout: applyRawEdge(layout, edge, rawLayout, preserveOppositeEdge),
+        state: nextState,
+      };
+    }
+
+    if (nearLockedTarget) {
+      nextState[edge] = {
+        target: edgeState?.target,
+        suppressed: true,
+      };
+      return { layout, state: nextState };
+    }
+
+    return { layout, state: nextState };
+  }
+
+  if (nearestTarget === undefined) {
+    return { layout, state: nextState };
+  }
+
+  nextState[edge] = { target: nearestTarget, lockedAt: now };
+  return {
+    layout: applyEdgeLock(layout, edge, nearestTarget, preserveOppositeEdge),
+    state: nextState,
+  };
+};
+
+export const snapLayoutPositionToViewportGrid = (
+  layout: WidgetLayout,
+  options: ViewportGridSnapOptions = {},
+  state: ViewportGridSnapState = {},
+  now = Date.now()
+): ViewportGridSnapResult => {
+  const { bounds, disabled = false, siblingLayouts = [] } = options;
+  if (!bounds || disabled) return { layout, state: {} };
+
+  const gridX = getGridSize(bounds.width);
+  const gridY = getGridSize(bounds.height);
+  const horizontalTargets = getHorizontalTargets(
+    bounds,
+    siblingLayouts,
+    layout
+  );
+  const verticalTargets = getVerticalTargets(bounds, siblingLayouts, layout);
+  let result = {
+    ...layout,
+    x: snapToGrid(layout.x, bounds.x, gridX),
+    y: snapToGrid(layout.y, bounds.y, gridY),
+  };
+  let nextState = state;
+
+  const horizontalEdges: SnapEdge[] = ['left', 'right'];
+  const verticalEdges: SnapEdge[] = ['top', 'bottom'];
+
+  horizontalEdges.forEach((edge) => {
+    const next = lockEdgeIfNear(
+      result,
+      edge,
+      layout,
+      horizontalTargets,
+      EDGE_LOCK_THRESHOLD_PX,
+      nextState,
+      now,
+      false
+    );
+    result = next.layout;
+    nextState = next.state;
+  });
+
+  verticalEdges.forEach((edge) => {
+    const next = lockEdgeIfNear(
+      result,
+      edge,
+      layout,
+      verticalTargets,
+      EDGE_LOCK_THRESHOLD_PX,
+      nextState,
+      now,
+      false
+    );
+    result = next.layout;
+    nextState = next.state;
+  });
+
+  return { layout: result, state: nextState };
+};
+
+const enforceResizeMinimums = (
+  layout: WidgetLayout,
+  direction: ResizeDirection,
+  minWidth: number,
+  minHeight: number
+) => {
+  const nextLayout = { ...layout };
+
+  if (direction.includes('w') && nextLayout.width < minWidth) {
+    const rightEdge = nextLayout.x + nextLayout.width;
+    nextLayout.x = rightEdge - minWidth;
+    nextLayout.width = minWidth;
+  } else if (direction.includes('e')) {
+    nextLayout.width = Math.max(minWidth, nextLayout.width);
+  }
+
+  if (direction.includes('n') && nextLayout.height < minHeight) {
+    const bottomEdge = nextLayout.y + nextLayout.height;
+    nextLayout.y = bottomEdge - minHeight;
+    nextLayout.height = minHeight;
+  } else if (direction.includes('s')) {
+    nextLayout.height = Math.max(minHeight, nextLayout.height);
+  }
+
+  return nextLayout;
+};
+
+export const snapLayoutResizeToViewportGrid = (
+  layout: WidgetLayout,
+  direction: ResizeDirection,
+  options: ViewportGridSnapOptions,
+  minWidth: number,
+  minHeight: number,
+  state: ViewportGridSnapState = {},
+  now = Date.now()
+): ViewportGridSnapResult => {
+  const { bounds, disabled = false, siblingLayouts = [] } = options;
+  if (!bounds || disabled) return { layout, state: {} };
+
+  const snappedLayout = { ...layout };
+  const gridX = getGridSize(bounds.width);
+  const gridY = getGridSize(bounds.height);
+  const horizontalTargets = getHorizontalTargets(
+    bounds,
+    siblingLayouts,
+    layout
+  );
+  const verticalTargets = getVerticalTargets(bounds, siblingLayouts, layout);
+
+  if (direction.includes('e')) {
+    const rightEdge = snapToGrid(layout.x + layout.width, bounds.x, gridX);
+    snappedLayout.width = Math.max(minWidth, rightEdge - layout.x);
+  }
+
+  if (direction.includes('w')) {
+    const rightEdge = layout.x + layout.width;
+    const leftEdge = snapToGrid(layout.x, bounds.x, gridX);
+    const nextWidth = rightEdge - leftEdge;
+    snappedLayout.x = nextWidth < minWidth ? rightEdge - minWidth : leftEdge;
+    snappedLayout.width = Math.max(minWidth, nextWidth);
+  }
+
+  if (direction.includes('s')) {
+    const bottomEdge = snapToGrid(layout.y + layout.height, bounds.y, gridY);
+    snappedLayout.height = Math.max(minHeight, bottomEdge - layout.y);
+  }
+
+  if (direction.includes('n')) {
+    const bottomEdge = layout.y + layout.height;
+    const topEdge = snapToGrid(layout.y, bounds.y, gridY);
+    const nextHeight = bottomEdge - topEdge;
+    snappedLayout.y = nextHeight < minHeight ? bottomEdge - minHeight : topEdge;
+    snappedLayout.height = Math.max(minHeight, nextHeight);
+  }
+
+  let result = snappedLayout;
+  let nextState = state;
+
+  const activeEdges: SnapEdge[] = [
+    ...(direction.includes('w') ? (['left'] as const) : []),
+    ...(direction.includes('e') ? (['right'] as const) : []),
+    ...(direction.includes('n') ? (['top'] as const) : []),
+    ...(direction.includes('s') ? (['bottom'] as const) : []),
+  ];
+
+  activeEdges.forEach((edge) => {
+    const next = lockEdgeIfNear(
+      result,
+      edge,
+      layout,
+      edge === 'left' || edge === 'right' ? horizontalTargets : verticalTargets,
+      EDGE_LOCK_THRESHOLD_PX,
+      nextState,
+      now,
+      true
+    );
+    result = next.layout;
+    nextState = next.state;
+  });
+
+  return {
+    layout: enforceResizeMinimums(result, direction, minWidth, minHeight),
+    state: nextState,
+  };
+};

--- a/src/frontend/components/WidgetContainer/useDragWidget.ts
+++ b/src/frontend/components/WidgetContainer/useDragWidget.ts
@@ -1,10 +1,16 @@
 import { useState, useCallback, useRef, useEffect, PointerEvent } from 'react';
 import type { WidgetLayout } from '@irdashies/types';
+import {
+  ViewportGridSnapOptions,
+  ViewportGridSnapState,
+  snapLayoutPositionToViewportGrid,
+} from './snapToViewportGrid';
 
 interface UseDragWidgetOptions {
   layout: WidgetLayout;
   onLayoutChange: (layout: WidgetLayout) => void;
   enabled: boolean;
+  snapOptions?: ViewportGridSnapOptions;
 }
 
 interface DragState {
@@ -18,10 +24,12 @@ export function useDragWidget({
   layout,
   onLayoutChange,
   enabled,
+  snapOptions,
 }: UseDragWidgetOptions) {
   const [isDragging, setIsDragging] = useState(false);
   const dragStateRef = useRef<DragState | null>(null);
   const layoutRef = useRef(layout);
+  const snapStateRef = useRef<ViewportGridSnapState>({});
 
   // Keep layout ref updated
   useEffect(() => {
@@ -41,6 +49,7 @@ export function useDragWidget({
         startLayoutX: layoutRef.current.x,
         startLayoutY: layoutRef.current.y,
       };
+      snapStateRef.current = {};
       setIsDragging(true);
     },
     [enabled]
@@ -56,15 +65,25 @@ export function useDragWidget({
       const deltaX = e.clientX - dragStateRef.current.startX;
       const deltaY = e.clientY - dragStateRef.current.startY;
 
-      onLayoutChange({
+      const nextLayout = {
         ...layoutRef.current,
         x: dragStateRef.current.startLayoutX + deltaX,
         y: dragStateRef.current.startLayoutY + deltaY,
-      });
+      };
+
+      const snapped = snapLayoutPositionToViewportGrid(
+        nextLayout,
+        { ...snapOptions, disabled: e.shiftKey },
+        snapStateRef.current
+      );
+
+      snapStateRef.current = snapped.state;
+      onLayoutChange(snapped.layout);
     };
 
     const handlePointerUp = () => {
       dragStateRef.current = null;
+      snapStateRef.current = {};
       setIsDragging(false);
     };
 
@@ -75,7 +94,7 @@ export function useDragWidget({
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', handlePointerUp);
     };
-  }, [isDragging, onLayoutChange]);
+  }, [isDragging, onLayoutChange, snapOptions]);
 
   return {
     isDragging,

--- a/src/frontend/components/WidgetContainer/useDragWidget.ts
+++ b/src/frontend/components/WidgetContainer/useDragWidget.ts
@@ -20,6 +20,7 @@ interface DragState {
   startLayoutY: number;
 }
 
+/** Provides pointer-driven drag behaviour for a widget, with optional viewport grid snapping. */
 export function useDragWidget({
   layout,
   onLayoutChange,

--- a/src/frontend/components/WidgetContainer/useEdgeDistances.spec.tsx
+++ b/src/frontend/components/WidgetContainer/useEdgeDistances.spec.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useDashboard } from '@irdashies/context';
+import { useEdgeDistances } from './useEdgeDistances';
+
+vi.mock('@irdashies/context', () => ({
+  useDashboard: vi.fn(),
+}));
+
+const mockUseDashboard = vi.mocked(useDashboard);
+const mockDashboardContext = (
+  context: Partial<ReturnType<typeof useDashboard>>
+) => context as unknown as ReturnType<typeof useDashboard>;
+
+const displayBounds = {
+  x: -1920,
+  y: 0,
+  width: 1920,
+  height: 1080,
+};
+
+describe('useEdgeDistances', () => {
+  beforeEach(() => {
+    mockUseDashboard.mockReturnValue(
+      mockDashboardContext({
+        containerBoundsInfo: {
+          displayBounds,
+          expected: displayBounds,
+          actual: displayBounds,
+          offset: { x: 0, y: 0 },
+        },
+      })
+    );
+  });
+
+  it('calculates distances from each widget edge to the display bounds', () => {
+    const { result } = renderHook(() =>
+      useEdgeDistances({ x: -1800, y: 40, width: 300, height: 120 })
+    );
+
+    expect(result.current).toEqual({
+      left: 120,
+      top: 40,
+      right: 1500,
+      bottom: 920,
+    });
+  });
+
+  it('returns null when display bounds are unavailable', () => {
+    mockUseDashboard.mockReturnValue(
+      mockDashboardContext({
+        containerBoundsInfo: undefined,
+      })
+    );
+
+    const { result } = renderHook(() =>
+      useEdgeDistances({ x: 10, y: 20, width: 300, height: 120 })
+    );
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when disabled', () => {
+    const { result } = renderHook(() =>
+      useEdgeDistances({ x: -1800, y: 40, width: 300, height: 120 }, false)
+    );
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/src/frontend/components/WidgetContainer/useEdgeDistances.ts
+++ b/src/frontend/components/WidgetContainer/useEdgeDistances.ts
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import type { WidgetLayout } from '@irdashies/types';
+import { useDashboard } from '@irdashies/context';
+
+export interface EdgeDistances {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/**
+ * Computes pixel distances from each widget edge to the corresponding display edge.
+ * Returns null when displayBounds isn't available (e.g., before the first IPC message arrives).
+ */
+export const useEdgeDistances = (
+  layout: WidgetLayout,
+  enabled = true
+): EdgeDistances | null => {
+  const { containerBoundsInfo } = useDashboard();
+
+  return useMemo(() => {
+    if (!enabled) return null;
+
+    const displayBounds = containerBoundsInfo?.displayBounds;
+    if (!displayBounds) return null;
+
+    return {
+      left: layout.x - displayBounds.x,
+      top: layout.y - displayBounds.y,
+      right: displayBounds.x + displayBounds.width - (layout.x + layout.width),
+      bottom:
+        displayBounds.y + displayBounds.height - (layout.y + layout.height),
+    };
+  }, [layout, containerBoundsInfo, enabled]);
+};

--- a/src/frontend/components/WidgetContainer/useResizeWidget.ts
+++ b/src/frontend/components/WidgetContainer/useResizeWidget.ts
@@ -1,15 +1,12 @@
 import { useState, useCallback, useRef, useEffect, PointerEvent } from 'react';
 import type { WidgetLayout } from '@irdashies/types';
+import {
+  ViewportGridSnapOptions,
+  ViewportGridSnapState,
+  snapLayoutResizeToViewportGrid,
+} from './snapToViewportGrid';
 
-export type ResizeDirection =
-  | 'n'
-  | 's'
-  | 'e'
-  | 'w'
-  | 'ne'
-  | 'nw'
-  | 'se'
-  | 'sw';
+export type ResizeDirection = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
 
 interface UseResizeWidgetOptions {
   layout: WidgetLayout;
@@ -17,6 +14,7 @@ interface UseResizeWidgetOptions {
   enabled: boolean;
   minWidth?: number;
   minHeight?: number;
+  snapOptions?: ViewportGridSnapOptions;
 }
 
 interface ResizeState {
@@ -35,12 +33,14 @@ export function useResizeWidget({
   enabled,
   minWidth = MIN_WIDTH,
   minHeight = MIN_HEIGHT,
+  snapOptions,
 }: UseResizeWidgetOptions) {
   const [isResizing, setIsResizing] = useState(false);
   const [activeDirection, setActiveDirection] =
     useState<ResizeDirection | null>(null);
   const resizeStateRef = useRef<ResizeState | null>(null);
   const layoutRef = useRef(layout);
+  const snapStateRef = useRef<ViewportGridSnapState>({});
 
   // Keep layout ref updated
   useEffect(() => {
@@ -60,6 +60,7 @@ export function useResizeWidget({
         startY: e.clientY,
         startLayout: { ...layoutRef.current },
       };
+      snapStateRef.current = {};
       setIsResizing(true);
       setActiveDirection(direction);
     },
@@ -101,11 +102,22 @@ export function useResizeWidget({
         newLayout.height = newHeight;
       }
 
-      onLayoutChange(newLayout);
+      const snapped = snapLayoutResizeToViewportGrid(
+        newLayout,
+        direction,
+        { ...snapOptions, disabled: e.shiftKey },
+        minWidth,
+        minHeight,
+        snapStateRef.current
+      );
+
+      snapStateRef.current = snapped.state;
+      onLayoutChange(snapped.layout);
     };
 
     const handlePointerUp = () => {
       resizeStateRef.current = null;
+      snapStateRef.current = {};
       setIsResizing(false);
       setActiveDirection(null);
     };
@@ -117,7 +129,7 @@ export function useResizeWidget({
       window.removeEventListener('pointermove', handlePointerMove);
       window.removeEventListener('pointerup', handlePointerUp);
     };
-  }, [isResizing, minWidth, minHeight, onLayoutChange]);
+  }, [isResizing, minWidth, minHeight, onLayoutChange, snapOptions]);
 
   const getResizeHandleProps = useCallback(
     (direction: ResizeDirection) => ({

--- a/src/frontend/components/WidgetContainer/useResizeWidget.ts
+++ b/src/frontend/components/WidgetContainer/useResizeWidget.ts
@@ -27,6 +27,7 @@ interface ResizeState {
 const MIN_WIDTH = 100;
 const MIN_HEIGHT = 50;
 
+/** Provides pointer-driven resize behaviour for a widget, with optional viewport grid snapping. */
 export function useResizeWidget({
   layout,
   onLayoutChange,
@@ -146,6 +147,7 @@ export function useResizeWidget({
   };
 }
 
+/** Maps a resize direction to the appropriate CSS cursor string. */
 function getCursor(direction: ResizeDirection): string {
   const cursors: Record<ResizeDirection, string> = {
     n: 'ns-resize',

--- a/src/types/dashboardBridge.ts
+++ b/src/types/dashboardBridge.ts
@@ -28,6 +28,8 @@ export interface ContainerBoundsInfo {
   isPrimary?: boolean;
   /** Full display bounds — used for widget-to-display assignment filtering */
   displayBounds?: { x: number; y: number; width: number; height: number };
+  /** Bounds of all known displays — used by the primary window to exclude widgets that belong to another display */
+  allDisplayBounds?: { x: number; y: number; width: number; height: number }[];
 }
 
 export interface DashboardBridge {

--- a/src/types/dashboardLayout.ts
+++ b/src/types/dashboardLayout.ts
@@ -135,6 +135,8 @@ export interface GeneralSettingsType {
   compactMode?: 'off' | 'compact' | 'ultra';
   overlayAlwaysOnTop?: boolean;
   enableNetworkAccess?: boolean;
+  showEditModePixelDistances?: boolean;
+  snapEditModeWidgetsToGrid?: boolean;
   /** Driver tag groups and mappings for overlays */
   driverTagSettings?: DriverTagSettings;
 }

--- a/src/types/dashboardLayout.ts
+++ b/src/types/dashboardLayout.ts
@@ -135,8 +135,10 @@ export interface GeneralSettingsType {
   compactMode?: 'off' | 'compact' | 'ultra';
   overlayAlwaysOnTop?: boolean;
   enableNetworkAccess?: boolean;
-  showEditModePixelDistances?: boolean;
-  snapEditModeWidgetsToGrid?: boolean;
+  editMode?: {
+    pixelDistances?: boolean;
+    snapToGrid?: boolean;
+  };
   /** Driver tag groups and mappings for overlays */
   driverTagSettings?: DriverTagSettings;
 }

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1183,8 +1183,10 @@ export const defaultDashboard: {
     compactMode: 'off' as const,
     overlayAlwaysOnTop: true,
     enableNetworkAccess: false,
-    showEditModePixelDistances: true,
-    snapEditModeWidgetsToGrid: true,
+    editMode: {
+      pixelDistances: false,
+      snapToGrid: false,
+    },
   },
 };
 

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -49,8 +49,8 @@ export const defaultDashboard: {
         background: {
           opacity: 80,
         },
-        foreground: { 
-          opacity: 70, 
+        foreground: {
+          opacity: 70,
         },
         countryFlags: {
           enabled: true,
@@ -386,8 +386,8 @@ export const defaultDashboard: {
         background: {
           opacity: 80,
         },
-        foreground: { 
-          opacity: 70, 
+        foreground: {
+          opacity: 70,
         },
         position: {
           enabled: true,
@@ -1183,6 +1183,8 @@ export const defaultDashboard: {
     compactMode: 'off' as const,
     overlayAlwaysOnTop: true,
     enableNetworkAccess: false,
+    showEditModePixelDistances: true,
+    snapEditModeWidgetsToGrid: true,
   },
 };
 


### PR DESCRIPTION
## Description

Adds edit-mode layout helpers for positioning overlay widgets more precisely.

Changes:
- Show pixel distances from the selected widget to the active display bounds.
- Snap widget dragging and resizing to a viewport-derived grid.
- Snap widget edges to display edges and nearby sibling widget edges.
    - The snap breaks if the cursor is moved away from the edge for 400ms.
- Allow holding Shift while dragging or resizing to temporarily bypass snapping.
- Add _General_ settings toggles for pixel distance labels and grid snapping.
- Fix widget assignment on multi-monitor setups: widgets on a secondary display no longer appear duplicated in the primary window.

Implementation notes:
- Snapping logic is isolated in `snapToViewportGrid.ts` and covered by unit tests.
- Edge distances use display bounds from the dashboard context and return `null` when bounds are unavailable or the setting is disabled.
- Existing dashboards default both settings to enabled via fallback handling and `defaultDashboard.ts`.

## Screenshots

### Before
Before state shown in recording below.

### After

This screen recording shows: 

- The before state (both settings disabled)
- Enabling just the pixel distance overlay while in edit mode
- Enabling snapping and showing widgets snap to viewport and other widget's edges

https://github.com/user-attachments/assets/81233efe-eec7-4aa3-8af0-fd3ba08c3583

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
    - I tested multi-monitor support earlier while in iRacing, but not since I cleaned it up to prep for this PR this evening. Can test again tomorrow morning. 
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Widget grid snapping in edit mode with improved edge locking and sibling alignment.
  * Visual edge-distance labels showing pixel distances from widgets to display edges.
  * "Edit Mode" settings to toggle distance labels and grid snapping (defaults: disabled).
  * Hold Shift to temporarily disable snapping during drag/resize.
  * New interactive stories showcasing multi-widget edit mode, distance labels, and snapping.

* **Tests**
  * Added unit tests covering snapping behavior, edge locking, and edge-distance calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->