### PR TITLE
feat: add Simple display mode to Blind Spot Monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ bin/
 docs/features/
 docs/reference/relatives.js
 docs/superpowers/
+.superpowers/
 COMMIT_REVIEW.md
 LAP_TIME_DELTA_BUG_ANALYSIS.md
 .vs/

--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,6 @@ docs/features/
 docs/reference/relatives.js
 docs/superpowers/
 .superpowers/
-.remember/
 COMMIT_REVIEW.md
 LAP_TIME_DELTA_BUG_ANALYSIS.md
 .vs/

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ docs/features/
 docs/reference/relatives.js
 docs/superpowers/
 .superpowers/
+.remember/
 COMMIT_REVIEW.md
 LAP_TIME_DELTA_BUG_ANALYSIS.md
 .vs/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,7 @@ import reactHooks from "eslint-plugin-react-hooks";
 import storybook from "eslint-plugin-storybook";
 
 export default defineConfig([
-  { ignores: ['**/.vite/**', '**/out/**', '**/coverage/**', 'storybook-static/**', '**/dist/**'] },
+  { ignores: ['**/.vite/**', '**/out/**', '**/coverage/**', 'storybook-static/**', '**/dist/**', '**/.remember/**'] },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: { ...globals.browser, ...globals.node } } },
   js.configs.recommended,

--- a/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.stories.tsx
+++ b/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.stories.tsx
@@ -8,18 +8,27 @@ import { CarLeftRight } from '@irdashies/types';
 
 type BlindSpotMonitorStoryProps = Omit<
   BlindSpotMonitorDisplayProps,
-  'indicatorColor'
-> & { indicatorColor?: string };
+  'indicatorColor' | 'thresholdColor1' | 'thresholdColor2'
+> & {
+  indicatorColor?: string;
+  thresholdColor1?: string;
+  thresholdColor2?: string;
+};
+
+const parseColor = (c?: string) =>
+  c ? parseInt(c.replace('#', ''), 16) : undefined;
 
 const BlindSpotMonitorDisplayStory = ({
   indicatorColor,
+  thresholdColor1,
+  thresholdColor2,
   ...props
 }: BlindSpotMonitorStoryProps) => (
   <BlindSpotMonitorDisplay
     {...props}
-    indicatorColor={
-      indicatorColor ? parseInt(indicatorColor.replace('#', ''), 16) : undefined
-    }
+    indicatorColor={parseColor(indicatorColor)}
+    thresholdColor1={parseColor(thresholdColor1)}
+    thresholdColor2={parseColor(thresholdColor2)}
   />
 );
 
@@ -75,6 +84,25 @@ export default {
       control: { type: 'range', min: 0, max: 10, step: 1 },
     },
     indicatorColor: {
+      control: { type: 'color' },
+    },
+    displayMode: {
+      control: { type: 'select' },
+      options: ['standard', 'simple'],
+    },
+    simpleSize: {
+      control: { type: 'range', min: 20, max: 120, step: 1 },
+    },
+    simpleVerticalPosition: {
+      control: { type: 'range', min: 0, max: 100, step: 1 },
+    },
+    thresholdColorsEnabled: {
+      control: 'boolean',
+    },
+    thresholdColor1: {
+      control: { type: 'color' },
+    },
+    thresholdColor2: {
       control: { type: 'color' },
     },
   },
@@ -408,4 +436,57 @@ export const CarsPassingBothSides: Story = {
   render: (args) => (
     <CarsPassingBothSidesAnimation {...toAnimationProps(args)} />
   ),
+};
+
+const simpleBase = {
+  show: true,
+  displayMode: 'simple' as const,
+  simpleSize: 44,
+  simpleVerticalPosition: 50,
+  thresholdColorsEnabled: false,
+  leftPercent: 0,
+  rightPercent: 0,
+};
+
+export const SimpleModeCarOnLeft: Story = {
+  args: {
+    ...simpleBase,
+    leftState: CarLeftRight.CarLeft,
+    rightState: CarLeftRight.Off,
+  },
+};
+
+export const SimpleModeCarOnRight: Story = {
+  args: {
+    ...simpleBase,
+    leftState: CarLeftRight.Off,
+    rightState: CarLeftRight.CarRight,
+  },
+};
+
+export const SimpleModeTwoCarsLeft: Story = {
+  args: {
+    ...simpleBase,
+    leftState: CarLeftRight.Cars2Left,
+    rightState: CarLeftRight.Off,
+  },
+};
+
+export const SimpleModeTwoCarsRight: Story = {
+  args: {
+    ...simpleBase,
+    leftState: CarLeftRight.Off,
+    rightState: CarLeftRight.Cars2Right,
+  },
+};
+
+export const SimpleModeThresholdColors: Story = {
+  args: {
+    ...simpleBase,
+    leftState: CarLeftRight.CarLeft,
+    rightState: CarLeftRight.Cars2Right,
+    thresholdColorsEnabled: true,
+    thresholdColor1: '#f5a623',
+    thresholdColor2: '#ef4444',
+  },
 };

--- a/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
@@ -140,7 +140,9 @@ export const BlindSpotMonitor = () => {
 
   const sessionVisible = useSessionVisibility(settings?.sessionVisibility);
   const isSimple = settings?.displayMode === 'simple';
-  const activeState = isDemoMode && isSimple ? DEMO_STATE_SIMPLE : state;
+  const forcePreview =
+    isDemoMode || (isSimple && (settings?.thresholdColorsEnabled ?? false));
+  const activeState = forcePreview ? DEMO_STATE_SIMPLE : state;
 
   if (!isDemoMode && !sessionVisible) return <></>;
   if (!isDemoMode && settings?.showOnlyWhenOnTrack && !isOnTrack) return <></>;

--- a/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
@@ -19,6 +19,7 @@ export interface BlindSpotMonitorDisplayProps {
   displayMode?: 'standard' | 'simple';
   simpleSize?: number;
   simpleVerticalPosition?: number;
+  simpleShowCount?: boolean;
   thresholdColorsEnabled?: boolean;
   thresholdColor1?: number;
   thresholdColor2?: number;
@@ -45,6 +46,7 @@ export const BlindSpotMonitorDisplay = ({
   displayMode = 'standard',
   simpleSize = 44,
   simpleVerticalPosition = 50,
+  simpleShowCount = true,
   thresholdColorsEnabled = false,
   thresholdColor1 = DEFAULT_THRESHOLD_COLOR_1,
   thresholdColor2 = DEFAULT_THRESHOLD_COLOR_2,
@@ -67,6 +69,7 @@ export const BlindSpotMonitorDisplay = ({
           carCount={carCountFromState(leftState)}
           size={simpleSize}
           verticalPosition={simpleVerticalPosition}
+          showCount={simpleShowCount}
           indicatorColor={indicatorColor ?? DEFAULT_INDICATOR_COLOR}
           thresholdColorsEnabled={thresholdColorsEnabled}
           thresholdColor1={thresholdColor1}
@@ -78,6 +81,7 @@ export const BlindSpotMonitorDisplay = ({
           carCount={carCountFromState(rightState)}
           size={simpleSize}
           verticalPosition={simpleVerticalPosition}
+          showCount={simpleShowCount}
           indicatorColor={indicatorColor ?? DEFAULT_INDICATOR_COLOR}
           thresholdColorsEnabled={thresholdColorsEnabled}
           thresholdColor1={thresholdColor1}
@@ -138,6 +142,7 @@ export const BlindSpotMonitor = () => {
       displayMode={settings?.displayMode}
       simpleSize={settings?.simpleSize}
       simpleVerticalPosition={settings?.simpleVerticalPosition}
+      simpleShowCount={settings?.simpleShowCount}
       thresholdColorsEnabled={settings?.thresholdColorsEnabled}
       thresholdColor1={settings?.thresholdColor1}
       thresholdColor2={settings?.thresholdColor2}

--- a/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
@@ -1,6 +1,7 @@
 import { useBlindSpotMonitor } from './hooks/useBlindSpotMonitor';
 import { useBlindSpotMonitorSettings } from './hooks/useBlindSpotMonitorSettings';
 import { BlindSpotMonitorIndicator } from './components/BlindSpotMonitorIndicator';
+import { BlindSpotMonitorSimpleIndicator } from './components/BlindSpotMonitorSimpleIndicator';
 import { useSessionVisibility, useTelemetryValue } from '@irdashies/context';
 import { CarLeftRight } from '@irdashies/types';
 
@@ -15,7 +16,20 @@ export interface BlindSpotMonitorDisplayProps {
   width?: number;
   borderSize?: number;
   indicatorColor?: number;
+  displayMode?: 'standard' | 'simple';
+  simpleSize?: number;
+  simpleVerticalPosition?: number;
+  thresholdColorsEnabled?: boolean;
+  thresholdColor1?: number;
+  thresholdColor2?: number;
 }
+
+const DEFAULT_INDICATOR_COLOR = 16096779;
+const DEFAULT_THRESHOLD_COLOR_1 = 16096779;
+const DEFAULT_THRESHOLD_COLOR_2 = 15680580;
+
+const carCountFromState = (state: CarLeftRight): 1 | 2 =>
+  state === CarLeftRight.Cars2Left || state === CarLeftRight.Cars2Right ? 2 : 1;
 
 export const BlindSpotMonitorDisplay = ({
   show,
@@ -28,6 +42,12 @@ export const BlindSpotMonitorDisplay = ({
   width,
   borderSize,
   indicatorColor,
+  displayMode = 'standard',
+  simpleSize = 44,
+  simpleVerticalPosition = 50,
+  thresholdColorsEnabled = false,
+  thresholdColor1 = DEFAULT_THRESHOLD_COLOR_1,
+  thresholdColor2 = DEFAULT_THRESHOLD_COLOR_2,
 }: BlindSpotMonitorDisplayProps) => {
   const showLeft =
     show &&
@@ -37,6 +57,35 @@ export const BlindSpotMonitorDisplay = ({
     show &&
     (rightState === CarLeftRight.CarRight ||
       rightState === CarLeftRight.Cars2Right);
+
+  if (displayMode === 'simple') {
+    return (
+      <div className="w-full h-full relative">
+        <BlindSpotMonitorSimpleIndicator
+          side="left"
+          visible={showLeft}
+          carCount={carCountFromState(leftState)}
+          size={simpleSize}
+          verticalPosition={simpleVerticalPosition}
+          indicatorColor={indicatorColor ?? DEFAULT_INDICATOR_COLOR}
+          thresholdColorsEnabled={thresholdColorsEnabled}
+          thresholdColor1={thresholdColor1}
+          thresholdColor2={thresholdColor2}
+        />
+        <BlindSpotMonitorSimpleIndicator
+          side="right"
+          visible={showRight}
+          carCount={carCountFromState(rightState)}
+          size={simpleSize}
+          verticalPosition={simpleVerticalPosition}
+          indicatorColor={indicatorColor ?? DEFAULT_INDICATOR_COLOR}
+          thresholdColorsEnabled={thresholdColorsEnabled}
+          thresholdColor1={thresholdColor1}
+          thresholdColor2={thresholdColor2}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="w-full h-full relative">
@@ -86,6 +135,12 @@ export const BlindSpotMonitor = () => {
       width={settings?.width}
       borderSize={settings?.borderSize}
       indicatorColor={settings?.indicatorColor}
+      displayMode={settings?.displayMode}
+      simpleSize={settings?.simpleSize}
+      simpleVerticalPosition={settings?.simpleVerticalPosition}
+      thresholdColorsEnabled={settings?.thresholdColorsEnabled}
+      thresholdColor1={settings?.thresholdColor1}
+      thresholdColor2={settings?.thresholdColor2}
     />
   );
 };

--- a/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
@@ -139,10 +139,7 @@ export const BlindSpotMonitor = () => {
   const isOnTrack = useTelemetryValue<boolean>('IsOnTrack') ?? false;
 
   const sessionVisible = useSessionVisibility(settings?.sessionVisibility);
-  const isSimple = settings?.displayMode === 'simple';
-  const forcePreview =
-    isDemoMode || (isSimple && (settings?.thresholdColorsEnabled ?? false));
-  const activeState = forcePreview ? DEMO_STATE_SIMPLE : state;
+  const activeState = isDemoMode ? DEMO_STATE_SIMPLE : state;
 
   if (!isDemoMode && !sessionVisible) return <></>;
   if (!isDemoMode && settings?.showOnlyWhenOnTrack && !isOnTrack) return <></>;

--- a/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
@@ -2,7 +2,11 @@ import { useBlindSpotMonitor } from './hooks/useBlindSpotMonitor';
 import { useBlindSpotMonitorSettings } from './hooks/useBlindSpotMonitorSettings';
 import { BlindSpotMonitorIndicator } from './components/BlindSpotMonitorIndicator';
 import { BlindSpotMonitorSimpleIndicator } from './components/BlindSpotMonitorSimpleIndicator';
-import { useSessionVisibility, useTelemetryValue } from '@irdashies/context';
+import {
+  useDashboard,
+  useSessionVisibility,
+  useTelemetryValue,
+} from '@irdashies/context';
 import { CarLeftRight } from '@irdashies/types';
 
 export interface BlindSpotMonitorDisplayProps {
@@ -119,22 +123,36 @@ export const BlindSpotMonitorDisplay = ({
   );
 };
 
+const DEMO_STATE_SIMPLE = {
+  show: true,
+  leftState: CarLeftRight.CarLeft,
+  rightState: CarLeftRight.Cars2Right,
+  leftPercent: 0,
+  rightPercent: 0,
+  disableTransition: true,
+};
+
 export const BlindSpotMonitor = () => {
   const state = useBlindSpotMonitor();
   const settings = useBlindSpotMonitorSettings();
+  const { isDemoMode } = useDashboard();
   const isOnTrack = useTelemetryValue<boolean>('IsOnTrack') ?? false;
 
-  if (!useSessionVisibility(settings?.sessionVisibility)) return <></>;
-  if (settings?.showOnlyWhenOnTrack && !isOnTrack) return <></>;
+  const sessionVisible = useSessionVisibility(settings?.sessionVisibility);
+  const isSimple = settings?.displayMode === 'simple';
+  const activeState = isDemoMode && isSimple ? DEMO_STATE_SIMPLE : state;
+
+  if (!isDemoMode && !sessionVisible) return <></>;
+  if (!isDemoMode && settings?.showOnlyWhenOnTrack && !isOnTrack) return <></>;
 
   return (
     <BlindSpotMonitorDisplay
-      show={state.show}
-      leftState={state.leftState}
-      rightState={state.rightState}
-      leftPercent={state.leftPercent}
-      rightPercent={state.rightPercent}
-      disableTransition={state.disableTransition}
+      show={activeState.show}
+      leftState={activeState.leftState}
+      rightState={activeState.rightState}
+      leftPercent={activeState.leftPercent}
+      rightPercent={activeState.rightPercent}
+      disableTransition={activeState.disableTransition}
       bgOpacity={settings?.background?.opacity}
       width={settings?.width}
       borderSize={settings?.borderSize}

--- a/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
+++ b/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
@@ -33,7 +33,7 @@ export const BlindSpotMonitorSimpleIndicator = ({
 
   return (
     <div
-      className={`absolute ${side === 'left' ? 'left-0' : 'right-0'}`}
+      className={`absolute flex items-center justify-center ${side === 'left' ? 'left-0' : 'right-0'}`}
       style={{
         top: `${verticalPosition}%`,
         transform: 'translateY(-50%)',
@@ -41,16 +41,20 @@ export const BlindSpotMonitorSimpleIndicator = ({
         height: `${size}px`,
         backgroundColor: colorHex,
         borderRadius: '6px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontSize: `${Math.round(size * 0.5)}px`,
-        fontWeight: 700,
-        fontFamily: 'inherit',
-        color: '#1e293b',
       }}
     >
-      {showCount && carCount}
+      {showCount && (
+        <span
+          className={`bg-black/70 rounded-full text-amber-500 font-semibold text-shadow-md${carCount === 2 ? ' animate-blink' : ''}`}
+          style={{
+            fontFamily: 'inherit',
+            fontSize: `${Math.round(size * 0.42)}px`,
+            padding: `${Math.round(size * 0.05)}px ${Math.round(size * 0.1)}px`,
+          }}
+        >
+          {carCount}
+        </span>
+      )}
     </div>
   );
 };

--- a/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
+++ b/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
@@ -4,6 +4,7 @@ export interface BlindSpotMonitorSimpleIndicatorProps {
   carCount: 1 | 2;
   size: number;
   verticalPosition: number;
+  showCount: boolean;
   indicatorColor: number;
   thresholdColorsEnabled: boolean;
   thresholdColor1: number;
@@ -16,6 +17,7 @@ export const BlindSpotMonitorSimpleIndicator = ({
   carCount,
   size,
   verticalPosition,
+  showCount,
   indicatorColor,
   thresholdColorsEnabled,
   thresholdColor1,
@@ -44,10 +46,11 @@ export const BlindSpotMonitorSimpleIndicator = ({
         justifyContent: 'center',
         fontSize: `${Math.round(size * 0.5)}px`,
         fontWeight: 700,
+        fontFamily: 'inherit',
         color: '#1e293b',
       }}
     >
-      {carCount}
+      {showCount && carCount}
     </div>
   );
 };

--- a/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
+++ b/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
@@ -1,0 +1,53 @@
+export interface BlindSpotMonitorSimpleIndicatorProps {
+  side: 'left' | 'right';
+  visible: boolean;
+  carCount: 1 | 2;
+  size: number;
+  verticalPosition: number;
+  indicatorColor: number;
+  thresholdColorsEnabled: boolean;
+  thresholdColor1: number;
+  thresholdColor2: number;
+}
+
+export const BlindSpotMonitorSimpleIndicator = ({
+  side,
+  visible,
+  carCount,
+  size,
+  verticalPosition,
+  indicatorColor,
+  thresholdColorsEnabled,
+  thresholdColor1,
+  thresholdColor2,
+}: BlindSpotMonitorSimpleIndicatorProps) => {
+  if (!visible) return null;
+
+  let color = indicatorColor;
+  if (thresholdColorsEnabled) {
+    color = carCount >= 2 ? thresholdColor2 : thresholdColor1;
+  }
+  const colorHex = `#${color.toString(16).padStart(6, '0')}`;
+
+  return (
+    <div
+      className={`absolute ${side === 'left' ? 'left-0' : 'right-0'}`}
+      style={{
+        top: `${verticalPosition}%`,
+        transform: 'translateY(-50%)',
+        width: `${size}px`,
+        height: `${size}px`,
+        backgroundColor: colorHex,
+        borderRadius: '6px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: `${Math.round(size * 0.5)}px`,
+        fontWeight: 700,
+        color: '#1e293b',
+      }}
+    >
+      {carCount}
+    </div>
+  );
+};

--- a/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
+++ b/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
@@ -33,7 +33,7 @@ export const BlindSpotMonitorSimpleIndicator = ({
 
   return (
     <div
-      className={`absolute flex items-center justify-center ${side === 'left' ? 'left-0' : 'right-0'}`}
+      className={`absolute ${side === 'left' ? 'left-0' : 'right-0'}`}
       style={{
         top: `${verticalPosition}%`,
         transform: 'translateY(-50%)',
@@ -41,20 +41,16 @@ export const BlindSpotMonitorSimpleIndicator = ({
         height: `${size}px`,
         backgroundColor: colorHex,
         borderRadius: '6px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: `${Math.round(size * 0.5)}px`,
+        fontWeight: 700,
+        fontFamily: 'inherit',
+        color: '#1e293b',
       }}
     >
-      {showCount && (
-        <span
-          className={`bg-black/70 rounded-full text-amber-500 font-semibold text-shadow-md${carCount === 2 ? ' animate-blink' : ''}`}
-          style={{
-            fontFamily: 'inherit',
-            fontSize: `${Math.round(size * 0.42)}px`,
-            padding: `${Math.round(size * 0.05)}px ${Math.round(size * 0.1)}px`,
-          }}
-        >
-          {carCount}
-        </span>
-      )}
+      {showCount && carCount}
     </div>
   );
 };

--- a/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
+++ b/src/frontend/components/BlindSpotMonitor/components/BlindSpotMonitorSimpleIndicator.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react';
+
 export interface BlindSpotMonitorSimpleIndicatorProps {
   side: 'left' | 'right';
   visible: boolean;
@@ -11,46 +13,50 @@ export interface BlindSpotMonitorSimpleIndicatorProps {
   thresholdColor2: number;
 }
 
-export const BlindSpotMonitorSimpleIndicator = ({
-  side,
-  visible,
-  carCount,
-  size,
-  verticalPosition,
-  showCount,
-  indicatorColor,
-  thresholdColorsEnabled,
-  thresholdColor1,
-  thresholdColor2,
-}: BlindSpotMonitorSimpleIndicatorProps) => {
-  if (!visible) return null;
+export const BlindSpotMonitorSimpleIndicator = memo(
+  ({
+    side,
+    visible,
+    carCount,
+    size,
+    verticalPosition,
+    showCount,
+    indicatorColor,
+    thresholdColorsEnabled,
+    thresholdColor1,
+    thresholdColor2,
+  }: BlindSpotMonitorSimpleIndicatorProps) => {
+    if (!visible) return null;
 
-  let color = indicatorColor;
-  if (thresholdColorsEnabled) {
-    color = carCount >= 2 ? thresholdColor2 : thresholdColor1;
+    let color = indicatorColor;
+    if (thresholdColorsEnabled) {
+      color = carCount >= 2 ? thresholdColor2 : thresholdColor1;
+    }
+    const colorHex = `#${color.toString(16).padStart(6, '0')}`;
+
+    return (
+      <div
+        className={`absolute ${side === 'left' ? 'left-0' : 'right-0'}`}
+        style={{
+          top: `${verticalPosition}%`,
+          transform: 'translateY(-50%)',
+          width: `${size}px`,
+          height: `${size}px`,
+          backgroundColor: colorHex,
+          borderRadius: '6px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: `${Math.round(size * 0.5)}px`,
+          fontWeight: 700,
+          fontFamily: 'inherit',
+          color: '#1e293b',
+        }}
+      >
+        {showCount && carCount}
+      </div>
+    );
   }
-  const colorHex = `#${color.toString(16).padStart(6, '0')}`;
+);
 
-  return (
-    <div
-      className={`absolute ${side === 'left' ? 'left-0' : 'right-0'}`}
-      style={{
-        top: `${verticalPosition}%`,
-        transform: 'translateY(-50%)',
-        width: `${size}px`,
-        height: `${size}px`,
-        backgroundColor: colorHex,
-        borderRadius: '6px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontSize: `${Math.round(size * 0.5)}px`,
-        fontWeight: 700,
-        fontFamily: 'inherit',
-        color: '#1e293b',
-      }}
-    >
-      {showCount && carCount}
-    </div>
-  );
-};
+BlindSpotMonitorSimpleIndicator.displayName = 'BlindSpotMonitorSimpleIndicator';

--- a/src/frontend/components/Settings/sections/BlindSpotMonitorSettings.tsx
+++ b/src/frontend/components/Settings/sections/BlindSpotMonitorSettings.tsx
@@ -9,6 +9,7 @@ import {
 import { SessionVisibility } from '../components/SessionVisibility';
 import { TabButton } from '../components/TabButton';
 import { SettingSliderRow } from '../components/SettingSliderRow';
+import { SettingSelectRow } from '../components/SettingSelectRow';
 import { SettingsSection } from '../components/SettingSection';
 import { SettingDivider } from '../components/SettingDivider';
 import { SettingToggleRow } from '../components/SettingToggleRow';
@@ -82,79 +83,198 @@ export const BlindSpotMonitorSettings = () => {
             {/* DISPLAY TAB */}
             {activeTab === 'display' && (
               <SettingsSection title="Display">
-                {/* Background Opacity */}
-                <SettingSliderRow
-                  title="Background Opacity"
-                  value={settings.config.background?.opacity ?? 30}
-                  units="%"
-                  min={0}
-                  max={100}
-                  step={5}
-                  onChange={(v) =>
-                    handleConfigChange({ background: { opacity: v } })
-                  }
+                {/* Display Mode */}
+                <SettingSelectRow
+                  title="Display Mode"
+                  description="Visual style of the blind spot indicator."
+                  value={settings.config.displayMode ?? 'standard'}
+                  options={[
+                    { label: 'Standard', value: 'standard' },
+                    { label: 'Simple', value: 'simple' },
+                  ]}
+                  onChange={(v) => handleConfigChange({ displayMode: v })}
                 />
 
-                {/* Width */}
-                <SettingSliderRow
-                  title="Width"
-                  description="Width of the blind spot indicator in pixels."
-                  value={settings.config.width ?? 20}
-                  units="px"
-                  min={5}
-                  max={100}
-                  step={1}
-                  onChange={(v) => handleConfigChange({ width: v })}
-                />
-
-                {/* Border Size */}
-                <SettingSliderRow
-                  title="Border Size"
-                  description="Border thickness of the blind spot indicator in pixels."
-                  value={settings.config.borderSize ?? 1}
-                  units="px"
-                  min={0}
-                  max={20}
-                  step={1}
-                  onChange={(v) => handleConfigChange({ borderSize: v })}
-                />
-
-                {/* Indicator Color */}
-                <div className="flex items-center justify-between gap-4 py-2">
-                  <div>
-                    <p className="text-sm font-medium text-slate-200">
-                      Indicator Color
-                    </p>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className="rounded border-2"
-                      style={{
-                        width: '20px',
-                        height: '20px',
-                        backgroundColor: `#${(settings.config.indicatorColor ?? 16096779).toString(16).padStart(6, '0')}`,
-                        borderColor: `#${(settings.config.indicatorColor ?? 16096779).toString(16).padStart(6, '0')}`,
-                      }}
-                    />
-                    <select
-                      value={settings.config.indicatorColor ?? 16096779}
-                      onChange={(e) =>
-                        handleConfigChange({
-                          indicatorColor: parseInt(e.target.value),
-                        })
+                {/* Standard settings */}
+                {(settings.config.displayMode ?? 'standard') === 'standard' && (
+                  <>
+                    <SettingSliderRow
+                      title="Background Opacity"
+                      value={settings.config.background?.opacity ?? 30}
+                      units="%"
+                      min={0}
+                      max={100}
+                      step={5}
+                      onChange={(v) =>
+                        handleConfigChange({ background: { opacity: v } })
                       }
-                      className="px-3 py-1.5 bg-slate-700 text-slate-300 rounded border border-slate-600 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 text-sm"
-                    >
-                      {Array.from(HIGHLIGHT_COLOR_PRESETS.entries()).map(
-                        ([key, value]) => (
-                          <option key={key} value={key}>
-                            {value}
-                          </option>
-                        )
-                      )}
-                    </select>
-                  </div>
-                </div>
+                    />
+                    <SettingSliderRow
+                      title="Width"
+                      description="Width of the blind spot indicator in pixels."
+                      value={settings.config.width ?? 20}
+                      units="px"
+                      min={5}
+                      max={100}
+                      step={1}
+                      onChange={(v) => handleConfigChange({ width: v })}
+                    />
+                    <SettingSliderRow
+                      title="Border Size"
+                      description="Border thickness of the blind spot indicator in pixels."
+                      value={settings.config.borderSize ?? 1}
+                      units="px"
+                      min={0}
+                      max={20}
+                      step={1}
+                      onChange={(v) => handleConfigChange({ borderSize: v })}
+                    />
+                    <div className="flex items-center justify-between gap-4 py-2">
+                      <div>
+                        <p className="text-sm font-medium text-slate-200">
+                          Indicator Color
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span
+                          className="rounded border-2"
+                          style={{
+                            width: '20px',
+                            height: '20px',
+                            backgroundColor: `#${(settings.config.indicatorColor ?? 16096779).toString(16).padStart(6, '0')}`,
+                            borderColor: `#${(settings.config.indicatorColor ?? 16096779).toString(16).padStart(6, '0')}`,
+                          }}
+                        />
+                        <select
+                          value={settings.config.indicatorColor ?? 16096779}
+                          onChange={(e) =>
+                            handleConfigChange({
+                              indicatorColor: parseInt(e.target.value),
+                            })
+                          }
+                          className="px-3 py-1.5 bg-slate-700 text-slate-300 rounded border border-slate-600 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 text-sm"
+                        >
+                          {Array.from(HIGHLIGHT_COLOR_PRESETS.entries()).map(
+                            ([key, value]) => (
+                              <option key={key} value={key}>
+                                {value}
+                              </option>
+                            )
+                          )}
+                        </select>
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {/* Simple settings */}
+                {settings.config.displayMode === 'simple' && (
+                  <>
+                    <SettingSliderRow
+                      title="Square Size"
+                      description="Width and height of the indicator square in pixels."
+                      value={settings.config.simpleSize ?? 44}
+                      units="px"
+                      min={20}
+                      max={120}
+                      step={1}
+                      onChange={(v) => handleConfigChange({ simpleSize: v })}
+                    />
+                    <SettingSliderRow
+                      title="Vertical Position"
+                      description="Vertical placement within the widget. 0% = top, 50% = centre, 100% = bottom."
+                      value={settings.config.simpleVerticalPosition ?? 50}
+                      units="%"
+                      min={0}
+                      max={100}
+                      step={1}
+                      onChange={(v) =>
+                        handleConfigChange({ simpleVerticalPosition: v })
+                      }
+                    />
+                    <SettingDivider />
+                    <SettingToggleRow
+                      title="Threshold Colours"
+                      description="Change colour based on the number of cars detected."
+                      enabled={settings.config.thresholdColorsEnabled ?? false}
+                      onToggle={(v) =>
+                        handleConfigChange({ thresholdColorsEnabled: v })
+                      }
+                    />
+                    {settings.config.thresholdColorsEnabled && (
+                      <>
+                        <div className="flex items-center justify-between gap-4 py-2">
+                          <p className="text-sm text-slate-400">1 car colour</p>
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="rounded border-2"
+                              style={{
+                                width: '20px',
+                                height: '20px',
+                                backgroundColor: `#${(settings.config.thresholdColor1 ?? 16096779).toString(16).padStart(6, '0')}`,
+                                borderColor: `#${(settings.config.thresholdColor1 ?? 16096779).toString(16).padStart(6, '0')}`,
+                              }}
+                            />
+                            <select
+                              value={
+                                settings.config.thresholdColor1 ?? 16096779
+                              }
+                              onChange={(e) =>
+                                handleConfigChange({
+                                  thresholdColor1: parseInt(e.target.value),
+                                })
+                              }
+                              className="px-3 py-1.5 bg-slate-700 text-slate-300 rounded border border-slate-600 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 text-sm"
+                            >
+                              {Array.from(
+                                HIGHLIGHT_COLOR_PRESETS.entries()
+                              ).map(([key, value]) => (
+                                <option key={key} value={key}>
+                                  {value}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+                        <div className="flex items-center justify-between gap-4 py-2">
+                          <p className="text-sm text-slate-400">
+                            2+ cars colour
+                          </p>
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="rounded border-2"
+                              style={{
+                                width: '20px',
+                                height: '20px',
+                                backgroundColor: `#${(settings.config.thresholdColor2 ?? 15680580).toString(16).padStart(6, '0')}`,
+                                borderColor: `#${(settings.config.thresholdColor2 ?? 15680580).toString(16).padStart(6, '0')}`,
+                              }}
+                            />
+                            <select
+                              value={
+                                settings.config.thresholdColor2 ?? 15680580
+                              }
+                              onChange={(e) =>
+                                handleConfigChange({
+                                  thresholdColor2: parseInt(e.target.value),
+                                })
+                              }
+                              className="px-3 py-1.5 bg-slate-700 text-slate-300 rounded border border-slate-600 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 text-sm"
+                            >
+                              {Array.from(
+                                HIGHLIGHT_COLOR_PRESETS.entries()
+                              ).map(([key, value]) => (
+                                <option key={key} value={key}>
+                                  {value}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+                      </>
+                    )}
+                  </>
+                )}
               </SettingsSection>
             )}
 

--- a/src/frontend/components/Settings/sections/BlindSpotMonitorSettings.tsx
+++ b/src/frontend/components/Settings/sections/BlindSpotMonitorSettings.tsx
@@ -202,14 +202,51 @@ export const BlindSpotMonitorSettings = () => {
                     />
                     <SettingDivider />
                     <SettingToggleRow
-                      title="Threshold Colours"
-                      description="Change colour based on the number of cars detected."
+                      title="Colour by Car Count"
+                      description="Use different colours based on how many cars are in your blind spot."
                       enabled={settings.config.thresholdColorsEnabled ?? false}
                       onToggle={(v) =>
                         handleConfigChange({ thresholdColorsEnabled: v })
                       }
                     />
-                    {settings.config.thresholdColorsEnabled && (
+                    {!(settings.config.thresholdColorsEnabled ?? false) && (
+                      <div className="flex items-center justify-between gap-4 py-2">
+                        <div>
+                          <p className="text-sm font-medium text-slate-200">
+                            Square Colour
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span
+                            className="rounded border-2"
+                            style={{
+                              width: '20px',
+                              height: '20px',
+                              backgroundColor: `#${(settings.config.indicatorColor ?? 16096779).toString(16).padStart(6, '0')}`,
+                              borderColor: `#${(settings.config.indicatorColor ?? 16096779).toString(16).padStart(6, '0')}`,
+                            }}
+                          />
+                          <select
+                            value={settings.config.indicatorColor ?? 16096779}
+                            onChange={(e) =>
+                              handleConfigChange({
+                                indicatorColor: parseInt(e.target.value),
+                              })
+                            }
+                            className="px-3 py-1.5 bg-slate-700 text-slate-300 rounded border border-slate-600 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 text-sm"
+                          >
+                            {Array.from(HIGHLIGHT_COLOR_PRESETS.entries()).map(
+                              ([key, value]) => (
+                                <option key={key} value={key}>
+                                  {value}
+                                </option>
+                              )
+                            )}
+                          </select>
+                        </div>
+                      </div>
+                    )}
+                    {(settings.config.thresholdColorsEnabled ?? false) && (
                       <>
                         <div className="flex items-center justify-between gap-4 py-2">
                           <p className="text-sm text-slate-400">1 car colour</p>

--- a/src/frontend/components/Settings/sections/BlindSpotMonitorSettings.tsx
+++ b/src/frontend/components/Settings/sections/BlindSpotMonitorSettings.tsx
@@ -192,6 +192,14 @@ export const BlindSpotMonitorSettings = () => {
                         handleConfigChange({ simpleVerticalPosition: v })
                       }
                     />
+                    <SettingToggleRow
+                      title="Show Count"
+                      description="Display the number of cars inside the indicator square."
+                      enabled={settings.config.simpleShowCount ?? true}
+                      onToggle={(v) =>
+                        handleConfigChange({ simpleShowCount: v })
+                      }
+                    />
                     <SettingDivider />
                     <SettingToggleRow
                       title="Threshold Colours"

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -928,6 +928,7 @@ export const defaultDashboard: {
         displayMode: 'standard',
         simpleSize: 44,
         simpleVerticalPosition: 50,
+        simpleShowCount: true,
         thresholdColorsEnabled: false,
         thresholdColor1: 16096779,
         thresholdColor2: 15680580,

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -925,6 +925,12 @@ export const defaultDashboard: {
         width: 20,
         borderSize: 1,
         indicatorColor: 16096779,
+        displayMode: 'standard',
+        simpleSize: 44,
+        simpleVerticalPosition: 50,
+        thresholdColorsEnabled: false,
+        thresholdColor1: 16096779,
+        thresholdColor2: 15680580,
         sessionVisibility: {
           race: true,
           loneQualify: true,

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -437,6 +437,12 @@ export interface BlindSpotMonitorConfig {
   borderSize?: number;
   indicatorColor?: number;
   sessionVisibility: SessionVisibilitySettings;
+  displayMode?: 'standard' | 'simple';
+  simpleSize?: number;
+  simpleVerticalPosition?: number;
+  thresholdColorsEnabled?: boolean;
+  thresholdColor1?: number;
+  thresholdColor2?: number;
 }
 
 export interface RejoinIndicatorConfig {

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -440,6 +440,7 @@ export interface BlindSpotMonitorConfig {
   displayMode?: 'standard' | 'simple';
   simpleSize?: number;
   simpleVerticalPosition?: number;
+  simpleShowCount?: boolean;
   thresholdColorsEnabled?: boolean;
   thresholdColor1?: number;
   thresholdColor2?: number;


### PR DESCRIPTION
## Description

Adds a new Simple display mode to the Blind Spot Monitor widget. Instead of full-height indicator bars, Simple mode renders small coloured squares on the left/right edges with an optional car count number.

Tested via Storybook stories.

### New settings (Simple mode)
- Square Size (20-120px, default 44px)
- Vertical Position (0% top, 50% centre, 100% bottom)
- Show Count toggle
- Colour by Car Count (off by default): 1 car = amber, 2+ cars = red, both configurable. Squares stay visible as a live colour preview when this option is on.
- Square Colour: single configurable colour when Colour by Car Count is off
- Values are hidden when no cars in range

Numbers inherit the app font from General settings.

## Screenshots

<img width="1128" height="971" alt="image" src="https://github.com/user-attachments/assets/f13d89ed-0b00-4aec-baf3-465c0456dea2" />

<img width="2493" height="1149" alt="image" src="https://github.com/user-attachments/assets/8d4b51db-0a0c-487c-9b03-b83c70747c09" />

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] All tests pass locally via `npm test`
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)