### PR TITLE
chore: update vendored iRacing SDK to 1.20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    # Pinned to windows-2022 (VS 2022 / v143 toolset). windows-latest moved to
+    # Windows Server 2025 + Visual Studio 2026, whose compiler hits an internal
+    # compiler error (C1001) building node-addon-api's napi-inl.h.
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1139,75 +1139,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/@electron/node-gyp": {
-      "version": "10.2.0-electron.1",
-      "resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
-      "integrity": "sha512-CrYo6TntjpoMO1SHjl5Pa/JoUsECNqNdB7Kx49WLQpWzPw53eEITJ2Hs9fh/ryUYDn4pxZz11StaBYBrLFJdqg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
-        "glob": "^8.1.0",
-        "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^10.2.1",
-        "nopt": "^6.0.0",
-        "proc-log": "^2.0.1",
-        "semver": "^7.3.5",
-        "tar": "^6.2.1",
-        "which": "^2.0.2"
-      },
-      "bin": {
-        "node-gyp": "bin/node-gyp.js"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@electron/node-gyp/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@electron/node-gyp/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@electron/node-gyp/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@electron/notarize": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
@@ -1316,32 +1247,24 @@
       }
     },
     "node_modules/@electron/rebuild": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.2.tgz",
-      "integrity": "sha512-19/KbIR/DAxbsCkiaGMXIdPnMCJLkcf8AvGnduJtWBs/CBwiAjY1apCqOLVxrXg+rtXFCngbXhBanWjxLUt1Mg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.0.4.tgz",
+      "integrity": "sha512-Rzc39XPdk/+/wBG8MfwAHohXflep0ITUfulb6Rgz3R0NeSB1noE+E9/M/cb8ftCAiyDD9PPhLuuWgE1GaInbKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/node-gyp": "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
         "@malept/cross-spawn-promise": "^2.0.0",
-        "chalk": "^4.0.0",
         "debug": "^4.1.1",
-        "detect-libc": "^2.0.1",
-        "fs-extra": "^10.0.0",
-        "got": "^11.7.0",
-        "node-abi": "^3.45.0",
-        "node-api-version": "^0.2.0",
-        "ora": "^5.1.0",
-        "read-binary-file-arch": "^1.0.6",
-        "semver": "^7.3.5",
-        "tar": "^6.0.5",
-        "yargs": "^17.0.1"
+        "node-abi": "^4.2.0",
+        "node-api-version": "^0.2.1",
+        "node-gyp": "^12.2.0",
+        "read-binary-file-arch": "^1.0.6"
       },
       "bin": {
         "electron-rebuild": "lib/cli.js"
       },
       "engines": {
-        "node": ">=12.13.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/universal": {
@@ -2090,13 +2013,6 @@
         }
       }
     },
-    "node_modules/@gar/promisify": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2370,6 +2286,19 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
@@ -2445,16 +2374,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2643,35 +2562,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@npmcli/fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@gar/promisify": "^1.1.3",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@npmcli/move-file": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
-      "deprecated": "This functionality has been moved to @npmcli/fs",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -4666,16 +4556,6 @@
       "integrity": "sha512-CReUjEyOxqGyIJOffC3z3W5LLp7IxdnYRtbfPQlmiGoaoNWAVHWDNm9mY4twIo56b0D3aJDOglDY7ZUAMKWdrQ==",
       "license": "MIT"
     },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
-      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -5982,11 +5862,14 @@
       "license": "Apache-2.0"
     },
     "node_modules/abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -6022,46 +5905,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/ajv": {
@@ -6524,18 +6367,6 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -6628,31 +6459,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -6684,90 +6490,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cacache": {
-      "version": "16.1.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^2.1.0",
-        "@npmcli/move-file": "^2.0.0",
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.1.0",
-        "glob": "^8.0.1",
-        "infer-owner": "^1.0.4",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "p-map": "^4.0.0",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^3.0.2",
-        "ssri": "^9.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^2.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cacache/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cacache/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -6948,13 +6670,13 @@
       }
     },
     "node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -6965,16 +6687,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cli-cursor": {
@@ -6988,19 +6700,6 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7031,81 +6730,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clone-response": {
@@ -7843,19 +7467,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8662,17 +8273,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -9746,19 +9346,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/fs-temp": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/fs-temp/-/fs-temp-1.2.1.tgz",
@@ -9920,6 +9507,7 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -10362,21 +9950,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
@@ -10389,30 +9962,6 @@
       },
       "engines": {
         "node": ">=10.19.0"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
@@ -10442,27 +9991,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -10536,13 +10064,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/infer-owner": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -10604,16 +10125,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -10864,23 +10375,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-lambda": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
-      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -12446,44 +11940,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/make-fetch-happen": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^16.1.0",
-        "http-cache-semantics": "^4.1.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^3.1.6",
-        "minipass-collect": "^1.0.2",
-        "minipass-fetch": "^2.0.3",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^9.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/make-fetch-happen/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -12677,127 +12133,26 @@
       }
     },
     "node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-collect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
-      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.1.6",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
-      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/minizlib": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "node": ">= 18"
       }
     },
     "node_modules/ms": {
@@ -12863,16 +12218,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/negotiator": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
-      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -12888,16 +12233,16 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.31.0.tgz",
+      "integrity": "sha512-Erq5w/t3syw3s4sDsUaX4QttIdBPsGKTT1DTRsCkTonGggczhlDKm/wDX3o+HPJpQ41EjXCbcmXf0tgr5YZJXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "semver": "^7.3.5"
+        "semver": "^7.6.3"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/node-addon-api": {
@@ -12995,6 +12340,67 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-gyp": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -13003,19 +12409,19 @@
       "license": "MIT"
     },
     "node_modules/nopt": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^1.0.0"
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/normalize-package-data": {
@@ -13259,64 +12665,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora/node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ora/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -13486,22 +12834,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -13644,16 +12976,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-type": {
@@ -13895,13 +13217,13 @@
       }
     },
     "node_modules/proc-log": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
-      "integrity": "sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/progress": {
@@ -13913,13 +13235,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
@@ -14238,21 +13553,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -14371,6 +13671,7 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14506,23 +13807,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -14654,27 +13938,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -15049,47 +14312,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
-      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.1.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
-      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.3",
-        "socks": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -15164,19 +14386,6 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true
-    },
-    "node_modules/ssri": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -15262,16 +14471,6 @@
       "optional": true,
       "engines": {
         "node": ">= 0.10.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -15589,40 +14788,31 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
       "dev": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/temp": {
       "version": "0.9.4",
@@ -16159,32 +15349,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/unique-filename": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
@@ -16303,13 +15467,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -16553,16 +15710,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {
@@ -16957,6 +16104,7 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -16985,25 +16133,6 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -17012,38 +16141,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/yauzl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irdashies",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irdashies",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@phosphor-icons/core": "^2.1.1",
@@ -1474,9 +1474,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -1491,9 +1491,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -1508,9 +1508,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -1525,9 +1525,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -1542,9 +1542,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -1559,9 +1559,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -1576,9 +1576,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -1593,9 +1593,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -1610,9 +1610,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -1627,9 +1627,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -1644,9 +1644,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -1661,9 +1661,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -1678,9 +1678,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -1695,9 +1695,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1712,9 +1712,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -1763,9 +1763,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -1780,9 +1780,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -1797,9 +1797,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -1814,9 +1814,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -1831,9 +1831,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -1848,9 +1848,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -1865,9 +1865,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -1882,9 +1882,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -1899,9 +1899,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],
@@ -4072,16 +4072,16 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.1.tgz",
-      "integrity": "sha512-IYqUdjoZe4VO2LFZlKL/gwy7DsQSWCq6hX+zc1MBmZo04yycDASk1tte57n9pdlW3ajw9yYMF/+lVBi+xQjyvw==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.4.tgz",
+      "integrity": "sha512-yPshCvtmQTq52T2sXuXgjy7B/QbhA/WIZxLYggptNjBL8BJMvbOfp9bAfCKh7+KpRWGqDZ6Y6tWL1Q48Wj3vtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "10.4.1",
+        "@storybook/csf-plugin": "10.4.4",
         "@storybook/icons": "^2.0.2",
-        "@storybook/react-dom-shim": "10.4.1",
+        "@storybook/react-dom-shim": "10.4.4",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -4092,7 +4092,7 @@
       },
       "peerDependencies": {
         "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.1"
+        "storybook": "^10.4.4"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4101,13 +4101,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.1.tgz",
-      "integrity": "sha512-/oyQrXoNOqN8SW5hNnYP+I1uvgFxKxWXj/EP6NXYzc5SQwImofgru+D2+6gDhL0+Q//+Hx05DJoQO2omvUJ8bQ==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.4.tgz",
+      "integrity": "sha512-VyuZ4mEvhhVXjJa1qXMWKH8ohnas0rgEuJDf6u4aJ54XeENFebPUEAHde1Qo2PflJ4rUdVdXieOZzKbYwP5RAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "10.4.1",
+        "@storybook/csf-plugin": "10.4.4",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -4115,14 +4115,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.4.1",
+        "storybook": "^10.4.4",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.1.tgz",
-      "integrity": "sha512-WdPepGBxDGOUDjYd8KxMtcf+us/2PAcnBczl77XtrnxxHNs0jWesxKkiJ9yiuGrge4BPhDeAj6rxjbBoaHxLBA==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.4.tgz",
+      "integrity": "sha512-1mzZyAwVUmAcw4WEUsJDVdSupkJf+Kf/f5uNAs4RzlBXA75P8YRkDKAb2EoMwsB5URiXFi9XoeAN/vWke0G6+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4135,7 +4135,7 @@
       "peerDependencies": {
         "esbuild": "*",
         "rollup": "*",
-        "storybook": "^10.4.1",
+        "storybook": "^10.4.4",
         "vite": "*",
         "webpack": "*"
       },
@@ -4173,14 +4173,14 @@
       }
     },
     "node_modules/@storybook/react": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.1.tgz",
-      "integrity": "sha512-WuYz4NaUk4gmFAMliSpCbV8w6jP5OY9juBfw1huwzu2S/k5FhnVXwmrUaL0fmf3Bq/7NgkzmBBbZr6I6LuHayQ==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.4.tgz",
+      "integrity": "sha512-6K5/uHrvjswrueyVpUt6IWGuSgYCMtMOYyVs86XJZYqKBV3Pv7nGsGNH7YSMLAVQBZW4CQqm2etd5Op0GHY9Kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.4.1",
+        "@storybook/react-dom-shim": "10.4.4",
         "react-docgen": "^8.0.2",
         "react-docgen-typescript": "^2.2.2"
       },
@@ -4193,7 +4193,7 @@
         "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.1",
+        "storybook": "^10.4.4",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -4209,9 +4209,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.1.tgz",
-      "integrity": "sha512-6QFqfDNH4DMrt7yHKRfpqRopsVUc/Az+sXIdJ39IetYnHUxL3nW4NVaPc6uy/8Qi8urzUyEXL/nn7cpSIP2aPQ==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.4.tgz",
+      "integrity": "sha512-y6SObmoW78AydE6VfKQSUmCkuqiaMPy9LgMpMdMEyWfJ/pSxBDMIKycr9dlRMJP1cvNgByaJgrusWtA46ndSQw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -4223,7 +4223,7 @@
         "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.1"
+        "storybook": "^10.4.4"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4235,16 +4235,16 @@
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.1.tgz",
-      "integrity": "sha512-zY6OzaXvXqBIUyc5ySE55/LAPQiF+o9ZyhQI978WMu4mY/fL7FpQ+ZVHRUCCgz/wTXtqE9jJwd/N10HI1kD0/Q==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.4.tgz",
+      "integrity": "sha512-hXw1c9Jq2eFzwmJ3u9phmszbHoPjwPLYjcR1Grd6Xbe2g3bReGH35urm/fTZ0HNdjXAgQlUaXp2bWw6vz0BHQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "10.4.1",
-        "@storybook/react": "10.4.1",
+        "@storybook/builder-vite": "10.4.4",
+        "@storybook/react": "10.4.4",
         "empathic": "^2.0.0",
         "magic-string": "^0.30.0",
         "react-docgen": "^8.0.0",
@@ -4258,7 +4258,7 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.1",
+        "storybook": "^10.4.4",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
@@ -8945,9 +8945,9 @@
       "optional": true
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -8958,32 +8958,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/escalade": {
@@ -9157,9 +9157,9 @@
       }
     },
     "node_modules/eslint-plugin-storybook": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.3.3.tgz",
-      "integrity": "sha512-jo8wZvKaJlxxrNvf4hCsROJP3CdlpaLiYewAs5Ww+PJxCrLelIi5XVHWOAgBvvr3H9WDKvUw8xuvqPYqAlpkFg==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.4.4.tgz",
+      "integrity": "sha512-RqEDQJRaeTdfSDRO9W2sKui4oLax6cSuKU/6vFXbiyEmyaACktkQce9DYEf2i5+MZ07y/X/1G0UZeY+WrPQlIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9167,7 +9167,7 @@
       },
       "peerDependencies": {
         "eslint": ">=8",
-        "storybook": "^10.3.3"
+        "storybook": "^10.4.4"
       }
     },
     "node_modules/eslint-scope": {
@@ -15207,9 +15207,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.1.tgz",
-      "integrity": "sha512-V1Zd2e+gBFufqAQVZ1JR8KLqALsEZ3JYSBnWwQbKa6zCfWWanR6AFMyuOkLt2gZOgGp3h2Riuz88pGNVTQSG0A==",
+      "version": "10.4.4",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.4.tgz",
+      "integrity": "sha512-Nn0qFRxU5fyABa6dGRftfL3lz0Y+HkKOaAkfytF8S4Q2K6Szwwq7TwPAEs3Wsj8hBQbYhsobrKADcPsyXQpJaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "url": "https://github.com/tariknz/irdashies"
   },
   "main": ".vite/build/main.js",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "scripts": {
     "start": "electron-forge start --enable-logging",
     "generate-assets": "npx tsx ./tools/index.ts",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "zustand": "^5.0.14"
   },
   "overrides": {
-    "yauzl": "^3.3.1"
+    "yauzl": "^3.3.1",
+    "@electron/rebuild": "^4.0.4"
   }
 }

--- a/src/app/irsdk/native/binding.gyp
+++ b/src/app/irsdk/native/binding.gyp
@@ -13,21 +13,6 @@
       ],
       "include_dirs": [
         "<!(node -p \"require('node-addon-api').include_dir\")",
-      ],
-      "conditions": [
-        ["OS=='win'", {
-          # Pin to the v143 (VS 2022 17.14) toolset. The VS 2026 (v144+)
-          # compiler hits an internal compiler error (C1001) building
-          # node-addon-api's napi-inl.h. The windows-latest image ships v143
-          # for x64 compatibility
-          # (Microsoft.VisualStudio.Component.VC.14.44.17.14.x86.x64), so
-          # forcing it here avoids the broken toolset without pinning the
-          # runner. See actions/runner-images#14215.
-          "configurations": {
-            "Release": { "msbuild_toolset": "v143" },
-            "Debug": { "msbuild_toolset": "v143" }
-          }
-        }]
       ]
     }
   ]

--- a/src/app/irsdk/native/binding.gyp
+++ b/src/app/irsdk/native/binding.gyp
@@ -13,6 +13,21 @@
       ],
       "include_dirs": [
         "<!(node -p \"require('node-addon-api').include_dir\")",
+      ],
+      "conditions": [
+        ["OS=='win'", {
+          # Pin to the v143 (VS 2022 17.14) toolset. The VS 2026 (v144+)
+          # compiler hits an internal compiler error (C1001) building
+          # node-addon-api's napi-inl.h. The windows-latest image ships v143
+          # for x64 compatibility
+          # (Microsoft.VisualStudio.Component.VC.14.44.17.14.x86.x64), so
+          # forcing it here avoids the broken toolset without pinning the
+          # runner. See actions/runner-images#14215.
+          "configurations": {
+            "Release": { "msbuild_toolset": "v143" },
+            "Debug": { "msbuild_toolset": "v143" }
+          }
+        }]
       ]
     }
   ]

--- a/src/app/irsdk/native/irsdk_node.cc
+++ b/src/app/irsdk/native/irsdk_node.cc
@@ -421,7 +421,13 @@ static bool SessionIsUTF8(const char *session) {
   if (!key) return false;
   const char *p = key + strlen("Encoding:");
   while (*p == ' ' || *p == '\t') ++p;
-  return _strnicmp(p, "UTF8", 4) == 0 || _strnicmp(p, "UTF-8", 5) == 0;
+  // Require the value token to end at a delimiter so we don't match a prefix
+  // like "UTF8X" and wrongly skip the Windows-1252 conversion.
+  auto isDelim = [](char ch) {
+    return ch == '\0' || ch == '\r' || ch == '\n' || ch == ' ' || ch == '\t';
+  };
+  return (_strnicmp(p, "UTF8", 4) == 0 && isDelim(p[4])) ||
+         (_strnicmp(p, "UTF-8", 5) == 0 && isDelim(p[5]));
 }
 
 Napi::Value iRacingSdkNode::GetSessionData(const Napi::CallbackInfo &info)

--- a/src/app/irsdk/native/irsdk_node.cc
+++ b/src/app/irsdk/native/irsdk_node.cc
@@ -239,7 +239,7 @@ Napi::Value iRacingSdkNode::BroadcastMessage(const Napi::CallbackInfo &info)
   case irsdk_BroadcastPitCommand: // arg1 == irsdk_PitCommandMode
   case irsdk_BroadcastFFBCommand: // arg1 == irsdk_FFBCommandMode
   case irsdk_BroadcastReplaySearchSessionTime:
-  case irskd_BroadcastReplaySetPlayPosition:
+  case irsdk_BroadcastReplaySetPlayPosition:
     printf("BroadcastMessage(msgType: %d, arg1: %d, arg2: %f)\n", msgType, arg1, (float)arg2.FloatValue());
     irsdk_broadcastMsg(msgType, arg1, (float)arg2.FloatValue());
     break;

--- a/src/app/irsdk/native/irsdk_node.cc
+++ b/src/app/irsdk/native/irsdk_node.cc
@@ -410,6 +410,20 @@ std::string ConvertToUTF8(const char* input) {
     return result;
 }
 
+// Detect whether the iRacing session string is already UTF-8 encoded.
+// Newer sim builds emit "Encoding: UTF8" under WeekendInfo and send the
+// session YAML as UTF-8; older builds send Windows-1252 (iso-8859-1).
+// Mirrors irsdkClient::isSessionStrUTF8() from SDK 1.20 without pulling in
+// the (uncompiled) irsdk_client wrapper.
+static bool SessionIsUTF8(const char *session) {
+  if (!session) return false;
+  const char *key = strstr(session, "Encoding:");
+  if (!key) return false;
+  const char *p = key + strlen("Encoding:");
+  while (*p == ' ' || *p == '\t') ++p;
+  return _strnicmp(p, "UTF8", 4) == 0 || _strnicmp(p, "UTF-8", 5) == 0;
+}
+
 Napi::Value iRacingSdkNode::GetSessionData(const Napi::CallbackInfo &info)
 {
   int latestUpdate = irsdk_getSessionInfoStrUpdate();
@@ -422,8 +436,15 @@ Napi::Value iRacingSdkNode::GetSessionData(const Napi::CallbackInfo &info)
   if (session == NULL) {
     return Napi::String::New(info.Env(), "");
   }
-  
-  // Convert Windows-1252 to UTF-8
+
+  // If the sim already gave us UTF-8, pass it through untouched. Running the
+  // Windows-1252 converter over real UTF-8 would double-encode multi-byte
+  // sequences (e.g. "ü" -> "Ã¼").
+  if (SessionIsUTF8(session)) {
+    return Napi::String::New(info.Env(), session);
+  }
+
+  // Legacy path: convert Windows-1252 to UTF-8
   std::string utf8Session = ConvertToUTF8(session);
   return Napi::String::New(info.Env(), utf8Session.c_str());
 }

--- a/src/app/irsdk/native/lib/irsdk_defines.h
+++ b/src/app/irsdk/native/lib/irsdk_defines.h
@@ -134,61 +134,17 @@ static const int irsdk_VarTypeBytes[irsdk_ETCount] =
 	8		// irsdk_double
 };
 
-// bit fields
-enum irsdk_EngineWarnings 
-{
-	irsdk_waterTempWarning		= 0x01,
-	irsdk_fuelPressureWarning	= 0x02,
-	irsdk_oilPressureWarning	= 0x04,
-	irsdk_engineStalled			= 0x08,
-	irsdk_pitSpeedLimiter		= 0x10,
-	irsdk_revLimiterActive		= 0x20,
-	irsdk_oilTempWarning		= 0x40,
-};
-
-// global flags
-enum irsdk_Flags
-{
-	// global flags
-	irsdk_checkered				= 0x00000001,
-	irsdk_white					= 0x00000002,
-	irsdk_green					= 0x00000004,
-	irsdk_yellow				= 0x00000008,
-	irsdk_red					= 0x00000010,
-	irsdk_blue					= 0x00000020,
-	irsdk_debris				= 0x00000040,
-	irsdk_crossed				= 0x00000080,
-	irsdk_yellowWaving			= 0x00000100,
-	irsdk_oneLapToGreen			= 0x00000200,
-	irsdk_greenHeld				= 0x00000400,
-	irsdk_tenToGo				= 0x00000800,
-	irsdk_fiveToGo				= 0x00001000,
-	irsdk_randomWaving			= 0x00002000,
-	irsdk_caution				= 0x00004000,
-	irsdk_cautionWaving			= 0x00008000,
-
-	// drivers black flags
-	irsdk_black					= 0x00010000,
-	irsdk_disqualify			= 0x00020000,
-	irsdk_servicible			= 0x00040000, // car is allowed service (not a flag)
-	irsdk_furled				= 0x00080000,
-	irsdk_repair				= 0x00100000,
-
-	// start lights
-	irsdk_startHidden			= 0x10000000,
-	irsdk_startReady			= 0x20000000,
-	irsdk_startSet				= 0x40000000,
-	irsdk_startGo				= 0x80000000,
-};
-
+//---
 
 // status 
 enum irsdk_TrkLoc
 {
 	irsdk_NotInWorld = -1,
-	irsdk_OffTrack,
+	irsdk_OffTrack = 0,
 	irsdk_InPitStall,
-	irsdk_AproachingPits,
+	// This indicates the lead in to pit road, as well as the pit road itself (where speed limits are enforced)
+	// if you just want to know that your on the pit road surface look at the live value 'OnPitRoad'
+	irsdk_AproachingPits, 
 	irsdk_OnTrack
 };
 
@@ -229,7 +185,7 @@ enum irsdk_TrkSurf
 
 enum irsdk_SessionState
 {
-	irsdk_StateInvalid,
+	irsdk_StateInvalid = 0,
 	irsdk_StateGetInCar,
 	irsdk_StateWarmup,
 	irsdk_StateParadeLaps,
@@ -240,40 +196,13 @@ enum irsdk_SessionState
 
 enum irsdk_CarLeftRight
 {
-	irsdk_LROff,
+	irsdk_LROff = 0,
 	irsdk_LRClear,			// no cars around us.
 	irsdk_LRCarLeft,		// there is a car to our left.
 	irsdk_LRCarRight,		// there is a car to our right.
 	irsdk_LRCarLeftRight,	// there are cars on each side.
 	irsdk_LR2CarsLeft,		// there are two cars to our left.
 	irsdk_LR2CarsRight		// there are two cars to our right.
-};
-
-enum irsdk_CameraState
-{
-	irsdk_IsSessionScreen          = 0x0001, // the camera tool can only be activated if viewing the session screen (out of car)
-	irsdk_IsScenicActive           = 0x0002, // the scenic camera is active (no focus car)
-
-	//these can be changed with a broadcast message
-	irsdk_CamToolActive            = 0x0004,
-	irsdk_UIHidden                 = 0x0008,
-	irsdk_UseAutoShotSelection     = 0x0010,
-	irsdk_UseTemporaryEdits        = 0x0020,
-	irsdk_UseKeyAcceleration       = 0x0040,
-	irsdk_UseKey10xAcceleration    = 0x0080,
-	irsdk_UseMouseAimMode          = 0x0100
-};
-
-enum irsdk_PitSvFlags
-{
-	irsdk_LFTireChange		= 0x0001,
-	irsdk_RFTireChange		= 0x0002,
-	irsdk_LRTireChange		= 0x0004,
-	irsdk_RRTireChange		= 0x0008,
-
-	irsdk_FuelFill			= 0x0010,
-	irsdk_WindshieldTearoff	= 0x0020,
-	irsdk_FastRepair		= 0x0040
 };
 
 enum irsdk_PitSvStatus
@@ -301,11 +230,131 @@ enum irsdk_PaceMode
 	irsdk_PaceModeNotPacing,
 };
 
+enum irsdk_TrackWetness
+{
+  irsdk_TrackWetness_UNKNOWN = 0,
+  irsdk_TrackWetness_Dry,
+  irsdk_TrackWetness_MostlyDry,
+  irsdk_TrackWetness_VeryLightlyWet,
+  irsdk_TrackWetness_LightlyWet,
+  irsdk_TrackWetness_ModeratelyWet,
+  irsdk_TrackWetness_VeryWet,
+  irsdk_TrackWetness_ExtremelyWet
+};
+
+enum irsdk_IncidentFlags
+{
+	// first byte is incident report flag
+	// only one of these will be used
+	irsdk_Incident_RepNoReport					= 0x0000, // no penalty 
+	irsdk_Incident_RepOutOfControl				= 0x0001, // "Loss of Control (2x)"
+	irsdk_Incident_RepOffTrack					= 0x0002, // "Off Track (1x)"
+	irsdk_Incident_RepOffTrackOngoing			= 0x0003, // not currently sent
+	irsdk_Incident_RepContactWithWorld			= 0x0004, // "Contact (0x)"
+	irsdk_Incident_RepCollisionWithWorld		= 0x0005, // "Contact (2x)"
+	irsdk_Incident_RepCollisionWithWorldOngoing = 0x0006, // not currently sent
+	irsdk_Incident_RepContactWithCar			= 0x0007, // "Car Contact (0x)"
+	irsdk_Incident_RepCollisionWithCar			= 0x0008, // "Car Contact (4x)"
+
+	// second byte is incident penalty
+	// only one of these will be used
+	irsdk_Incident_PenNoReport					= 0x0000, // no penalty
+	irsdk_Incident_PenZeroX						= 0x0100, // 0x
+	irsdk_Incident_PenOneX						= 0x0200, // 1x
+	irsdk_Incident_PenTwoX						= 0x0300, // 2x
+	irsdk_Incident_PenFourX						= 0x0400, // 4x
+
+	// not enums, used to seperate the above incident report field
+	// from the incident penalty field
+	IRSDK_INCIDENT_REP_MASK						= 0x000000FF,
+	IRSDK_INCIDENT_PEN_MASK						= 0x0000FF00,
+};
+
+//---
+
+// bit fields
+enum irsdk_EngineWarnings 
+{
+	irsdk_waterTempWarning		= 0x0001,
+	irsdk_fuelPressureWarning	= 0x0002,
+	irsdk_oilPressureWarning	= 0x0004,
+	irsdk_engineStalled			= 0x0008,
+	irsdk_pitSpeedLimiter		= 0x0010,
+	irsdk_revLimiterActive		= 0x0020,
+	irsdk_oilTempWarning		= 0x0040,
+
+	irsdk_mandRepNeeded			= 0x0080, // car needs mandatory repairs
+	irsdk_optRepNeeded			= 0x0100, // car needs optional repairs
+};
+
+// global flags
+enum irsdk_Flags
+{
+	// global flags
+	irsdk_checkered				= 0x00000001,
+	irsdk_white					= 0x00000002,
+	irsdk_green					= 0x00000004,
+	irsdk_yellow				= 0x00000008,
+	irsdk_red					= 0x00000010,
+	irsdk_blue					= 0x00000020,
+	irsdk_debris				= 0x00000040,
+	irsdk_crossed				= 0x00000080,
+	irsdk_yellowWaving			= 0x00000100,
+	irsdk_oneLapToGreen			= 0x00000200,
+	irsdk_greenHeld				= 0x00000400,
+	irsdk_tenToGo				= 0x00000800,
+	irsdk_fiveToGo				= 0x00001000,
+	irsdk_randomWaving			= 0x00002000,
+	irsdk_caution				= 0x00004000,
+	irsdk_cautionWaving			= 0x00008000,
+
+	// drivers black flags
+	irsdk_black					= 0x00010000,
+	irsdk_disqualify			= 0x00020000,
+	irsdk_servicible			= 0x00040000, // car is allowed service (not a flag)
+	irsdk_furled				= 0x00080000,
+	irsdk_repair				= 0x00100000,
+	irsdk_dqScoringInvalid		= 0x00200000, // car is disqualified and scoring is disabled
+
+	// start lights
+	irsdk_startHidden			= 0x10000000,
+	irsdk_startReady			= 0x20000000,
+	irsdk_startSet				= 0x40000000,
+	irsdk_startGo				= 0x80000000,
+};
+
+enum irsdk_CameraState
+{
+	irsdk_IsSessionScreen       = 0x0001, // the camera tool can only be activated if viewing the session screen (out of car)
+	irsdk_IsScenicActive        = 0x0002, // the scenic camera is active (no focus car)
+
+	//these can be changed with a broadcast message
+	irsdk_CamToolActive         = 0x0004,
+	irsdk_UIHidden              = 0x0008,
+	irsdk_UseAutoShotSelection  = 0x0010,
+	irsdk_UseTemporaryEdits     = 0x0020,
+	irsdk_UseKeyAcceleration    = 0x0040,
+	irsdk_UseKey10xAcceleration = 0x0080,
+	irsdk_UseMouseAimMode       = 0x0100
+};
+
+enum irsdk_PitSvFlags
+{
+	irsdk_LFTireChange			= 0x0001,
+	irsdk_RFTireChange			= 0x0002,
+	irsdk_LRTireChange			= 0x0004,
+	irsdk_RRTireChange			= 0x0008,
+
+	irsdk_FuelFill				= 0x0010,
+	irsdk_WindshieldTearoff		= 0x0020,
+	irsdk_FastRepair			= 0x0040
+};
+
 enum irsdk_PaceFlags
 {
-	irsdk_PaceFlagsEndOfLine = 0x01,
-	irsdk_PaceFlagsFreePass = 0x02,
-	irsdk_PaceFlagsWavedAround = 0x04,
+	irsdk_PaceFlagsEndOfLine	= 0x0001,
+	irsdk_PaceFlagsFreePass		= 0x0002,
+	irsdk_PaceFlagsWavedAround	= 0x0004,
 };
 
 //----
@@ -338,9 +387,10 @@ struct irsdk_varHeader
 
 struct irsdk_varBuf
 {
-	int tickCount;		// used to detect changes in data
+	int tickCount;		// used to detect changes in data (updated AFTER write completes)
 	int bufOffset;		// offset from header
-	int pad[2];			// (16 byte align)
+	int tickCountBegin;	// updated BEFORE write starts (for torn read detection)
+	int pad[1];			// (16 byte align)
 };
 
 struct irsdk_header
@@ -361,7 +411,9 @@ struct irsdk_header
 
 	int numBuf;				// <= IRSDK_MAX_BUFS (3 for now)
 	int bufLen;				// length in bytes for one line
-	int pad1[2];			// (16 byte align)
+	int curBufTickCount;	// stashed copy of the current tickCount, can read this to see if new data is available
+	unsigned char curBuf;	// index of the most recently written buffer (0 to IRSDK_MAX_BUFS-1)
+	char pad1[3];			// 16 byte align
 	irsdk_varBuf varBuf[IRSDK_MAX_BUFS]; // buffers of data being written to
 };
 
@@ -406,7 +458,7 @@ enum irsdk_BroadcastMsg
 	irsdk_BroadcastCamSwitchNum,	      // driver #, group, camera
 	irsdk_BroadcastCamSetState,           // irsdk_CameraState, unused, unused 
 	irsdk_BroadcastReplaySetPlaySpeed,    // speed, slowMotion, unused
-	irskd_BroadcastReplaySetPlayPosition, // irsdk_RpyPosMode, Frame Number (high, low)
+	irsdk_BroadcastReplaySetPlayPosition, // irsdk_RpyPosMode, Frame Number (high, low)
 	irsdk_BroadcastReplaySearch,          // irsdk_RpySrchMode, unused, unused
 	irsdk_BroadcastReplaySetState,        // irsdk_RpyStateMode, unused, unused
 	irsdk_BroadcastReloadTextures,        // irsdk_ReloadTexturesMode, carIdx, unused
@@ -441,6 +493,7 @@ enum irsdk_PitCommandMode				// this only works when the driver is in the car
 	irsdk_PitCommand_ClearWS,			// Uncheck Clean the winshield checkbox
 	irsdk_PitCommand_ClearFR,			// Uncheck request a fast repair
 	irsdk_PitCommand_ClearFuel,			// Uncheck add fuel
+	irsdk_PitCommand_TC,				// Change tire compound
 };
 
 enum irsdk_TelemCommandMode				// You can call this any time, but telemtry only records when driver is in there car

--- a/src/app/irsdk/native/lib/irsdk_utils.cpp
+++ b/src/app/irsdk/native/lib/irsdk_utils.cpp
@@ -44,6 +44,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <crtdbg.h>
 #endif
 
+// memory read barrier, keeps compiler from reordering our memory reads
+#include <intrin.h>
+#pragma intrinsic(_ReadBarrier)
+
 #include "irsdk_defines.h"
 
 // for timeBeginPeriod()
@@ -142,10 +146,10 @@ bool irsdk_getNewData(char *data)
 			return false;
 		}
 
-		int latest = 0;
-		for(int i=1; i<pHeader->numBuf; i++)
-			if(pHeader->varBuf[latest].tickCount < pHeader->varBuf[i].tickCount)
-			   latest = i;	
+		// use curBuf to find the most recently written buffer
+		int latest = pHeader->curBuf;
+		if(latest < 0 || latest >= pHeader->numBuf)
+			latest = 0;
 
 		// if newer than last recieved, than report new data
 		if(lastTickCount < pHeader->varBuf[latest].tickCount)
@@ -156,9 +160,18 @@ bool irsdk_getNewData(char *data)
 				// try twice to get the data out
 				for(int count = 0; count < 2; count++)
 				{
-					int curTickCount =  pHeader->varBuf[latest].tickCount;
+					// Read tickCount (updated AFTER write completes)
+					int curTickCount = pHeader->varBuf[latest].tickCount;
+
+					_ReadBarrier();
+
 					memcpy(data, pSharedMem + pHeader->varBuf[latest].bufOffset, pHeader->bufLen);
-					if(curTickCount ==  pHeader->varBuf[latest].tickCount)
+
+					_ReadBarrier();
+
+					// Read tickCountBegin (updated BEFORE write starts)
+					// If they match, no write was in progress during our read
+					if(curTickCount == pHeader->varBuf[latest].tickCountBegin)
 					{
 						lastTickCount = curTickCount;
 						lastValidTime = time(NULL);
@@ -338,7 +351,7 @@ unsigned int irsdk_getBroadcastMsgID()
 
 void irsdk_broadcastMsg(irsdk_BroadcastMsg msg, int var1, int var2, int var3)
 {
-	irsdk_broadcastMsg(msg, var1, static_cast<int>MAKELONG(var2, var3));
+	irsdk_broadcastMsg(msg, var1, (int)MAKELONG(var2, var3));
 }
 
 void irsdk_broadcastMsg(irsdk_BroadcastMsg msg, int var1, float var2)

--- a/src/app/irsdk/types/enums.ts
+++ b/src/app/irsdk/types/enums.ts
@@ -33,6 +33,8 @@ export enum GlobalFlags {
   Servicible = 0x00040000,
   Furled = 0x00080000,
   Repair = 0x00100000,
+  /** Car is disqualified and scoring is disabled */
+  DqScoringInvalid = 0x00200000,
 
   // Start lights
   StartHidden = 0x10000000,
@@ -42,13 +44,32 @@ export enum GlobalFlags {
 }
 
 export enum EngineWarnings {
-  WaterTempWarning = 0x01,
-  FuelPressureWarning = 0x02,
-  OilPressureWarning = 0x04,
-  EngineStalled = 0x08,
-  PitSpeedLimiter = 0x10,
-  RevLimiterActive = 0x20,
-  OilTempWarning = 0x40,
+  WaterTempWarning = 0x0001,
+  FuelPressureWarning = 0x0002,
+  OilPressureWarning = 0x0004,
+  EngineStalled = 0x0008,
+  PitSpeedLimiter = 0x0010,
+  RevLimiterActive = 0x0020,
+  OilTempWarning = 0x0040,
+  /** Car needs mandatory repairs */
+  MandRepNeeded = 0x0080,
+  /** Car needs optional repairs */
+  OptRepNeeded = 0x0100,
+}
+
+/**
+ * Track wetness / rain state.
+ * Reported by the `TrackWetness` telemetry variable.
+ */
+export enum TrackWetness {
+  Unknown = 0,
+  Dry,
+  MostlyDry,
+  VeryLightlyWet,
+  LightlyWet,
+  ModeratelyWet,
+  VeryWet,
+  ExtremelyWet,
 }
 
 export enum PitSvFlags {
@@ -86,9 +107,48 @@ export enum PaceMode {
 }
 
 export enum PaceFlags {
-  EndOfLine = 0x01,
-  FreePass = 0x02,
-  WavedAround = 0x04,
+  EndOfLine = 0x0001,
+  FreePass = 0x0002,
+  WavedAround = 0x0004,
+}
+
+/**
+ * Incident report/penalty bitfield.
+ * The low byte is the incident report; the high byte is the penalty.
+ * Mask with `IncidentReportMask` / `IncidentPenaltyMask` to separate them.
+ */
+export enum IncidentFlags {
+  // Incident report (low byte) — only one will be set
+  /** No penalty */
+  RepNoReport = 0x0000,
+  /** "Loss of Control (2x)" */
+  RepOutOfControl = 0x0001,
+  /** "Off Track (1x)" */
+  RepOffTrack = 0x0002,
+  /** Not currently sent */
+  RepOffTrackOngoing = 0x0003,
+  /** "Contact (0x)" */
+  RepContactWithWorld = 0x0004,
+  /** "Contact (2x)" */
+  RepCollisionWithWorld = 0x0005,
+  /** Not currently sent */
+  RepCollisionWithWorldOngoing = 0x0006,
+  /** "Car Contact (0x)" */
+  RepContactWithCar = 0x0007,
+  /** "Car Contact (4x)" */
+  RepCollisionWithCar = 0x0008,
+
+  // Incident penalty (high byte) — only one will be set
+  // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values -- distinct penalty-byte value that coincides with RepNoReport
+  PenNoReport = 0x0000,
+  PenZeroX = 0x0100,
+  PenOneX = 0x0200,
+  PenTwoX = 0x0300,
+  PenFourX = 0x0400,
+
+  // Masks to separate the report field from the penalty field
+  IncidentReportMask = 0x000000ff,
+  IncidentPenaltyMask = 0x0000ff00,
 }
 
 export enum CarLeftRight {
@@ -155,7 +215,7 @@ export enum BroadcastMessages {
   /** Trigger video capture. */
   VideoCapture,
   /** Unused. */
-  Last
+  Last,
 }
 
 export enum CameraState {
@@ -216,6 +276,8 @@ export enum PitCommand {
   ClearFR,
   /** Uncheck add fuel */
   ClearFuel,
+  /** Change tire compound */
+  TC,
 }
 
 export enum TelemetryCommand {

--- a/src/frontend/components/Standings/hooks/useTrackWetness.tsx
+++ b/src/frontend/components/Standings/hooks/useTrackWetness.tsx
@@ -1,15 +1,16 @@
 import { useMemo } from 'react';
 import { useTelemetry } from '@irdashies/context';
+import { TrackWetness } from '@irdashies/types';
 
 const wetnessLevels: Record<number, string> = {
-  0: '',
-  1: 'Dry',
-  2: 'Mostly Dry',
-  3: 'Very Lightly Wet',
-  4: 'Lightly Wet',
-  5: 'Moderately Wet',
-  6: 'Very Wet',
-  7: 'Extremely Wet',
+  [TrackWetness.Unknown]: '',
+  [TrackWetness.Dry]: 'Dry',
+  [TrackWetness.MostlyDry]: 'Mostly Dry',
+  [TrackWetness.VeryLightlyWet]: 'Very Lightly Wet',
+  [TrackWetness.LightlyWet]: 'Lightly Wet',
+  [TrackWetness.ModeratelyWet]: 'Moderately Wet',
+  [TrackWetness.VeryWet]: 'Very Wet',
+  [TrackWetness.ExtremelyWet]: 'Extremely Wet',
 };
 
 export const useTrackWetness = () => {

--- a/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
+++ b/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
@@ -25,8 +25,12 @@ export interface WeatherTrackWetnessProps {
 
 export const WeatherTrackWetness = memo(
   ({ trackMoisture, variant = 'default' }: WeatherTrackWetnessProps) => {
-    // Calculate wetness percentage (0-100%)
-    const normalizedMoisture = trackMoisture || MIN_WETNESS;
+    // Calculate wetness percentage (0-100%), clamped so out-of-range
+    // moisture values can't produce negative or >100% widths.
+    const normalizedMoisture = Math.min(
+      MAX_WETNESS,
+      Math.max(MIN_WETNESS, trackMoisture ?? MIN_WETNESS)
+    );
     const wetnessScale = MAX_WETNESS - MIN_WETNESS;
     const trackWetnessPct =
       ((normalizedMoisture - MIN_WETNESS) / wetnessScale) * 100;

--- a/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
+++ b/src/frontend/components/Weather/WeatherTrackWetness/WeatherTrackWetness.tsx
@@ -1,20 +1,21 @@
 import { DropIcon, SunIcon, WavesIcon } from '@phosphor-icons/react';
 import { memo } from 'react';
+import { TrackWetness } from '@irdashies/types';
 
 // Track wetness constants
-const MIN_WETNESS = 1;
-const MAX_WETNESS = 7; // Extremely Wet
-const DEFAULT_WETNESS = 0;
+const MIN_WETNESS = TrackWetness.Dry;
+const MAX_WETNESS = TrackWetness.ExtremelyWet;
+const DEFAULT_WETNESS = TrackWetness.Unknown;
 const FALLBACK_TRACK_STATE = 'N/A';
 const WETNESS_LEVELS: Record<number, string> = {
-  0: '',
-  1: 'Dry',
-  2: 'Mostly Dry',
-  3: 'Very Lightly Wet',
-  4: 'Lightly Wet',
-  5: 'Moderately Wet',
-  6: 'Very Wet',
-  7: 'Extremely Wet',
+  [TrackWetness.Unknown]: '',
+  [TrackWetness.Dry]: 'Dry',
+  [TrackWetness.MostlyDry]: 'Mostly Dry',
+  [TrackWetness.VeryLightlyWet]: 'Very Lightly Wet',
+  [TrackWetness.LightlyWet]: 'Lightly Wet',
+  [TrackWetness.ModeratelyWet]: 'Moderately Wet',
+  [TrackWetness.VeryWet]: 'Very Wet',
+  [TrackWetness.ExtremelyWet]: 'Extremely Wet',
 };
 
 export interface WeatherTrackWetnessProps {

--- a/src/types/enum.ts
+++ b/src/types/enum.ts
@@ -4,6 +4,8 @@ import {
   EngineWarnings as SDKEngineWarnings,
   TrackLocation as SDKTrackLocation,
   CarLeftRight as SDKCarLeftRight,
+  TrackWetness as SDKTrackWetness,
+  IncidentFlags as SDKIncidentFlags,
 } from '../app/irsdk/types/enums';
 
 export { SDKGlobalFlags as GlobalFlags };
@@ -11,3 +13,5 @@ export { SDKSessionState as SessionState };
 export { SDKEngineWarnings as EngineWarnings };
 export { SDKTrackLocation as TrackLocation };
 export { SDKCarLeftRight as CarLeftRight };
+export { SDKTrackWetness as TrackWetness };
+export { SDKIncidentFlags as IncidentFlags };


### PR DESCRIPTION
## Description

Updates the vendored iRacing SDK (`src/app/irsdk/native/lib/`) from its previous (pre-1.20) version to **SDK 1.20**, and mirrors the new enums into TypeScript. Both report `IRSDK_VER = 2`, so the wire protocol is unchanged — this brings in the reliability fix and new definitions.

**Native (C++)**
- **Torn-read fix** in `irsdk_utils.cpp` — `getNewData` now reads `pHeader->curBuf` directly and validates the copy against `tickCountBegin` with `_ReadBarrier()` bracketing, instead of scanning for the max `tickCount` and rechecking once. This eliminates half-updated reads of the 60 Hz telemetry buffer.
- **`irsdk_defines.h`** brought up to 1.20: reinterprets previously-reserved header padding (`tickCountBegin`, `curBuf`, `curBufTickCount` — same struct size, binary-compatible) and adds `TrackWetness` (8-level), `IncidentFlags`, `EngineWarnings.{mandRepNeeded,optRepNeeded}`, `GlobalFlags.dqScoringInvalid`, `PitCommand TC`.
- **UTF-8 encoding guard** in `irsdk_node.cc` — when the sim reports `Encoding: UTF8` (1.20+), `GetSessionData` now passes the session string through untouched instead of running the Windows-1252 → UTF-8 converter over it. Previously the converter ran unconditionally, which would double-encode real UTF-8 (e.g. `ü` → `Ã¼`) once the sim switches encodings. Reimplemented inline rather than vendoring the uncompiled `irsdk_client` wrapper's `isSessionStrUTF8()`.

**TypeScript**
- Added the new enums (`TrackWetness`, `IncidentFlags`, `EngineWarnings` mand/opt repair, `GlobalFlags.DqScoringInvalid`, `PitCommand.TC`) and re-exported `TrackWetness`/`IncidentFlags` from `@irdashies/types`.
- Replaced the two duplicated magic-number wetness maps (`useTrackWetness`, `WeatherTrackWetness`) with the new `TrackWetness` enum so labels stay tied to the SDK definition.

### Testing
- `npm test` — all 910 tests pass.
- `tsc --noEmit` and `npm run lint` clean.
- ⚠️ **The native addon was NOT compiled in this PR** — it was developed on macOS, and the C++ uses MSVC-only intrinsics (`<intrin.h>`, `_ReadBarrier`, `_strnicmp`) that only build during Windows packaging. The code matches what iRacing ships, but **the Windows compile + an in-sim smoke test still need a pass before merge.**

## Screenshots

### Before
No user-visible change. Track-wetness labels render identically; the refactor is internal (enum vs. magic numbers).

### After
Same UI. Robustness/correctness only (telemetry torn reads + session-string encoding).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enum-based Track Wetness labels, including an explicit **Unknown** state for weather display
  * Added **Incident Flags** with report/penalty mask constants
  * Extended pit command support with tire compound (**TC**) and enhanced replay set-play-position broadcast handling
  * Expanded engine warnings and global flags for additional repair/scoring indicators
* **Bug Fixes**
  * Prevent double UTF-8 re-encoding of session text when already marked as UTF-8
  * Improved shared-memory reads to reduce torn-read risk and select the latest buffer more reliably
* **Chores**
  * Pinned dependency resolution and stabilized Windows CI runner selection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->