### PR TITLE
feat: add new cars (incl. BMW M2 G87) and regenerate track maps

### DIFF
--- a/src/frontend/components/Standings/components/CarManufacturer/carManufacturerMapping.ts
+++ b/src/frontend/components/Standings/components/CarManufacturer/carManufacturerMapping.ts
@@ -266,4 +266,8 @@ export const CAR_ID_TO_CAR_MANUFACTURER: Record<
   208: { name: 'Porsche 911 Cup (992.2)', manufacturer: 'porsche' },
   210: { name: 'Audi RS3 LMS Gen2 TCR', manufacturer: 'audi' },
   211: { name: 'NASCAR Truck RAM 1500 TRX', manufacturer: 'dodgeram' },
+  213: { name: 'EURO NASCAR V8GP', manufacturer: 'unknown' },
+  214: { name: 'Formula Vee - Cutlass', manufacturer: 'vw' },
+  215: { name: 'Formula Vee - Conqueror', manufacturer: 'vw' },
+  216: { name: 'BMW M2 Racing (G87)', manufacturer: 'bmw' },
 };


### PR DESCRIPTION
## Description

Adds 4 cars that were missing from the car manufacturer logo mapping (`carManufacturerMapping.ts`), cross-referenced against the iRacing car list in `asset-data/cars.json`:

| ID | Car | Logo |
|----|-----|------|
| 213 | EURO NASCAR V8GP | `unknown` (spec car, no manufacturer) |
| 214 | Formula Vee - Cutlass | `vw` |
| 215 | Formula Vee - Conqueror | `vw` |
| 216 | **BMW M2 Racing (G87)** | `bmw` |

The BMW M2 uses the `bmw` logo to stay consistent with every other BMW entry in the table.

Also regenerated `tracks.json` via `npm run generate-assets`. No tracks were added or removed (466 → 466); the only substantive change is the **start/finish line geometry** for the two newest tracks, **Charlotte Motor Speedway — Dirt Road** (587) and **Qualcomm Circuit / San Diego** (589). The remainder of the diff is coordinate-precision and key-ordering noise.

## Screenshots

### Before
Cars 213–216 fell back to the `unknown` manufacturer logo in standings.

### After
BMW M2 Racing (G87) and the other 3 cars now show their correct manufacturer logos.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 4 new car models: EURO NASCAR V8GP, Formula Vee - Cutlass, Formula Vee - Conqueror, and BMW M2 Racing (G87).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->