### PR TITLE
feat: configurable radio icon persistence with distinct lingering state

### DIFF
--- a/src/frontend/components/Settings/sections/RelativeSettings.tsx
+++ b/src/frontend/components/Settings/sections/RelativeSettings.tsx
@@ -572,6 +572,19 @@ export const RelativeSettings = () => {
                         handleConfigChange({ useLivePosition: newValue })
                       }
                     />
+
+                    <SettingSliderRow
+                      title="Radio Icon Duration"
+                      description="How long the speaker icon keeps showing after a driver stops talking. Set to 0 to only show it while they are actively transmitting."
+                      value={settings.config.radio?.persistenceSeconds ?? 3}
+                      units="s"
+                      min={0}
+                      max={10}
+                      step={0.5}
+                      onChange={(v) =>
+                        handleConfigChange({ radio: { persistenceSeconds: v } })
+                      }
+                    />
                   </SettingsSection>
 
                   <SettingDivider />

--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -759,6 +759,19 @@ export const StandingsSettings = () => {
                         handleConfigChange({ useLivePosition: newValue })
                       }
                     />
+
+                    <SettingSliderRow
+                      title="Radio Icon Duration"
+                      description="How long the speaker icon keeps showing after a driver stops talking. Set to 0 to only show it while they are actively transmitting."
+                      value={settings.config.radio?.persistenceSeconds ?? 3}
+                      units="s"
+                      min={0}
+                      max={10}
+                      step={0.5}
+                      onChange={(v) =>
+                        handleConfigChange({ radio: { persistenceSeconds: v } })
+                      }
+                    />
                   </SettingsSection>
 
                   <SettingDivider />

--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -221,6 +221,7 @@ export const Relative = () => {
           onPitRoad={result.onPitRoad}
           onTrack={result.onTrack}
           radioActive={result.radioActive}
+          radioTransmitting={result.radioTransmitting}
           isLapped={result.lappedState === 'behind'}
           isLappingAhead={result.lappedState === 'ahead'}
           flairId={
@@ -308,7 +309,11 @@ export const Relative = () => {
       >
         <TitleBar titleBarSettings={settings?.titleBar} />
         {settings?.headerBar && (settings.headerBar.enabled ?? false) && (
-          <SessionBar settings={settings.headerBar} opacity={settings?.foreground?.opacity} position="header" />
+          <SessionBar
+            settings={settings.headerBar}
+            opacity={settings?.foreground?.opacity}
+            position="header"
+          />
         )}
         <table
           className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
@@ -316,7 +321,11 @@ export const Relative = () => {
           <tbody>{rows}</tbody>
         </table>
         {settings?.footerBar && (settings.footerBar.enabled ?? true) && (
-          <SessionBar settings={settings.footerBar} opacity={settings?.foreground?.opacity} position="footer" />
+          <SessionBar
+            settings={settings.footerBar}
+            opacity={settings?.foreground?.opacity}
+            position="footer"
+          />
         )}
       </FlagContour>
     );
@@ -332,7 +341,11 @@ export const Relative = () => {
     >
       <TitleBar titleBarSettings={settings?.titleBar} />
       {settings?.headerBar && (settings.headerBar.enabled ?? false) && (
-        <SessionBar settings={settings.headerBar} opacity={settings?.foreground?.opacity} position="header" />
+        <SessionBar
+          settings={settings.headerBar}
+          opacity={settings?.foreground?.opacity}
+          position="header"
+        />
       )}
       <table
         className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
@@ -340,7 +353,11 @@ export const Relative = () => {
         <tbody>{rows}</tbody>
       </table>
       {settings?.footerBar && (settings.footerBar.enabled ?? true) && (
-        <SessionBar settings={settings.footerBar} opacity={settings?.foreground?.opacity} position="footer" />
+        <SessionBar
+          settings={settings.footerBar}
+          opacity={settings?.foreground?.opacity}
+          position="footer"
+        />
       )}
     </FlagContour>
   );

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -90,7 +90,11 @@ export const Standings = () => {
     >
       <TitleBar titleBarSettings={settings?.titleBar} />
       {settings?.headerBar && (settings.headerBar.enabled ?? true) && (
-        <SessionBar settings={settings.headerBar} opacity={settings?.foreground?.opacity} position="header" />
+        <SessionBar
+          settings={settings.headerBar}
+          opacity={settings?.foreground?.opacity}
+          position="header"
+        />
       )}
       <table
         className={`w-full table-auto text-sm border-separate ${tableBorderSpacing}`}
@@ -207,6 +211,7 @@ export const Standings = () => {
                         onPitRoad={result.onPitRoad}
                         onTrack={result.onTrack}
                         radioActive={result.radioActive}
+                        radioTransmitting={result.radioTransmitting}
                         isMultiClass={isMultiClass}
                         flairId={
                           (settings?.countryFlags?.enabled ?? true)
@@ -270,7 +275,11 @@ export const Standings = () => {
         </tbody>
       </table>
       {settings?.footerBar && (settings.footerBar.enabled ?? true) && (
-        <SessionBar settings={settings.footerBar} opacity={settings?.foreground?.opacity} position="footer" />
+        <SessionBar
+          settings={settings.footerBar}
+          opacity={settings?.foreground?.opacity}
+          position="footer"
+        />
       )}
     </div>
   );

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.stories.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState, type ComponentProps } from 'react';
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { DriverInfoRow } from './DriverInfoRow';
 import { useCurrentSessionType } from '@irdashies/context';
@@ -113,6 +114,79 @@ export const RadioActiveWithStatus: Story = {
     radioActive: true,
     penalty: true,
   },
+};
+
+// Live transmission: the icon pulses at full strength.
+export const RadioTransmitting: Story = {
+  name: 'Radio - Transmitting (live)',
+  args: {
+    ...Primary.args,
+    radioActive: true,
+    radioTransmitting: true,
+  },
+};
+
+// Lingering state: the driver has stopped talking but the icon is held visible
+// by the persistence window — static and dimmed to distinguish it from live.
+export const RadioLingering: Story = {
+  name: 'Radio - Lingering (recently spoke)',
+  args: {
+    ...Primary.args,
+    radioActive: true,
+    radioTransmitting: false,
+  },
+};
+
+// Interactive demo of the full lifecycle the radio persistence produces:
+// idle -> transmitting (pulsing) -> lingering (static + dimmed) -> idle.
+const radioLifecyclePhases = [
+  { label: 'Idle', radioActive: false, radioTransmitting: false, ms: 1500 },
+  {
+    label: 'Transmitting (pulsing)',
+    radioActive: true,
+    radioTransmitting: true,
+    ms: 2500,
+  },
+  {
+    label: 'Lingering (static + dimmed)',
+    radioActive: true,
+    radioTransmitting: false,
+    ms: 3000,
+  },
+];
+
+const RadioPersistenceDemoComponent = () => {
+  const [phase, setPhase] = useState(0);
+
+  useEffect(() => {
+    const timer = setTimeout(
+      () => setPhase((p) => (p + 1) % radioLifecyclePhases.length),
+      radioLifecyclePhases[phase].ms
+    );
+    return () => clearTimeout(timer);
+  }, [phase]);
+
+  const current = radioLifecyclePhases[phase];
+
+  return (
+    <>
+      <DriverInfoRow
+        {...(Primary.args as ComponentProps<typeof DriverInfoRow>)}
+        radioActive={current.radioActive}
+        radioTransmitting={current.radioTransmitting}
+      />
+      <tr>
+        <td className="pt-3 text-xs text-slate-300" colSpan={99}>
+          State: <span className="text-amber-300">{current.label}</span>
+        </td>
+      </tr>
+    </>
+  );
+};
+
+export const RadioPersistenceLifecycle: Story = {
+  name: 'Radio - Persistence lifecycle',
+  render: () => <RadioPersistenceDemoComponent />,
 };
 
 export const IsPlayer: Story = {

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -49,6 +49,7 @@ interface DriverRowInfoProps {
   onPitRoad?: boolean;
   onTrack?: boolean;
   radioActive?: boolean;
+  radioTransmitting?: boolean;
   isLapped?: boolean;
   isLappingAhead?: boolean;
   hidden?: boolean;
@@ -198,6 +199,7 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
     onPitRoad,
     onTrack,
     radioActive,
+    radioTransmitting,
     isLapped,
     isLappingAhead,
     hidden,
@@ -352,6 +354,7 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
           <DriverNameCell
             key="driverName"
             radioActive={radioActive}
+            radioTransmitting={radioTransmitting}
             repair={repair}
             penalty={penalty}
             slowdown={slowdown}
@@ -633,6 +636,7 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
     name,
     teamName,
     radioActive,
+    radioTransmitting,
     onPitRoad,
     carTrackSurface,
     prevCarTrackSurface,

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverNameCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverNameCell.tsx
@@ -79,6 +79,7 @@ interface DriverNameCellProps {
   fullName?: string;
   nameFormat?: DriverNameFormat;
   radioActive?: boolean;
+  radioTransmitting?: boolean;
   repair?: boolean;
   penalty?: boolean;
   slowdown?: boolean;
@@ -97,6 +98,7 @@ export const DriverNameCell = memo(
     fullName,
     nameFormat,
     radioActive,
+    radioTransmitting,
     repair,
     penalty,
     slowdown,
@@ -114,6 +116,10 @@ export const DriverNameCell = memo(
           nameFormat ?? 'name-middlename-surname'
         )
       : (name ?? '');
+
+    // Fall back to radioActive when transmitting state isn't supplied, so
+    // callers that only know "icon on/off" keep the original pulsing icon.
+    const isRadioTransmitting = radioTransmitting ?? radioActive;
 
     const shouldAnimate = !!label && (!nameDisplay || nameDisplay === 'both');
     const staticText = nameDisplay === 'label' && label ? label : displayName;
@@ -158,9 +164,15 @@ export const DriverNameCell = memo(
       >
         <div className="flex items-center overflow-hidden">
           <span
-            className={`animate-pulse transition-[width] duration-300 ${
-              radioActive ? 'w-4 mr-1' : 'w-0 overflow-hidden'
-            }`}
+            className={[
+              'transition-[width,opacity] duration-300',
+              radioActive ? 'w-4 mr-1' : 'w-0 overflow-hidden',
+              // While actively transmitting the icon pulses at full strength.
+              // Once they stop (but the icon lingers) it goes static and dims,
+              // so a recent transmission reads differently from a live one.
+              isRadioTransmitting ? 'animate-pulse' : '',
+              radioActive && !isRadioTransmitting ? 'opacity-60' : '',
+            ].join(' ')}
           >
             <SpeakerHighIcon className="mt-px" size={16} />
           </span>

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -52,6 +52,7 @@ export interface Standings {
     estLapTime: number;
   };
   radioActive?: boolean;
+  radioTransmitting?: boolean;
   iratingChange?: number;
   carId?: number;
   lapTimeDeltas?: number[]; // Array of deltas vs player's recent laps, most recent last
@@ -122,6 +123,7 @@ export const createDriverStandings = (
     carIdxOnPitRoadValue?: boolean[];
     carIdxTrackSurfaceValue?: TrackLocation[];
     radioTransmitCarIdx?: number[];
+    radioTransmittingCarIdx?: number[];
     carIdxTireCompoundValue?: number[];
     isOnTrack?: boolean;
     carIdxSessionFlags?: number[];
@@ -193,6 +195,9 @@ export const createDriverStandings = (
           estLapTime: driver.CarClassEstLapTime,
         },
         radioActive: telemetry.radioTransmitCarIdx?.includes(driver.CarIdx),
+        radioTransmitting: telemetry.radioTransmittingCarIdx?.includes(
+          driver.CarIdx
+        ),
         carId: driver.CarID,
         lapTimeDeltas: undefined,
         lastPitLap: lastPitLap[driver.CarIdx] ?? undefined,
@@ -303,6 +308,9 @@ export const createDriverStandings = (
           estLapTime: driver.CarClassEstLapTime,
         },
         radioActive: telemetry.radioTransmitCarIdx?.includes(result.CarIdx),
+        radioTransmitting: telemetry.radioTransmittingCarIdx?.includes(
+          result.CarIdx
+        ),
         carId: driver.CarID,
         lapTimeDeltas:
           result.CarIdx === session.playerIdx
@@ -400,6 +408,9 @@ export const createDriverStandings = (
           estLapTime: driver.CarClassEstLapTime,
         },
         radioActive: telemetry.radioTransmitCarIdx?.includes(driver.CarIdx),
+        radioTransmitting: telemetry.radioTransmittingCarIdx?.includes(
+          driver.CarIdx
+        ),
         carId: driver.CarID,
         lapTimeDeltas: undefined,
         lastPitLap: lastPitLap[driver.CarIdx] ?? undefined,

--- a/src/frontend/components/Standings/hooks/index.ts
+++ b/src/frontend/components/Standings/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useHighlightColor';
 export * from './useTrackMapSettings';
 export * from './useDriverTagMap';
 export * from './useInformationBarSettings';
+export * from './useRadioActiveCarIdxs';

--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -24,6 +24,7 @@ import {
 import { GlobalFlags, SessionState } from '@irdashies/types';
 import { useDriverLivePositions } from './useDriverLivePositions';
 import { useRelativeSettings } from './useRelativeSettings';
+import { useRadioActiveCarIdxs } from './useRadioActiveCarIdxs';
 
 const getLastTimeState = (
   lastTime: number | undefined,
@@ -156,7 +157,10 @@ export const useDriverStandings = () => {
     enabled: useLivePositionStandings,
   });
   const drivers = useDrivers();
-  const radioTransmitCarIdx = useTelemetryValue('RadioTransmitCarIdx');
+  const { active: radioActiveCarIdxs, transmitting: radioTransmittingCarIdxs } =
+    useRadioActiveCarIdxs(
+      (relativeSettings?.radio?.persistenceSeconds ?? 3) * 1000
+    );
   const carStates = useCarState();
   // Use focus car index which handles spectator mode (uses CamCarIdx when spectating)
   const playerCarIdx = useFocusCarIdx();
@@ -273,7 +277,8 @@ export const useDriverStandings = () => {
         onTrack: carState?.onTrack ?? false,
         tireCompound: carState?.tireCompound ?? 0,
         carClass: driver.carClass,
-        radioActive: driverPos.carIdx === radioTransmitCarIdx,
+        radioActive: radioActiveCarIdxs.includes(driverPos.carIdx),
+        radioTransmitting: radioTransmittingCarIdxs.includes(driverPos.carIdx),
         carId: driver.carId,
         lastPitLap: driverPos.lastPitLap,
         lastLap: driverPos.lastLap,
@@ -309,7 +314,8 @@ export const useDriverStandings = () => {
     drivers,
     sessionType,
     useLivePositionStandings,
-    radioTransmitCarIdx,
+    radioActiveCarIdxs,
+    radioTransmittingCarIdxs,
     driverLivePositions,
     fastestLapCarIdx,
     isOfficial,

--- a/src/frontend/components/Standings/hooks/useDriverStandings.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverStandings.tsx
@@ -29,6 +29,7 @@ import {
 import type { StandingsWidgetSettings } from '@irdashies/types';
 import { useDriverLivePositions } from './useDriverLivePositions';
 import { useStandingsSettings } from './useStandingsSettings';
+import { useRadioActiveCarIdxs } from './useRadioActiveCarIdxs';
 import { TrackLocation } from '@irdashies/types';
 import type { SessionResults } from '@irdashies/types';
 
@@ -94,9 +95,8 @@ export const useDriverStandings = (
   const carIdxLapDistPct = useTelemetryValuesRounded('CarIdxLapDistPct', 3);
   const carIdxTrackSurface =
     useTelemetryValues<TrackLocation[]>('CarIdxTrackSurface');
-  const radioTransmitCarIdx = useTelemetryValues<number[]>(
-    'RadioTransmitCarIdx'
-  );
+  const { active: radioTransmitCarIdx, transmitting: radioTransmittingCarIdx } =
+    useRadioActiveCarIdxs((settings?.radio?.persistenceSeconds ?? 3) * 1000);
   const carIdxTireCompound = useTelemetryValues<number[]>('CarIdxTireCompound');
   const carIdxSessionFlags = useTelemetryValues<number[]>('CarIdxSessionFlags');
   const isOfficial = useSessionIsOfficial();
@@ -128,6 +128,7 @@ export const useDriverStandings = (
         carIdxOnPitRoadValue: carIdxOnPitRoad,
         carIdxTrackSurfaceValue: carIdxTrackSurface,
         radioTransmitCarIdx: radioTransmitCarIdx,
+        radioTransmittingCarIdx: radioTransmittingCarIdx,
         carIdxTireCompoundValue: carIdxTireCompound,
         carIdxSessionFlags: carIdxSessionFlags,
       },
@@ -207,6 +208,7 @@ export const useDriverStandings = (
     carIdxOnPitRoad,
     carIdxTrackSurface,
     radioTransmitCarIdx,
+    radioTransmittingCarIdx,
     carIdxTireCompound,
     carIdxSessionFlags,
     positions,

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.spec.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.spec.tsx
@@ -1,0 +1,88 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, vi, expect, beforeEach, afterEach } from 'vitest';
+import { useTelemetryValues } from '@irdashies/context';
+import { useRadioActiveCarIdxs } from './useRadioActiveCarIdxs';
+
+vi.mock('@irdashies/context');
+
+describe('useRadioActiveCarIdxs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('passes the live value straight through when persistence is disabled', () => {
+    vi.mocked(useTelemetryValues).mockReturnValue([5] as number[]);
+    const { result } = renderHook(() => useRadioActiveCarIdxs(0));
+    expect(result.current.active).toEqual([5]);
+    expect(result.current.transmitting).toEqual([5]);
+  });
+
+  it('filters out the -1 idle sentinel from transmitting', () => {
+    vi.mocked(useTelemetryValues).mockReturnValue([-1] as number[]);
+    const { result } = renderHook(() => useRadioActiveCarIdxs(0));
+    expect(result.current.transmitting).toEqual([]);
+  });
+
+  it('keeps a car active for the persistence window after it stops transmitting', () => {
+    vi.mocked(useTelemetryValues).mockReturnValue([5] as number[]);
+    const { result, rerender } = renderHook(
+      ({ value }) => {
+        vi.mocked(useTelemetryValues).mockReturnValue(value as number[]);
+        return useRadioActiveCarIdxs(3000);
+      },
+      { initialProps: { value: [5] } }
+    );
+
+    // Effect runs and records the active car.
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(result.current.active).toEqual([5]);
+    expect(result.current.transmitting).toEqual([5]);
+
+    // Driver stops transmitting; icon should linger but no longer "transmit".
+    rerender({ value: [-1] });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.active).toEqual([5]);
+    expect(result.current.transmitting).toEqual([]);
+
+    // After the full window elapses, the car clears even with no new telemetry.
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+    expect(result.current.active).toEqual([]);
+  });
+
+  it('refreshes the window each time a car is seen transmitting again', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => {
+        vi.mocked(useTelemetryValues).mockReturnValue(value as number[]);
+        return useRadioActiveCarIdxs(3000);
+      },
+      { initialProps: { value: [5] } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    // Seen again before expiry — resets the countdown.
+    rerender({ value: [5] });
+    rerender({ value: [-1] });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(result.current.active).toEqual([5]);
+
+    act(() => {
+      vi.advanceTimersByTime(1200);
+    });
+    expect(result.current.active).toEqual([]);
+  });
+});

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTelemetryValues } from '@irdashies/context';
+
+export interface RadioActiveCarIdxs {
+  /** Cars whose speaker icon should be shown (currently transmitting OR within
+   * the persistence window after they stopped). */
+  active: number[];
+  /** Cars transmitting on the radio right now this telemetry frame. */
+  transmitting: number[];
+}
+
+/**
+ * Tracks which car indices should show the radio/speaker icon.
+ *
+ * iRacing only reports a car as transmitting for the exact frames it holds the
+ * push-to-talk, so the icon can flash and vanish before a driver looks up from
+ * a corner. When `persistenceMs > 0`, a car stays in `active` for that long
+ * after it stops transmitting, keeping the icon visible long enough to notice.
+ * When `persistenceMs <= 0`, `active` equals the live `transmitting` set.
+ *
+ * `transmitting` always reflects the live telemetry, so callers can render the
+ * lingering state (active but no longer transmitting) differently.
+ */
+export const useRadioActiveCarIdxs = (
+  persistenceMs: number
+): RadioActiveCarIdxs => {
+  const radioTransmitCarIdx = useTelemetryValues<number[]>(
+    'RadioTransmitCarIdx'
+  );
+  const lastSeenRef = useRef<Map<number, number>>(new Map());
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  const [persisted, setPersisted] = useState<number[]>([]);
+
+  const transmitting = useMemo(
+    () => radioTransmitCarIdx.filter((carIdx) => carIdx >= 0),
+    [radioTransmitCarIdx]
+  );
+
+  useEffect(() => {
+    if (persistenceMs <= 0) {
+      lastSeenRef.current.clear();
+      return;
+    }
+
+    const lastSeen = lastSeenRef.current;
+    const now = Date.now();
+
+    // Refresh the "last seen transmitting" timestamp for every active car.
+    for (const carIdx of transmitting) {
+      lastSeen.set(carIdx, now);
+    }
+
+    const recompute = () => {
+      const t = Date.now();
+      let soonestExpiry = Infinity;
+      const active: number[] = [];
+      for (const [carIdx, seenAt] of lastSeen) {
+        const expiresAt = seenAt + persistenceMs;
+        if (t < expiresAt) {
+          active.push(carIdx);
+          soonestExpiry = Math.min(soonestExpiry, expiresAt);
+        } else {
+          lastSeen.delete(carIdx);
+        }
+      }
+
+      active.sort((a, b) => a - b);
+      setPersisted((prev) =>
+        prev.length === active.length && prev.every((v, i) => v === active[i])
+          ? prev
+          : active
+      );
+
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      // Schedule a follow-up so the icon clears even when no new telemetry
+      // arrives to trigger a re-render (e.g. an idle, silent grid).
+      if (soonestExpiry !== Infinity) {
+        timeoutRef.current = setTimeout(recompute, soonestExpiry - t + 16);
+      }
+    };
+
+    recompute();
+
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [transmitting, persistenceMs]);
+
+  return useMemo(
+    () => ({
+      active: persistenceMs > 0 ? persisted : transmitting,
+      transmitting,
+    }),
+    [persistenceMs, persisted, transmitting]
+  );
+};

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -81,6 +81,9 @@ export const defaultDashboard: {
           enabled: true,
           hideIfSingleMake: false,
         },
+        radio: {
+          persistenceSeconds: 3,
+        },
         lapTimeDeltas: {
           enabled: false,
           numLaps: 3,
@@ -418,6 +421,9 @@ export const defaultDashboard: {
         carManufacturer: {
           enabled: true,
           hideIfSingleMake: false,
+        },
+        radio: {
+          persistenceSeconds: 3,
         },
         badge: {
           enabled: true,

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -151,6 +151,7 @@ export interface StandingsConfig {
   };
   compound: { enabled: boolean };
   carManufacturer: { enabled: boolean; hideIfSingleMake?: boolean };
+  radio?: { persistenceSeconds: number };
   lapTimeDeltas: { enabled: boolean; numLaps: number; decimalPlaces: number };
   avgLapTime: { enabled: boolean; numLaps: number; timeFormat: TimeFormat };
   titleBar: { enabled: boolean; progressBar: { enabled: boolean } };
@@ -179,6 +180,7 @@ export interface RelativeConfig {
   fastestTime: { enabled: boolean; timeFormat: TimeFormat };
   compound: { enabled: boolean };
   carManufacturer: { enabled: boolean; hideIfSingleMake?: boolean };
+  radio?: { persistenceSeconds: number };
   titleBar: { enabled: boolean; progressBar: { enabled: boolean } };
   headerBar: SessionBarConfig;
   footerBar: SessionBarConfig;


### PR DESCRIPTION
## Description

The radio/speaker icon in the **Standings** and **Relative** widgets was driven directly by iRacing's `RadioTransmitCarIdx`, which only flags a car for the exact frames it's transmitting. In practice the icon flashed and vanished the instant someone stopped talking — often before you could glance up from a corner to see who it was.

This PR makes the icon **linger** for a configurable window after a driver stops talking, and makes the lingering state **visually distinct** from a live transmission.

**What changed:**
- New shared `useRadioActiveCarIdxs` hook that keeps a car "active" for a configurable window after it stops transmitting. A self-clearing timer removes it at expiry, and `setState` is guarded by an element-wise equality check so the hook stays cold at 60fps (no per-frame re-renders).
- **Distinct states:** while a driver is actively transmitting the icon **pulses at full strength**; once they stop (and the icon is just lingering) it becomes **static and dims to ~60% opacity**, so a recent transmission reads differently from a live one.
- New **"Radio Icon Duration"** slider (0–10s) in both Standings and Relative settings → *Options → Driver Standings*. Default is **3s**; setting it to **0** restores the original transmit-only behavior.
- `radioTransmitting` threaded through `createStandings`, `DriverInfoRow`, and `DriverNameCell` (falls back to `radioActive` when not supplied, so existing callers keep the original pulsing icon).
- Default config added to `defaultDashboard.ts` for both widgets; existing dashboards pick it up via the merge-on-load.

**Testing:**
- `npm test` — all 910 tests pass, including new unit tests for `useRadioActiveCarIdxs` (persistence window, expiry, window-refresh, live-vs-lingering split).
- `npm run lint` — clean.
- Verified visually in Storybook (see new stories below). Not yet tested in a live iRacing session.

## Screenshots

### Before
The speaker icon appeared only while a driver was actively transmitting and disappeared immediately when they stopped — easy to miss.

### After
The icon stays visible for a configurable duration (default 3s) after a driver stops talking. Live transmission pulses at full opacity; the lingering hold-over is static and dimmed.


https://github.com/user-attachments/assets/74f8e2a4-b00e-4015-8970-d5f7d2d74bd3

<img width="794" height="948" alt="image" src="https://github.com/user-attachments/assets/7f8d2455-b40c-43ba-8b27-687d0c822f3b" />



New Storybook stories under `widgets/Standings/components/DriverInfoRow`:
- **Radio - Transmitting (live)** — pulsing, full opacity
- **Radio - Lingering (recently spoke)** — static, dimmed
- **Radio - Persistence lifecycle** — interactive demo cycling idle → transmitting → lingering → idle

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Radio Icon Duration" setting in Standings and Relative widget options to control how long the speaker icon persists after transmission ends (default: 3 seconds, configurable from 0–10 seconds; 0 shows icon only while actively transmitting)
  * Radio speaker icon now visually distinguishes between active transmission and lingering post-transmission states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->