### PR TITLE
fix: track wetness state text overflows at narrow widths

### DIFF
--- a/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.stories.tsx
+++ b/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.stories.tsx
@@ -23,3 +23,16 @@ export const Primary: Story = {
     trackMoisture: 5,
   },
 };
+
+export const Narrow150px: Story = {
+  args: {
+    trackMoisture: 5,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-25">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
+++ b/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
@@ -70,10 +70,7 @@ export const WeatherTrackWetness = memo(
         {/* Header row with consistency label styling */}
         <div className="flex flex-row gap-x-2 items-center text-sm mb-2">
           <WavesIcon className="flex-none" />
-          <span className="truncate min-w-0 flex-1 @max-[120px]:hidden">
-            Wetness
-          </span>
-          <div className="flex-none whitespace-nowrap text-right capitalize">
+          <div className="flex-1 min-w-0 truncate capitalize">
             {trackStateLabel}
           </div>
         </div>


### PR DESCRIPTION
## Description

The track wetness widget header had two issues at narrow widths:

1. The static **"Wetness"** label was meant to hide below 120px via a `@max-[120px]:hidden` container query — but that query never matched because there was no `@container` ancestor. It only *looked* hidden because it was `flex-1 truncate` and got squeezed to zero width by the value beside it.
2. The state value (e.g. "Very Lightly Wet") used `flex-none whitespace-nowrap`, so it could never shrink and **overflowed the widget box** at narrow widths.

This PR drops the redundant "Wetness" label entirely and left-aligns the state value with `min-w-0 truncate`, so it always ellipsizes to fit the available width. A `Narrow150px` Storybook story was added to cover constrained widths.

Tested in Storybook at 100px, 150px, and 250px widths.

## Screenshots

### Before
At narrow widths the state value overflowed the widget (text ran outside the rounded box), and the "Wetness" label squeezed the value to near-zero.

<img width="167" height="90" alt="image" src="https://github.com/user-attachments/assets/7bb17d09-b3d6-47d8-ab3e-2548ecd571f6" />


<img width="168" height="429" alt="image" src="https://github.com/user-attachments/assets/7861e756-3b2f-405c-a506-4191dcedb5d4" />


### After
- **100px**: `≈ Very Light…` — left-aligned, truncated, fits cleanly
- **250px**: `≈ Very Lightly Wet` — full text, left-aligned

<img width="124" height="78" alt="image" src="https://github.com/user-attachments/assets/0de9b1eb-f589-4e58-8685-9dc0fbbcaf8e" />

<img width="155" height="410" alt="image" src="https://github.com/user-attachments/assets/ef5ebc35-0bca-45de-a546-d7a8560a2944" />


## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)