### PR TITLE
feat: weather widget layout options and separate wind widget

### DIFF
--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -20,6 +20,7 @@ import { InformationBar } from './components/InformationBar/InformationBar';
 import { SlowCarAhead } from './components/SlowCarAhead/SlowCarAhead';
 import { SectorDelta } from './components/SectorDelta/SectorDelta';
 import type { WidgetConfigMap } from '@irdashies/types';
+import type { ElementType } from 'react';
 
 export {
   Standings,
@@ -45,13 +46,7 @@ export {
   SectorDelta,
 };
 
-// TODO: type this better, right now the config comes from settings
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export const WIDGET_MAP: Record<
-  keyof WidgetConfigMap,
-  (config?: any) => React.JSX.Element | null
-> = {
-  /* eslint-enable @typescript-eslint/no-explicit-any */
+export const WIDGET_MAP: Record<keyof WidgetConfigMap, ElementType> = {
   standings: Standings,
   input: Input,
   relative: Relative,

--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -4,6 +4,7 @@ import { Relative } from './components/Standings/Relative';
 import { TrackMap } from './components/TrackMap/TrackMap';
 import { FlatTrackMap } from './components/TrackMap/FlatTrackMap';
 import { Weather } from './components/Weather';
+import { Wind } from './components/Wind';
 import { FasterCarsFromBehind } from './components/FasterCarsFromBehind/FasterCarsFromBehind';
 import { FuelCalculator } from './components/FuelCalculator';
 import { BlindSpotMonitor } from './components/BlindSpotMonitor/BlindSpotMonitor';
@@ -27,6 +28,7 @@ export {
   TrackMap,
   FlatTrackMap,
   Weather,
+  Wind,
   FasterCarsFromBehind,
   FuelCalculator,
   BlindSpotMonitor,
@@ -56,6 +58,7 @@ export const WIDGET_MAP: Record<
   map: TrackMap,
   flatmap: FlatTrackMap,
   weather: Weather,
+  wind: Wind,
   fastercarsfrombehind: FasterCarsFromBehind,
   fuel: FuelCalculator,
   blindspotmonitor: BlindSpotMonitor,

--- a/src/frontend/components/Settings/SettingsLoader.tsx
+++ b/src/frontend/components/Settings/SettingsLoader.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'react-router-dom';
 import { StandingsSettings } from './sections/StandingsSettings';
 import { RelativeSettings } from './sections/RelativeSettings';
 import { WeatherSettings } from './sections/WeatherSettings';
+import { WindSettings } from './sections/WindSettings';
 import { TrackMapSettings } from './sections/TrackMapSettings';
 import { FlatTrackMapSettings } from './sections/FlatTrackMapSettings';
 import { AdvancedSettings } from './sections/AdvancedSettings';
@@ -56,6 +57,8 @@ export const SettingsLoader = ({ previewMode }: SettingsLoaderProps = {}) => {
       return <RelativeSettings />;
     case 'weather':
       return <WeatherSettings />;
+    case 'wind':
+      return <WindSettings />;
     case 'fuel':
       return <FuelSettings widgetId={widget?.id} />;
     case 'map':

--- a/src/frontend/components/Settings/SettingsMenu.tsx
+++ b/src/frontend/components/Settings/SettingsMenu.tsx
@@ -157,6 +157,12 @@ const widgetItems: MenuItem[] = [
     label: 'Weather',
     widgetType: 'weather',
   },
+  {
+    to: '/settings/wind',
+    path: '/wind',
+    label: 'Wind',
+    widgetType: 'wind',
+  },
 ];
 
 const bottomItems: MenuItem[] = [

--- a/src/frontend/components/Settings/sections/WeatherSettings.tsx
+++ b/src/frontend/components/Settings/sections/WeatherSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { BaseSettingsSection } from '../components/BaseSettingsSection';
 import {
   WeatherWidgetSettings,
@@ -45,6 +45,24 @@ const sortableSettings: SortableSetting[] = [
 ];
 
 const defaultConfig = getWidgetDefaultConfig('weather');
+const sortableSettingIds = sortableSettings.map((setting) => setting.id);
+
+const mergeItemsOrder = (itemsOrder = defaultConfig.displayOrder) => {
+  const mergedOrder = [...itemsOrder];
+
+  sortableSettingIds.forEach((id) => {
+    if (!mergedOrder.includes(id)) {
+      mergedOrder.push(id);
+    }
+  });
+
+  return mergedOrder;
+};
+
+const areStringArraysEqual = (first: string[] | undefined, second: string[]) =>
+  Array.isArray(first) &&
+  first.length === second.length &&
+  first.every((value, index) => value === second[index]);
 
 const DisplaySettingsList = ({
   itemsOrder,
@@ -91,18 +109,22 @@ const DisplaySettingsList = ({
 };
 
 export const WeatherSettings = () => {
-  const { currentDashboard } = useDashboard();
+  const { currentDashboard, onDashboardUpdated } = useDashboard();
+  const onDashboardUpdatedRef = useRef(onDashboardUpdated);
   const savedSettings = currentDashboard?.widgets.find(
     (w) => w.id === SETTING_ID
   ) as WeatherWidgetSettings | undefined;
+  const savedConfig = savedSettings?.config ?? defaultConfig;
+  const mergedSavedConfig = {
+    ...savedConfig,
+    displayOrder: mergeItemsOrder(savedConfig.displayOrder),
+  };
   const [settings, setSettings] = useState<WeatherWidgetSettings>({
     enabled: savedSettings?.enabled ?? false,
-    config:
-      (savedSettings?.config as WeatherWidgetSettings['config']) ??
-      defaultConfig,
+    config: mergedSavedConfig,
   });
 
-  const [itemsOrder, setItemsOrder] = useState(settings.config.displayOrder);
+  const [itemsOrder, setItemsOrder] = useState(mergedSavedConfig.displayOrder);
 
   // Tab state with persistence
   const [activeTab, setActiveTab] = useState<SettingsTabType>(
@@ -112,6 +134,60 @@ export const WeatherSettings = () => {
   useEffect(() => {
     localStorage.setItem('weatherTab', activeTab);
   }, [activeTab]);
+
+  useEffect(() => {
+    onDashboardUpdatedRef.current = onDashboardUpdated;
+  }, [onDashboardUpdated]);
+
+  useEffect(() => {
+    if (!currentDashboard) return;
+
+    const savedConfig = savedSettings?.config ?? defaultConfig;
+    const mergedDisplayOrder = mergeItemsOrder(savedConfig.displayOrder);
+    const nextSettings: WeatherWidgetSettings = {
+      enabled: savedSettings?.enabled ?? false,
+      config: {
+        ...savedConfig,
+        displayOrder: mergedDisplayOrder,
+      },
+    };
+
+    let isActive = true;
+
+    queueMicrotask(() => {
+      if (!isActive) return;
+
+      setSettings(nextSettings);
+      setItemsOrder(mergedDisplayOrder);
+    });
+
+    if (
+      savedSettings &&
+      onDashboardUpdatedRef.current &&
+      !areStringArraysEqual(savedConfig.displayOrder, mergedDisplayOrder)
+    ) {
+      const updatedWidgets = currentDashboard.widgets.map((widget) =>
+        widget.id === SETTING_ID
+          ? {
+              ...widget,
+              config: {
+                ...savedConfig,
+                displayOrder: mergedDisplayOrder,
+              },
+            }
+          : widget
+      );
+
+      onDashboardUpdatedRef.current({
+        ...currentDashboard,
+        widgets: updatedWidgets,
+      });
+    }
+
+    return () => {
+      isActive = false;
+    };
+  }, [currentDashboard, savedSettings]);
 
   if (!currentDashboard) {
     return <>Loading...</>;

--- a/src/frontend/components/Settings/sections/WeatherSettings.tsx
+++ b/src/frontend/components/Settings/sections/WeatherSettings.tsx
@@ -38,6 +38,7 @@ const sortableSettings: SortableSetting[] = [
   { id: 'trackTemp', label: 'Track Temperature', configKey: 'trackTemp' },
   { id: 'airTemp', label: 'Air Temperature', configKey: 'airTemp' },
   { id: 'wind', label: 'Wind', configKey: 'wind' },
+  { id: 'humidity', label: 'Humidity', configKey: 'humidity' },
   { id: 'precipitation', label: 'Precipitation', configKey: 'precipitation' },
   { id: 'wetness', label: 'Wetness', configKey: 'wetness' },
   { id: 'trackState', label: 'Track State', configKey: 'trackState' },
@@ -64,7 +65,8 @@ const DisplaySettingsList = ({
       onReorder={(newItems) => onReorder(newItems.map((i) => i.id))}
       renderItem={(setting, sortableProps) => {
         const configValue = settings.config[setting.configKey];
-        const isEnabled = (configValue as { enabled: boolean }).enabled;
+        const isEnabled =
+          (configValue as { enabled?: boolean } | undefined)?.enabled ?? true;
 
         return (
           <DraggableSettingItem
@@ -72,10 +74,10 @@ const DisplaySettingsList = ({
             label={setting.label}
             enabled={isEnabled}
             onToggle={(enabled) => {
-              const cv = settings.config[setting.configKey] as {
-                enabled: boolean;
-                [key: string]: unknown;
-              };
+              const cv =
+                (settings.config[setting.configKey] as
+                  | { enabled?: boolean; [key: string]: unknown }
+                  | undefined) ?? {};
               handleConfigChange({
                 [setting.configKey]: { ...cv, enabled },
               });
@@ -194,6 +196,30 @@ export const WeatherSettings = () => {
                       handleConfigChange({ background: { opacity: v } })
                     }
                   />
+
+                  <SettingButtonGroupRow<'vertical' | 'horizontal'>
+                    title="Layout"
+                    value={settings.config.layout ?? 'vertical'}
+                    options={[
+                      { label: 'Vertical', value: 'vertical' },
+                      { label: 'Horizontal', value: 'horizontal' },
+                    ]}
+                    onChange={(v) => handleConfigChange({ layout: v })}
+                  />
+
+                  {settings.config.layout === 'horizontal' && (
+                    <SettingButtonGroupRow<'compact' | 'full'>
+                      title="Horizontal View"
+                      value={settings.config.horizontalMode ?? 'compact'}
+                      options={[
+                        { label: 'Compact', value: 'compact' },
+                        { label: 'Full', value: 'full' },
+                      ]}
+                      onChange={(v) =>
+                        handleConfigChange({ horizontalMode: v })
+                      }
+                    />
+                  )}
 
                   <SettingButtonGroupRow<'auto' | 'Metric' | 'Imperial'>
                     title="Temperature Units"

--- a/src/frontend/components/Settings/sections/WeatherSettings.tsx
+++ b/src/frontend/components/Settings/sections/WeatherSettings.tsx
@@ -4,6 +4,7 @@ import {
   WeatherWidgetSettings,
   SettingsTabType,
   getWidgetDefaultConfig,
+  type WeatherConfig,
 } from '@irdashies/types';
 import { useDashboard } from '@irdashies/context';
 import { TabButton } from '../components/TabButton';
@@ -64,6 +65,95 @@ const areStringArraysEqual = (first: string[] | undefined, second: string[]) =>
   first.length === second.length &&
   first.every((value, index) => value === second[index]);
 
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizeEnabledConfig = (
+  value: unknown,
+  fallback: { enabled: boolean }
+) => ({
+  enabled:
+    isObjectRecord(value) && typeof value.enabled === 'boolean'
+      ? value.enabled
+      : fallback.enabled,
+});
+
+const normalizeSessionVisibility = (
+  value: unknown
+): WeatherConfig['sessionVisibility'] => {
+  const saved = isObjectRecord(value) ? value : {};
+  const fallback = defaultConfig.sessionVisibility;
+
+  return {
+    race: typeof saved.race === 'boolean' ? saved.race : fallback.race,
+    loneQualify:
+      typeof saved.loneQualify === 'boolean'
+        ? saved.loneQualify
+        : fallback.loneQualify,
+    openQualify:
+      typeof saved.openQualify === 'boolean'
+        ? saved.openQualify
+        : fallback.openQualify,
+    practice:
+      typeof saved.practice === 'boolean' ? saved.practice : fallback.practice,
+    offlineTesting:
+      typeof saved.offlineTesting === 'boolean'
+        ? saved.offlineTesting
+        : fallback.offlineTesting,
+  };
+};
+
+const normalizeWeatherConfig = (config: unknown): WeatherConfig => {
+  const saved = isObjectRecord(config) ? config : {};
+  const background = isObjectRecord(saved.background) ? saved.background : {};
+  const displayOrder = Array.isArray(saved.displayOrder)
+    ? saved.displayOrder.filter((id): id is string => typeof id === 'string')
+    : defaultConfig.displayOrder;
+
+  return {
+    ...defaultConfig,
+    background: {
+      opacity:
+        typeof background.opacity === 'number'
+          ? background.opacity
+          : defaultConfig.background.opacity,
+    },
+    layout:
+      saved.layout === 'vertical' || saved.layout === 'horizontal'
+        ? saved.layout
+        : defaultConfig.layout,
+    horizontalMode:
+      saved.horizontalMode === 'compact' || saved.horizontalMode === 'full'
+        ? saved.horizontalMode
+        : defaultConfig.horizontalMode,
+    displayOrder,
+    showOnlyWhenOnTrack:
+      typeof saved.showOnlyWhenOnTrack === 'boolean'
+        ? saved.showOnlyWhenOnTrack
+        : defaultConfig.showOnlyWhenOnTrack,
+    airTemp: normalizeEnabledConfig(saved.airTemp, defaultConfig.airTemp),
+    trackTemp: normalizeEnabledConfig(saved.trackTemp, defaultConfig.trackTemp),
+    humidity: normalizeEnabledConfig(saved.humidity, defaultConfig.humidity),
+    wetness: normalizeEnabledConfig(saved.wetness, defaultConfig.wetness),
+    trackState: normalizeEnabledConfig(
+      saved.trackState,
+      defaultConfig.trackState
+    ),
+    precipitation: normalizeEnabledConfig(
+      saved.precipitation,
+      defaultConfig.precipitation
+    ),
+    wind: normalizeEnabledConfig(saved.wind, defaultConfig.wind),
+    units:
+      saved.units === 'auto' ||
+      saved.units === 'Metric' ||
+      saved.units === 'Imperial'
+        ? saved.units
+        : defaultConfig.units,
+    sessionVisibility: normalizeSessionVisibility(saved.sessionVisibility),
+  };
+};
+
 const DisplaySettingsList = ({
   itemsOrder,
   onReorder,
@@ -114,17 +204,17 @@ export const WeatherSettings = () => {
   const savedSettings = currentDashboard?.widgets.find(
     (w) => w.id === SETTING_ID
   ) as WeatherWidgetSettings | undefined;
-  const savedConfig = savedSettings?.config ?? defaultConfig;
-  const mergedSavedConfig = {
-    ...savedConfig,
-    displayOrder: mergeItemsOrder(savedConfig.displayOrder),
+  const normalizedConfig = normalizeWeatherConfig(savedSettings?.config);
+  const mergedConfig = {
+    ...normalizedConfig,
+    displayOrder: mergeItemsOrder(normalizedConfig.displayOrder),
   };
   const [settings, setSettings] = useState<WeatherWidgetSettings>({
     enabled: savedSettings?.enabled ?? false,
-    config: mergedSavedConfig,
+    config: mergedConfig,
   });
 
-  const [itemsOrder, setItemsOrder] = useState(mergedSavedConfig.displayOrder);
+  const [itemsOrder, setItemsOrder] = useState(mergedConfig.displayOrder);
 
   // Tab state with persistence
   const [activeTab, setActiveTab] = useState<SettingsTabType>(
@@ -142,12 +232,12 @@ export const WeatherSettings = () => {
   useEffect(() => {
     if (!currentDashboard) return;
 
-    const savedConfig = savedSettings?.config ?? defaultConfig;
-    const mergedDisplayOrder = mergeItemsOrder(savedConfig.displayOrder);
+    const normalizedConfig = normalizeWeatherConfig(savedSettings?.config);
+    const mergedDisplayOrder = mergeItemsOrder(normalizedConfig.displayOrder);
     const nextSettings: WeatherWidgetSettings = {
       enabled: savedSettings?.enabled ?? false,
       config: {
-        ...savedConfig,
+        ...normalizedConfig,
         displayOrder: mergedDisplayOrder,
       },
     };
@@ -164,14 +254,14 @@ export const WeatherSettings = () => {
     if (
       savedSettings &&
       onDashboardUpdatedRef.current &&
-      !areStringArraysEqual(savedConfig.displayOrder, mergedDisplayOrder)
+      !areStringArraysEqual(normalizedConfig.displayOrder, mergedDisplayOrder)
     ) {
       const updatedWidgets = currentDashboard.widgets.map((widget) =>
         widget.id === SETTING_ID
           ? {
               ...widget,
               config: {
-                ...savedConfig,
+                ...normalizedConfig,
                 displayOrder: mergedDisplayOrder,
               },
             }

--- a/src/frontend/components/Settings/sections/WeatherSettings.tsx
+++ b/src/frontend/components/Settings/sections/WeatherSettings.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BaseSettingsSection } from '../components/BaseSettingsSection';
 import {
   WeatherWidgetSettings,
   SettingsTabType,
   getWidgetDefaultConfig,
-  type WeatherConfig,
 } from '@irdashies/types';
 import { useDashboard } from '@irdashies/context';
 import { TabButton } from '../components/TabButton';
@@ -48,130 +47,12 @@ const sortableSettings: SortableSetting[] = [
 const defaultConfig = getWidgetDefaultConfig('weather');
 const sortableSettingIds = sortableSettings.map((setting) => setting.id);
 
-const mergeItemsOrder = (itemsOrder = defaultConfig.displayOrder) => {
-  const mergedOrder = [...itemsOrder];
-
-  sortableSettingIds.forEach((id) => {
-    if (!mergedOrder.includes(id)) {
-      mergedOrder.push(id);
-    }
-  });
-
-  return mergedOrder;
-};
-
-const areStringArraysEqual = (first: string[] | undefined, second: string[]) =>
-  Array.isArray(first) &&
-  first.length === second.length &&
-  first.every((value, index) => value === second[index]);
-
-const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const normalizeEnabledConfig = (
-  value: unknown,
-  fallback: { enabled: boolean }
-) => ({
-  enabled:
-    isObjectRecord(value) && typeof value.enabled === 'boolean'
-      ? value.enabled
-      : fallback.enabled,
-});
-
-const isSortableSettingId = (value: unknown): value is string =>
-  typeof value === 'string' && sortableSettingIds.includes(value);
-
-const normalizeDisplayOrder = (value: unknown) => {
-  if (!Array.isArray(value)) {
-    return defaultConfig.displayOrder;
-  }
-
-  const displayOrder: string[] = [];
-
-  value.forEach((id) => {
-    if (isSortableSettingId(id) && !displayOrder.includes(id)) {
-      displayOrder.push(id);
-    }
-  });
-
-  return displayOrder.length > 0 ? displayOrder : defaultConfig.displayOrder;
-};
-
-const normalizeSessionVisibility = (
-  value: unknown
-): WeatherConfig['sessionVisibility'] => {
-  const saved = isObjectRecord(value) ? value : {};
-  const fallback = defaultConfig.sessionVisibility;
-
-  return {
-    race: typeof saved.race === 'boolean' ? saved.race : fallback.race,
-    loneQualify:
-      typeof saved.loneQualify === 'boolean'
-        ? saved.loneQualify
-        : fallback.loneQualify,
-    openQualify:
-      typeof saved.openQualify === 'boolean'
-        ? saved.openQualify
-        : fallback.openQualify,
-    practice:
-      typeof saved.practice === 'boolean' ? saved.practice : fallback.practice,
-    offlineTesting:
-      typeof saved.offlineTesting === 'boolean'
-        ? saved.offlineTesting
-        : fallback.offlineTesting,
-  };
-};
-
-const normalizeWeatherConfig = (config: unknown): WeatherConfig => {
-  const saved = isObjectRecord(config) ? config : {};
-  const background = isObjectRecord(saved.background)
-    ? saved.background
-    : undefined;
-  const val = background?.opacity;
-  const opacity = Number.isFinite(val)
-    ? Math.max(0, Math.min(100, Number(val)))
-    : defaultConfig.background.opacity;
-  const displayOrder = normalizeDisplayOrder(saved.displayOrder);
-
-  return {
-    ...defaultConfig,
-    background: {
-      opacity,
-    },
-    layout:
-      saved.layout === 'vertical' || saved.layout === 'horizontal'
-        ? saved.layout
-        : defaultConfig.layout,
-    horizontalMode:
-      saved.horizontalMode === 'compact' || saved.horizontalMode === 'full'
-        ? saved.horizontalMode
-        : defaultConfig.horizontalMode,
-    displayOrder,
-    showOnlyWhenOnTrack:
-      typeof saved.showOnlyWhenOnTrack === 'boolean'
-        ? saved.showOnlyWhenOnTrack
-        : defaultConfig.showOnlyWhenOnTrack,
-    airTemp: normalizeEnabledConfig(saved.airTemp, defaultConfig.airTemp),
-    trackTemp: normalizeEnabledConfig(saved.trackTemp, defaultConfig.trackTemp),
-    humidity: normalizeEnabledConfig(saved.humidity, defaultConfig.humidity),
-    wetness: normalizeEnabledConfig(saved.wetness, defaultConfig.wetness),
-    trackState: normalizeEnabledConfig(
-      saved.trackState,
-      defaultConfig.trackState
-    ),
-    precipitation: normalizeEnabledConfig(
-      saved.precipitation,
-      defaultConfig.precipitation
-    ),
-    wind: normalizeEnabledConfig(saved.wind, defaultConfig.wind),
-    units:
-      saved.units === 'auto' ||
-      saved.units === 'Metric' ||
-      saved.units === 'Imperial'
-        ? saved.units
-        : defaultConfig.units,
-    sessionVisibility: normalizeSessionVisibility(saved.sessionVisibility),
-  };
+const getItemsOrder = (itemsOrder = defaultConfig.displayOrder) => {
+  const validIds = new Set(sortableSettingIds);
+  const filtered = itemsOrder.filter((id) => validIds.has(id));
+  const present = new Set(filtered);
+  const missing = sortableSettingIds.filter((id) => !present.has(id));
+  return [...filtered, ...missing];
 };
 
 const DisplaySettingsList = ({
@@ -219,22 +100,20 @@ const DisplaySettingsList = ({
 };
 
 export const WeatherSettings = () => {
-  const { currentDashboard, onDashboardUpdated } = useDashboard();
-  const onDashboardUpdatedRef = useRef(onDashboardUpdated);
+  const { currentDashboard } = useDashboard();
   const savedSettings = currentDashboard?.widgets.find(
     (w) => w.id === SETTING_ID
   ) as WeatherWidgetSettings | undefined;
-  const normalizedConfig = normalizeWeatherConfig(savedSettings?.config);
-  const mergedConfig = {
-    ...normalizedConfig,
-    displayOrder: mergeItemsOrder(normalizedConfig.displayOrder),
-  };
+  const initialConfig =
+    (savedSettings?.config as WeatherWidgetSettings['config']) ?? defaultConfig;
   const [settings, setSettings] = useState<WeatherWidgetSettings>({
     enabled: savedSettings?.enabled ?? false,
-    config: mergedConfig,
+    config: initialConfig,
   });
 
-  const [itemsOrder, setItemsOrder] = useState(mergedConfig.displayOrder);
+  const [itemsOrder, setItemsOrder] = useState(() =>
+    getItemsOrder(initialConfig.displayOrder)
+  );
 
   // Tab state with persistence
   const [activeTab, setActiveTab] = useState<SettingsTabType>(
@@ -244,60 +123,6 @@ export const WeatherSettings = () => {
   useEffect(() => {
     localStorage.setItem('weatherTab', activeTab);
   }, [activeTab]);
-
-  useEffect(() => {
-    onDashboardUpdatedRef.current = onDashboardUpdated;
-  }, [onDashboardUpdated]);
-
-  useEffect(() => {
-    if (!currentDashboard) return;
-
-    const normalizedConfig = normalizeWeatherConfig(savedSettings?.config);
-    const mergedDisplayOrder = mergeItemsOrder(normalizedConfig.displayOrder);
-    const nextSettings: WeatherWidgetSettings = {
-      enabled: savedSettings?.enabled ?? false,
-      config: {
-        ...normalizedConfig,
-        displayOrder: mergedDisplayOrder,
-      },
-    };
-
-    let isActive = true;
-
-    queueMicrotask(() => {
-      if (!isActive) return;
-
-      setSettings(nextSettings);
-      setItemsOrder(mergedDisplayOrder);
-    });
-
-    if (
-      savedSettings &&
-      onDashboardUpdatedRef.current &&
-      !areStringArraysEqual(normalizedConfig.displayOrder, mergedDisplayOrder)
-    ) {
-      const updatedWidgets = currentDashboard.widgets.map((widget) =>
-        widget.id === SETTING_ID
-          ? {
-              ...widget,
-              config: {
-                ...normalizedConfig,
-                displayOrder: mergedDisplayOrder,
-              },
-            }
-          : widget
-      );
-
-      onDashboardUpdatedRef.current({
-        ...currentDashboard,
-        widgets: updatedWidgets,
-      });
-    }
-
-    return () => {
-      isActive = false;
-    };
-  }, [currentDashboard, savedSettings]);
 
   if (!currentDashboard) {
     return <>Loading...</>;

--- a/src/frontend/components/Settings/sections/WeatherSettings.tsx
+++ b/src/frontend/components/Settings/sections/WeatherSettings.tsx
@@ -78,6 +78,25 @@ const normalizeEnabledConfig = (
       : fallback.enabled,
 });
 
+const isSortableSettingId = (value: unknown): value is string =>
+  typeof value === 'string' && sortableSettingIds.includes(value);
+
+const normalizeDisplayOrder = (value: unknown) => {
+  if (!Array.isArray(value)) {
+    return defaultConfig.displayOrder;
+  }
+
+  const displayOrder: string[] = [];
+
+  value.forEach((id) => {
+    if (isSortableSettingId(id) && !displayOrder.includes(id)) {
+      displayOrder.push(id);
+    }
+  });
+
+  return displayOrder.length > 0 ? displayOrder : defaultConfig.displayOrder;
+};
+
 const normalizeSessionVisibility = (
   value: unknown
 ): WeatherConfig['sessionVisibility'] => {
@@ -105,18 +124,19 @@ const normalizeSessionVisibility = (
 
 const normalizeWeatherConfig = (config: unknown): WeatherConfig => {
   const saved = isObjectRecord(config) ? config : {};
-  const background = isObjectRecord(saved.background) ? saved.background : {};
-  const displayOrder = Array.isArray(saved.displayOrder)
-    ? saved.displayOrder.filter((id): id is string => typeof id === 'string')
-    : defaultConfig.displayOrder;
+  const background = isObjectRecord(saved.background)
+    ? saved.background
+    : undefined;
+  const val = background?.opacity;
+  const opacity = Number.isFinite(val)
+    ? Math.max(0, Math.min(100, Number(val)))
+    : defaultConfig.background.opacity;
+  const displayOrder = normalizeDisplayOrder(saved.displayOrder);
 
   return {
     ...defaultConfig,
     background: {
-      opacity:
-        typeof background.opacity === 'number'
-          ? background.opacity
-          : defaultConfig.background.opacity,
+      opacity,
     },
     layout:
       saved.layout === 'vertical' || saved.layout === 'horizontal'

--- a/src/frontend/components/Settings/sections/WindSettings.tsx
+++ b/src/frontend/components/Settings/sections/WindSettings.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { BaseSettingsSection } from '../components/BaseSettingsSection';
 import {
   getWidgetDefaultConfig,
+  type DashboardWidget,
   type WindWidgetSettings,
 } from '@irdashies/types';
 import { useDashboard } from '@irdashies/context';
@@ -15,16 +16,85 @@ import { SettingsSection } from '../components/SettingSection';
 const SETTING_ID = 'wind';
 const defaultConfig = getWidgetDefaultConfig('wind');
 
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isSessionVisibility = (value: unknown) => {
+  if (!isObjectRecord(value)) return false;
+
+  return (
+    typeof value.race === 'boolean' &&
+    typeof value.loneQualify === 'boolean' &&
+    typeof value.openQualify === 'boolean' &&
+    typeof value.practice === 'boolean' &&
+    typeof value.offlineTesting === 'boolean'
+  );
+};
+
+const isWindConfig = (
+  config: object | undefined
+): config is WindWidgetSettings['config'] => {
+  if (!isObjectRecord(config)) return false;
+
+  const { background, units, showOnlyWhenOnTrack, sessionVisibility } = config;
+
+  return (
+    isObjectRecord(background) &&
+    typeof background.opacity === 'number' &&
+    (units === 'auto' || units === 'Metric' || units === 'Imperial') &&
+    typeof showOnlyWhenOnTrack === 'boolean' &&
+    isSessionVisibility(sessionVisibility)
+  );
+};
+
+const isWindWidgetSettings = (
+  widget: DashboardWidget | undefined
+): widget is DashboardWidget & WindWidgetSettings =>
+  widget?.id === SETTING_ID && isWindConfig(widget.config);
+
 export const WindSettings = () => {
   const { currentDashboard } = useDashboard();
   const savedSettings = currentDashboard?.widgets.find(
     (w) => w.id === SETTING_ID
-  ) as WindWidgetSettings | undefined;
+  );
   const [settings, setSettings] = useState<WindWidgetSettings>({
-    enabled: savedSettings?.enabled ?? false,
-    config:
-      (savedSettings?.config as WindWidgetSettings['config']) ?? defaultConfig,
+    enabled: isWindWidgetSettings(savedSettings)
+      ? savedSettings.enabled
+      : false,
+    config: isWindWidgetSettings(savedSettings)
+      ? savedSettings.config
+      : defaultConfig,
   });
+
+  useEffect(() => {
+    if (!currentDashboard) return;
+
+    const nextSettings: WindWidgetSettings = {
+      enabled: isWindWidgetSettings(savedSettings)
+        ? savedSettings.enabled
+        : false,
+      config: isWindWidgetSettings(savedSettings)
+        ? savedSettings.config
+        : defaultConfig,
+    };
+
+    let isActive = true;
+
+    queueMicrotask(() => {
+      if (!isActive) return;
+
+      setSettings((settings) =>
+        settings.enabled === nextSettings.enabled &&
+        settings.config === nextSettings.config
+          ? settings
+          : nextSettings
+      );
+    });
+
+    return () => {
+      isActive = false;
+    };
+  }, [currentDashboard, savedSettings]);
 
   if (!currentDashboard) {
     return <>Loading...</>;

--- a/src/frontend/components/Settings/sections/WindSettings.tsx
+++ b/src/frontend/components/Settings/sections/WindSettings.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { BaseSettingsSection } from '../components/BaseSettingsSection';
+import {
+  getWidgetDefaultConfig,
+  type WindWidgetSettings,
+} from '@irdashies/types';
+import { useDashboard } from '@irdashies/context';
+import { SessionVisibility } from '../components/SessionVisibility';
+import { SettingButtonGroupRow } from '../components/SettingButtonGroupRow';
+import { SettingDivider } from '../components/SettingDivider';
+import { SettingSliderRow } from '../components/SettingSliderRow';
+import { SettingToggleRow } from '../components/SettingToggleRow';
+import { SettingsSection } from '../components/SettingSection';
+
+const SETTING_ID = 'wind';
+const defaultConfig = getWidgetDefaultConfig('wind');
+
+export const WindSettings = () => {
+  const { currentDashboard } = useDashboard();
+  const savedSettings = currentDashboard?.widgets.find(
+    (w) => w.id === SETTING_ID
+  ) as WindWidgetSettings | undefined;
+  const [settings, setSettings] = useState<WindWidgetSettings>({
+    enabled: savedSettings?.enabled ?? false,
+    config:
+      (savedSettings?.config as WindWidgetSettings['config']) ?? defaultConfig,
+  });
+
+  if (!currentDashboard) {
+    return <>Loading...</>;
+  }
+
+  return (
+    <BaseSettingsSection
+      title="Wind"
+      description="Show wind direction and speed."
+      settings={settings}
+      onSettingsChange={(s) => setSettings(s)}
+      widgetId={SETTING_ID}
+    >
+      {(handleConfigChange) => (
+        <div className="space-y-4">
+          <SettingsSection title="Options">
+            <SettingSliderRow
+              title="Background Opacity"
+              value={settings.config.background.opacity ?? 80}
+              units="%"
+              min={0}
+              max={100}
+              step={1}
+              onChange={(v) =>
+                handleConfigChange({ background: { opacity: v } })
+              }
+            />
+
+            <SettingButtonGroupRow<'auto' | 'Metric' | 'Imperial'>
+              title="Speed Units"
+              value={settings.config.units ?? 'auto'}
+              options={[
+                { label: 'Auto', value: 'auto' },
+                { label: 'km/h', value: 'Metric' },
+                { label: 'mph', value: 'Imperial' },
+              ]}
+              onChange={(v) => handleConfigChange({ units: v })}
+            />
+          </SettingsSection>
+
+          <SettingsSection title="Visibility">
+            <SessionVisibility
+              sessionVisibility={settings.config.sessionVisibility}
+              handleConfigChange={handleConfigChange}
+            />
+
+            <SettingDivider />
+
+            <SettingToggleRow
+              title="Show only when on track"
+              description="If enabled, wind will only be shown when driving"
+              enabled={settings.config.showOnlyWhenOnTrack ?? false}
+              onToggle={(newValue) =>
+                handleConfigChange({ showOnlyWhenOnTrack: newValue })
+              }
+            />
+          </SettingsSection>
+        </div>
+      )}
+    </BaseSettingsSection>
+  );
+};

--- a/src/frontend/components/Settings/sections/index.ts
+++ b/src/frontend/components/Settings/sections/index.ts
@@ -1,6 +1,7 @@
 export * from './StandingsSettings';
 export * from './RelativeSettings';
 export * from './WeatherSettings';
+export * from './WindSettings';
 export * from './TrackMapSettings';
 export * from './FuelSettings';
 export * from './GarageCoverSettings';

--- a/src/frontend/components/Weather/Weather.stories.tsx
+++ b/src/frontend/components/Weather/Weather.stories.tsx
@@ -1,19 +1,52 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Weather } from './Weather';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import {
+  TelemetryDecorator,
+  TelemetryDecoratorWithConfig,
+} from '@irdashies/storybook';
 
 export default {
   component: Weather,
   title: 'widgets/Weather',
-  decorators: [(Story) => (
-    <div style={{ width: '150px' }}>
-      <Story />
-    </div>
-  )],
 } as Meta;
 
 type Story = StoryObj<typeof Weather>;
 
 export const Primary: Story = {
-  decorators: [TelemetryDecorator('/test-data/1731637331038')],
+  decorators: [
+    (Story, context) => (
+      <div style={{ width: '150px' }}>
+        {TelemetryDecorator('/test-data/1731637331038')(Story, context)}
+      </div>
+    ),
+  ],
+};
+
+export const Horizontal: Story = {
+  decorators: [
+    (Story, context) => (
+      <div style={{ width: '360px' }}>
+        {TelemetryDecoratorWithConfig('/test-data/1731637331038', {
+          weather: {
+            layout: 'horizontal',
+          },
+        })(Story, context)}
+      </div>
+    ),
+  ],
+};
+
+export const HorizontalFull: Story = {
+  decorators: [
+    (Story, context) => (
+      <div style={{ width: '520px' }}>
+        {TelemetryDecoratorWithConfig('/test-data/1731637331038', {
+          weather: {
+            layout: 'horizontal',
+            horizontalMode: 'full',
+          },
+        })(Story, context)}
+      </div>
+    ),
+  ],
 };

--- a/src/frontend/components/Weather/Weather.stories.tsx
+++ b/src/frontend/components/Weather/Weather.stories.tsx
@@ -25,7 +25,7 @@ export const Primary: Story = {
 export const Horizontal: Story = {
   decorators: [
     (Story, context) => (
-      <div style={{ width: '360px' }}>
+      <div style={{ width: '640px' }}>
         {TelemetryDecoratorWithConfig('/test-data/1731637331038', {
           weather: {
             layout: 'horizontal',
@@ -39,7 +39,7 @@ export const Horizontal: Story = {
 export const HorizontalFull: Story = {
   decorators: [
     (Story, context) => (
-      <div style={{ width: '520px' }}>
+      <div style={{ width: '900px' }}>
         {TelemetryDecoratorWithConfig('/test-data/1731637331038', {
           weather: {
             layout: 'horizontal',

--- a/src/frontend/components/Weather/Weather.tsx
+++ b/src/frontend/components/Weather/Weather.tsx
@@ -1,9 +1,11 @@
 import {
+  useDashboard,
   useTelemetryValue,
   useSessionVisibility,
   useThrottledWeather,
 } from '@irdashies/context';
 import { useTrackTemperature } from './hooks/useTrackTemperature';
+import { useWindDemoData } from '../../domain/weather/useWindDemoData';
 import { WeatherTemp } from './WeatherTemp/WeatherTemp';
 import { WeatherTrackWetness } from './WeatherTrackWetness/WeatherTrackWetness';
 import { WeatherTrackRubbered } from './WeatherTrackRubbered/WeatherTrackRubbered';
@@ -25,6 +27,7 @@ type WeatherColumnId =
   | 'trackState';
 
 export const Weather = () => {
+  const { isDemoMode } = useDashboard();
   const settings = useWeatherSettings();
   const displayUnits = useTelemetryValue('DisplayUnits'); // 0 = imperial, 1 = metric
   const isOnTrack = useTelemetryValue('IsOnTrack');
@@ -49,6 +52,9 @@ export const Weather = () => {
   // Derived values
   const relativeWindDirection =
     (weather.windDirection ?? 0) - (weather.windYaw ?? 0);
+  const demoWind = useWindDemoData(isDemoMode, isMetric);
+  const windSpeedMs = demoWind?.speedMs ?? weather.windVelocity;
+  const windDirection = demoWind?.direction ?? relativeWindDirection;
 
   // Column ordering: depends ONLY on settings, NOT on telemetry data.
   // Settings change when the user edits config (very rare during a session).
@@ -131,8 +137,8 @@ export const Weather = () => {
         return (
           <WindDirection
             key={id}
-            speedMs={weather.windVelocity}
-            direction={relativeWindDirection}
+            speedMs={windSpeedMs}
+            direction={windDirection}
             metric={isMetric}
             variant={componentVariant}
           />

--- a/src/frontend/components/Weather/Weather.tsx
+++ b/src/frontend/components/Weather/Weather.tsx
@@ -3,7 +3,7 @@ import {
   useSessionVisibility,
   useThrottledWeather,
 } from '@irdashies/context';
-import { useTrackTemperature } from '../Standings/hooks/useTrackTemperature';
+import { useTrackTemperature } from './hooks/useTrackTemperature';
 import { WeatherTemp } from './WeatherTemp/WeatherTemp';
 import { WeatherTrackWetness } from './WeatherTrackWetness/WeatherTrackWetness';
 import { WeatherTrackRubbered } from './WeatherTrackRubbered/WeatherTrackRubbered';
@@ -53,12 +53,21 @@ export const Weather = () => {
   // Column ordering: depends ONLY on settings, NOT on telemetry data.
   // Settings change when the user edits config (very rare during a session).
   const displayOrder = settings?.displayOrder as string[] | undefined;
+  const layout = settings?.layout ?? 'vertical';
+  const horizontalMode = settings?.horizontalMode ?? 'compact';
+  const componentVariant =
+    layout === 'vertical'
+      ? 'default'
+      : horizontalMode === 'compact'
+        ? 'compact'
+        : 'inline';
 
   const visibleColumnIds = useMemo(() => {
     const allColumns: { id: WeatherColumnId; enabled: boolean }[] = [
       { id: 'trackTemp', enabled: settings?.trackTemp?.enabled ?? true },
       { id: 'airTemp', enabled: settings?.airTemp?.enabled ?? true },
       { id: 'wind', enabled: settings?.wind?.enabled ?? true },
+      { id: 'humidity', enabled: settings?.humidity?.enabled ?? true },
       {
         id: 'precipitation',
         enabled: settings?.precipitation?.enabled ?? true,
@@ -86,6 +95,7 @@ export const Weather = () => {
     settings?.trackTemp?.enabled,
     settings?.airTemp?.enabled,
     settings?.wind?.enabled,
+    settings?.humidity?.enabled,
     settings?.precipitation?.enabled,
     settings?.wetness?.enabled,
     settings?.trackState?.enabled,
@@ -104,6 +114,7 @@ export const Weather = () => {
             title="Track"
             value={trackTemp}
             icon={RoadHorizonIcon}
+            variant={componentVariant}
           />
         );
       case 'airTemp':
@@ -113,6 +124,7 @@ export const Weather = () => {
             title="Air"
             value={airTemp}
             icon={ThermometerIcon}
+            variant={componentVariant}
           />
         );
       case 'wind':
@@ -122,23 +134,41 @@ export const Weather = () => {
             speedMs={weather.windVelocity}
             direction={relativeWindDirection}
             metric={isMetric}
+            variant={componentVariant}
           />
         );
       case 'humidity':
-        return <WeatherHumidity key={id} humidity={weather.humidity} />;
+        return (
+          <WeatherHumidity
+            key={id}
+            humidity={weather.humidity}
+            variant={componentVariant}
+          />
+        );
       case 'precipitation':
         return (
           <WeatherPrecipitation
             key={id}
             precipitation={weather.precipitation}
+            variant={componentVariant}
           />
         );
       case 'wetness':
         return (
-          <WeatherTrackWetness key={id} trackMoisture={weather.trackMoisture} />
+          <WeatherTrackWetness
+            key={id}
+            trackMoisture={weather.trackMoisture}
+            variant={componentVariant}
+          />
         );
       case 'trackState':
-        return <WeatherTrackRubbered key={id} trackRubbered={trackRubbered} />;
+        return (
+          <WeatherTrackRubbered
+            key={id}
+            trackRubbered={trackRubbered}
+            variant={componentVariant}
+          />
+        );
     }
   };
 
@@ -156,7 +186,13 @@ export const Weather = () => {
         ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
       }}
     >
-      <div className="flex flex-col w-full gap-2">
+      <div
+        className={
+          layout === 'horizontal'
+            ? 'flex flex-row flex-wrap w-full gap-1'
+            : 'flex flex-col w-full gap-2'
+        }
+      >
         {visibleColumnIds.map(renderColumn)}
       </div>
     </div>

--- a/src/frontend/components/Weather/WeatherHumidity/WeatherHumidity.tsx
+++ b/src/frontend/components/Weather/WeatherHumidity/WeatherHumidity.tsx
@@ -3,30 +3,56 @@ import { DropHalfIcon, DropIcon } from '@phosphor-icons/react';
 
 interface Props {
   humidity: number | undefined | null;
+  variant?: 'default' | 'compact' | 'inline';
 }
 
-export const WeatherHumidity = memo(({ humidity }: Props) => {
-  const hasHumidity = humidity !== undefined && humidity !== null;
-  const humidityValue = hasHumidity ? Number(humidity.toFixed(2)) : 0;
-  const humidityPercent = humidityValue * 100;
+export const WeatherHumidity = memo(
+  ({ humidity, variant = 'default' }: Props) => {
+    const hasHumidity = humidity !== undefined && humidity !== null;
+    const humidityValue = hasHumidity ? Number(humidity.toFixed(2)) : 0;
+    const humidityPercent = humidityValue * 100;
+    const Icon = humidityPercent <= 50 ? DropIcon : DropHalfIcon;
+    const value = hasHumidity ? `${Math.round(humidityPercent)}%` : '- %';
 
-  return (
-    <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
-      <div className="flex flex-row gap-x-2 items-center text-sm">
-        {hasHumidity &&
-          (humidityPercent <= 50 ? (
-            <DropIcon className="flex-none" />
-          ) : (
-            <DropHalfIcon className="flex-none" />
-          ))}
-        <span className="truncate min-w-0 flex-1 @max-[120px]:hidden">
-          Humidity
-        </span>
-        <div className="flex-none whitespace-nowrap text-right">
-          {hasHumidity ? `${Math.round(humidityPercent)}%` : '- %'}
+    if (variant === 'compact') {
+      return (
+        <div
+          className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0"
+          title="Humidity"
+        >
+          <div className="flex items-center gap-x-1.5">
+            <Icon size={12} className="flex-none text-white/50" />
+            <div className="text-sm font-medium truncate">{value}</div>
+          </div>
+        </div>
+      );
+    }
+
+    if (variant === 'inline') {
+      return (
+        <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
+          <div className="flex items-center gap-x-1.5 text-sm">
+            <Icon size={12} className="flex-none text-white/50" />
+            <span className="truncate min-w-0">Humidity</span>
+            <div className="flex-none whitespace-nowrap text-right font-medium">
+              {value}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
+        <div className="flex flex-row gap-x-2 items-center text-sm">
+          <Icon className="flex-none" />
+          <span className="truncate min-w-0 flex-1 @max-[120px]:hidden">
+            Humidity
+          </span>
+          <div className="flex-none whitespace-nowrap text-right">{value}</div>
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 WeatherHumidity.displayName = 'WeatherHumidity';

--- a/src/frontend/components/Weather/WeatherHumidity/WeatherHumidity.tsx
+++ b/src/frontend/components/Weather/WeatherHumidity/WeatherHumidity.tsx
@@ -33,7 +33,7 @@ export const WeatherHumidity = memo(
         <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
           <div className="flex items-center gap-x-1.5 text-sm">
             <Icon size={12} className="flex-none text-white/50" />
-            <span className="truncate min-w-0">Humidity</span>
+            <span className="truncate min-w-0 text-white/60">Humidity</span>
             <div className="flex-none whitespace-nowrap text-right font-medium">
               {value}
             </div>

--- a/src/frontend/components/Weather/WeatherPrecipitation/WeatherPrecipitation.tsx
+++ b/src/frontend/components/Weather/WeatherPrecipitation/WeatherPrecipitation.tsx
@@ -3,28 +3,58 @@ import { CloudRainIcon } from '@phosphor-icons/react';
 
 interface Props {
   precipitation: number | undefined | null;
+  variant?: 'default' | 'compact' | 'inline';
 }
 
-export const WeatherPrecipitation = memo(({ precipitation }: Props) => {
-  const hasPrecipitation =
-    precipitation !== undefined && precipitation !== null;
-  // iRacing provides precipitation as 0.0 to 1.0 decimal
-  const precipitationPercent = hasPrecipitation
-    ? Math.round(precipitation * 100)
-    : 0;
+export const WeatherPrecipitation = memo(
+  ({ precipitation, variant = 'default' }: Props) => {
+    const hasPrecipitation =
+      precipitation !== undefined && precipitation !== null;
+    // iRacing provides precipitation as 0.0 to 1.0 decimal
+    const precipitationPercent = hasPrecipitation
+      ? Math.round(precipitation * 100)
+      : 0;
+    const value = hasPrecipitation ? `${precipitationPercent}%` : '- %';
 
-  return (
-    <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
-      <div className="flex flex-row gap-x-2 items-center text-sm">
-        <CloudRainIcon className="flex-none" />
-        <span className="truncate min-w-0 flex-1 @max-[120px]:hidden">
-          Precipitation
-        </span>
-        <div className="flex-none whitespace-nowrap text-right">
-          {hasPrecipitation ? `${precipitationPercent}%` : '- %'}
+    if (variant === 'compact') {
+      return (
+        <div
+          className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0"
+          title="Precipitation"
+        >
+          <div className="flex items-center gap-x-1.5">
+            <CloudRainIcon size={12} className="flex-none text-white/50" />
+            <div className="text-sm font-medium truncate">{value}</div>
+          </div>
+        </div>
+      );
+    }
+
+    if (variant === 'inline') {
+      return (
+        <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
+          <div className="flex items-center gap-x-1.5 text-sm">
+            <CloudRainIcon size={12} className="flex-none text-white/50" />
+            <span className="truncate min-w-0">Precipitation</span>
+            <div className="flex-none whitespace-nowrap text-right font-medium">
+              {value}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
+        <div className="flex flex-row gap-x-2 items-center text-sm">
+          <CloudRainIcon className="flex-none" />
+          <span className="truncate min-w-0 flex-1 @max-[120px]:hidden">
+            Precipitation
+          </span>
+          <div className="flex-none whitespace-nowrap text-right">{value}</div>
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 WeatherPrecipitation.displayName = 'WeatherPrecipitation';

--- a/src/frontend/components/Weather/WeatherPrecipitation/WeatherPrecipitation.tsx
+++ b/src/frontend/components/Weather/WeatherPrecipitation/WeatherPrecipitation.tsx
@@ -35,7 +35,9 @@ export const WeatherPrecipitation = memo(
         <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
           <div className="flex items-center gap-x-1.5 text-sm">
             <CloudRainIcon size={12} className="flex-none text-white/50" />
-            <span className="truncate min-w-0">Precipitation</span>
+            <span className="truncate min-w-0 text-white/60">
+              Precipitation
+            </span>
             <div className="flex-none whitespace-nowrap text-right font-medium">
               {value}
             </div>

--- a/src/frontend/components/Weather/WeatherTemp/WeatherTemp.tsx
+++ b/src/frontend/components/Weather/WeatherTemp/WeatherTemp.tsx
@@ -4,19 +4,50 @@ export interface WeatherTempProps {
   title: string;
   value: string;
   icon: React.ElementType;
+  variant?: 'default' | 'compact' | 'inline';
 }
 
-export const WeatherTemp = memo(({ title, value, icon: Icon }: WeatherTempProps) => {
-  return (
-    <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
-      <div className="flex flex-row gap-x-2 items-center text-sm">
-        <Icon className="flex-none" />
-        <span className="truncate min-w-0 flex-1 @max-[120px]:hidden">
-          {title}
-        </span>
-        <div className="flex-none whitespace-nowrap text-right">{value}</div>
+export const WeatherTemp = memo(
+  ({ title, value, icon: Icon, variant = 'default' }: WeatherTempProps) => {
+    if (variant === 'compact') {
+      return (
+        <div
+          className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0"
+          title={title}
+        >
+          <div className="flex items-center gap-x-1.5">
+            <Icon size={12} className="flex-none text-white/50" />
+            <div className="text-sm font-medium truncate">{value}</div>
+          </div>
+        </div>
+      );
+    }
+
+    if (variant === 'inline') {
+      return (
+        <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
+          <div className="flex items-center gap-x-1.5 text-sm">
+            <Icon size={12} className="flex-none text-white/50" />
+            <span className="truncate min-w-0">{title}</span>
+            <div className="flex-none whitespace-nowrap text-right font-medium">
+              {value}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
+        <div className="flex flex-row gap-x-2 items-center text-sm">
+          <Icon className="flex-none" />
+          <span className="truncate min-w-0 flex-1 @max-[120px]:hidden">
+            {title}
+          </span>
+          <div className="flex-none whitespace-nowrap text-right">{value}</div>
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 WeatherTemp.displayName = 'WeatherTemp';

--- a/src/frontend/components/Weather/WeatherTemp/WeatherTemp.tsx
+++ b/src/frontend/components/Weather/WeatherTemp/WeatherTemp.tsx
@@ -28,7 +28,7 @@ export const WeatherTemp = memo(
         <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
           <div className="flex items-center gap-x-1.5 text-sm">
             <Icon size={12} className="flex-none text-white/50" />
-            <span className="truncate min-w-0">{title}</span>
+            <span className="truncate min-w-0 text-white/60">{title}</span>
             <div className="flex-none whitespace-nowrap text-right font-medium">
               {value}
             </div>

--- a/src/frontend/components/Weather/WeatherTrackRubbered/WeatherTrackRubbered.tsx
+++ b/src/frontend/components/Weather/WeatherTrackRubbered/WeatherTrackRubbered.tsx
@@ -29,7 +29,7 @@ export const WeatherTrackRubbered = memo(
         <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
           <div className="flex items-center gap-x-1.5 text-sm">
             <PathIcon size={12} className="flex-none text-white/50" />
-            <span className="truncate min-w-0">Rubber</span>
+            <span className="truncate min-w-0 text-white/60">Rubber</span>
             <div
               className="flex-none whitespace-nowrap text-right font-medium capitalize"
               title={trackRubbered ?? 'N/A'}

--- a/src/frontend/components/Weather/WeatherTrackRubbered/WeatherTrackRubbered.tsx
+++ b/src/frontend/components/Weather/WeatherTrackRubbered/WeatherTrackRubbered.tsx
@@ -3,22 +3,58 @@ import { PathIcon } from '@phosphor-icons/react';
 
 interface Props {
   trackRubbered: string | undefined;
+  variant?: 'default' | 'compact' | 'inline';
 }
 
-export const WeatherTrackRubbered = memo(({ trackRubbered }: Props) => {
-  return (
-    <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
-      <div className="flex flex-row gap-x-2 items-center text-sm">
-        <PathIcon className="flex-none" />
-        <span className="flex-none @max-[160px]:hidden">Rubber</span>
-        <div
-          className="flex-1 min-w-0 truncate text-right capitalize"
-          title={trackRubbered ?? 'N/A'}
-        >
-          {trackRubbered ?? 'N/A'}
+export const WeatherTrackRubbered = memo(
+  ({ trackRubbered, variant = 'default' }: Props) => {
+    if (variant === 'compact') {
+      return (
+        <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
+          <div className="flex items-center gap-x-1.5">
+            <PathIcon size={12} className="flex-none text-white/50" />
+            <div
+              className="text-sm font-medium capitalize truncate"
+              title={trackRubbered ?? 'N/A'}
+            >
+              {trackRubbered ?? 'N/A'}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (variant === 'inline') {
+      return (
+        <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
+          <div className="flex items-center gap-x-1.5 text-sm">
+            <PathIcon size={12} className="flex-none text-white/50" />
+            <span className="truncate min-w-0">Rubber</span>
+            <div
+              className="flex-none whitespace-nowrap text-right font-medium capitalize"
+              title={trackRubbered ?? 'N/A'}
+            >
+              {trackRubbered ?? 'N/A'}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
+        <div className="flex flex-row gap-x-2 items-center text-sm">
+          <PathIcon className="flex-none" />
+          <span className="flex-none @max-[160px]:hidden">Rubber</span>
+          <div
+            className="flex-1 min-w-0 truncate text-right capitalize"
+            title={trackRubbered ?? 'N/A'}
+          >
+            {trackRubbered ?? 'N/A'}
+          </div>
         </div>
       </div>
-    </div>
-  );
-});
+    );
+  }
+);
 WeatherTrackRubbered.displayName = 'WeatherTrackRubbered';

--- a/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
+++ b/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
@@ -18,10 +18,11 @@ const WETNESS_LEVELS: Record<number, string> = {
 
 export interface WeatherTrackWetnessProps {
   trackMoisture?: number;
+  variant?: 'default' | 'compact' | 'inline';
 }
 
 export const WeatherTrackWetness = memo(
-  ({ trackMoisture }: WeatherTrackWetnessProps) => {
+  ({ trackMoisture, variant = 'default' }: WeatherTrackWetnessProps) => {
     // Calculate wetness percentage (0-100%)
     const normalizedMoisture = trackMoisture || MIN_WETNESS;
     const wetnessScale = MAX_WETNESS - MIN_WETNESS;
@@ -34,6 +35,33 @@ export const WeatherTrackWetness = memo(
       safeTrackMoisture in WETNESS_LEVELS
         ? WETNESS_LEVELS[safeTrackMoisture]
         : 'Unknown';
+
+    if (variant === 'compact') {
+      return (
+        <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
+          <div className="flex items-center gap-x-1.5">
+            <WavesIcon size={12} className="flex-none text-white/50" />
+            <span className="text-sm font-medium capitalize truncate">
+              {trackState}
+            </span>
+          </div>
+        </div>
+      );
+    }
+
+    if (variant === 'inline') {
+      return (
+        <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
+          <div className="flex items-center gap-x-1.5 text-sm">
+            <WavesIcon size={12} className="flex-none text-white/50" />
+            <span className="truncate min-w-0">Wetness</span>
+            <div className="flex-none whitespace-nowrap text-right font-medium capitalize">
+              {trackState}
+            </div>
+          </div>
+        </div>
+      );
+    }
 
     return (
       <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">

--- a/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
+++ b/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
@@ -5,6 +5,7 @@ import { memo } from 'react';
 const MIN_WETNESS = 1;
 const MAX_WETNESS = 7; // Extremely Wet
 const DEFAULT_WETNESS = 0;
+const FALLBACK_TRACK_STATE = 'N/A';
 const WETNESS_LEVELS: Record<number, string> = {
   0: '',
   1: 'Dry',
@@ -35,6 +36,7 @@ export const WeatherTrackWetness = memo(
       safeTrackMoisture in WETNESS_LEVELS
         ? WETNESS_LEVELS[safeTrackMoisture]
         : 'Unknown';
+    const trackStateLabel = trackState || FALLBACK_TRACK_STATE;
 
     if (variant === 'compact') {
       return (
@@ -42,7 +44,7 @@ export const WeatherTrackWetness = memo(
           <div className="flex items-center gap-x-1.5">
             <WavesIcon size={12} className="flex-none text-white/50" />
             <span className="text-sm font-medium capitalize truncate">
-              {trackState}
+              {trackStateLabel}
             </span>
           </div>
         </div>
@@ -56,7 +58,7 @@ export const WeatherTrackWetness = memo(
             <WavesIcon size={12} className="flex-none text-white/50" />
             <span className="truncate min-w-0 text-white/60">Wetness</span>
             <div className="flex-none whitespace-nowrap text-right font-medium capitalize">
-              {trackState}
+              {trackStateLabel}
             </div>
           </div>
         </div>
@@ -72,7 +74,7 @@ export const WeatherTrackWetness = memo(
             Wetness
           </span>
           <div className="flex-none whitespace-nowrap text-right capitalize">
-            {trackState}
+            {trackStateLabel}
           </div>
         </div>
 

--- a/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
+++ b/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
@@ -54,7 +54,7 @@ export const WeatherTrackWetness = memo(
         <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
           <div className="flex items-center gap-x-1.5 text-sm">
             <WavesIcon size={12} className="flex-none text-white/50" />
-            <span className="truncate min-w-0">Wetness</span>
+            <span className="truncate min-w-0 text-white/60">Wetness</span>
             <div className="flex-none whitespace-nowrap text-right font-medium capitalize">
               {trackState}
             </div>

--- a/src/frontend/components/Weather/WindDirection/WindDirection.tsx
+++ b/src/frontend/components/Weather/WindDirection/WindDirection.tsx
@@ -1,5 +1,6 @@
 import { WindIcon } from '@phosphor-icons/react';
 import { memo, useRef, useEffect, useState } from 'react';
+import { getWindIntensityClass } from '../../../domain/weather/wind';
 
 export interface WindDirectionProps {
   speedMs?: number;
@@ -50,6 +51,7 @@ export const WindDirection = memo(
 
     const [normalizedAngle, setNormalizedAngle] = useState<number>(0);
     const prevAngleRef = useRef<number>(0);
+    const windIntensityClass = getWindIntensityClass(speed);
 
     useEffect(() => {
       if (direction === undefined) return;
@@ -74,13 +76,13 @@ export const WindDirection = memo(
     if (variant === 'compact') {
       return (
         <div
-          className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0"
+          className={`bg-slate-800/70 px-2 py-1 rounded-sm min-w-0 transition-colors duration-300 ${windIntensityClass}`}
           title="Wind"
         >
           <div className="flex items-center gap-x-1.5">
             <WindArrow
               normalizedAngle={normalizedAngle}
-              className="flex-none size-5 stroke-current box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out text-white/70"
+              className="flex-none size-5 stroke-current box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out"
               strokeWidth="stroke-[5]"
             />
             <div className="text-sm font-medium truncate">{displaySpeed}</div>
@@ -91,14 +93,16 @@ export const WindDirection = memo(
 
     if (variant === 'inline') {
       return (
-        <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
+        <div
+          className={`bg-slate-800/70 px-2 py-1 rounded-sm min-w-0 transition-colors duration-300 ${windIntensityClass}`}
+        >
           <div className="flex items-center gap-x-1.5 text-sm">
+            <span className="truncate min-w-0 text-white/60">Wind</span>
             <WindArrow
               normalizedAngle={normalizedAngle}
-              className="flex-none size-5 stroke-current box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out text-white/70"
+              className="flex-none size-5 stroke-current box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out"
               strokeWidth="stroke-[5]"
             />
-            <span className="truncate min-w-0">Wind</span>
             <div className="flex-none whitespace-nowrap text-right font-medium">
               {displaySpeed}
             </div>
@@ -116,7 +120,10 @@ export const WindDirection = memo(
           </span>
         </div>
         <div className="flex justify-center">
-          <div className="flex aspect-square relative w-full max-w-[120px] mx-auto items-center justify-center">
+          <div
+            id="wind"
+            className={`flex aspect-square relative w-full max-w-[120px] mx-auto items-center justify-center transition-colors duration-300 ${windIntensityClass}`}
+          >
             <WindArrow
               normalizedAngle={normalizedAngle}
               className="absolute stroke-current w-full h-full box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out"

--- a/src/frontend/components/Weather/WindDirection/WindDirection.tsx
+++ b/src/frontend/components/Weather/WindDirection/WindDirection.tsx
@@ -5,10 +5,43 @@ export interface WindDirectionProps {
   speedMs?: number;
   direction?: number;
   metric?: boolean;
+  variant?: 'default' | 'compact' | 'inline';
 }
 
+interface WindArrowProps {
+  normalizedAngle: number;
+  className: string;
+  strokeWidth: string;
+}
+
+const WindArrow = ({
+  normalizedAngle,
+  className,
+  strokeWidth,
+}: WindArrowProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 60 60"
+    aria-hidden="true"
+    className={className}
+    style={{
+      rotate: `calc(${normalizedAngle} * 1rad + 0.5turn)`,
+    }}
+  >
+    <path
+      d="M48 8A28 28 90 0158 30c0 15.464-12.536 28-28 28S2 45.464 2 30A28 28 90 0112 8M22 9 30 1l8 8"
+      className={strokeWidth}
+    />
+  </svg>
+);
+
 export const WindDirection = memo(
-  ({ speedMs, direction, metric = true }: WindDirectionProps) => {
+  ({
+    speedMs,
+    direction,
+    metric = true,
+    variant = 'default',
+  }: WindDirectionProps) => {
     // Convert m/s to user's preferred unit
     const speed =
       speedMs !== undefined
@@ -36,6 +69,44 @@ export const WindDirection = memo(
       prevAngleRef.current = currentAngle;
     }, [direction]);
 
+    const displaySpeed = speed !== undefined ? Math.round(speed) : '-';
+
+    if (variant === 'compact') {
+      return (
+        <div
+          className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0"
+          title="Wind"
+        >
+          <div className="flex items-center gap-x-1.5">
+            <WindArrow
+              normalizedAngle={normalizedAngle}
+              className="flex-none size-5 stroke-current box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out text-white/70"
+              strokeWidth="stroke-[5]"
+            />
+            <div className="text-sm font-medium truncate">{displaySpeed}</div>
+          </div>
+        </div>
+      );
+    }
+
+    if (variant === 'inline') {
+      return (
+        <div className="bg-slate-800/70 px-2 py-1 rounded-sm min-w-0">
+          <div className="flex items-center gap-x-1.5 text-sm">
+            <WindArrow
+              normalizedAngle={normalizedAngle}
+              className="flex-none size-5 stroke-current box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out text-white/70"
+              strokeWidth="stroke-[5]"
+            />
+            <span className="truncate min-w-0">Wind</span>
+            <div className="flex-none whitespace-nowrap text-right font-medium">
+              {displaySpeed}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="bg-slate-800/70 p-2 rounded-sm w-full min-w-0">
         <div className="flex flex-row gap-x-2 items-center text-sm mb-3">
@@ -45,23 +116,15 @@ export const WindDirection = memo(
           </span>
         </div>
         <div className="flex justify-center">
-          <div
-            id="wind"
-            className="flex aspect-square relative w-full max-w-[120px] mx-auto items-center justify-center"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 60 60"
-              className="absolute stroke-current stroke-[3] w-full h-full box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out"
-              style={{
-                rotate: `calc(${normalizedAngle} * 1rad + 0.5turn)`,
-              }}
-            >
-              <path d="M48 8A28 28 90 0158 30c0 15.464-12.536 28-28 28S2 45.464 2 30A28 28 90 0112 8M22 9 30 1l8 8" />
-            </svg>
+          <div className="flex aspect-square relative w-full max-w-[120px] mx-auto items-center justify-center">
+            <WindArrow
+              normalizedAngle={normalizedAngle}
+              className="absolute stroke-current w-full h-full box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out"
+              strokeWidth="stroke-[3]"
+            />
 
             <div className="absolute w-full h-full flex justify-center items-center text-[32px]">
-              {speed !== undefined ? Math.round(speed) : '-'}
+              {displaySpeed}
             </div>
           </div>
         </div>

--- a/src/frontend/components/Weather/WindDirection/WindDirection.tsx
+++ b/src/frontend/components/Weather/WindDirection/WindDirection.tsx
@@ -85,7 +85,9 @@ export const WindDirection = memo(
               className="flex-none size-5 stroke-current box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out"
               strokeWidth="stroke-[5]"
             />
-            <div className="text-sm font-medium truncate">{displaySpeed}</div>
+            <div className="text-sm font-medium truncate tabular-nums text-right min-w-[3ch]">
+              {displaySpeed}
+            </div>
           </div>
         </div>
       );
@@ -103,7 +105,7 @@ export const WindDirection = memo(
               className="flex-none size-5 stroke-current box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out"
               strokeWidth="stroke-[5]"
             />
-            <div className="flex-none whitespace-nowrap text-right font-medium">
+            <div className="flex-none whitespace-nowrap text-right font-medium tabular-nums min-w-[3ch]">
               {displaySpeed}
             </div>
           </div>

--- a/src/frontend/components/Weather/hooks/useTrackTemperature.tsx
+++ b/src/frontend/components/Weather/hooks/useTrackTemperature.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { useTelemetryValueRounded } from '@irdashies/context';
+
+interface UseTrackTemperatureOptions {
+  airTempUnit?: 'Metric' | 'Imperial';
+  trackTempUnit?: 'Metric' | 'Imperial';
+}
+
+export const useTrackTemperature = (
+  options: UseTrackTemperatureOptions = {}
+) => {
+  const { airTempUnit = 'Metric', trackTempUnit = 'Metric' } = options;
+  const trackTempVal = useTelemetryValueRounded('TrackTempCrew', 0);
+  const airTempVal = useTelemetryValueRounded('AirTemp', 0);
+
+  const trackTemp = useMemo(() => {
+    const trackTemp = trackTempVal ?? 0;
+    const displayTemp =
+      trackTempUnit === 'Imperial' ? (trackTemp * 9) / 5 + 32 : trackTemp;
+    const unit = trackTempUnit === 'Imperial' ? 'F' : 'C';
+    return `${displayTemp.toFixed(0)}°${unit}`;
+  }, [trackTempVal, trackTempUnit]);
+
+  const airTemp = useMemo(() => {
+    const airTemp = airTempVal ?? 0;
+    const displayTemp =
+      airTempUnit === 'Imperial' ? (airTemp * 9) / 5 + 32 : airTemp;
+    const unit = airTempUnit === 'Imperial' ? 'F' : 'C';
+    return `${displayTemp.toFixed(0)}°${unit}`;
+  }, [airTempVal, airTempUnit]);
+
+  return { trackTemp, airTemp };
+};

--- a/src/frontend/components/Weather/hooks/useTrackTemperature.tsx
+++ b/src/frontend/components/Weather/hooks/useTrackTemperature.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useTelemetryValueRounded } from '@irdashies/context';
+import { useTelemetryValue } from '@irdashies/context';
 
 interface UseTrackTemperatureOptions {
   airTempUnit?: 'Metric' | 'Imperial';
@@ -10,15 +10,15 @@ export const useTrackTemperature = (
   options: UseTrackTemperatureOptions = {}
 ) => {
   const { airTempUnit = 'Metric', trackTempUnit = 'Metric' } = options;
-  const trackTempVal = useTelemetryValueRounded('TrackTempCrew', 0);
-  const airTempVal = useTelemetryValueRounded('AirTemp', 0);
+  const trackTempVal = useTelemetryValue('TrackTempCrew');
+  const airTempVal = useTelemetryValue('AirTemp');
 
   const trackTemp = useMemo(() => {
     const trackTemp = trackTempVal ?? 0;
     const displayTemp =
       trackTempUnit === 'Imperial' ? (trackTemp * 9) / 5 + 32 : trackTemp;
     const unit = trackTempUnit === 'Imperial' ? 'F' : 'C';
-    return `${displayTemp.toFixed(0)}°${unit}`;
+    return `${Math.round(displayTemp)}°${unit}`;
   }, [trackTempVal, trackTempUnit]);
 
   const airTemp = useMemo(() => {
@@ -26,7 +26,7 @@ export const useTrackTemperature = (
     const displayTemp =
       airTempUnit === 'Imperial' ? (airTemp * 9) / 5 + 32 : airTemp;
     const unit = airTempUnit === 'Imperial' ? 'F' : 'C';
-    return `${displayTemp.toFixed(0)}°${unit}`;
+    return `${Math.round(displayTemp)}°${unit}`;
   }, [airTempVal, airTempUnit]);
 
   return { trackTemp, airTemp };

--- a/src/frontend/components/Wind/Wind.stories.tsx
+++ b/src/frontend/components/Wind/Wind.stories.tsx
@@ -5,9 +5,16 @@ import { Wind } from './Wind';
 export default {
   component: Wind,
   title: 'widgets/Wind',
-  decorators: [TelemetryDecorator()],
 } as Meta;
 
 type Story = StoryObj<typeof Wind>;
 
-export const Primary: Story = {};
+export const Primary: Story = {
+  decorators: [
+    (Story, context) => (
+      <div style={{ width: '150px', height: '180px' }}>
+        {TelemetryDecorator('/test-data/1731637331038')(Story, context)}
+      </div>
+    ),
+  ],
+};

--- a/src/frontend/components/Wind/Wind.stories.tsx
+++ b/src/frontend/components/Wind/Wind.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TelemetryDecorator } from '@irdashies/storybook';
+import { Wind } from './Wind';
+
+export default {
+  component: Wind,
+  title: 'widgets/Wind',
+  decorators: [TelemetryDecorator()],
+} as Meta;
+
+type Story = StoryObj<typeof Wind>;
+
+export const Primary: Story = {};

--- a/src/frontend/components/Wind/Wind.tsx
+++ b/src/frontend/components/Wind/Wind.tsx
@@ -1,0 +1,43 @@
+import {
+  useSessionVisibility,
+  useTelemetryValue,
+  useThrottledWeather,
+} from '@irdashies/context';
+import { useWindSettings } from './hooks/useWindSettings';
+import { WindDirection } from './WindDirection/WindDirection';
+
+export const Wind = () => {
+  const settings = useWindSettings();
+  const displayUnits = useTelemetryValue('DisplayUnits');
+  const isOnTrack = useTelemetryValue('IsOnTrack');
+  const isSessionVisible = useSessionVisibility(settings?.sessionVisibility);
+
+  const unitSetting = settings?.units ?? 'auto';
+  const isMetric =
+    unitSetting === 'auto' ? displayUnits === 1 : unitSetting === 'Metric';
+
+  const weather = useThrottledWeather();
+  const relativeWindDirection =
+    (weather.windDirection ?? 0) - (weather.windYaw ?? 0);
+
+  if (settings?.showOnlyWhenOnTrack && !isOnTrack) {
+    return null;
+  }
+
+  if (!isSessionVisible) return <></>;
+
+  return (
+    <div
+      className="w-full rounded-sm p-2 bg-slate-800/(--bg-opacity)"
+      style={{
+        ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
+      }}
+    >
+      <WindDirection
+        speedMs={weather.windVelocity}
+        direction={relativeWindDirection}
+        metric={isMetric}
+      />
+    </div>
+  );
+};

--- a/src/frontend/components/Wind/Wind.tsx
+++ b/src/frontend/components/Wind/Wind.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import {
   useDashboard,
   useSessionVisibility,
@@ -8,7 +9,7 @@ import { useWindSettings } from './hooks/useWindSettings';
 import { WindDirection } from './WindDirection/WindDirection';
 import { useWindDemoData } from '../../domain/weather/useWindDemoData';
 
-export const Wind = () => {
+export const Wind = memo(() => {
   const { isDemoMode } = useDashboard();
   const settings = useWindSettings();
   const displayUnits = useTelemetryValue('DisplayUnits');
@@ -59,4 +60,5 @@ export const Wind = () => {
       />
     </div>
   );
-};
+});
+Wind.displayName = 'Wind';

--- a/src/frontend/components/Wind/Wind.tsx
+++ b/src/frontend/components/Wind/Wind.tsx
@@ -1,12 +1,15 @@
 import {
+  useDashboard,
   useSessionVisibility,
   useTelemetryValue,
   useThrottledWeather,
 } from '@irdashies/context';
 import { useWindSettings } from './hooks/useWindSettings';
 import { WindDirection } from './WindDirection/WindDirection';
+import { useWindDemoData } from '../../domain/weather/useWindDemoData';
 
 export const Wind = () => {
+  const { isDemoMode } = useDashboard();
   const settings = useWindSettings();
   const displayUnits = useTelemetryValue('DisplayUnits');
   const isOnTrack = useTelemetryValue('IsOnTrack');
@@ -14,11 +17,32 @@ export const Wind = () => {
 
   const unitSetting = settings?.units ?? 'auto';
   const isMetric =
-    unitSetting === 'auto' ? displayUnits === 1 : unitSetting === 'Metric';
+    unitSetting === 'auto'
+      ? displayUnits === undefined || displayUnits === 1
+      : unitSetting === 'Metric';
 
   const weather = useThrottledWeather();
   const relativeWindDirection =
     (weather.windDirection ?? 0) - (weather.windYaw ?? 0);
+  const demoWind = useWindDemoData(isDemoMode, isMetric);
+
+  const containerClassName =
+    'w-full h-full rounded-sm p-2 bg-slate-800/(--bg-opacity)';
+  const containerStyle = {
+    ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
+  };
+
+  if (demoWind) {
+    return (
+      <div className={containerClassName} style={containerStyle}>
+        <WindDirection
+          speedMs={demoWind.speedMs}
+          direction={demoWind.direction}
+          metric={isMetric}
+        />
+      </div>
+    );
+  }
 
   if (settings?.showOnlyWhenOnTrack && !isOnTrack) {
     return null;
@@ -27,12 +51,7 @@ export const Wind = () => {
   if (!isSessionVisible) return <></>;
 
   return (
-    <div
-      className="w-full rounded-sm p-2 bg-slate-800/(--bg-opacity)"
-      style={{
-        ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
-      }}
-    >
+    <div className={containerClassName} style={containerStyle}>
       <WindDirection
         speedMs={weather.windVelocity}
         direction={relativeWindDirection}

--- a/src/frontend/components/Wind/WindDirection/WindDirection.tsx
+++ b/src/frontend/components/Wind/WindDirection/WindDirection.tsx
@@ -1,0 +1,51 @@
+import { memo, useEffect, useRef, useState } from 'react';
+
+export interface WindDirectionProps {
+  speedMs?: number;
+  direction?: number;
+  metric?: boolean;
+}
+
+export const WindDirection = memo(
+  ({ speedMs, direction, metric = true }: WindDirectionProps) => {
+    const speed =
+      speedMs !== undefined ? speedMs * (metric ? 3.6 : 2.23694) : undefined;
+    const [normalizedAngle, setNormalizedAngle] = useState(0);
+    const prevAngleRef = useRef(0);
+
+    useEffect(() => {
+      if (direction === undefined) return;
+
+      const prevAngle = prevAngleRef.current;
+      let diff = direction - prevAngle;
+
+      while (diff > Math.PI) diff -= 2 * Math.PI;
+      while (diff < -Math.PI) diff += 2 * Math.PI;
+
+      setNormalizedAngle((prev) => prev + diff);
+      prevAngleRef.current = direction;
+    }, [direction]);
+
+    return (
+      <div className="flex justify-center">
+        <div className="flex aspect-square relative w-full max-w-[120px] mx-auto items-center justify-center">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 60 60"
+            className="absolute stroke-current stroke-[3] w-full h-full box-border fill-none origin-center transform-gpu transition-transform duration-1000 ease-out"
+            style={{
+              rotate: `calc(${normalizedAngle} * 1rad + 0.5turn)`,
+            }}
+          >
+            <path d="M48 8A28 28 90 0158 30c0 15.464-12.536 28-28 28S2 45.464 2 30A28 28 90 0112 8M22 9 30 1l8 8" />
+          </svg>
+
+          <div className="absolute w-full h-full flex justify-center items-center text-[32px]">
+            {speed !== undefined ? Math.round(speed) : '-'}
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+WindDirection.displayName = 'WindDirection';

--- a/src/frontend/components/Wind/WindDirection/WindDirection.tsx
+++ b/src/frontend/components/Wind/WindDirection/WindDirection.tsx
@@ -57,7 +57,7 @@ export const WindDirection = memo(
         className="flex h-full w-full min-h-0 min-w-0 items-center justify-center"
       >
         <div
-          id="wind"
+          data-testid="wind-direction"
           className={`relative flex aspect-square items-center justify-center transition-colors duration-300 ${windIntensityClass}`}
           style={{ width: visualSize, height: visualSize }}
         >

--- a/src/frontend/components/Wind/WindDirection/WindDirection.tsx
+++ b/src/frontend/components/Wind/WindDirection/WindDirection.tsx
@@ -1,4 +1,5 @@
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { getWindIntensityClass } from '../../../domain/weather/wind';
 
 export interface WindDirectionProps {
   speedMs?: number;
@@ -12,6 +13,9 @@ export const WindDirection = memo(
       speedMs !== undefined ? speedMs * (metric ? 3.6 : 2.23694) : undefined;
     const [normalizedAngle, setNormalizedAngle] = useState(0);
     const prevAngleRef = useRef(0);
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const [size, setSize] = useState<number | null>(null);
+    const windIntensityClass = getWindIntensityClass(speed);
 
     useEffect(() => {
       if (direction === undefined) return;
@@ -26,9 +30,37 @@ export const WindDirection = memo(
       prevAngleRef.current = direction;
     }, [direction]);
 
+    useLayoutEffect(() => {
+      const node = containerRef.current;
+      if (!node) return;
+
+      const updateSize = () => {
+        const { clientWidth, clientHeight } = node;
+        if (!clientWidth || !clientHeight) return;
+
+        setSize(Math.round(Math.min(clientWidth, clientHeight)));
+      };
+
+      updateSize();
+      const observer = new ResizeObserver(updateSize);
+      observer.observe(node);
+
+      return () => observer.disconnect();
+    }, []);
+
+    const visualSize = size ? `${size}px` : '100%';
+    const fontSize = size ? Math.max(10, Math.round(size * 0.27)) : 32;
+
     return (
-      <div className="flex justify-center">
-        <div className="flex aspect-square relative w-full max-w-[120px] mx-auto items-center justify-center">
+      <div
+        ref={containerRef}
+        className="flex h-full w-full min-h-0 min-w-0 items-center justify-center"
+      >
+        <div
+          id="wind"
+          className={`relative flex aspect-square items-center justify-center transition-colors duration-300 ${windIntensityClass}`}
+          style={{ width: visualSize, height: visualSize }}
+        >
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 60 60"
@@ -40,7 +72,10 @@ export const WindDirection = memo(
             <path d="M48 8A28 28 90 0158 30c0 15.464-12.536 28-28 28S2 45.464 2 30A28 28 90 0112 8M22 9 30 1l8 8" />
           </svg>
 
-          <div className="absolute w-full h-full flex justify-center items-center text-[32px]">
+          <div
+            className="absolute flex h-full w-full items-center justify-center leading-none"
+            style={{ fontSize }}
+          >
             {speed !== undefined ? Math.round(speed) : '-'}
           </div>
         </div>

--- a/src/frontend/components/Wind/hooks/useWindSettings.tsx
+++ b/src/frontend/components/Wind/hooks/useWindSettings.tsx
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { useDashboard } from '@irdashies/context';
+import type { WindWidgetSettings } from '@irdashies/types';
+
+export const useWindSettings = () => {
+  const { currentDashboard } = useDashboard();
+
+  return useMemo(
+    () =>
+      currentDashboard?.widgets.find((w) => w.id === 'wind')
+        ?.config as unknown as WindWidgetSettings['config'],
+    [currentDashboard]
+  );
+};

--- a/src/frontend/components/Wind/hooks/useWindSettings.tsx
+++ b/src/frontend/components/Wind/hooks/useWindSettings.tsx
@@ -1,14 +1,51 @@
 import { useMemo } from 'react';
 import { useDashboard } from '@irdashies/context';
-import type { WindWidgetSettings } from '@irdashies/types';
+import {
+  getWidgetDefaultConfig,
+  type WindWidgetSettings,
+} from '@irdashies/types';
 
-export const useWindSettings = () => {
+const defaultConfig = getWidgetDefaultConfig('wind');
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isSessionVisibility = (value: unknown) => {
+  if (!isObjectRecord(value)) return false;
+
+  return (
+    typeof value.race === 'boolean' &&
+    typeof value.loneQualify === 'boolean' &&
+    typeof value.openQualify === 'boolean' &&
+    typeof value.practice === 'boolean' &&
+    typeof value.offlineTesting === 'boolean'
+  );
+};
+
+const isWindConfig = (
+  config: object | undefined
+): config is WindWidgetSettings['config'] => {
+  if (!isObjectRecord(config)) return false;
+
+  const { background, units, showOnlyWhenOnTrack, sessionVisibility } = config;
+
+  return (
+    isObjectRecord(background) &&
+    typeof background.opacity === 'number' &&
+    (units === 'auto' || units === 'Metric' || units === 'Imperial') &&
+    typeof showOnlyWhenOnTrack === 'boolean' &&
+    isSessionVisibility(sessionVisibility)
+  );
+};
+
+export const useWindSettings = (): WindWidgetSettings['config'] => {
   const { currentDashboard } = useDashboard();
 
-  return useMemo(
-    () =>
-      currentDashboard?.widgets.find((w) => w.id === 'wind')
-        ?.config as unknown as WindWidgetSettings['config'],
-    [currentDashboard]
-  );
+  return useMemo(() => {
+    const config = currentDashboard?.widgets.find(
+      (w) => w.id === 'wind'
+    )?.config;
+
+    return isWindConfig(config) ? config : defaultConfig;
+  }, [currentDashboard]);
 };

--- a/src/frontend/components/Wind/index.tsx
+++ b/src/frontend/components/Wind/index.tsx
@@ -1,0 +1,1 @@
+export * from './Wind';

--- a/src/frontend/constants/widgetNames.ts
+++ b/src/frontend/constants/widgetNames.ts
@@ -11,6 +11,7 @@ export const WIDGET_NAMES: Record<WidgetId, string> = {
   map: 'Track Map',
   flatmap: 'Flat Track Map',
   weather: 'Weather',
+  wind: 'Wind',
   fastercarsfrombehind: 'Faster Cars From Behind',
   fuel: 'Fuel Calculator',
   blindspotmonitor: 'Blind Spot Monitor',

--- a/src/frontend/domain/weather/useWindDemoData.spec.tsx
+++ b/src/frontend/domain/weather/useWindDemoData.spec.tsx
@@ -1,0 +1,41 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useWindDemoData } from './useWindDemoData';
+import { WIND_DEMO_INTERVAL_MS } from './wind';
+
+describe('useWindDemoData', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns null when demo mode is off', () => {
+    const { result } = renderHook(() => useWindDemoData(false, true));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns a cycling sample while demo mode is on', () => {
+    const { result } = renderHook(() => useWindDemoData(true, true));
+
+    expect(result.current?.speedMs).toBeCloseTo(2 / 3.6);
+    expect(result.current?.direction).toBeCloseTo(0);
+
+    act(() => {
+      vi.advanceTimersByTime(WIND_DEMO_INTERVAL_MS);
+    });
+    expect(result.current?.speedMs).toBeCloseTo(8 / 3.6);
+
+    act(() => {
+      vi.advanceTimersByTime(WIND_DEMO_INTERVAL_MS * 3);
+    });
+    expect(result.current?.speedMs).toBeCloseTo(44 / 3.6);
+  });
+
+  it('uses imperial conversion when metric is false', () => {
+    const { result } = renderHook(() => useWindDemoData(true, false));
+    expect(result.current?.speedMs).toBeCloseTo(2 / 2.23694);
+  });
+});

--- a/src/frontend/domain/weather/useWindDemoData.tsx
+++ b/src/frontend/domain/weather/useWindDemoData.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import {
+  getDemoWindData,
+  WIND_DEMO_INTERVAL_MS,
+  type WindDemoData,
+} from './wind';
+
+export const useWindDemoData = (
+  isDemoMode: boolean,
+  metric: boolean
+): WindDemoData | null => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (!isDemoMode) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      setIndex((current) => current + 1);
+    }, WIND_DEMO_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, [isDemoMode]);
+
+  if (!isDemoMode) return null;
+
+  return getDemoWindData(index, metric);
+};

--- a/src/frontend/domain/weather/wind.spec.ts
+++ b/src/frontend/domain/weather/wind.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getDemoWindData,
+  getWindIntensityClass,
+  WIND_DEMO_INTERVAL_MS,
+} from './wind';
+
+describe('wind domain', () => {
+  describe('getWindIntensityClass', () => {
+    it('returns white when speed is undefined or below 5', () => {
+      expect(getWindIntensityClass(undefined)).toBe('text-white');
+      expect(getWindIntensityClass(0)).toBe('text-white');
+      expect(getWindIntensityClass(4.9)).toBe('text-white');
+    });
+
+    it('scales colour through the intensity ramp', () => {
+      expect(getWindIntensityClass(5)).toBe('text-sky-300');
+      expect(getWindIntensityClass(14.9)).toBe('text-sky-300');
+      expect(getWindIntensityClass(15)).toBe('text-emerald-300');
+      expect(getWindIntensityClass(29.9)).toBe('text-emerald-300');
+      expect(getWindIntensityClass(30)).toBe('text-orange-300');
+      expect(getWindIntensityClass(39.9)).toBe('text-orange-300');
+      expect(getWindIntensityClass(40)).toBe('text-red-400');
+      expect(getWindIntensityClass(200)).toBe('text-red-400');
+    });
+  });
+
+  describe('getDemoWindData', () => {
+    it('returns the first sample in m/s for metric mode', () => {
+      const sample = getDemoWindData(0, true);
+      expect(sample.speedMs).toBeCloseTo(2 / 3.6);
+      expect(sample.direction).toBeCloseTo(0);
+    });
+
+    it('converts the demo speed when in imperial mode', () => {
+      const sample = getDemoWindData(0, false);
+      expect(sample.speedMs).toBeCloseTo(2 / 2.23694);
+    });
+
+    it('cycles through the demo samples by index', () => {
+      const samples = [0, 1, 2, 3, 4, 5].map((i) => getDemoWindData(i, true));
+      expect(samples[1].direction).toBeCloseTo(Math.PI * 0.25);
+      expect(samples[4].direction).toBeCloseTo(Math.PI * 1.75);
+      expect(samples[5].direction).toBeCloseTo(samples[0].direction);
+    });
+  });
+
+  it('exposes a cycling interval that is at least one frame', () => {
+    expect(WIND_DEMO_INTERVAL_MS).toBeGreaterThan(16);
+  });
+});

--- a/src/frontend/domain/weather/wind.ts
+++ b/src/frontend/domain/weather/wind.ts
@@ -1,0 +1,37 @@
+export interface WindDemoData {
+  speedMs: number;
+  direction: number;
+}
+
+const WIND_DEMO_VALUES = [
+  { speed: 2, direction: 0 },
+  { speed: 8, direction: Math.PI * 0.25 },
+  { speed: 20, direction: Math.PI * 0.75 },
+  { speed: 35, direction: Math.PI * 1.25 },
+  { speed: 44, direction: Math.PI * 1.75 },
+];
+
+export const WIND_DEMO_INTERVAL_MS = 1500;
+
+export const getDemoWindData = (
+  index: number,
+  metric: boolean
+): WindDemoData => {
+  const demoValue = WIND_DEMO_VALUES[index % WIND_DEMO_VALUES.length];
+  const speedMs = demoValue.speed / (metric ? 3.6 : 2.23694);
+
+  return {
+    speedMs,
+    direction: demoValue.direction,
+  };
+};
+
+export const getWindIntensityClass = (speed?: number) => {
+  if (speed === undefined) return 'text-white';
+  if (speed < 5) return 'text-white';
+  if (speed < 15) return 'text-sky-300';
+  if (speed < 30) return 'text-emerald-300';
+  if (speed < 40) return 'text-orange-300';
+
+  return 'text-red-400';
+};

--- a/src/types/defaultDashboard.spec.ts
+++ b/src/types/defaultDashboard.spec.ts
@@ -210,6 +210,12 @@ describe('getWidgetDefaultConfig', () => {
     expect(config.humidity.enabled).toBe(true);
   });
 
+  it('returns the wind config', () => {
+    const config = getWidgetDefaultConfig('wind');
+    expect(config.background.opacity).toBe(80);
+    expect(config.units).toBe('auto');
+  });
+
   it('throws for unknown widget id', () => {
     expect(() =>
       getWidgetDefaultConfig('nonexistent' as 'standings')

--- a/src/types/defaultDashboard.spec.ts
+++ b/src/types/defaultDashboard.spec.ts
@@ -203,6 +203,13 @@ describe('getWidgetDefaultConfig', () => {
     expect(config.enableLogging).toBe(false);
   });
 
+  it('returns the weather config with layout and humidity fields', () => {
+    const config = getWidgetDefaultConfig('weather');
+    expect(config.layout).toBe('vertical');
+    expect(config.horizontalMode).toBe('compact');
+    expect(config.humidity.enabled).toBe(true);
+  });
+
   it('throws for unknown widget id', () => {
     expect(() =>
       getWidgetDefaultConfig('nonexistent' as 'standings')

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -734,6 +734,30 @@ export const defaultDashboard: {
       },
     },
     {
+      id: 'wind',
+      enabled: false,
+      layout: {
+        x: 1334,
+        y: 471,
+        width: 174,
+        height: 200,
+      },
+      config: {
+        background: {
+          opacity: 80,
+        },
+        units: 'auto',
+        showOnlyWhenOnTrack: false,
+        sessionVisibility: {
+          race: true,
+          loneQualify: true,
+          openQualify: true,
+          practice: true,
+          offlineTesting: true,
+        },
+      },
+    },
+    {
       id: 'fastercarsfrombehind',
       enabled: false,
       layout: {

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -49,8 +49,8 @@ export const defaultDashboard: {
         background: {
           opacity: 80,
         },
-        foreground: { 
-          opacity: 70, 
+        foreground: {
+          opacity: 70,
         },
         countryFlags: {
           enabled: true,
@@ -386,8 +386,8 @@ export const defaultDashboard: {
         background: {
           opacity: 80,
         },
-        foreground: { 
-          opacity: 70, 
+        foreground: {
+          opacity: 70,
         },
         position: {
           enabled: true,
@@ -690,6 +690,8 @@ export const defaultDashboard: {
         background: {
           opacity: 25,
         },
+        layout: 'vertical',
+        horizontalMode: 'compact',
         units: 'auto',
         displayOrder: [
           'trackTemp',

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -200,10 +200,13 @@ export interface RelativeConfig {
 
 export interface WeatherConfig {
   background: { opacity: number };
+  layout?: 'vertical' | 'horizontal';
+  horizontalMode?: 'compact' | 'full';
   displayOrder: string[];
   showOnlyWhenOnTrack?: boolean;
   airTemp: { enabled: boolean };
   trackTemp: { enabled: boolean };
+  humidity: { enabled: boolean };
   wetness: { enabled: boolean };
   trackState: { enabled: boolean };
   precipitation: { enabled: boolean };

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -215,6 +215,13 @@ export interface WeatherConfig {
   sessionVisibility: SessionVisibilitySettings;
 }
 
+export interface WindConfig {
+  background: { opacity: number };
+  units: 'auto' | 'Metric' | 'Imperial';
+  showOnlyWhenOnTrack: boolean;
+  sessionVisibility: SessionVisibilitySettings;
+}
+
 export interface TrackMapConfig {
   turnLabels: {
     enabled: boolean;
@@ -580,6 +587,7 @@ export interface WidgetConfigMap {
   standings: StandingsConfig;
   relative: RelativeConfig;
   weather: WeatherConfig;
+  wind: WindConfig;
   map: TrackMapConfig;
   flatmap: FlatTrackMapConfig;
   input: InputConfig;
@@ -668,6 +676,7 @@ export interface ShiftPointSettings {
 export type StandingsWidgetSettings = BaseWidgetSettings<StandingsConfig>;
 export type RelativeWidgetSettings = BaseWidgetSettings<RelativeConfig>;
 export type WeatherWidgetSettings = BaseWidgetSettings<WeatherConfig>;
+export type WindWidgetSettings = BaseWidgetSettings<WindConfig>;
 export type TrackMapWidgetSettings = BaseWidgetSettings<TrackMapConfig>;
 export type FlatTrackMapWidgetSettings = BaseWidgetSettings<FlatTrackMapConfig>;
 export type SteerWidgetSettings = BaseWidgetSettings<SteerConfig>;


### PR DESCRIPTION
## Description

Adds horizontal and vertical layout options for the `Weather` widget and introduces a new standalone `Wind` widget. Also shares a common wind demo data source and intensity colour ramp across every wind surface so the three wind instances (`Weather` vertical, `Weather` horizontal, standalone `Wind`) stay visually consistent in demo mode and during live use.

Highlights:

- `Weather` widget now supports `vertical` and `horizontal` layouts, with `compact` and `full` modes for horizontal.
- Wires up `humidity` as a `Weather` display option. The telemetry value was already being read but wasn't exposed in the settings list, so it could never be toggled on or off.
- New `Wind` widget with responsive sizing driven by `ResizeObserver`, so the compass scales to whatever container it's placed in.
- New `src/frontend/domain/weather/wind.ts` and `useWindDemoData` hook centralise the demo cycling values, the intensity colour ramp, and the metric/imperial conversion.
- All three wind renderers consume the same `useWindDemoData(isDemoMode, isMetric)` hook so they animate in sync when iRacing is not running.
- `Weather` inline cells mute their label colour (`text-white/60`) so labels read as labels rather than competing with values. `Wind` inline reorders to `label → compass → value` to match the row hierarchy.
- New unit tests for the shared wind domain module and the demo hook.
- Storybook stories for `Wind`, plus widened `Weather` horizontal stories so all cells sit on one row.

Verified in Storybook against the test data and tested in an AI race on iRacing with Kapps running at the same time to confirm values.

## Screenshots

### Before

Weather widget with vertical-only layout. Note: _humidity_ is not displayed as an available option in the _Display_ toggles on `main` right now, even though it's technically wired up.

> [!NOTE]
> The wind widget isn't colored based on wind intensity on main right now, but I didn't bother checking out to main to get the screenshot.

<img width="310" height="838" alt="CleanShot 2026-05-26 at 15 38 03@2x" src="https://github.com/user-attachments/assets/6b2beace-eac2-4729-be35-c85c27150ba4" />


### After

Actually wiring up humidity so it's a valid option to toggle in the `Weather` widget settings:

<img width="1168" height="1256" alt="adding_humidity" src="https://github.com/user-attachments/assets/3e10ffba-487d-442a-883d-49157ebf3d50" />

Horizontal layout for `Weather` widget in `Full` mode so icons and labels are rendered ahead of values:

<img width="934" height="447" alt="weather_horizontal_full_mode" src="https://github.com/user-attachments/assets/e0f21e0a-c78b-45cd-af5d-a0f5e8517973" />

Horizontal layout for `Weather` widget in `Compact` mode so just icons are rendered ahead of values:

<img width="934" height="447" alt="weather_horizontal_compact_mode" src="https://github.com/user-attachments/assets/bb3bac14-86c0-48dc-95cb-4d0ccf3e4e36" />

Example of shared wind-related demo data showing the color changes based on wind intensity: 

https://github.com/user-attachments/assets/a9eda866-fead-406c-ba35-89486d238ad5

> [!NOTE]
> I've fixed the resize bump when the wind element in `Weather` horizontal mode doesn't have the same resize bump when it goes from 1 => 2 chars. 

https://github.com/user-attachments/assets/cf8c6ac9-0f4a-40a0-8243-b783237ee6cf

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
    - Tested in an AI race, with Kapps on too and confirmed all values were the same, and wind worked exactly the same
- [x] All tests pass locally via `npm test`
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Wind widget with configurable background opacity, units, session visibility, and optional on-track-only display; Settings section and menu entry included.
  * Weather supports vertical/horizontal layouts with a horizontal-mode selector.

* **UI Improvements**
  * Humidity added to weather display settings; display toggles default to enabled and display order is normalized/merge-safe.
  * Compact/inline variants for multiple weather subcomponents for improved responsive layouts.

* **Demos / Stories**
  * Wind demo data and hook; Storybook updated for Weather and Wind.

* **Tests**
  * Added tests for wind demo data and wind utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->