### PR TITLE
feat: border radius controls

### DIFF
--- a/.storybook/borderRadiusDecorator.tsx
+++ b/.storybook/borderRadiusDecorator.tsx
@@ -1,0 +1,109 @@
+import type { ArgTypes, Decorator } from '@storybook/react-vite';
+import type { WidgetBorderRadiusSettings } from '@irdashies/types';
+import {
+  MAX_BORDER_RADIUS,
+  WIDGET_BORDER_RADIUS_CLASS,
+  getWidgetBorderRadiusStyle,
+} from '@irdashies/utils/borderRadius';
+
+export interface BorderRadiusStoryArgs {
+  globalBorderRadius: number;
+  borderRadiusMode: WidgetBorderRadiusSettings['mode'];
+  uniformBorderRadius: number;
+  topLeftBorderRadius: number;
+  topRightBorderRadius: number;
+  bottomRightBorderRadius: number;
+  bottomLeftBorderRadius: number;
+}
+
+export const borderRadiusStoryArgs = {
+  globalBorderRadius: 2,
+  borderRadiusMode: 'inherit',
+  uniformBorderRadius: 8,
+  topLeftBorderRadius: 0,
+  topRightBorderRadius: 8,
+  bottomRightBorderRadius: 16,
+  bottomLeftBorderRadius: 24,
+} as Record<string, unknown>;
+
+export const borderRadiusStoryArgTypes: ArgTypes = {
+  globalBorderRadius: {
+    name: 'Global Radius',
+    control: { type: 'range', min: 0, max: MAX_BORDER_RADIUS, step: 1 },
+    table: { category: 'Border Radius' },
+  },
+  borderRadiusMode: {
+    name: 'Mode',
+    control: 'select',
+    options: ['inherit', 'uniform', 'corners'],
+    table: { category: 'Border Radius' },
+  },
+  uniformBorderRadius: {
+    name: 'Uniform Radius',
+    control: { type: 'range', min: 0, max: MAX_BORDER_RADIUS, step: 1 },
+    if: { arg: 'borderRadiusMode', eq: 'uniform' },
+    table: { category: 'Border Radius' },
+  },
+  topLeftBorderRadius: {
+    name: 'Top Left',
+    control: { type: 'range', min: 0, max: MAX_BORDER_RADIUS, step: 1 },
+    if: { arg: 'borderRadiusMode', eq: 'corners' },
+    table: { category: 'Border Radius' },
+  },
+  topRightBorderRadius: {
+    name: 'Top Right',
+    control: { type: 'range', min: 0, max: MAX_BORDER_RADIUS, step: 1 },
+    if: { arg: 'borderRadiusMode', eq: 'corners' },
+    table: { category: 'Border Radius' },
+  },
+  bottomRightBorderRadius: {
+    name: 'Bottom Right',
+    control: { type: 'range', min: 0, max: MAX_BORDER_RADIUS, step: 1 },
+    if: { arg: 'borderRadiusMode', eq: 'corners' },
+    table: { category: 'Border Radius' },
+  },
+  bottomLeftBorderRadius: {
+    name: 'Bottom Left',
+    control: { type: 'range', min: 0, max: MAX_BORDER_RADIUS, step: 1 },
+    if: { arg: 'borderRadiusMode', eq: 'corners' },
+    table: { category: 'Border Radius' },
+  },
+};
+
+const getStoryBorderRadiusSettings = (
+  args: Partial<BorderRadiusStoryArgs>
+): WidgetBorderRadiusSettings => {
+  if (args.borderRadiusMode === 'uniform') {
+    return {
+      mode: 'uniform',
+      radius: args.uniformBorderRadius,
+    };
+  }
+
+  if (args.borderRadiusMode === 'corners') {
+    return {
+      mode: 'corners',
+      corners: {
+        topLeft: args.topLeftBorderRadius,
+        topRight: args.topRightBorderRadius,
+        bottomRight: args.bottomRightBorderRadius,
+        bottomLeft: args.bottomLeftBorderRadius,
+      },
+    };
+  }
+
+  return { mode: 'inherit' };
+};
+
+export const BorderRadiusDecorator: Decorator = (Story, context) => {
+  const args = context.args as Partial<BorderRadiusStoryArgs>;
+  const style = getWidgetBorderRadiusStyle(getStoryBorderRadiusSettings(args), {
+    borderRadius: args.globalBorderRadius,
+  });
+
+  return (
+    <div className={WIDGET_BORDER_RADIUS_CLASS} style={style}>
+      <Story />
+    </div>
+  );
+};

--- a/.storybook/index.ts
+++ b/.storybook/index.ts
@@ -1,3 +1,4 @@
 export * from './telemetryDecorator';
+export * from './borderRadiusDecorator';
 export * from './DynamicTelemetrySelector';
 export * from './mockDashboardBridge';

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,9 +315,10 @@ npm run storybook  # Port 6006
 3. Add settings to `src/frontend/components/Settings/SettingsLoader.tsx`
 4. Add settings menu item to `src/frontend/components/Settings/SettingsMenu.tsx`
 5. Add type to `src/types/widgetConfigs.ts`
-6. Create `.stories.tsx`
-7. Register in `WidgetIndex.tsx`
-8. Add default config in `src/types/defaultDashboard.ts`
+6. For widgets with a visible rectangular background surface, add the widget type to `WIDGET_BORDER_RADIUS_SUPPORTED_TYPES` in `src/frontend/utils/borderRadius.ts` and apply `widget-radius-surface` to that surface. Leave widgets with no meaningful corners out of the allowlist.
+7. Create `.stories.tsx`
+8. Register in `WidgetIndex.tsx`
+9. Add default config in `src/types/defaultDashboard.ts`
 
 ### Adding a Hook
 

--- a/docs/ARCHITECTURE_RULES.md
+++ b/docs/ARCHITECTURE_RULES.md
@@ -170,7 +170,8 @@ Imports flow **downward** in this list. A layer may import from any layer below 
 - **R7.2** Heavy memoised components MUST receive primitive props (string/number/boolean), not freshly-allocated objects. Either flatten props in the parent, or attach a custom `propsAreEqual` to the `memo()` wrapper.
 - **R7.3** UI text is plain strings. **Never use emojis** — use Phosphor icons (`@phosphor-icons/react`).
 - **R7.4** Styling is Tailwind-only. No custom CSS unless theme-level.
-- **R7.5** Every widget has a `.stories.tsx` decorated with `TelemetryDecorator()` (or the channel-snapshot decorators introduced in Phase 3).
+- **R7.5** Widgets with a visible rectangular background surface MUST apply `widget-radius-surface` to that surface so global and per-widget border radius settings work. Radius support is opt-in through `WIDGET_BORDER_RADIUS_SUPPORTED_TYPES`; the settings UI and widget wrapper MUST both use that allowlist. Do not use broad CSS selectors or `!important` overrides to force widget radii. Widgets without a meaningful rectangular surface or corners, and non-user-facing diagnostic overlays such as Telemetry Inspector, MUST stay out of the allowlist.
+- **R7.6** Every widget has a `.stories.tsx` decorated with `TelemetryDecorator()` (or the channel-snapshot decorators introduced in Phase 3).
 
 ---
 

--- a/src/frontend/components/CornerNameOverlay/CornerNameOverlay.stories.tsx
+++ b/src/frontend/components/CornerNameOverlay/CornerNameOverlay.stories.tsx
@@ -1,6 +1,11 @@
-import { Meta, StoryObj } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CornerNameOverlay } from './CornerNameOverlay';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import {
+  BorderRadiusDecorator,
+  TelemetryDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 
 // Real recorded sessions are used so the bundled-data lookup resolves naturally
 // from WeekendInfo.TrackName — no manual store overrides. As the recording
@@ -10,13 +15,16 @@ export default {
   component: CornerNameOverlay,
   title: 'widgets/CornerNameOverlay',
   args: {
+    ...borderRadiusStoryArgs,
     showCornerNumber: true,
     showProgressBar: true,
     showTrackPct: true,
     fontSize: 18,
     opacity: 0.9,
   },
+  argTypes: borderRadiusStoryArgTypes,
   decorators: [
+    BorderRadiusDecorator,
     (Story) => (
       <div className="w-72">
         <Story />

--- a/src/frontend/components/CornerNameOverlay/CornerNameOverlay.tsx
+++ b/src/frontend/components/CornerNameOverlay/CornerNameOverlay.tsx
@@ -21,7 +21,7 @@ export const CornerNameOverlay = ({
 
   return (
     <div
-      className="w-full rounded-sm p-2 relative overflow-hidden"
+      className="widget-radius-surface w-full rounded-sm p-2 relative overflow-hidden"
       style={{ backgroundColor: `rgba(15, 23, 42, ${opacity})` }}
     >
       {/* Main content */}

--- a/src/frontend/components/DashboardView/DashboardView.tsx
+++ b/src/frontend/components/DashboardView/DashboardView.tsx
@@ -11,10 +11,15 @@ import { useDashboard } from '@irdashies/context';
 import { getWidget } from '../../WidgetIndex';
 import { getWidgetName } from '../../constants/widgetNames';
 import { ResizeIcon, XIcon } from '@phosphor-icons/react';
-import type { DashboardWidget } from '@irdashies/types';
+import type { DashboardWidget, GeneralSettingsType } from '@irdashies/types';
 import { useDragWidget, useResizeWidget } from '../WidgetContainer';
 import { ResizeHandles } from '../WidgetContainer/ResizeHandle';
 import logger from '@irdashies/utils/logger';
+import {
+  WIDGET_BORDER_RADIUS_CLASS,
+  getWidgetBorderRadiusStyle,
+  supportsWidgetBorderRadius,
+} from '@irdashies/utils/borderRadius';
 
 interface WidgetPosition {
   x: number;
@@ -30,6 +35,7 @@ interface DashboardWidgetItemProps {
   onPositionChange: (widgetId: string, position: WidgetPosition) => void;
   onClick: (widgetId: string) => void;
   onCloseBorder: () => void;
+  generalSettings?: GeneralSettingsType;
 }
 
 const DashboardWidgetItem = memo(
@@ -40,6 +46,7 @@ const DashboardWidgetItem = memo(
     onPositionChange,
     onClick,
     onCloseBorder,
+    generalSettings,
   }: DashboardWidgetItemProps) => {
     const [localLayout, setLocalLayout] = useState(position);
     const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -120,6 +127,11 @@ const DashboardWidgetItem = memo(
       width: localLayout.width,
       height: localLayout.height,
     };
+    const widgetType = widget.type || widget.id;
+    const supportsBorderRadius = supportsWidgetBorderRadius(widgetType);
+    const borderRadiusStyle = supportsBorderRadius
+      ? getWidgetBorderRadiusStyle(widget.borderRadius, generalSettings)
+      : undefined;
 
     return (
       <div style={containerStyle} data-widget-id={widget.id}>
@@ -164,7 +176,15 @@ const DashboardWidgetItem = memo(
               }
             `}</style>
             <div className="widget-content w-full h-full">
-              <WidgetComponent {...widget.config} />
+              <div
+                className={[
+                  'w-full h-full',
+                  supportsBorderRadius ? WIDGET_BORDER_RADIUS_CLASS : '',
+                ].join(' ')}
+                style={borderRadiusStyle}
+              >
+                <WidgetComponent {...widget.config} />
+              </div>
             </div>
           </div>
         </div>
@@ -369,6 +389,7 @@ export const DashboardView = () => {
             onPositionChange={handlePositionChange}
             onClick={handleWidgetClick}
             onCloseBorder={handleCloseBorder}
+            generalSettings={currentDashboard.generalSettings}
           />
         );
       })}

--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.stories.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.stories.tsx
@@ -3,7 +3,12 @@ import {
   FasterCarsFromBehind,
   FasterCarsFromBehindDisplay,
 } from './FasterCarsFromBehind';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import {
+  BorderRadiusDecorator,
+  TelemetryDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 
 // Mock the settings hook for stories
 const mockSettings = {
@@ -29,7 +34,10 @@ const mockSettings = {
 export default {
   component: FasterCarsFromBehindDisplay,
   title: 'widgets/FasterCarsFromBehind',
+  decorators: [BorderRadiusDecorator],
+  args: borderRadiusStoryArgs,
   argTypes: {
+    ...borderRadiusStoryArgTypes,
     classColor: {
       options: [undefined, 0xffda59, 0x33ceff, 0xff5888, 0xae6bff, 0xffffff],
       control: { type: 'select' },

--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { useSessionVisibility, useDashboard } from '@irdashies/context';
 import { useCarBehind } from './hooks/useCarBehind';
 import { useFasterCarsSettings } from './hooks/useFasterCarsSettings';
@@ -50,78 +51,84 @@ export const FasterCarsFromBehind = () => {
   );
 };
 
-export const FasterCarsFromBehindDisplay = ({
-  name,
-  license,
-  rating,
-  distance,
-  percent,
-  classColor,
-}: FasterCarsFromBehindProps) => {
-  const settings = useFasterCarsSettings();
+export const FasterCarsFromBehindDisplay = memo(
+  function FasterCarsFromBehindDisplay({
+    name,
+    license,
+    rating,
+    distance,
+    percent,
+    classColor,
+  }: FasterCarsFromBehindProps) {
+    const settings = useFasterCarsSettings();
 
-  if (!name) {
-    return null;
-  }
+    if (!name) {
+      return null;
+    }
 
-  const animate = distance && distance > -1.5 ? 'animate-pulse' : '';
-  const red = percent || 0;
-  const green = 100 - (percent || 0);
-  const background = getTailwindStyle(classColor, undefined, true).classHeader;
+    const animate = distance && distance > -1.5 ? 'animate-pulse' : '';
+    const red = percent || 0;
+    const green = 100 - (percent || 0);
+    const background = getTailwindStyle(
+      classColor,
+      undefined,
+      true
+    ).classHeader;
 
-  name = settings?.removeNumbersFromName ? name.replace(/\d/g, '') : name;
+    name = settings?.removeNumbersFromName ? name.replace(/\d/g, '') : name;
 
-  return (
-    <div
-      className={`widget-radius-surface w-full rounded-sm ${background} ${animate}`}
-    >
+    return (
       <div
-        className={`flex p-1 ${(settings?.showName || settings?.showBadge) && settings?.showDistance ? 'justify-between' : settings?.showDistance ? 'justify-end' : 'justify-start'}`}
+        className={`widget-radius-surface w-full rounded-sm ${background} ${animate}`}
       >
-        <div className="flex gap-1">
-          {settings?.showName && (
+        <div
+          className={`flex p-1 ${(settings?.showName || settings?.showBadge) && settings?.showDistance ? 'justify-between' : settings?.showDistance ? 'justify-end' : 'justify-start'}`}
+        >
+          <div className="flex gap-1">
+            {settings?.showName && (
+              <div className="rounded-sm text-lg bg-gray-700 p-1 px-2">
+                {name}
+              </div>
+            )}
+            {settings?.showBadge && (
+              <div className="flex align-center">
+                <DriverRatingBadge
+                  license={license}
+                  rating={rating}
+                  format={
+                    settings.badgeFormat as
+                      | 'license-color-fullrating-combo'
+                      | 'fullrating-color-no-license'
+                      | 'license-color-fullrating-bw'
+                      | 'license-color-rating-bw'
+                      | 'license-color-rating-bw-no-license'
+                      | 'rating-color-no-license'
+                      | 'license-bw-rating-bw'
+                      | 'rating-only-bw-rating-bw'
+                      | 'license-bw-rating-bw-no-license'
+                      | 'rating-bw-no-license'
+                      | 'fullrating-bw-no-license'
+                      | 'rating-only-color-rating-bw'
+                  }
+                />
+              </div>
+            )}
+          </div>
+          {settings?.showDistance && (
             <div className="rounded-sm text-lg bg-gray-700 p-1 px-2">
-              {name}
-            </div>
-          )}
-          {settings?.showBadge && (
-            <div className="flex align-center">
-              <DriverRatingBadge
-                license={license}
-                rating={rating}
-                format={
-                  settings.badgeFormat as
-                    | 'license-color-fullrating-combo'
-                    | 'fullrating-color-no-license'
-                    | 'license-color-fullrating-bw'
-                    | 'license-color-rating-bw'
-                    | 'license-color-rating-bw-no-license'
-                    | 'rating-color-no-license'
-                    | 'license-bw-rating-bw'
-                    | 'rating-only-bw-rating-bw'
-                    | 'license-bw-rating-bw-no-license'
-                    | 'rating-bw-no-license'
-                    | 'fullrating-bw-no-license'
-                    | 'rating-only-color-rating-bw'
-                }
-              />
+              {distance?.toFixed(1)}
             </div>
           )}
         </div>
-        {settings?.showDistance && (
-          <div className="rounded-sm text-lg bg-gray-700 p-1 px-2">
-            {distance?.toFixed(1)}
-          </div>
-        )}
-      </div>
 
-      <div
-        className={`rounded-b-sm bg-white h-2 flex-none`}
-        style={{
-          width: `${percent ?? 0}%`,
-          backgroundColor: `rgb(${red}%, ${green}%, 0%)`,
-        }}
-      ></div>
-    </div>
-  );
-};
+        <div
+          className={`rounded-b-sm bg-white h-2 flex-none`}
+          style={{
+            width: `${percent ?? 0}%`,
+            backgroundColor: `rgb(${red}%, ${green}%, 0%)`,
+          }}
+        ></div>
+      </div>
+    );
+  }
+);

--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
@@ -78,9 +78,7 @@ export const FasterCarsFromBehindDisplay = memo(
     name = settings?.removeNumbersFromName ? name.replace(/\d/g, '') : name;
 
     return (
-      <div
-        className={`widget-radius-surface w-full rounded-sm ${background} ${animate}`}
-      >
+      <div className={`widget-radius-surface w-full ${background} ${animate}`}>
         <div
           className={`flex p-1 ${(settings?.showName || settings?.showBadge) && settings?.showDistance ? 'justify-between' : settings?.showDistance ? 'justify-end' : 'justify-start'}`}
         >

--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
@@ -72,7 +72,9 @@ export const FasterCarsFromBehindDisplay = ({
   name = settings?.removeNumbersFromName ? name.replace(/\d/g, '') : name;
 
   return (
-    <div className={`w-full rounded-sm ${background} ${animate}`}>
+    <div
+      className={`widget-radius-surface w-full rounded-sm ${background} ${animate}`}
+    >
       <div
         className={`flex p-1 ${(settings?.showName || settings?.showBadge) && settings?.showDistance ? 'justify-between' : settings?.showDistance ? 'justify-end' : 'justify-start'}`}
       >

--- a/src/frontend/components/Flag/Flag.stories.tsx
+++ b/src/frontend/components/Flag/Flag.stories.tsx
@@ -1,10 +1,18 @@
 import React, { useEffect, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { FlagDisplay } from './Flag';
+import {
+  BorderRadiusDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 
 const meta: Meta<typeof FlagDisplay> = {
   title: 'widgets/Flag',
   component: FlagDisplay,
+  decorators: [BorderRadiusDecorator],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
 };
 
 export default meta;

--- a/src/frontend/components/Flag/Flag.tsx
+++ b/src/frontend/components/Flag/Flag.tsx
@@ -272,7 +272,7 @@ export const FlagDisplay = ({
       className="w-full h-full flex items-center justify-center"
     >
       <div
-        className="widget-radius-surface flex flex-col items-center gap-[3%] bg-slate-900/(--bg-opacity) rounded-2xl border-4 border-slate-800/(--bg-opacity)"
+        className="widget-radius-surface flex flex-col items-center gap-[3%] bg-slate-900/(--bg-opacity) border-4 border-slate-800/(--bg-opacity)"
         style={{
           ...bgOpacityStyle,
           boxShadow: containerShadow,

--- a/src/frontend/components/Flag/Flag.tsx
+++ b/src/frontend/components/Flag/Flag.tsx
@@ -250,7 +250,7 @@ export const FlagDisplay = ({
   if (fullBleed) {
     return (
       <div
-        className="flex flex-col items-stretch gap-0 bg-slate-900/(--bg-opacity) border-4 border-slate-800/(--bg-opacity) w-full h-full box-border m-0 p-0"
+        className="widget-radius-surface flex flex-col items-stretch gap-0 bg-slate-900/(--bg-opacity) border-4 border-slate-800/(--bg-opacity) w-full h-full box-border m-0 p-0"
         style={{ ...bgOpacityStyle, boxShadow: containerShadow }}
       >
         <div
@@ -272,7 +272,7 @@ export const FlagDisplay = ({
       className="w-full h-full flex items-center justify-center"
     >
       <div
-        className="flex flex-col items-center gap-[3%] bg-slate-900/(--bg-opacity) rounded-2xl border-4 border-slate-800/(--bg-opacity)"
+        className="widget-radius-surface flex flex-col items-center gap-[3%] bg-slate-900/(--bg-opacity) rounded-2xl border-4 border-slate-800/(--bg-opacity)"
         style={{
           ...bgOpacityStyle,
           boxShadow: containerShadow,

--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -1,8 +1,11 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { FuelCalculator } from './FuelCalculator';
 import {
+  BorderRadiusDecorator,
   TelemetryDecorator,
   DynamicTelemetrySelector,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
 } from '@irdashies/storybook';
 import { useState, useEffect } from 'react';
 import { useFuelStore } from './FuelStore';
@@ -11,6 +14,9 @@ import type { FuelLapData } from './types';
 export default {
   component: FuelCalculator,
   title: 'widgets/FuelCalculator',
+  decorators: [BorderRadiusDecorator],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
 } as Meta;
 
 type Story = StoryObj<typeof FuelCalculator>;

--- a/src/frontend/components/FuelCalculator/FuelCalculator.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.tsx
@@ -342,7 +342,7 @@ export const FuelCalculator = (props: FuelCalculatorProps) => {
 
   return (
     <div
-      className={`relative w-full flex flex-col ${borderWidth} box-border transition-colors duration-500 rounded-sm bg-slate-800/(--bg-opacity) overflow-hidden ${paddingClass}`}
+      className={`widget-radius-surface relative w-full flex flex-col ${borderWidth} box-border transition-colors duration-500 rounded-sm bg-slate-800/(--bg-opacity) overflow-hidden ${paddingClass}`}
       style={{
         fontFamily:
           "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",

--- a/src/frontend/components/GarageCover/GarageCover.tsx
+++ b/src/frontend/components/GarageCover/GarageCover.tsx
@@ -48,7 +48,7 @@ export const GarageCover = () => {
   }
 
   return (
-    <div className="w-full h-full flex items-center justify-center rounded-sm bg-slate-800">
+    <div className="widget-radius-surface w-full h-full flex items-center justify-center rounded-sm bg-slate-800">
       <img
         src={imageUrl || logoSvg}
         alt="Garage Cover"

--- a/src/frontend/components/InformationBar/InformationBar.stories.tsx
+++ b/src/frontend/components/InformationBar/InformationBar.stories.tsx
@@ -1,7 +1,12 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { ComponentProps } from 'react';
 import { SessionBar } from '../Standings/components/SessionBar/SessionBar';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import {
+  BorderRadiusDecorator,
+  TelemetryDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 import { SessionBarConfig } from '@irdashies/types';
 
 /**
@@ -11,7 +16,9 @@ import { SessionBarConfig } from '@irdashies/types';
 const meta: Meta = {
   title: 'widgets/InformationBar',
   component: SessionBar,
-  decorators: [TelemetryDecorator()],
+  decorators: [BorderRadiusDecorator, TelemetryDecorator()],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
   parameters: {
     layout: 'fullscreen',
   },
@@ -72,7 +79,7 @@ export const Primary: Story = {
     controls: { disable: true },
   },
   render: (args) => (
-    <div className="w-full bg-slate-800/80 p-2">
+    <div className="widget-radius-surface w-full bg-slate-800/80 p-2">
       <SessionBar {...args} />
     </div>
   ),
@@ -173,7 +180,7 @@ export const Playground: StoryObj<PlaygroundArgs> = {
 
     return (
       <div
-        className="w-full bg-slate-800 rounded-sm p-2"
+        className="widget-radius-surface w-full bg-slate-800 rounded-sm p-2"
         style={{ opacity: args.backgroundOpacity / 100 }}
       >
         <SessionBar settings={config} standalone />

--- a/src/frontend/components/InformationBar/InformationBar.tsx
+++ b/src/frontend/components/InformationBar/InformationBar.tsx
@@ -31,12 +31,16 @@ export const InformationBar = () => {
 
   return (
     <div
-      className={`w-full bg-slate-800/(--bg-opacity) rounded-sm ${!isCompact ? 'p-2' : ''} overflow-hidden pointer-events-none`}
+      className={`widget-radius-surface w-full bg-slate-800/(--bg-opacity) rounded-sm ${!isCompact ? 'p-2' : ''} overflow-hidden pointer-events-none`}
       style={{
         ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 60}%`,
       }}
     >
-      <SessionBar settings={settings} opacity={settings?.foreground?.opacity} standalone />
+      <SessionBar
+        settings={settings}
+        opacity={settings?.foreground?.opacity}
+        standalone
+      />
     </div>
   );
 };

--- a/src/frontend/components/Input/Input.stories.tsx
+++ b/src/frontend/components/Input/Input.stories.tsx
@@ -1,14 +1,19 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Input } from './Input';
 import {
+  BorderRadiusDecorator,
   TelemetryDecorator,
   TelemetryDecoratorWithConfig,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
 } from '@irdashies/storybook';
 
 const meta: Meta<typeof Input> = {
   component: Input,
   title: 'widgets/Input',
-  decorators: [TelemetryDecorator()],
+  decorators: [BorderRadiusDecorator, TelemetryDecorator()],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
 };
 export default meta;
 

--- a/src/frontend/components/Input/InputContainer/InputContainer.tsx
+++ b/src/frontend/components/Input/InputContainer/InputContainer.tsx
@@ -133,7 +133,7 @@ export const InputContainer = ({
 
   return (
     <div
-      className="w-full h-full inline-flex gap-1 p-2 rounded-md flex-row bg-slate-800/(--bg-opacity)"
+      className="widget-radius-surface w-full h-full inline-flex gap-1 p-2 rounded-md flex-row bg-slate-800/(--bg-opacity)"
       style={{
         ['--bg-opacity' as string]: `${settings.background?.opacity ?? 80}%`,
       }}

--- a/src/frontend/components/LapTimeLog/LapTimeLog.stories.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { LapTimeLogDisplay } from './LapTimeLog';
 import type { LapTimeLogConfig } from '@irdashies/types';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import {
+  BorderRadiusDecorator,
+  TelemetryDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 
 interface LapEntry {
   lap: number;
@@ -15,11 +20,17 @@ const meta: Meta<typeof LapTimeLogDisplay> = {
   parameters: {
     layout: 'centered',
   },
-  decorators: [TelemetryDecorator(), (Story) => (
-    <div style={{ width: '250px' }}>
-      <Story />
-    </div>
-  )],
+  decorators: [
+    TelemetryDecorator(),
+    BorderRadiusDecorator,
+    (Story) => (
+      <div style={{ width: '250px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
 };
 
 export default meta;
@@ -102,11 +113,11 @@ export const NewPersonalBest: Story = {
   args: {
     ...baseArgs,
     current: 4.5, // within 5 seconds
-    lastlap: 91.2, 
+    lastlap: 91.2,
     bestlap: 91.2,
     alltimelap: 91.2, // new personal best
     settings: mockConfig({
-      showAllTimeLap: true,     
+      showAllTimeLap: true,
     }),
   },
 };
@@ -116,7 +127,7 @@ export const NewSessionBest: Story = {
   args: {
     ...baseArgs,
     current: 3.2, // within 5 seconds
-    lastlap: 90.9, 
+    lastlap: 90.9,
     bestlap: 90.9, // new session best
     overall: 90.2,
     settings: mockConfig(),

--- a/src/frontend/components/LapTimeLog/LapTimeLog.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.tsx
@@ -131,7 +131,7 @@ export const LapTimeLogDisplay = ({
       value > 0 &&
       Math.abs(lastlap - value) < 0.001;
     const isSessionBest = isMatchingLap(bestlap);
-    const isOverallBest = isMatchingLap(overall);    
+    const isOverallBest = isMatchingLap(overall);
     const isPersonalBest = isMatchingLap(alltimelap);
     bgColor = 'bg-slate-900';
     if (isSessionBest) bgColor = 'bg-green-700';
@@ -152,7 +152,7 @@ export const LapTimeLogDisplay = ({
   return (
     <div className={`h-full flex ${alignment}`}>
       <div
-        className={`w-full text-sm bg-slate-800/[var(--bg-opacity)] rounded-md text-white ${!isCompact ? 'p-2' : 'p-0.5'}`}
+        className={`widget-radius-surface w-full text-sm bg-slate-800/[var(--bg-opacity)] rounded-md text-white ${!isCompact ? 'p-2' : 'p-0.5'}`}
         style={
           {
             '--bg-opacity': `${settings.background.opacity}%`,
@@ -226,11 +226,7 @@ export const LapTimeLogDisplay = ({
                         : 'text-zinc-400'
                   }`}
                 >
-                  {formatDelta(
-                    hasPredictedDelta
-                      ? delta
-                      : 0
-                  )}
+                  {formatDelta(hasPredictedDelta ? delta : 0)}
                 </div>
               )}
             </div>

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -146,6 +146,7 @@ export const OverlayContainer = memo(() => {
             widget={widget}
             siblingLayouts={siblingLayoutsByWidgetId.get(widget.id)}
             editMode={editMode}
+            generalSettings={currentDashboard.generalSettings}
             zIndex={index + 1}
             onLayoutChange={handleLayoutChange}
             onDisable={handleDisableWidget}

--- a/src/frontend/components/PitlaneHelper/PitlaneHelper.stories.tsx
+++ b/src/frontend/components/PitlaneHelper/PitlaneHelper.stories.tsx
@@ -1,88 +1,100 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import {
+  BorderRadiusDecorator,
+  TelemetryDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 import { PitlaneHelperBody } from './PitlaneHelper';
 
 const meta: Meta<typeof PitlaneHelperBody> = {
   title: 'Widgets/PitlaneHelper',
   component: PitlaneHelperBody,
-  decorators: [TelemetryDecorator()],
+  decorators: [BorderRadiusDecorator, TelemetryDecorator()],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
   parameters: {
     layout: 'centered',
-  }
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Mock data factories
-const mockSpeed = (overrides = {}) => ({
-  speedKph: 100,
-  speedMph: 62,
-  deltaKph: 0,
-  deltaMph: 0,
-  limitKph: 80,
-  limitMph: 50,
-  isSpeeding: false,
-  isSeverelyOver: false,
-  isPulsing: false,
-  colorClass: 'text-green-500',
-  ...overrides,
-} as const);
+const mockSpeed = (overrides = {}) =>
+  ({
+    speedKph: 100,
+    speedMph: 62,
+    deltaKph: 0,
+    deltaMph: 0,
+    limitKph: 80,
+    limitMph: 50,
+    isSpeeding: false,
+    isSeverelyOver: false,
+    isPulsing: false,
+    colorClass: 'text-green-500',
+    ...overrides,
+  }) as const;
 
-const mockPosition = (overrides = {}) => ({
-  distanceToPitEntry: 500,
-  distanceToPit: 100,
-  distanceToPitExit: 200,
-  isEarlyPitbox: false,
-  progressPercent: 0,
-  isApproaching: false,
-  pitboxPct: 0,
-  playerPct: 0,
-  ...overrides,
-} as const);
+const mockPosition = (overrides = {}) =>
+  ({
+    distanceToPitEntry: 500,
+    distanceToPit: 100,
+    distanceToPitExit: 200,
+    isEarlyPitbox: false,
+    progressPercent: 0,
+    isApproaching: false,
+    pitboxPct: 0,
+    playerPct: 0,
+    ...overrides,
+  }) as const;
 
-const mockConfig = (overrides = {}) => ({
-  background: { opacity: 80 },
-  showSpeedBar: true,
-  showSpeedSummary: true,
-  showSpeedDelta: true,
-  speedLimitStyle: 'european' as const,
-  speedBarOrientation: 'vertical' as const,
-  showProgressBar: true,
-  progressBarOrientation: 'horizontal' as const,
-  showPastPitBox: true,
-  approachDistance: 500,
-  showMode: 'approaching' as const,
-  earlyPitboxThreshold: 75,
-  showPitExitInputs: false,
-  pitExitInputs: { throttle: true, clutch: true },
-  showInputsPhase: 'always' as const,
-  enablePitLimiterWarning: true,
-  enableEarlyPitboxWarning: true,
-  showPitlaneTraffic: true,
-  sessionVisibility: {
-    race: true,
-    loneQualify: false,
-    openQualify: false,
-    practice: true,
-    offlineTesting: true,
-  },
-  ...overrides,
-} as const);
+const mockConfig = (overrides = {}) =>
+  ({
+    background: { opacity: 80 },
+    showSpeedBar: true,
+    showSpeedSummary: true,
+    showSpeedDelta: true,
+    speedLimitStyle: 'european' as const,
+    speedBarOrientation: 'vertical' as const,
+    showProgressBar: true,
+    progressBarOrientation: 'horizontal' as const,
+    showPastPitBox: true,
+    approachDistance: 500,
+    showMode: 'approaching' as const,
+    earlyPitboxThreshold: 75,
+    showPitExitInputs: false,
+    pitExitInputs: { throttle: true, clutch: true },
+    showInputsPhase: 'always' as const,
+    enablePitLimiterWarning: true,
+    enableEarlyPitboxWarning: true,
+    showPitlaneTraffic: true,
+    sessionVisibility: {
+      race: true,
+      loneQualify: false,
+      openQualify: false,
+      practice: true,
+      offlineTesting: true,
+    },
+    ...overrides,
+  }) as const;
 
-const mockLimiterWarning = (overrides = {}) => ({
-  showWarning: false,
-  warningText: '',
-  isTeamRaceWarning: false,
-  ...overrides,
-} as const);
+const mockLimiterWarning = (overrides = {}) =>
+  ({
+    showWarning: false,
+    warningText: '',
+    isTeamRaceWarning: false,
+    ...overrides,
+  }) as const;
 
-const mockTraffic = (overrides = {}) => ({
-  totalCars: 0,
-  carsAhead: 0,
-  carsBehind: 0,
-  ...overrides,
-} as const);
+const mockTraffic = (overrides = {}) =>
+  ({
+    totalCars: 0,
+    carsAhead: 0,
+    carsBehind: 0,
+    ...overrides,
+  }) as const;
 
 // Documentation component showing the actual widget states
 export const Documentation = () => {
@@ -299,7 +311,12 @@ export const OnPitRoad: Story = {
     </div>
   ),
   args: {
-    speed: mockSpeed({ speedKph: 70, speedMph: 43, deltaKph: -10, deltaMph: -6 }),
+    speed: mockSpeed({
+      speedKph: 70,
+      speedMph: 43,
+      deltaKph: -10,
+      deltaMph: -6,
+    }),
     position: mockPosition({ distanceToPit: 80 }),
     config: mockConfig(),
     displayKph: true,
@@ -320,9 +337,17 @@ export const AtPitboxAmerican: Story = {
     </div>
   ),
   args: {
-    speed: mockSpeed({ speedKph: 35, speedMph: 22, deltaKph: -45, deltaMph: -28 }),
+    speed: mockSpeed({
+      speedKph: 35,
+      speedMph: 22,
+      deltaKph: -45,
+      deltaMph: -28,
+    }),
     position: mockPosition({ distanceToPit: 0 }),
-    config: mockConfig({ speedLimitStyle: 'american', speedBarOrientation: 'horizontal' }),
+    config: mockConfig({
+      speedLimitStyle: 'american',
+      speedBarOrientation: 'horizontal',
+    }),
     displayKph: true,
     onPitRoad: true,
     inBlendZone: false,
@@ -350,7 +375,10 @@ export const SpeedingInactiveInputs: Story = {
       colorClass: 'text-red-600',
     }),
     position: mockPosition({ distanceToPit: 80 }),
-    config: mockConfig({ showPitExitInputs: true, progressBarOrientation: 'vertical' }),
+    config: mockConfig({
+      showPitExitInputs: true,
+      progressBarOrientation: 'vertical',
+    }),
     displayKph: true,
     onPitRoad: true,
     inBlendZone: false,
@@ -381,7 +409,11 @@ export const SeverelyOver: Story = {
       colorClass: 'text-white',
     }),
     position: mockPosition({ distanceToPit: 30 }),
-    config: mockConfig({ speedLimitStyle: 'none', speedBarOrientation: 'horizontal', progressBarOrientation: 'vertical' }),
+    config: mockConfig({
+      speedLimitStyle: 'none',
+      speedBarOrientation: 'horizontal',
+      progressBarOrientation: 'vertical',
+    }),
     displayKph: true,
     onPitRoad: true,
     inBlendZone: false,
@@ -404,7 +436,12 @@ export const EarlyPitbox: Story = {
     </div>
   ),
   args: {
-    speed: mockSpeed({ speedKph: 50, speedMph: 31, deltaKph: -30, deltaMph: -19 }),
+    speed: mockSpeed({
+      speedKph: 50,
+      speedMph: 31,
+      deltaKph: -30,
+      deltaMph: -19,
+    }),
     position: mockPosition({ distanceToPit: 20, isEarlyPitbox: true }),
     config: mockConfig({ showSpeedDelta: false }),
     displayKph: true,
@@ -483,7 +520,10 @@ export const VerticalProgress: Story = {
       limitMph: 50,
     }),
     position: mockPosition({ distanceToPitEntry: 160 }),
-    config: mockConfig({ progressBarOrientation: 'vertical', showSpeedSummary: false }),
+    config: mockConfig({
+      progressBarOrientation: 'vertical',
+      showSpeedSummary: false,
+    }),
     displayKph: false,
     onPitRoad: false,
     inBlendZone: false,
@@ -494,7 +534,6 @@ export const VerticalProgress: Story = {
   },
 };
 
-
 // Exiting pit lane
 export const ExitingPitLane: Story = {
   render: (args) => (
@@ -503,7 +542,12 @@ export const ExitingPitLane: Story = {
     </div>
   ),
   args: {
-    speed: mockSpeed({ speedKph: 120, speedMph: 75, deltaKph: 40, deltaMph: 25 }),
+    speed: mockSpeed({
+      speedKph: 120,
+      speedMph: 75,
+      deltaKph: 40,
+      deltaMph: 25,
+    }),
     position: mockPosition({ distanceToPit: -50, distanceToPitExit: 100 }),
     config: mockConfig({ progressBarOrientation: 'vertical' }),
     displayKph: true,
@@ -524,7 +568,12 @@ export const ExitingWithInputs: Story = {
     </div>
   ),
   args: {
-    speed: mockSpeed({ speedKph: 120, speedMph: 75, deltaKph: 40, deltaMph: 25 }),
+    speed: mockSpeed({
+      speedKph: 120,
+      speedMph: 75,
+      deltaKph: 40,
+      deltaMph: 25,
+    }),
     position: mockPosition({ distanceToPit: -50, distanceToPitExit: 100 }),
     config: mockConfig({ showPitExitInputs: true }),
     displayKph: true,

--- a/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
+++ b/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
@@ -198,13 +198,13 @@ export const PitlaneHelperBody = ({
   traffic,
 }: PitlaneHelperBodyProps) => {
   return (
-    <>
-      <div
-        className="flex h-full flex-col gap-2 p-2 text-white font-medium rounded-t bg-slate-800/(--bg-opacity)"
-        style={{
-          ['--bg-opacity' as string]: `${config.background.opacity ?? 0}%`,
-        }}
-      >
+    <div
+      className="widget-radius-surface flex h-full flex-col bg-slate-800/(--bg-opacity)"
+      style={{
+        ['--bg-opacity' as string]: `${config.background.opacity ?? 0}%`,
+      }}
+    >
+      <div className="flex min-h-0 flex-1 flex-col gap-2 p-2 text-white font-medium">
         {/* Row 1: Speed delta */}
         {config.showSpeedSummary && (
           <div
@@ -398,12 +398,7 @@ export const PitlaneHelperBody = ({
         limiterWarning.showWarning ||
         showEarlyPitboxWarning ||
         (config.showPitlaneTraffic && traffic.totalCars > 0)) && (
-        <div
-          className="flex flex-col gap-2 p-2 rounded-b bg-slate-800/(--bg-opacity)"
-          style={{
-            ['--bg-opacity' as string]: `${config.background?.opacity ?? 0}%`,
-          }}
-        >
+        <div className="flex flex-none flex-col gap-2 p-2">
           {onPitRoad && Math.abs(position.distanceToPit) < 5 && (
             <div className="text-center text-xs font-bold py-1 px-2 bg-green-600 rounded">
               At Pitbox
@@ -442,6 +437,6 @@ export const PitlaneHelperBody = ({
           )}
         </div>
       )}
-    </>
+    </div>
   );
 };

--- a/src/frontend/components/RejoinIndicator/RejoinIndicator.stories.tsx
+++ b/src/frontend/components/RejoinIndicator/RejoinIndicator.stories.tsx
@@ -1,9 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { RejoinIndicatorDisplay } from './RejoinIndicator';
+import {
+  BorderRadiusDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 
 const meta: Meta<typeof RejoinIndicatorDisplay> = {
   title: 'widgets/RejoinIndicator',
   component: RejoinIndicatorDisplay,
+  decorators: [BorderRadiusDecorator],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
 };
 
 export default meta;

--- a/src/frontend/components/RejoinIndicator/RejoinIndicator.tsx
+++ b/src/frontend/components/RejoinIndicator/RejoinIndicator.tsx
@@ -38,7 +38,12 @@ export const RejoinIndicator = () => {
   // Generate demo data when in demo mode
   if (isDemoMode) {
     const demoData = getDemoRejoinData(settings);
-    return <RejoinIndicatorDisplay gap={demoData.gap} status={demoData.status as 'Clear' | 'Caution' | 'Do Not Rejoin'} />;
+    return (
+      <RejoinIndicatorDisplay
+        gap={demoData.gap}
+        status={demoData.status as 'Clear' | 'Caution' | 'Do Not Rejoin'}
+      />
+    );
   }
 
   // If we don't have dashboard settings or no focused player, hide
@@ -121,15 +126,13 @@ export const RejoinIndicator = () => {
 
   return (
     <div
-      className={`w-full flex justify-between rounded-sm p-2 font-bold text-white ${statusBg}`}
+      className={`widget-radius-surface w-full flex justify-between rounded-sm p-2 font-bold text-white ${statusBg}`}
     >
       <div className="text-lg">{gapLabel}s</div>
       <div className="text-lg">{status.label}</div>
     </div>
   );
 };
-
-
 
 export const RejoinIndicatorDisplay = ({
   gap,
@@ -149,7 +152,7 @@ export const RejoinIndicatorDisplay = ({
 
   return (
     <div
-      className={`w-full flex justify-between rounded-sm p-2 font-bold text-white ${statusBg}`}
+      className={`widget-radius-surface w-full flex justify-between rounded-sm p-2 font-bold text-white ${statusBg}`}
     >
       <div className="text-lg">{gapLabel}</div>
       <div className="text-lg">{status}</div>

--- a/src/frontend/components/SectorDelta/SectorDelta.stories.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.stories.tsx
@@ -6,14 +6,20 @@ import {
   useReferenceLapStore,
   useSessionStore,
 } from '@irdashies/context';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import {
+  BorderRadiusDecorator,
+  TelemetryDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 import type { ReferenceLap } from '@irdashies/types';
 
 export default {
   component: SectorDelta,
   title: 'widgets/SectorDelta',
-  decorators: [TelemetryDecorator()],
+  decorators: [BorderRadiusDecorator, TelemetryDecorator()],
   args: {
+    ...borderRadiusStoryArgs,
     background: { opacity: 80 },
     showOnlyWhenOnTrack: false,
     ghostComparison: 'prefer-ghost',
@@ -25,6 +31,7 @@ export default {
       offlineTesting: true,
     },
   },
+  argTypes: borderRadiusStoryArgTypes,
 } as Meta;
 
 type Story = StoryObj<typeof SectorDelta>;

--- a/src/frontend/components/SectorDelta/SectorDelta.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.tsx
@@ -213,7 +213,7 @@ export const SectorDelta = ({
 
   return (
     <div
-      className="flex flex-row items-center gap-1 p-1 rounded-sm"
+      className="widget-radius-surface flex flex-row items-center gap-1 p-1 rounded-sm"
       style={{ backgroundColor: `rgba(15, 23, 42, ${opacity})` }}
     >
       {useGhost && (

--- a/src/frontend/components/Settings/components/BaseSettingsSection.tsx
+++ b/src/frontend/components/Settings/components/BaseSettingsSection.tsx
@@ -1,7 +1,22 @@
-import { ReactNode, useState } from 'react';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
 import { ToggleSwitch } from './ToggleSwitch';
-import { BaseWidgetSettings } from '@irdashies/types';
+import type {
+  BaseWidgetSettings,
+  BorderRadiusCorners,
+  SettingsTabType,
+  WidgetBorderRadiusSettings,
+} from '@irdashies/types';
 import { useDashboard } from '@irdashies/context';
+import { SettingButtonGroupRow } from './SettingButtonGroupRow';
+import { SettingSliderRow } from './SettingSliderRow';
+import {
+  MAX_BORDER_RADIUS,
+  clampBorderRadius,
+  normalizeBorderRadiusCorners,
+  normalizeWidgetBorderRadiusSettings,
+  supportsWidgetBorderRadius,
+} from '@irdashies/utils/borderRadius';
 
 interface BaseSettingsSectionProps<T> {
   title: string;
@@ -14,7 +29,18 @@ interface BaseSettingsSectionProps<T> {
     | ReactNode;
   onConfigChange?: (config: Partial<T>) => void;
   disableInternalScroll?: boolean;
+  activeSettingsTab?: SettingsTabType;
 }
+
+const CORNER_LABELS: {
+  key: keyof BorderRadiusCorners;
+  title: string;
+}[] = [
+  { key: 'topLeft', title: 'Top Left' },
+  { key: 'topRight', title: 'Top Right' },
+  { key: 'bottomRight', title: 'Bottom Right' },
+  { key: 'bottomLeft', title: 'Bottom Left' },
+];
 
 export const BaseSettingsSection = <T,>({
   title,
@@ -25,6 +51,7 @@ export const BaseSettingsSection = <T,>({
   children,
   onConfigChange,
   disableInternalScroll = false,
+  activeSettingsTab,
 }: BaseSettingsSectionProps<T>) => {
   const { currentDashboard, onDashboardUpdated } = useDashboard();
   const [localSettings, setLocalSettings] = useState<BaseWidgetSettings<T>>(
@@ -35,6 +62,10 @@ export const BaseSettingsSection = <T,>({
   const updatedWidget = currentDashboard?.widgets.find(
     (w) => w.id === widgetId
   );
+  const widgetType = updatedWidget?.type || widgetId;
+  const shouldShowBorderRadiusControls =
+    supportsWidgetBorderRadius(widgetType) &&
+    (!activeSettingsTab || activeSettingsTab === 'options');
   const [prevWidgetData, setPrevWidgetData] = useState(updatedWidget);
 
   if (JSON.stringify(updatedWidget) !== JSON.stringify(prevWidgetData)) {
@@ -68,6 +99,99 @@ export const BaseSettingsSection = <T,>({
     onSettingsChange?.(updatedSettings);
     updateDashboard(updatedSettings);
     onConfigChange?.(newConfig);
+  };
+
+  const globalBorderRadius = clampBorderRadius(
+    currentDashboard?.generalSettings?.borderRadius
+  );
+  const globalBorderRadiusCorners: BorderRadiusCorners = {
+    topLeft: globalBorderRadius,
+    topRight: globalBorderRadius,
+    bottomRight: globalBorderRadius,
+    bottomLeft: globalBorderRadius,
+  };
+  const borderRadius = normalizeWidgetBorderRadiusSettings(
+    updatedWidget?.borderRadius
+  );
+  const borderRadiusCorners = normalizeBorderRadiusCorners(
+    borderRadius.mode === 'corners' ? borderRadius.corners : undefined,
+    globalBorderRadiusCorners
+  );
+
+  const handleBorderRadiusChange = (
+    newBorderRadius: WidgetBorderRadiusSettings
+  ) => {
+    if (!currentDashboard || !onDashboardUpdated || !widgetId) return;
+
+    const widgetExists = currentDashboard.widgets.some(
+      (w) => w.id === widgetId
+    );
+    const updatedWidgets = widgetExists
+      ? currentDashboard.widgets.map((widget) =>
+          widget.id === widgetId
+            ? { ...widget, borderRadius: newBorderRadius }
+            : widget
+        )
+      : [
+          ...currentDashboard.widgets,
+          {
+            id: widgetId,
+            enabled: localSettings.enabled,
+            config: localSettings.config as unknown as Record<string, unknown>,
+            layout: { x: 50, y: 50, width: 400, height: 300 },
+            borderRadius: newBorderRadius,
+          },
+        ];
+
+    onDashboardUpdated({ ...currentDashboard, widgets: updatedWidgets });
+  };
+
+  const handleBorderRadiusModeChange = (
+    mode: WidgetBorderRadiusSettings['mode']
+  ) => {
+    if (mode === 'inherit') {
+      handleBorderRadiusChange({ mode });
+      return;
+    }
+
+    if (mode === 'uniform') {
+      handleBorderRadiusChange({
+        mode,
+        radius:
+          borderRadius.mode === 'uniform'
+            ? clampBorderRadius(borderRadius.radius)
+            : globalBorderRadius,
+      });
+      return;
+    }
+
+    handleBorderRadiusChange({
+      mode,
+      corners:
+        borderRadius.mode === 'corners'
+          ? borderRadiusCorners
+          : globalBorderRadiusCorners,
+    });
+  };
+
+  const handleUniformBorderRadiusChange = (radius: number) => {
+    handleBorderRadiusChange({
+      mode: 'uniform',
+      radius: clampBorderRadius(radius),
+    });
+  };
+
+  const handleCornerBorderRadiusChange = (
+    corner: keyof BorderRadiusCorners,
+    value: number
+  ) => {
+    handleBorderRadiusChange({
+      mode: 'corners',
+      corners: {
+        ...borderRadiusCorners,
+        [corner]: clampBorderRadius(value),
+      },
+    });
   };
 
   const [showResetConfirm, setShowResetConfirm] = useState(false);
@@ -174,11 +298,57 @@ export const BaseSettingsSection = <T,>({
       <div
         className={`${disableInternalScroll ? '' : 'flex-1 overflow-y-auto min-h-0'} mt-4`}
       >
-        {children && (
+        {(children || shouldShowBorderRadiusControls) && (
           <div className="space-y-4">
             {typeof children === 'function'
               ? children(handleConfigChange)
               : children}
+
+            {shouldShowBorderRadiusControls && (
+              <div className="space-y-4 px-4">
+                <SettingButtonGroupRow
+                  title="Border Radius"
+                  value={borderRadius.mode}
+                  options={[
+                    { label: 'Global', value: 'inherit' },
+                    { label: 'Uniform', value: 'uniform' },
+                    { label: 'Corners', value: 'corners' },
+                  ]}
+                  onChange={handleBorderRadiusModeChange}
+                />
+
+                {borderRadius.mode === 'uniform' && (
+                  <SettingSliderRow
+                    title="Radius"
+                    units="px"
+                    value={clampBorderRadius(borderRadius.radius)}
+                    min={0}
+                    max={MAX_BORDER_RADIUS}
+                    step={1}
+                    onChange={handleUniformBorderRadiusChange}
+                  />
+                )}
+
+                {borderRadius.mode === 'corners' && (
+                  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                    {CORNER_LABELS.map(({ key, title }) => (
+                      <SettingSliderRow
+                        key={key}
+                        title={title}
+                        units="px"
+                        value={borderRadiusCorners[key]}
+                        min={0}
+                        max={MAX_BORDER_RADIUS}
+                        step={1}
+                        onChange={(value) =>
+                          handleCornerBorderRadiusChange(key, value)
+                        }
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         )}
 

--- a/src/frontend/components/Settings/sections/BlindSpotMonitorSettings.tsx
+++ b/src/frontend/components/Settings/sections/BlindSpotMonitorSettings.tsx
@@ -50,6 +50,7 @@ export const BlindSpotMonitorSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/CornerNameSettings.tsx
+++ b/src/frontend/components/Settings/sections/CornerNameSettings.tsx
@@ -31,10 +31,12 @@ export const CornerNameSettings = () => {
       defaultConfig,
   });
 
-  const [activeTab, setActiveTab] = useState<SettingsTabType>(
-    () =>
-      (localStorage.getItem('cornerNameTab') as SettingsTabType) || 'display'
-  );
+  const [activeTab, setActiveTab] = useState<SettingsTabType>(() => {
+    const savedTab = localStorage.getItem(
+      'cornerNameTab'
+    ) as SettingsTabType | null;
+    return savedTab === 'styling' ? 'options' : savedTab || 'display';
+  });
 
   useEffect(() => {
     localStorage.setItem('cornerNameTab', activeTab);
@@ -49,6 +51,7 @@ export const CornerNameSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">
@@ -61,11 +64,11 @@ export const CornerNameSettings = () => {
               Display
             </TabButton>
             <TabButton
-              id="styling"
+              id="options"
               activeTab={activeTab}
               setActiveTab={setActiveTab}
             >
-              Appearance
+              Options
             </TabButton>
             <TabButton
               id="visibility"
@@ -102,8 +105,8 @@ export const CornerNameSettings = () => {
               </SettingsSection>
             )}
 
-            {activeTab === 'styling' && (
-              <SettingsSection title="Appearance">
+            {activeTab === 'options' && (
+              <SettingsSection title="Options">
                 <SettingNumberRow
                   title="Font Size"
                   description="Base font size for corner names (px)"

--- a/src/frontend/components/Settings/sections/FasterCarsFromBehindSettings.tsx
+++ b/src/frontend/components/Settings/sections/FasterCarsFromBehindSettings.tsx
@@ -49,6 +49,7 @@ export const FasterCarsFromBehindSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId="fastercarsfrombehind"
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/FlagSettings.tsx
+++ b/src/frontend/components/Settings/sections/FlagSettings.tsx
@@ -51,6 +51,7 @@ export const FlagSettings = () => {
       settings={settings as FlagWidgetSettings}
       onSettingsChange={(s) => setSettings(s as FlagWidgetSettings)}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/FlatTrackMapSettings.tsx
+++ b/src/frontend/components/Settings/sections/FlatTrackMapSettings.tsx
@@ -53,6 +53,7 @@ export const FlatTrackMapSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId="flatmap"
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/FuelSettings/SingleFuelWidgetSettings.tsx
+++ b/src/frontend/components/Settings/sections/FuelSettings/SingleFuelWidgetSettings.tsx
@@ -136,6 +136,7 @@ export const SingleFuelWidgetSettings = ({
       settings={settings}
       onSettingsChange={setSettings}
       widgetId={widgetId}
+      activeSettingsTab={activeTab}
       disableInternalScroll={true}
     >
       {(handleConfigChange) => {

--- a/src/frontend/components/Settings/sections/GeneralSettings.tsx
+++ b/src/frontend/components/Settings/sections/GeneralSettings.tsx
@@ -2,6 +2,11 @@ import { useState } from 'react';
 import { useDashboard } from '@irdashies/context';
 import type { GeneralSettingsType } from '@irdashies/types';
 import { BaseSettingsSection } from '../components/BaseSettingsSection';
+import {
+  DEFAULT_BORDER_RADIUS,
+  MAX_BORDER_RADIUS,
+  clampBorderRadius,
+} from '@irdashies/utils/borderRadius';
 
 const FONT_PRESETS = {
   lato: 'Lato',
@@ -96,6 +101,9 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
     startMinimized: currentDashboard?.generalSettings?.startMinimized ?? false,
     closeToTray: currentDashboard?.generalSettings?.closeToTray ?? true,
     compactMode: currentDashboard?.generalSettings?.compactMode ?? 'off',
+    borderRadius: clampBorderRadius(
+      currentDashboard?.generalSettings?.borderRadius ?? DEFAULT_BORDER_RADIUS
+    ),
     overlayAlwaysOnTop:
       currentDashboard?.generalSettings?.overlayAlwaysOnTop ?? true,
     enableNetworkAccess:
@@ -113,9 +121,13 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
   }
 
   const updateDashboard = (newSettings: GeneralSettingsType) => {
+    const mergedSettings = {
+      ...currentDashboard.generalSettings,
+      ...newSettings,
+    };
     const updatedDashboard = {
       ...currentDashboard,
-      generalSettings: newSettings,
+      generalSettings: mergedSettings,
     };
     onDashboardUpdated(updatedDashboard);
   };
@@ -269,6 +281,15 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
     updateDashboard(newSettings);
   };
 
+  const handleBorderRadiusChange = (borderRadius: number) => {
+    const newSettings = {
+      ...settings,
+      borderRadius: clampBorderRadius(borderRadius),
+    };
+    setSettings(newSettings);
+    updateDashboard(newSettings);
+  };
+
   const handleOverlayAlwaysOnTopChange = (enabled: boolean) => {
     const newSettings = { ...settings, overlayAlwaysOnTop: enabled };
     setSettings(newSettings);
@@ -389,6 +410,37 @@ export const GeneralSettings = ({ previewMode }: GeneralSettingsProps = {}) => {
               onChange={handleSliderChange}
               className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer slider accent-blue-500"
             />
+          </div>
+        </div>
+
+        {/* Border Radius Setting */}
+        <div className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-medium text-slate-200">
+              Border Radius
+            </h3>
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-slate-300">
+                {settings.borderRadius ?? DEFAULT_BORDER_RADIUS}px
+              </span>
+            </div>
+          </div>
+
+          <div className="mt-4">
+            <input
+              type="range"
+              min={0}
+              max={MAX_BORDER_RADIUS}
+              step={1}
+              value={settings.borderRadius ?? DEFAULT_BORDER_RADIUS}
+              onChange={(e) =>
+                handleBorderRadiusChange(parseFloat(e.target.value))
+              }
+              className="w-full h-2 bg-slate-700 rounded-lg appearance-none cursor-pointer slider accent-blue-500"
+            />
+            <p className="mt-2 text-sm text-slate-500">
+              Default corner radius for widgets that inherit the global setting.
+            </p>
           </div>
         </div>
 

--- a/src/frontend/components/Settings/sections/InformationBarSettings.tsx
+++ b/src/frontend/components/Settings/sections/InformationBarSettings.tsx
@@ -54,6 +54,7 @@ export const InformationBarSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId="infobar"
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/InputSettings.tsx
+++ b/src/frontend/components/Settings/sections/InputSettings.tsx
@@ -118,6 +118,7 @@ export const InputSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId="input"
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => {
         const handleDisplayOrderChange = (newOrder: string[]) => {

--- a/src/frontend/components/Settings/sections/LapTimeLogSettings.tsx
+++ b/src/frontend/components/Settings/sections/LapTimeLogSettings.tsx
@@ -51,6 +51,7 @@ export const LapTimeLogSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/PitlaneHelperSettings.tsx
+++ b/src/frontend/components/Settings/sections/PitlaneHelperSettings.tsx
@@ -51,6 +51,7 @@ export const PitlaneHelperSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/RejoinIndicatorSettings.tsx
+++ b/src/frontend/components/Settings/sections/RejoinIndicatorSettings.tsx
@@ -47,6 +47,7 @@ export const RejoinIndicatorSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">
@@ -69,7 +70,7 @@ export const RejoinIndicatorSettings = () => {
           </div>
 
           <div>
-            {/* DISPLAY TAB */}
+            {/* OPTIONS TAB */}
             {activeTab === 'options' && (
               <SettingsSection title="Options">
                 <SettingNumberRow

--- a/src/frontend/components/Settings/sections/RelativeSettings.tsx
+++ b/src/frontend/components/Settings/sections/RelativeSettings.tsx
@@ -446,6 +446,7 @@ export const RelativeSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId="relative"
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => {
         const handleDisplayOrderChange = (newOrder: string[]) => {

--- a/src/frontend/components/Settings/sections/SectorDeltaSettings.tsx
+++ b/src/frontend/components/Settings/sections/SectorDeltaSettings.tsx
@@ -54,6 +54,7 @@ export const SectorDeltaSettings = () => {
       settings={settings as SectorDeltaWidgetSettings}
       onSettingsChange={(s) => setSettings(s as SectorDeltaWidgetSettings)}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/SlowCarAheadSettings.tsx
+++ b/src/frontend/components/Settings/sections/SlowCarAheadSettings.tsx
@@ -52,6 +52,7 @@ export const SlowCarAheadSettings = () => {
       settings={settings as SlowCarAheadWidgetSettings}
       onSettingsChange={(s) => setSettings(s as SlowCarAheadWidgetSettings)}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => (
         <div className="space-y-4">

--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -556,6 +556,7 @@ export const StandingsSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => {
         const handleDisplayOrderChange = (newOrder: string[]) => {

--- a/src/frontend/components/Settings/sections/TachometerSettings.tsx
+++ b/src/frontend/components/Settings/sections/TachometerSettings.tsx
@@ -423,6 +423,7 @@ export const TachometerSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId="tachometer"
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => {
         const config = settings.config;

--- a/src/frontend/components/Settings/sections/TrackMapSettings.tsx
+++ b/src/frontend/components/Settings/sections/TrackMapSettings.tsx
@@ -128,6 +128,7 @@ export const TrackMapSettings = () => {
       settings={settings}
       onSettingsChange={setSettings}
       widgetId="map"
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => {
         configChangeHandlerRef.current = handleConfigChange;

--- a/src/frontend/components/Settings/sections/WeatherSettings.tsx
+++ b/src/frontend/components/Settings/sections/WeatherSettings.tsx
@@ -137,6 +137,7 @@ export const WeatherSettings = () => {
       settings={settings}
       onSettingsChange={(s) => setSettings(s)}
       widgetId={SETTING_ID}
+      activeSettingsTab={activeTab}
     >
       {(handleConfigChange) => {
         const handleDisplayOrderChange = (newOrder: string[]) => {

--- a/src/frontend/components/Standings/Relative.stories.tsx
+++ b/src/frontend/components/Standings/Relative.stories.tsx
@@ -1,9 +1,12 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Relative } from './Relative';
 import {
+  BorderRadiusDecorator,
   TelemetryDecorator,
   DynamicTelemetrySelector,
   TelemetryDecoratorWithConfig,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
 } from '@irdashies/storybook';
 import {
   DashboardProvider,
@@ -325,6 +328,9 @@ const RelativeWithoutHeaderFooter = () => {
 export default {
   component: Relative,
   title: 'widgets/Relative',
+  decorators: [BorderRadiusDecorator],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
   parameters: {
     controls: {
       exclude: ['telemetryPath'],

--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -1,10 +1,13 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Standings } from './Standings';
 import {
+  BorderRadiusDecorator,
   TelemetryDecorator,
   DynamicTelemetrySelector,
   TelemetryDecoratorWithConfig,
   mockDashboardBridge,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
 } from '@irdashies/storybook';
 import {
   DashboardProvider,
@@ -236,6 +239,9 @@ const StandingsWithoutHeaderFooter = () => {
 export default {
   component: Standings,
   title: 'widgets/Standings',
+  decorators: [BorderRadiusDecorator],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
 } as Meta;
 
 type Story = StoryObj<typeof Standings>;

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -83,14 +83,18 @@ export const Standings = () => {
 
   return (
     <div
-      className={`w-full bg-slate-800/(--bg-opacity) rounded-sm ${!isCompact ? 'p-2' : ''} text-white overflow-hidden`}
+      className={`widget-radius-surface w-full bg-slate-800/(--bg-opacity) rounded-sm ${!isCompact ? 'p-2' : ''} text-white overflow-hidden`}
       style={{
         ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 0}%`,
       }}
     >
       <TitleBar titleBarSettings={settings?.titleBar} />
       {settings?.headerBar && (settings.headerBar.enabled ?? true) && (
-        <SessionBar settings={settings.headerBar} opacity={settings?.foreground?.opacity} position="header" />
+        <SessionBar
+          settings={settings.headerBar}
+          opacity={settings?.foreground?.opacity}
+          position="header"
+        />
       )}
       <table
         className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
@@ -270,7 +274,11 @@ export const Standings = () => {
         </tbody>
       </table>
       {settings?.footerBar && (settings.footerBar.enabled ?? true) && (
-        <SessionBar settings={settings.footerBar} opacity={settings?.foreground?.opacity} position="footer" />
+        <SessionBar
+          settings={settings.footerBar}
+          opacity={settings?.foreground?.opacity}
+          position="footer"
+        />
       )}
     </div>
   );

--- a/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.tsx
+++ b/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.tsx
@@ -317,7 +317,7 @@ export const Tachometer = ({
           {shouldShowRpmBox && rpmOrientation === 'horizontal' && (
             <div
               id="rpm-text"
-              className={`bg-slate-800/(--bg-opacity) text-base absolute right-[-8em] flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
+              className="bg-slate-800/(--bg-opacity) text-base absolute right-[-8em] flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center"
               style={{
                 ...getRpmBoxStyle(),
                 height: '2em',
@@ -347,7 +347,7 @@ export const Tachometer = ({
         {shouldShowRpmBox && rpmOrientation !== 'horizontal' && (
           <div
             id="rpm-text"
-            className={`bg-slate-800/(--bg-opacity) text-base flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center`}
+            className="bg-slate-800/(--bg-opacity) text-base flex min-w-[6em] font-mono font-bold text-white px-4 mx-2 rounded-lg transition-colors duration-200 whitespace-nowrap justify-center items-center"
             style={{
               ...getRpmBoxStyle(),
               height: '1.5em',

--- a/src/frontend/components/TwitchChat/TwitchChat.stories.tsx
+++ b/src/frontend/components/TwitchChat/TwitchChat.stories.tsx
@@ -3,6 +3,11 @@ import { useEffect, useRef, useState } from 'react';
 import type { ChatMessage } from './types';
 import { ChatMessageList } from './TwitchChat';
 import { DEMO_MESSAGES, DEMO_MESSAGE_INTERVAL_MS } from './demoData';
+import {
+  BorderRadiusDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 
 const MAX_VISIBLE_MESSAGES = 10;
 
@@ -79,12 +84,15 @@ export default {
   component: ChatMessageList,
   title: 'widgets/TwitchChat',
   decorators: [
+    BorderRadiusDecorator,
     (Story) => (
       <div style={{ width: '350px', height: '400px' }}>
         <Story />
       </div>
     ),
   ],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
 } as Meta<typeof ChatMessageList>;
 
 type Story = StoryObj<typeof ChatMessageList>;

--- a/src/frontend/components/TwitchChat/TwitchChat.tsx
+++ b/src/frontend/components/TwitchChat/TwitchChat.tsx
@@ -82,37 +82,39 @@ export const ChatMessageList = ({
 
   return (
     <div
-      className="w-full h-full flex flex-col justify-end overflow-hidden bg-slate-800/[var(--bg-opacity)] rounded-sm px-3 py-2 text-white align-bottom border-0 transition-all duration-300"
+      className="widget-radius-surface w-full h-full flex flex-col justify-end overflow-hidden bg-slate-800/[var(--bg-opacity)] rounded-sm px-3 py-2 text-white align-bottom border-0 transition-all duration-300"
       style={
         {
           '--bg-opacity': `${background.opacity}%`,
         } as React.CSSProperties
       }
     >
-      {messages.filter((m) => !removedIds.has(m.id)).map((m) => {
-        const fading = (autoHide?.enabled ?? false) && fadingIds.has(m.id);
-        return (
-          <div
-            key={m.id}
-            style={{
-              marginBottom: 8,
-              fontSize: `${fontSize}px`,
-              opacity: fading ? 0 : 1,
-              transition: fading
-                ? `opacity ${FADE_DURATION_MS}ms linear`
-                : undefined,
-            }}
-          >
-            <strong style={{ color: m.color ?? '#a970ff' }}>{m.user}</strong>:{' '}
-            <MessageWithEmotes
-              text={m.text}
-              emotes={m.emotes}
-              fontSize={fontSize}
-              thirdPartyEmotes={thirdPartyEmotes}
-            />
-          </div>
-        );
-      })}
+      {messages
+        .filter((m) => !removedIds.has(m.id))
+        .map((m) => {
+          const fading = (autoHide?.enabled ?? false) && fadingIds.has(m.id);
+          return (
+            <div
+              key={m.id}
+              style={{
+                marginBottom: 8,
+                fontSize: `${fontSize}px`,
+                opacity: fading ? 0 : 1,
+                transition: fading
+                  ? `opacity ${FADE_DURATION_MS}ms linear`
+                  : undefined,
+              }}
+            >
+              <strong style={{ color: m.color ?? '#a970ff' }}>{m.user}</strong>:{' '}
+              <MessageWithEmotes
+                text={m.text}
+                emotes={m.emotes}
+                fontSize={fontSize}
+                thirdPartyEmotes={thirdPartyEmotes}
+              />
+            </div>
+          );
+        })}
     </div>
   );
 };

--- a/src/frontend/components/Weather/Weather.stories.tsx
+++ b/src/frontend/components/Weather/Weather.stories.tsx
@@ -1,13 +1,26 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Weather } from './Weather';
 import {
+  BorderRadiusDecorator,
   TelemetryDecorator,
   TelemetryDecoratorWithConfig,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
 } from '@irdashies/storybook';
 
 export default {
   component: Weather,
   title: 'widgets/Weather',
+  decorators: [
+    BorderRadiusDecorator,
+    (Story) => (
+      <div style={{ width: '150px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
 } as Meta;
 
 type Story = StoryObj<typeof Weather>;

--- a/src/frontend/components/Weather/Weather.tsx
+++ b/src/frontend/components/Weather/Weather.tsx
@@ -187,7 +187,7 @@ export const Weather = () => {
 
   return (
     <div
-      className="@container w-full rounded-sm p-2 bg-slate-800/(--bg-opacity)"
+      className="widget-radius-surface @container w-full rounded-sm p-2 bg-slate-800/(--bg-opacity)"
       style={{
         ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
       }}

--- a/src/frontend/components/WidgetContainer/WidgetContainer.tsx
+++ b/src/frontend/components/WidgetContainer/WidgetContainer.tsx
@@ -7,7 +7,11 @@ import {
   useMemo,
   CSSProperties,
 } from 'react';
-import type { DashboardWidget, WidgetLayout } from '@irdashies/types';
+import type {
+  DashboardWidget,
+  GeneralSettingsType,
+  WidgetLayout,
+} from '@irdashies/types';
 import { useDragWidget } from './useDragWidget';
 import { useResizeWidget } from './useResizeWidget';
 import { ResizeHandles } from './ResizeHandle';
@@ -16,11 +20,17 @@ import { useEdgeDistances } from './useEdgeDistances';
 import { getWidgetName } from '../../constants/widgetNames';
 import { ResizeIcon, GearIcon, XIcon } from '@phosphor-icons/react';
 import { useContainerOffset, useDashboard } from '@irdashies/context';
+import {
+  WIDGET_BORDER_RADIUS_CLASS,
+  getWidgetBorderRadiusStyle,
+  supportsWidgetBorderRadius,
+} from '@irdashies/utils/borderRadius';
 
 export interface WidgetContainerProps {
   widget: DashboardWidget;
   siblingLayouts?: WidgetLayout[];
   editMode: boolean;
+  generalSettings?: GeneralSettingsType;
   zIndex: number;
   onLayoutChange: (widgetId: string, layout: WidgetLayout) => void;
   onDisable?: (widgetId: string) => void;
@@ -33,6 +43,7 @@ export const WidgetContainer = memo(
     widget,
     siblingLayouts = [],
     editMode,
+    generalSettings,
     zIndex,
     onLayoutChange,
     onDisable,
@@ -175,11 +186,24 @@ export const WidgetContainer = memo(
     };
 
     const widgetName = getWidgetName(id);
+    const widgetType = widget.type || widget.id;
+    const supportsBorderRadius = supportsWidgetBorderRadius(widgetType);
+    const borderRadiusStyle = supportsBorderRadius
+      ? getWidgetBorderRadiusStyle(widget.borderRadius, generalSettings)
+      : undefined;
 
     return (
       <div style={containerStyle} data-widget-id={id}>
         {/* Widget content */}
-        <div className={`w-full h-full pointer-events-none`}>{children}</div>
+        <div
+          className={[
+            'w-full h-full pointer-events-none',
+            supportsBorderRadius ? WIDGET_BORDER_RADIUS_CLASS : '',
+          ].join(' ')}
+          style={borderRadiusStyle}
+        >
+          {children}
+        </div>
 
         {/* Edit mode overlay */}
         {editMode && (

--- a/src/frontend/components/Wind/Wind.stories.tsx
+++ b/src/frontend/components/Wind/Wind.stories.tsx
@@ -1,16 +1,24 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import {
+  BorderRadiusDecorator,
+  TelemetryDecorator,
+  borderRadiusStoryArgTypes,
+  borderRadiusStoryArgs,
+} from '@irdashies/storybook';
 import { Wind } from './Wind';
 
 export default {
   component: Wind,
   title: 'widgets/Wind',
+  args: borderRadiusStoryArgs,
+  argTypes: borderRadiusStoryArgTypes,
 } as Meta;
 
 type Story = StoryObj<typeof Wind>;
 
 export const Primary: Story = {
   decorators: [
+    BorderRadiusDecorator,
     (Story, context) => (
       <div style={{ width: '150px', height: '180px' }}>
         {TelemetryDecorator('/test-data/1731637331038')(Story, context)}

--- a/src/frontend/components/Wind/Wind.stories.tsx
+++ b/src/frontend/components/Wind/Wind.stories.tsx
@@ -10,6 +10,7 @@ import { Wind } from './Wind';
 export default {
   component: Wind,
   title: 'widgets/Wind',
+  decorators: [BorderRadiusDecorator],
   args: borderRadiusStoryArgs,
   argTypes: borderRadiusStoryArgTypes,
 } as Meta;
@@ -18,7 +19,6 @@ type Story = StoryObj<typeof Wind>;
 
 export const Primary: Story = {
   decorators: [
-    BorderRadiusDecorator,
     (Story, context) => (
       <div style={{ width: '150px', height: '180px' }}>
         {TelemetryDecorator('/test-data/1731637331038')(Story, context)}

--- a/src/frontend/components/Wind/Wind.tsx
+++ b/src/frontend/components/Wind/Wind.tsx
@@ -28,7 +28,7 @@ export const Wind = memo(() => {
   const demoWind = useWindDemoData(isDemoMode, isMetric);
 
   const containerClassName =
-    'w-full h-full rounded-sm p-2 bg-slate-800/(--bg-opacity)';
+    'widget-radius-surface w-full h-full rounded-sm p-2 bg-slate-800/(--bg-opacity)';
   const containerStyle = {
     ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
   };

--- a/src/frontend/theme.css
+++ b/src/frontend/theme.css
@@ -118,6 +118,14 @@ html {
   color-scheme: dark;
 }
 
+.widget-radius-clip .widget-radius-surface {
+  border-top-left-radius: var(--widget-border-radius-top-left);
+  border-top-right-radius: var(--widget-border-radius-top-right);
+  border-bottom-right-radius: var(--widget-border-radius-bottom-right);
+  border-bottom-left-radius: var(--widget-border-radius-bottom-left);
+  overflow: hidden;
+}
+
 .overlay-window.overlay-theme-font-face-lato {
   font-family: 'Lato', sans-serif;
 }

--- a/src/frontend/utils/FlagContour.tsx
+++ b/src/frontend/utils/FlagContour.tsx
@@ -19,7 +19,7 @@ export const FlagContour = ({
 }: FlagContourProps) => {
   const containerClassName = `w-full bg-slate-800/(--bg-opacity) rounded-sm ${
     !compactMode ? 'p-2' : ''
-  } overflow-hidden ${flags.enabled ? 'border-solid' : ''}`;
+  } overflow-hidden widget-radius-surface ${flags.enabled ? 'border-solid' : ''}`;
 
   const containerStyle = {
     ['--bg-opacity' as string]: `${backgroundOpacity}%`,

--- a/src/frontend/utils/borderRadius.spec.ts
+++ b/src/frontend/utils/borderRadius.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_BORDER_RADIUS,
+  WIDGET_BORDER_RADIUS_SUPPORTED_TYPES,
+  clampBorderRadius,
+  getWidgetBorderRadiusStyle,
+  normalizeBorderRadiusCorners,
+  normalizeWidgetBorderRadiusSettings,
+  supportsWidgetBorderRadius,
+} from './borderRadius';
+
+describe('borderRadius utilities', () => {
+  const expectedCornerStyle = (
+    topLeft: number,
+    topRight: number,
+    bottomRight: number,
+    bottomLeft: number
+  ) => ({
+    borderTopLeftRadius: topLeft,
+    borderTopRightRadius: topRight,
+    borderBottomRightRadius: bottomRight,
+    borderBottomLeftRadius: bottomLeft,
+    '--widget-border-radius-top-left': `${topLeft}px`,
+    '--widget-border-radius-top-right': `${topRight}px`,
+    '--widget-border-radius-bottom-right': `${bottomRight}px`,
+    '--widget-border-radius-bottom-left': `${bottomLeft}px`,
+  });
+
+  it('clamps missing and invalid values to the default', () => {
+    expect(clampBorderRadius(undefined)).toBe(DEFAULT_BORDER_RADIUS);
+    expect(clampBorderRadius(Number.NaN)).toBe(DEFAULT_BORDER_RADIUS);
+    expect(clampBorderRadius(Number.POSITIVE_INFINITY)).toBe(
+      DEFAULT_BORDER_RADIUS
+    );
+  });
+
+  it('clamps values to the supported range', () => {
+    expect(clampBorderRadius(-4)).toBe(0);
+    expect(clampBorderRadius(12.4)).toBe(12);
+    expect(clampBorderRadius(48)).toBe(32);
+  });
+
+  it('allows border radius only for supported user-facing widgets', () => {
+    expect(WIDGET_BORDER_RADIUS_SUPPORTED_TYPES).toContain('standings');
+    expect(supportsWidgetBorderRadius('standings')).toBe(true);
+    expect(supportsWidgetBorderRadius('fuel')).toBe(true);
+    expect(supportsWidgetBorderRadius('wind')).toBe(true);
+    expect(supportsWidgetBorderRadius('cornername')).toBe(true);
+    expect(supportsWidgetBorderRadius('tachometer')).toBe(false);
+    expect(supportsWidgetBorderRadius('telemetryinspector')).toBe(false);
+    expect(supportsWidgetBorderRadius('map')).toBe(false);
+    expect(supportsWidgetBorderRadius('flatmap')).toBe(false);
+    expect(supportsWidgetBorderRadius('blindspotmonitor')).toBe(false);
+    expect(supportsWidgetBorderRadius('slowcarahead')).toBe(false);
+    expect(supportsWidgetBorderRadius('unknown-widget')).toBe(false);
+    expect(supportsWidgetBorderRadius(undefined)).toBe(false);
+  });
+
+  it('normalizes partial corner values', () => {
+    expect(
+      normalizeBorderRadiusCorners({
+        topLeft: 0,
+        bottomRight: 48,
+      })
+    ).toEqual({
+      topLeft: 0,
+      topRight: 2,
+      bottomRight: 32,
+      bottomLeft: 2,
+    });
+  });
+
+  it('normalizes missing and invalid widget settings to inherit mode', () => {
+    expect(normalizeWidgetBorderRadiusSettings(undefined)).toEqual({
+      mode: 'inherit',
+    });
+    expect(
+      normalizeWidgetBorderRadiusSettings({
+        mode: 'unknown',
+      } as never)
+    ).toEqual({
+      mode: 'inherit',
+    });
+  });
+
+  it('uses global radius when a widget inherits radius settings', () => {
+    expect(getWidgetBorderRadiusStyle(undefined, { borderRadius: 8 })).toEqual({
+      ...expectedCornerStyle(8, 8, 8, 8),
+    });
+
+    expect(
+      getWidgetBorderRadiusStyle({ mode: 'inherit' }, { borderRadius: 6 })
+    ).toEqual({
+      ...expectedCornerStyle(6, 6, 6, 6),
+    });
+  });
+
+  it('uses a uniform widget radius override', () => {
+    expect(
+      getWidgetBorderRadiusStyle(
+        { mode: 'uniform', radius: 10 },
+        { borderRadius: 4 }
+      )
+    ).toEqual({
+      borderRadius: 10,
+      ...expectedCornerStyle(10, 10, 10, 10),
+    });
+  });
+
+  it('uses per-corner widget radius overrides', () => {
+    expect(
+      getWidgetBorderRadiusStyle(
+        {
+          mode: 'corners',
+          corners: {
+            topLeft: 0,
+            topRight: 4,
+            bottomRight: 8,
+            bottomLeft: 12,
+          },
+        },
+        { borderRadius: 4 }
+      )
+    ).toEqual({
+      ...expectedCornerStyle(0, 4, 8, 12),
+    });
+  });
+});

--- a/src/frontend/utils/borderRadius.ts
+++ b/src/frontend/utils/borderRadius.ts
@@ -1,0 +1,151 @@
+import type { CSSProperties } from 'react';
+import type {
+  BorderRadiusCorners,
+  GeneralSettingsType,
+  WidgetConfigMap,
+  WidgetBorderRadiusSettings,
+} from '@irdashies/types';
+
+export const DEFAULT_BORDER_RADIUS = 2;
+export const MAX_BORDER_RADIUS = 32;
+
+export const DEFAULT_BORDER_RADIUS_CORNERS: BorderRadiusCorners = {
+  topLeft: DEFAULT_BORDER_RADIUS,
+  topRight: DEFAULT_BORDER_RADIUS,
+  bottomRight: DEFAULT_BORDER_RADIUS,
+  bottomLeft: DEFAULT_BORDER_RADIUS,
+};
+
+export const DEFAULT_WIDGET_BORDER_RADIUS: WidgetBorderRadiusSettings = {
+  mode: 'inherit',
+};
+
+export const WIDGET_BORDER_RADIUS_CLASS = 'widget-radius-clip';
+export const WIDGET_BORDER_RADIUS_SURFACE_CLASS = 'widget-radius-surface';
+
+export const WIDGET_BORDER_RADIUS_SUPPORTED_TYPES = [
+  'standings',
+  'relative',
+  'weather',
+  'wind',
+  'input',
+  'fuel',
+  'garagecover',
+  'rejoin',
+  'flag',
+  'fastercarsfrombehind',
+  'pitlanehelper',
+  'twitchchat',
+  'laptimelog',
+  'infobar',
+  'sectordelta',
+  'cornername',
+] as const satisfies readonly (keyof WidgetConfigMap)[];
+
+export type WidgetBorderRadiusSupportedType =
+  (typeof WIDGET_BORDER_RADIUS_SUPPORTED_TYPES)[number];
+
+const WIDGET_BORDER_RADIUS_SUPPORTED_TYPE_SET = new Set<string>(
+  WIDGET_BORDER_RADIUS_SUPPORTED_TYPES
+);
+
+const BORDER_RADIUS_MODES = new Set<WidgetBorderRadiusSettings['mode']>([
+  'inherit',
+  'uniform',
+  'corners',
+]);
+
+export const supportsWidgetBorderRadius = (
+  widgetType: string | undefined
+): widgetType is WidgetBorderRadiusSupportedType =>
+  typeof widgetType === 'string' &&
+  WIDGET_BORDER_RADIUS_SUPPORTED_TYPE_SET.has(widgetType);
+
+export const clampBorderRadius = (value: number | undefined): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_BORDER_RADIUS;
+  }
+
+  return Math.min(MAX_BORDER_RADIUS, Math.max(0, Math.round(value)));
+};
+
+export const normalizeBorderRadiusCorners = (
+  corners: WidgetBorderRadiusSettings['corners'] | undefined,
+  fallback: BorderRadiusCorners = DEFAULT_BORDER_RADIUS_CORNERS
+): BorderRadiusCorners => ({
+  topLeft: clampBorderRadius(corners?.topLeft ?? fallback.topLeft),
+  topRight: clampBorderRadius(corners?.topRight ?? fallback.topRight),
+  bottomRight: clampBorderRadius(corners?.bottomRight ?? fallback.bottomRight),
+  bottomLeft: clampBorderRadius(corners?.bottomLeft ?? fallback.bottomLeft),
+});
+
+export const normalizeWidgetBorderRadiusSettings = (
+  settings: WidgetBorderRadiusSettings | undefined
+): WidgetBorderRadiusSettings => {
+  if (!settings || !BORDER_RADIUS_MODES.has(settings.mode)) {
+    return DEFAULT_WIDGET_BORDER_RADIUS;
+  }
+
+  if (settings.mode === 'inherit') {
+    return DEFAULT_WIDGET_BORDER_RADIUS;
+  }
+
+  if (settings.mode === 'uniform') {
+    return {
+      mode: 'uniform',
+      radius: clampBorderRadius(settings.radius),
+    };
+  }
+
+  return {
+    mode: 'corners',
+    corners: normalizeBorderRadiusCorners(settings.corners),
+  };
+};
+
+const createBorderRadiusStyle = (
+  corners: BorderRadiusCorners
+): CSSProperties => ({
+  borderTopLeftRadius: corners.topLeft,
+  borderTopRightRadius: corners.topRight,
+  borderBottomRightRadius: corners.bottomRight,
+  borderBottomLeftRadius: corners.bottomLeft,
+  ['--widget-border-radius-top-left' as string]: `${corners.topLeft}px`,
+  ['--widget-border-radius-top-right' as string]: `${corners.topRight}px`,
+  ['--widget-border-radius-bottom-right' as string]: `${corners.bottomRight}px`,
+  ['--widget-border-radius-bottom-left' as string]: `${corners.bottomLeft}px`,
+});
+
+export const getWidgetBorderRadiusStyle = (
+  settings: WidgetBorderRadiusSettings | undefined,
+  generalSettings: GeneralSettingsType | undefined
+): CSSProperties => {
+  const normalizedSettings = normalizeWidgetBorderRadiusSettings(settings);
+  const globalRadius = clampBorderRadius(generalSettings?.borderRadius);
+
+  if (normalizedSettings.mode === 'inherit') {
+    return createBorderRadiusStyle({
+      topLeft: globalRadius,
+      topRight: globalRadius,
+      bottomRight: globalRadius,
+      bottomLeft: globalRadius,
+    });
+  }
+
+  if (normalizedSettings.mode === 'uniform') {
+    const radius = clampBorderRadius(normalizedSettings.radius);
+    return {
+      borderRadius: radius,
+      ...createBorderRadiusStyle({
+        topLeft: radius,
+        topRight: radius,
+        bottomRight: radius,
+        bottomLeft: radius,
+      }),
+    };
+  }
+
+  return createBorderRadiusStyle(
+    normalizeBorderRadiusCorners(normalizedSettings.corners)
+  );
+};

--- a/src/types/dashboardLayout.ts
+++ b/src/types/dashboardLayout.ts
@@ -12,6 +12,19 @@ export interface WidgetLayout {
   height: number;
 }
 
+export interface BorderRadiusCorners {
+  topLeft: number;
+  topRight: number;
+  bottomRight: number;
+  bottomLeft: number;
+}
+
+export interface WidgetBorderRadiusSettings {
+  mode: 'inherit' | 'uniform' | 'corners';
+  radius?: number;
+  corners?: Partial<BorderRadiusCorners>;
+}
+
 export interface DashboardWidget {
   /** Unique instance ID of the widget. */
   id: string;
@@ -25,6 +38,8 @@ export interface DashboardWidget {
   layout: WidgetLayout;
   /** Configuration for the widget. */
   config?: Record<string, unknown>;
+  /** Per-widget border radius override. Falls back to generalSettings.borderRadius when absent or set to 'inherit'. */
+  borderRadius?: WidgetBorderRadiusSettings;
 }
 
 export interface TagGroup {
@@ -133,6 +148,7 @@ export interface GeneralSettingsType {
   startMinimized?: boolean;
   closeToTray?: boolean;
   compactMode?: 'off' | 'compact' | 'ultra';
+  borderRadius?: number;
   overlayAlwaysOnTop?: boolean;
   enableNetworkAccess?: boolean;
   editMode?: {

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1255,6 +1255,7 @@ export const defaultDashboard: {
     startMinimized: false,
     closeToTray: true,
     compactMode: 'off' as const,
+    borderRadius: 2,
     overlayAlwaysOnTop: true,
     enableNetworkAccess: false,
     editMode: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,5 @@
     },
     "types": ["vite/client"]
   },
-  "exclude": ["site"]
+  "exclude": ["site", "storybook-static"]
 }


### PR DESCRIPTION
## Description

Adds global and per-widget border radius controls for supported user-facing widgets.

This PR introduces a global `General Settings > Border Radius` slider, defaulting to `2px`, and per-widget border radius controls under each supported widget's `Options` tab. Widgets can inherit the global radius, override it with a uniform radius, or configure individual corner radii.

The implementation is intentionally allowlist-based. Only widgets with a meaningful rectangular visual surface opt into border radius support via `WIDGET_BORDER_RADIUS_SUPPORTED_TYPES`. This keeps the global control scoped to user-facing widgets and avoids affecting diagnostic/internal overlays such as Telemetry Inspector or widgets where corner radius does not make visual sense.

The controls ship with the 2px global default which is currently in place as the default value. 

Also excludes the generated `storybook-static/` output from `tsconfig.json` so `tsc --noEmit` (lint) doesn't type-check Storybook build artifacts when present locally.

Supported widgets include the following: [0]

Notable special cases:

- `Tachometer` is intentionally excluded because the visible dial does not have a meaningful rectangular surface, and applying radius to the small RPM badge made the control appear ineffective.
- Track maps, flat maps, blind spot monitor, slow car ahead, heart rate, and Telemetry Inspector remain excluded from the allowlist.
- Telemetry Inspector also had stray radius surface markers removed so it stays fully outside the feature.
- Per-widget border radius controls only appear on `Options`, not across every widget settings tab.
- Corner Names previously used an `Appearance` tab; this was renamed to `Options` for consistency with other widgets and to align with the shared tab gating.
- Existing dashboard configs do not need migration. Missing values safely inherit the default/global setting.
- Border radius values are normalized and clamped from `0px` to `32px`, including invalid, missing, `NaN`, and infinite values.

This also updates Storybook coverage for supported widgets so border radius modes can be previewed visually, and updates contributor documentation to describe the allowlist-based opt-in model.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before

2px border radius applied to all corners of all widgets by default. 

### After

New option in _General settings_
<img width="590" height="298" alt="general_settings" src="https://github.com/user-attachments/assets/aa51dbcd-ed97-4ffa-9b00-2332031ff939" />

Screencap showing the controls being used in global mode, per-widget uniform, and per-widget per-corner controls:

https://github.com/user-attachments/assets/9d1352f1-09b7-4854-8e09-62e950effe3f

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

## Validation

Validated locally against latest upstream `main` after rebasing.

- `npm run lint`
- `npm test -- --no-coverage`
- `npm run build-storybook`
- Validated locally on my Mac by testing all settings extensively. 

## Architecture Notes

This follows the widget architecture rules by keeping the feature opt-in and scoped:

- Radius support is centralized in `src/frontend/utils/borderRadius.ts`.
- The settings UI and widget wrappers both use the same allowlist.
- Widget implementations opt in by applying `widget-radius-surface` to the actual visible rectangular surface.
- The global control only affects allowlisted widgets, not every overlay or internal surface.
- No `!important` overrides or broad CSS selectors are used.

[0]
- Standings
- Relative
- Weather
- Wind
- Input
- Fuel
- Garage Cover
- Rejoin Indicator
- Flag
- Faster Cars From Behind
- Pitlane Helper
- Twitch Chat
- Lap Time Log
- Information Bar
- Sector Delta
- Corner Names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global dashboard Border Radius setting plus per-widget controls with three modes: inherit, uniform, or per-corner.
  * Many widgets updated to honor border-radius styling and clipping for consistent visuals.
  * Storybook preview controls and decorator added to preview border-radius variations.

* **Documentation**
  * Architecture and onboarding docs updated with border-radius rules and checklist step.

* **Tests**
  * Unit tests added for border-radius utilities and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->