### PR TITLE
fix: nashville superspeedway, refine start/finish intersection

### DIFF
--- a/src/frontend/components/TrackMap/tracks/brokenTracks.ts
+++ b/src/frontend/components/TrackMap/tracks/brokenTracks.ts
@@ -21,9 +21,6 @@ export const BROKEN_TRACKS: BrokenTrack[] = [
   { id: 217, name: 'Irwindale Figure 8', issue: 'non-continuous' },
   { id: 388, name: 'Irwindale Figure 8', issue: 'non-continuous' },
 
-  // Nashville Superspeedway - no position
-  { id: 400, name: 'Nashville Superspeedway', issue: 'no position' },
-
   // LA Coliseum - two paths
   { id: 437, name: 'LA Coliseum', issue: 'two paths' },
 

--- a/tools/analyze-tracks.ts
+++ b/tools/analyze-tracks.ts
@@ -29,18 +29,23 @@ interface BrokenTracksByIssue {
 export const analyzeTracks = (): void => {
   // Read the tracks.json file
   const tracksData: Record<number, TrackDrawing | undefined> = JSON.parse(
-    fs.readFileSync('./src/frontend/components/TrackMap/tracks/tracks.json', 'utf8')
+    fs.readFileSync(
+      './src/frontend/components/TrackMap/tracks/tracks.json',
+      'utf8'
+    )
   );
 
   // Known broken track IDs from brokenTracks.ts (manually extracted)
-  const knownBrokenIds = BROKEN_TRACKS.map(track => track.id);
+  const knownBrokenIds = BROKEN_TRACKS.map((track) => track.id);
 
   // Read track info for names
-  const trackInfo: TrackInfo[] = JSON.parse(fs.readFileSync('./asset-data/track-info.json', 'utf8'));
+  const trackInfo: TrackInfo[] = JSON.parse(
+    fs.readFileSync('./asset-data/track-info.json', 'utf8')
+  );
 
   // Create a map of track IDs to track names
   const trackIdToName: Record<number, string> = {};
-  trackInfo.forEach(track => {
+  trackInfo.forEach((track) => {
     trackIdToName[track.track_id] = track.track_name;
   });
 
@@ -53,30 +58,32 @@ export const analyzeTracks = (): void => {
     missingActive: 0,
     missingBoth: 0,
     explicitlyBroken: 0,
-    brokenByIssue: {}
+    brokenByIssue: {},
   };
 
   Object.entries(tracksData).forEach(([trackId, trackData]) => {
     analysis.total++;
-    
+
     const id = parseInt(trackId);
     const trackName = trackIdToName[id] || `Track ${id}`;
-    
+
     // Check if track is explicitly marked as broken
     if (knownBrokenIds.includes(id)) {
       analysis.explicitlyBroken++;
       analysis.broken++;
       return;
     }
-    
+
     // Check for missing critical data
     const hasStartFinish = trackData?.startFinish?.point;
     const hasActive = trackData?.active?.inside;
-    
+
     if (!hasStartFinish && !hasActive) {
       analysis.missingBoth++;
       analysis.broken++;
-      console.log(`Track ${id} (${trackName}): Missing both startFinish and active`);
+      console.log(
+        `Track ${id} (${trackName}): Missing both startFinish and active`
+      );
     } else if (!hasStartFinish) {
       analysis.missingStartFinish++;
       analysis.broken++;
@@ -95,14 +102,19 @@ export const analyzeTracks = (): void => {
     'non-continuous': 0,
     'no position': 0,
     'two paths': 0,
-    'figure 8': 0
+    'figure 8': 0,
   };
 
-  knownBrokenIds.forEach(id => {
+  knownBrokenIds.forEach((id) => {
     // Determine issue type based on known broken tracks
-    if ([168, 173, 175, 176, 202, 207, 209, 211, 217, 388, 239, 240, 242, 246, 247].includes(id)) {
+    if (
+      [
+        168, 173, 175, 176, 202, 207, 209, 211, 217, 388, 239, 240, 242, 246,
+        247,
+      ].includes(id)
+    ) {
       brokenTracksByIssue['non-continuous']++;
-    } else if ([193, 400].includes(id)) {
+    } else if ([193].includes(id)) {
       brokenTracksByIssue['no position']++;
     } else if ([437, 452].includes(id)) {
       brokenTracksByIssue['two paths']++;
@@ -117,14 +129,26 @@ export const analyzeTracks = (): void => {
   console.log('| Category | Count | Percentage |');
   console.log('|----------|-------|------------|');
   console.log(`| **Total Tracks** | ${analysis.total} | 100% |`);
-  console.log(`| **Working Tracks** | ${analysis.working} | ${(analysis.working / analysis.total * 100).toFixed(1)}% |`);
-  console.log(`| **Broken Tracks** | ${analysis.broken} | ${(analysis.broken / analysis.total * 100).toFixed(1)}% |`);
+  console.log(
+    `| **Working Tracks** | ${analysis.working} | ${((analysis.working / analysis.total) * 100).toFixed(1)}% |`
+  );
+  console.log(
+    `| **Broken Tracks** | ${analysis.broken} | ${((analysis.broken / analysis.total) * 100).toFixed(1)}% |`
+  );
   console.log('| | | |');
   console.log('| **Breakdown of Broken Tracks:** | | |');
-  console.log(`| - Explicitly marked as broken | ${analysis.explicitlyBroken} | ${(analysis.explicitlyBroken / analysis.total * 100).toFixed(1)}% |`);
-  console.log(`| - Missing startFinish point | ${analysis.missingStartFinish} | ${(analysis.missingStartFinish / analysis.total * 100).toFixed(1)}% |`);
-  console.log(`| - Missing active path | ${analysis.missingActive} | ${(analysis.missingActive / analysis.total * 100).toFixed(1)}% |`);
-  console.log(`| - Missing both | ${analysis.missingBoth} | ${(analysis.missingBoth / analysis.total * 100).toFixed(1)}% |`);
+  console.log(
+    `| - Explicitly marked as broken | ${analysis.explicitlyBroken} | ${((analysis.explicitlyBroken / analysis.total) * 100).toFixed(1)}% |`
+  );
+  console.log(
+    `| - Missing startFinish point | ${analysis.missingStartFinish} | ${((analysis.missingStartFinish / analysis.total) * 100).toFixed(1)}% |`
+  );
+  console.log(
+    `| - Missing active path | ${analysis.missingActive} | ${((analysis.missingActive / analysis.total) * 100).toFixed(1)}% |`
+  );
+  console.log(
+    `| - Missing both | ${analysis.missingBoth} | ${((analysis.missingBoth / analysis.total) * 100).toFixed(1)}% |`
+  );
 
   console.log('\n=== BROKEN TRACKS BY ISSUE TYPE ===\n');
 
@@ -132,14 +156,20 @@ export const analyzeTracks = (): void => {
   console.log('|------------|-------|---------------------|');
   Object.entries(brokenTracksByIssue).forEach(([issue, count]) => {
     if (count > 0) {
-      console.log(`| ${issue} | ${count} | ${(count / analysis.broken * 100).toFixed(1)}% |`);
+      console.log(
+        `| ${issue} | ${count} | ${((count / analysis.broken) * 100).toFixed(1)}% |`
+      );
     }
   });
 
   console.log('\n=== DETAILED BREAKDOWN ===\n');
   console.log(`Total tracks analyzed: ${analysis.total}`);
-  console.log(`Working tracks: ${analysis.working} (${(analysis.working / analysis.total * 100).toFixed(1)}%)`);
-  console.log(`Broken tracks: ${analysis.broken} (${(analysis.broken / analysis.total * 100).toFixed(1)}%)`);
+  console.log(
+    `Working tracks: ${analysis.working} (${((analysis.working / analysis.total) * 100).toFixed(1)}%)`
+  );
+  console.log(
+    `Broken tracks: ${analysis.broken} (${((analysis.broken / analysis.total) * 100).toFixed(1)}%)`
+  );
   console.log(`  - Explicitly broken: ${analysis.explicitlyBroken}`);
   console.log(`  - Missing startFinish: ${analysis.missingStartFinish}`);
   console.log(`  - Missing active path: ${analysis.missingActive}`);

--- a/tools/svg-utils.ts
+++ b/tools/svg-utils.ts
@@ -172,7 +172,15 @@ export const findIntersectionPoint = (
 
         const intersection = lineIntersection(point1, point2, point3, point4);
         if (intersection) {
-          return { x: intersection.x, y: intersection.y, length: i };
+          const offset = Math.hypot(
+            intersection.x - point1.x,
+            intersection.y - point1.y
+          );
+          return {
+            x: intersection.x,
+            y: intersection.y,
+            length: i + offset,
+          };
         }
       }
     } else {
@@ -202,7 +210,15 @@ export const findIntersectionPoint = (
         const intersection = lineIntersection(point1, point2, point3, point4);
 
         if (intersection) {
-          return { x: intersection.x, y: intersection.y, length: i };
+          const offset = Math.hypot(
+            intersection.x - point1.x,
+            intersection.y - point1.y
+          );
+          return {
+            x: intersection.x,
+            y: intersection.y,
+            length: i + offset,
+          };
         }
       }
     }


### PR DESCRIPTION
## Description

`findIntersectionPoint` in `tools/svg-utils.ts` returned `length` as the start of the coarse sampling chunk where it detected the racing-line-vs-S/F-line intersection, rather than the actual arc length at the crossing point. With `step1 = totalLength / 500`, every track's stored `startFinish.point.length` was rounded down by up to ~0.2% of total length.

For Nashville Superspeedway (track 400) the intersection happens within the very first chunk (intersection at length ≈ 5.1, chunk covers [0, 6.68]), so `length` rounded to literal `0`. The truthy guard in `TrackCanvas.tsx:204` (`!trackDrawing?.startFinish?.point?.length`) then bailed out of position calculation entirely, so no cars rendered.

### Fix

Refine `length` from `i` to `i + chordOffset`, where `chordOffset` is the distance from the chunk-start point to the intersection point. Both branches of `findIntersectionPoint` (the path2-sampled and path2-segments-fallback paths) updated.

Regenerated `tracks.json`. Stats across the diff (per-track shift in `startFinish.point.length` vs old value):

| Metric | Value |
| --- | --- |
| Tracks with startFinish | 461 |
| Shifted within `[0, step1]` | 455 (98.7%) |
| Unchanged (exact chunk boundary) | 4 |
| Shifted slightly over step1 (chord vs arc-length rounding) | 2 (tracks 404, 429; 1.005× and 1.024×) |
| Mean shift / step1 | 0.5026 |
| Max shift | 13.59 units |

A mean shift/step1 of ~0.5 is the expected statistical signature of intersections distributed uniformly within their sampling chunks, which is the right shape for "rounded-to-bucket-start → refined-to-true-position."

Nashville Superspeedway removed from `BROKEN_TRACKS` (and from the matching `no position` bucket in `analyze-tracks.ts`). Two other tracks (513 Millbridge Speedway, 581 Lucas Oil Speedway) still surface as "Missing startFinish point" in the analyzer — pre-existing, separate issue.

## Screenshots

### Before
Track 400 in Storybook: track outline draws, but no driver markers ever appear because `calculatePositions` returns `{}` every tick.

### After
Driver markers move correctly around the oval; `tracks.json` `startFinish.point.length` for track 400 is `5.100` (matches the right-edge intersection of the S/F stripe with the racing line).


https://github.com/user-attachments/assets/7cc3a67d-d652-42e7-bcc2-ebf43dc40382



## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] All tests pass locally via `npm test` (28/28 in TrackMap)
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nashville Superspeedway is now available for use

* **Improvements**
  * Refined track data analysis and intersection detection calculations for enhanced accuracy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tariknz/irdashies/pull/568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->