### PR TITLE
chore: update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,18 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 2  # Fetch the last 2 commits to compare changes
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24'
         cache: 'npm'
 
     - name: Cache node_modules and native builds
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: cache-deps
       with:
         path: |
@@ -50,7 +50,7 @@ jobs:
       run: npm test
 
     - name: Upload coverage report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-report
         path: coverage 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -20,9 +20,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -33,7 +33,7 @@ jobs:
       - name: Build site
         run: npm run site:build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site/dist
 
@@ -45,4 +45,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Description

Clears the GitHub Actions deprecation warning about Node.js 20 actions ("Actions will be forced to run with Node.js 24 by default starting June 16th, 2026"). Bumps each flagged action to its latest major, all of which run on Node 24.

| Action | Old | New |
| --- | --- | --- |
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

Verified that every input/output the workflows actually use (`fetch-depth`, `node-version`, `cache`, `path`, `key`, `restore-keys`, `cache-hit`, `name`, `page_url`) is still present and unchanged at the new versions. The notable breaking change in `upload-artifact` (immutable artifacts — no re-upload to the same name in one run) does not affect us since CI does a single `coverage-report` upload.

No application code changes; CI/Pages workflows only.

## Screenshots

N/A — CI configuration change, no visual impact.

### Before
N/A

### After
N/A

## Type of Change

- [x] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)