### PR TITLE
fix: debounce radio transmit icon for rapid flip-flapping

### DIFF
--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -221,7 +221,6 @@ export const Relative = () => {
           onPitRoad={result.onPitRoad}
           onTrack={result.onTrack}
           radioActive={result.radioActive}
-          radioTransmitting={result.radioTransmitting}
           isLapped={result.lappedState === 'behind'}
           isLappingAhead={result.lappedState === 'ahead'}
           flairId={

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -211,7 +211,6 @@ export const Standings = () => {
                         onPitRoad={result.onPitRoad}
                         onTrack={result.onTrack}
                         radioActive={result.radioActive}
-                        radioTransmitting={result.radioTransmitting}
                         isMultiClass={isMultiClass}
                         flairId={
                           (settings?.countryFlags?.enabled ?? true)

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.stories.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState, type ComponentProps } from 'react';
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { DriverInfoRow } from './DriverInfoRow';
 import { useCurrentSessionType } from '@irdashies/context';
@@ -116,78 +115,10 @@ export const RadioActiveWithStatus: Story = {
   },
 };
 
-// Live transmission: the icon pulses at full strength.
-export const RadioTransmitting: Story = {
-  name: 'Radio - Transmitting (live)',
-  args: {
-    ...Primary.args,
-    radioActive: true,
-    radioTransmitting: true,
-  },
-};
-
-// Lingering state: the driver has stopped talking but the icon is held visible
-// by the persistence window — static and dimmed to distinguish it from live.
-export const RadioLingering: Story = {
-  name: 'Radio - Lingering (recently spoke)',
-  args: {
-    ...Primary.args,
-    radioActive: true,
-    radioTransmitting: false,
-  },
-};
-
-// Interactive demo of the full lifecycle the radio persistence produces:
-// idle -> transmitting (pulsing) -> lingering (static + dimmed) -> idle.
-const radioLifecyclePhases = [
-  { label: 'Idle', radioActive: false, radioTransmitting: false, ms: 1500 },
-  {
-    label: 'Transmitting (pulsing)',
-    radioActive: true,
-    radioTransmitting: true,
-    ms: 2500,
-  },
-  {
-    label: 'Lingering (static + dimmed)',
-    radioActive: true,
-    radioTransmitting: false,
-    ms: 3000,
-  },
-];
-
-const RadioPersistenceDemoComponent = () => {
-  const [phase, setPhase] = useState(0);
-
-  useEffect(() => {
-    const timer = setTimeout(
-      () => setPhase((p) => (p + 1) % radioLifecyclePhases.length),
-      radioLifecyclePhases[phase].ms
-    );
-    return () => clearTimeout(timer);
-  }, [phase]);
-
-  const current = radioLifecyclePhases[phase];
-
-  return (
-    <>
-      <DriverInfoRow
-        {...(Primary.args as ComponentProps<typeof DriverInfoRow>)}
-        radioActive={current.radioActive}
-        radioTransmitting={current.radioTransmitting}
-      />
-      <tr>
-        <td className="pt-3 text-xs text-slate-300" colSpan={99}>
-          State: <span className="text-amber-300">{current.label}</span>
-        </td>
-      </tr>
-    </>
-  );
-};
-
-export const RadioPersistenceLifecycle: Story = {
-  name: 'Radio - Persistence lifecycle',
-  render: () => <RadioPersistenceDemoComponent />,
-};
+// NOTE: DriverInfoRow only renders a single on/off icon. The debounce that
+// decides *when* radioActive flips off lives in useRadioActiveCarIdxs and is
+// demonstrated against the real telemetry store in its own stories file
+// (useRadioActiveCarIdxs.stories.tsx).
 
 export const IsPlayer: Story = {
   args: {

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -49,7 +49,6 @@ interface DriverRowInfoProps {
   onPitRoad?: boolean;
   onTrack?: boolean;
   radioActive?: boolean;
-  radioTransmitting?: boolean;
   isLapped?: boolean;
   isLappingAhead?: boolean;
   hidden?: boolean;
@@ -199,7 +198,6 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
     onPitRoad,
     onTrack,
     radioActive,
-    radioTransmitting,
     isLapped,
     isLappingAhead,
     hidden,
@@ -354,7 +352,6 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
           <DriverNameCell
             key="driverName"
             radioActive={radioActive}
-            radioTransmitting={radioTransmitting}
             repair={repair}
             penalty={penalty}
             slowdown={slowdown}
@@ -636,7 +633,6 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
     name,
     teamName,
     radioActive,
-    radioTransmitting,
     onPitRoad,
     carTrackSurface,
     prevCarTrackSurface,

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverNameCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/DriverNameCell.tsx
@@ -79,7 +79,6 @@ interface DriverNameCellProps {
   fullName?: string;
   nameFormat?: DriverNameFormat;
   radioActive?: boolean;
-  radioTransmitting?: boolean;
   repair?: boolean;
   penalty?: boolean;
   slowdown?: boolean;
@@ -98,7 +97,6 @@ export const DriverNameCell = memo(
     fullName,
     nameFormat,
     radioActive,
-    radioTransmitting,
     repair,
     penalty,
     slowdown,
@@ -116,10 +114,6 @@ export const DriverNameCell = memo(
           nameFormat ?? 'name-middlename-surname'
         )
       : (name ?? '');
-
-    // Fall back to radioActive when transmitting state isn't supplied, so
-    // callers that only know "icon on/off" keep the original pulsing icon.
-    const isRadioTransmitting = radioTransmitting ?? radioActive;
 
     const shouldAnimate = !!label && (!nameDisplay || nameDisplay === 'both');
     const staticText = nameDisplay === 'label' && label ? label : displayName;
@@ -166,12 +160,7 @@ export const DriverNameCell = memo(
           <span
             className={[
               'transition-[width,opacity] duration-300',
-              radioActive ? 'w-4 mr-1' : 'w-0 overflow-hidden',
-              // While actively transmitting the icon pulses at full strength.
-              // Once they stop (but the icon lingers) it goes static and dims,
-              // so a recent transmission reads differently from a live one.
-              isRadioTransmitting ? 'animate-pulse' : '',
-              radioActive && !isRadioTransmitting ? 'opacity-60' : '',
+              radioActive ? 'w-4 mr-1 animate-pulse' : 'w-0 overflow-hidden',
             ].join(' ')}
           >
             <SpeakerHighIcon className="mt-px" size={16} />

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -52,7 +52,6 @@ export interface Standings {
     estLapTime: number;
   };
   radioActive?: boolean;
-  radioTransmitting?: boolean;
   iratingChange?: number;
   carId?: number;
   lapTimeDeltas?: number[]; // Array of deltas vs player's recent laps, most recent last
@@ -123,7 +122,6 @@ export const createDriverStandings = (
     carIdxOnPitRoadValue?: boolean[];
     carIdxTrackSurfaceValue?: TrackLocation[];
     radioTransmitCarIdx?: number[];
-    radioTransmittingCarIdx?: number[];
     carIdxTireCompoundValue?: number[];
     isOnTrack?: boolean;
     carIdxSessionFlags?: number[];
@@ -195,9 +193,6 @@ export const createDriverStandings = (
           estLapTime: driver.CarClassEstLapTime,
         },
         radioActive: telemetry.radioTransmitCarIdx?.includes(driver.CarIdx),
-        radioTransmitting: telemetry.radioTransmittingCarIdx?.includes(
-          driver.CarIdx
-        ),
         carId: driver.CarID,
         lapTimeDeltas: undefined,
         lastPitLap: lastPitLap[driver.CarIdx] ?? undefined,
@@ -308,9 +303,6 @@ export const createDriverStandings = (
           estLapTime: driver.CarClassEstLapTime,
         },
         radioActive: telemetry.radioTransmitCarIdx?.includes(result.CarIdx),
-        radioTransmitting: telemetry.radioTransmittingCarIdx?.includes(
-          result.CarIdx
-        ),
         carId: driver.CarID,
         lapTimeDeltas:
           result.CarIdx === session.playerIdx
@@ -408,9 +400,6 @@ export const createDriverStandings = (
           estLapTime: driver.CarClassEstLapTime,
         },
         radioActive: telemetry.radioTransmitCarIdx?.includes(driver.CarIdx),
-        radioTransmitting: telemetry.radioTransmittingCarIdx?.includes(
-          driver.CarIdx
-        ),
         carId: driver.CarID,
         lapTimeDeltas: undefined,
         lastPitLap: lastPitLap[driver.CarIdx] ?? undefined,
@@ -454,29 +443,27 @@ export const groupStandingsByClass = (
 
   const getTop2Stats = (drivers: Standings[]) => {
     const validDrivers = drivers
-        .filter(
-            (d) =>
-                d.position !== undefined &&
-                d.fastestTime !== undefined &&
-                d.fastestTime > 0
-        )
-        .sort((a, b) => (a.position ?? 999) - (b.position ?? 999))
-        .slice(0, 2);
+      .filter(
+        (d) =>
+          d.position !== undefined &&
+          d.fastestTime !== undefined &&
+          d.fastestTime > 0
+      )
+      .sort((a, b) => (a.position ?? 999) - (b.position ?? 999))
+      .slice(0, 2);
 
     if (validDrivers.length === 0) {
-        return undefined;
+      return undefined;
     }
 
     const positions = validDrivers.map((d) => d.position ?? 999);
 
     return {
-        average:
-            positions.reduce((sum, pos) => sum + pos, 0) /
-            positions.length,
-        bestPosition: positions[0], // lower is better
+      average: positions.reduce((sum, pos) => sum + pos, 0) / positions.length,
+      bestPosition: positions[0], // lower is better
     };
   };
-  
+
   const sorted: [string, Standings[]][] = [];
   for (const [classId, drivers] of groupedByClassId) {
     sorted.push([String(classId), drivers]);
@@ -485,43 +472,39 @@ export const groupStandingsByClass = (
   const statsByClass = new Map(
     sorted.map(([id, drivers]) => [id, getTop2Stats(drivers)])
   );
-  
+
   sorted.sort(([idA, classA], [idB, classB]) => {
     const statsA = statsByClass.get(idA);
     const statsB = statsByClass.get(idB);
 
-          // Primary sort: average top-2 position
-          if (statsA && statsB) {
-              // Prioritize the overall leader
-              if (statsA.bestPosition === 1 && statsB.bestPosition !== 1) {
-                  return -1;
-              }
-              if (statsB.bestPosition === 1 && statsA.bestPosition !== 1) {
-                  return 1;
-              }
-
-              // Better Class Average Position Overall
-              if (statsA.average !== statsB.average) {
-                  return statsA.average - statsB.average;
-              }
-
-              // Tie-breaker: better leading position wins
-              if (statsA.bestPosition !== statsB.bestPosition) {
-                  return statsA.bestPosition - statsB.bestPosition;
-              }
-          }
-
-          // Prefer classes with valid timing data
-          if (statsA) return -1;
-          if (statsB) return 1;
-
-          // Final fallback: relative speed
-          return (
-              classB[0].carClass.relativeSpeed -
-              classA[0].carClass.relativeSpeed
-          );
+    // Primary sort: average top-2 position
+    if (statsA && statsB) {
+      // Prioritize the overall leader
+      if (statsA.bestPosition === 1 && statsB.bestPosition !== 1) {
+        return -1;
       }
-  );
+      if (statsB.bestPosition === 1 && statsA.bestPosition !== 1) {
+        return 1;
+      }
+
+      // Better Class Average Position Overall
+      if (statsA.average !== statsB.average) {
+        return statsA.average - statsB.average;
+      }
+
+      // Tie-breaker: better leading position wins
+      if (statsA.bestPosition !== statsB.bestPosition) {
+        return statsA.bestPosition - statsB.bestPosition;
+      }
+    }
+
+    // Prefer classes with valid timing data
+    if (statsA) return -1;
+    if (statsB) return 1;
+
+    // Final fallback: relative speed
+    return classB[0].carClass.relativeSpeed - classA[0].carClass.relativeSpeed;
+  });
   return sorted;
 };
 

--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -157,10 +157,9 @@ export const useDriverStandings = () => {
     enabled: useLivePositionStandings,
   });
   const drivers = useDrivers();
-  const { active: radioActiveCarIdxs, transmitting: radioTransmittingCarIdxs } =
-    useRadioActiveCarIdxs(
-      (relativeSettings?.radio?.persistenceSeconds ?? 3) * 1000
-    );
+  const radioActiveCarIdxs = useRadioActiveCarIdxs(
+    (relativeSettings?.radio?.persistenceSeconds ?? 3) * 1000
+  );
   const carStates = useCarState();
   // Use focus car index which handles spectator mode (uses CamCarIdx when spectating)
   const playerCarIdx = useFocusCarIdx();
@@ -278,7 +277,6 @@ export const useDriverStandings = () => {
         tireCompound: carState?.tireCompound ?? 0,
         carClass: driver.carClass,
         radioActive: radioActiveCarIdxs.includes(driverPos.carIdx),
-        radioTransmitting: radioTransmittingCarIdxs.includes(driverPos.carIdx),
         carId: driver.carId,
         lastPitLap: driverPos.lastPitLap,
         lastLap: driverPos.lastLap,
@@ -315,7 +313,6 @@ export const useDriverStandings = () => {
     sessionType,
     useLivePositionStandings,
     radioActiveCarIdxs,
-    radioTransmittingCarIdxs,
     driverLivePositions,
     fastestLapCarIdx,
     isOfficial,

--- a/src/frontend/components/Standings/hooks/useDriverStandings.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverStandings.tsx
@@ -95,8 +95,9 @@ export const useDriverStandings = (
   const carIdxLapDistPct = useTelemetryValuesRounded('CarIdxLapDistPct', 3);
   const carIdxTrackSurface =
     useTelemetryValues<TrackLocation[]>('CarIdxTrackSurface');
-  const { active: radioTransmitCarIdx, transmitting: radioTransmittingCarIdx } =
-    useRadioActiveCarIdxs((settings?.radio?.persistenceSeconds ?? 3) * 1000);
+  const radioTransmitCarIdx = useRadioActiveCarIdxs(
+    (settings?.radio?.persistenceSeconds ?? 3) * 1000
+  );
   const carIdxTireCompound = useTelemetryValues<number[]>('CarIdxTireCompound');
   const carIdxSessionFlags = useTelemetryValues<number[]>('CarIdxSessionFlags');
   const isOfficial = useSessionIsOfficial();
@@ -128,7 +129,6 @@ export const useDriverStandings = (
         carIdxOnPitRoadValue: carIdxOnPitRoad,
         carIdxTrackSurfaceValue: carIdxTrackSurface,
         radioTransmitCarIdx: radioTransmitCarIdx,
-        radioTransmittingCarIdx: radioTransmittingCarIdx,
         carIdxTireCompoundValue: carIdxTireCompound,
         carIdxSessionFlags: carIdxSessionFlags,
       },
@@ -208,7 +208,6 @@ export const useDriverStandings = (
     carIdxOnPitRoad,
     carIdxTrackSurface,
     radioTransmitCarIdx,
-    radioTransmittingCarIdx,
     carIdxTireCompound,
     carIdxSessionFlags,
     positions,

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.spec.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.spec.tsx
@@ -18,18 +18,16 @@ describe('useRadioActiveCarIdxs', () => {
   it('passes the live value straight through when persistence is disabled', () => {
     vi.mocked(useTelemetryValues).mockReturnValue([5] as number[]);
     const { result } = renderHook(() => useRadioActiveCarIdxs(0));
-    expect(result.current.active).toEqual([5]);
-    expect(result.current.transmitting).toEqual([5]);
+    expect(result.current).toEqual([5]);
   });
 
-  it('filters out the -1 idle sentinel from transmitting', () => {
+  it('filters out the -1 idle sentinel', () => {
     vi.mocked(useTelemetryValues).mockReturnValue([-1] as number[]);
     const { result } = renderHook(() => useRadioActiveCarIdxs(0));
-    expect(result.current.transmitting).toEqual([]);
+    expect(result.current).toEqual([]);
   });
 
   it('keeps a car active for the persistence window after it stops transmitting', () => {
-    vi.mocked(useTelemetryValues).mockReturnValue([5] as number[]);
     const { result, rerender } = renderHook(
       ({ value }) => {
         vi.mocked(useTelemetryValues).mockReturnValue(value as number[]);
@@ -42,22 +40,20 @@ describe('useRadioActiveCarIdxs', () => {
     act(() => {
       vi.advanceTimersByTime(0);
     });
-    expect(result.current.active).toEqual([5]);
-    expect(result.current.transmitting).toEqual([5]);
+    expect(result.current).toEqual([5]);
 
-    // Driver stops transmitting; icon should linger but no longer "transmit".
+    // Driver stops transmitting; icon should linger through the window.
     rerender({ value: [-1] });
     act(() => {
       vi.advanceTimersByTime(1000);
     });
-    expect(result.current.active).toEqual([5]);
-    expect(result.current.transmitting).toEqual([]);
+    expect(result.current).toEqual([5]);
 
     // After the full window elapses, the car clears even with no new telemetry.
     act(() => {
       vi.advanceTimersByTime(2100);
     });
-    expect(result.current.active).toEqual([]);
+    expect(result.current).toEqual([]);
   });
 
   it('refreshes the window each time a car is seen transmitting again', () => {
@@ -78,11 +74,48 @@ describe('useRadioActiveCarIdxs', () => {
     act(() => {
       vi.advanceTimersByTime(2000);
     });
-    expect(result.current.active).toEqual([5]);
+    expect(result.current).toEqual([5]);
 
     act(() => {
       vi.advanceTimersByTime(1200);
     });
-    expect(result.current.active).toEqual([]);
+    expect(result.current).toEqual([]);
+  });
+
+  it('stays solidly lit while a car flip-flaps the radio rapidly', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => {
+        vi.mocked(useTelemetryValues).mockReturnValue(value as number[]);
+        return useRadioActiveCarIdxs(3000);
+      },
+      { initialProps: { value: [5] } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    // Toggle on/off every 500ms for several cycles. The icon must never clear:
+    // each "on" frame keeps pushing the 3s deadline out.
+    for (let i = 0; i < 6; i++) {
+      rerender({ value: [-1] });
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(result.current).toEqual([5]);
+
+      rerender({ value: [5] });
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(result.current).toEqual([5]);
+    }
+
+    // Once they truly stop, it clears after the full window.
+    rerender({ value: [-1] });
+    act(() => {
+      vi.advanceTimersByTime(3100);
+    });
+    expect(result.current).toEqual([]);
   });
 });

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.stories.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.stories.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SpeakerHighIcon } from '@phosphor-icons/react';
+import { useTelemetryStore } from '@irdashies/context';
+import type { Telemetry } from '@irdashies/types';
+import { useRadioActiveCarIdxs } from './useRadioActiveCarIdxs';
+
+const DEMO_CAR_IDX = 7;
+
+// Push only the key the hook reads straight into the telemetry store.
+//
+// These stories intentionally do NOT use TelemetryDecorator: the mock bridge
+// streams a full telemetry frame at 60Hz and would clobber anything we inject
+// within ~16ms. Driving the store directly lets us flip-flap
+// RadioTransmitCarIdx deterministically and watch the *real* hook debounce it.
+const setRadioTransmit = (carIdxs: number[]) =>
+  useTelemetryStore.getState().setTelemetry({
+    RadioTransmitCarIdx: { value: carIdxs },
+  } as Telemetry);
+
+type DemoMode = 'flip-flap' | 'single-burst';
+
+const RadioDebounceHarness = ({
+  mode,
+  persistenceSeconds,
+}: {
+  mode: DemoMode;
+  persistenceSeconds: number;
+}) => {
+  const [rawTransmitting, setRawTransmitting] = useState(false);
+
+  useEffect(() => {
+    setRadioTransmit([-1]);
+
+    const timers: ReturnType<typeof setTimeout>[] = [];
+    const transmit = (on: boolean) => {
+      setRawTransmitting(on);
+      setRadioTransmit(on ? [DEMO_CAR_IDX] : [-1]);
+    };
+
+    if (mode === 'flip-flap') {
+      // Rapidly key the radio on/off — the bug that used to make the icon
+      // strobe. Each "on" frame re-arms the debounce, so it stays solidly lit.
+      let on = false;
+      const id = setInterval(() => {
+        on = !on;
+        transmit(on);
+      }, 500);
+      return () => {
+        clearInterval(id);
+        useTelemetryStore.getState().resetTelemetry();
+      };
+    }
+
+    // single-burst: transmit once, go silent, watch the icon linger then clear.
+    timers.push(setTimeout(() => transmit(true), 800));
+    timers.push(setTimeout(() => transmit(false), 1600));
+    return () => {
+      timers.forEach(clearTimeout);
+      useTelemetryStore.getState().resetTelemetry();
+    };
+  }, [mode]);
+
+  const active = useRadioActiveCarIdxs(persistenceSeconds * 1000);
+  const iconLit = active.includes(DEMO_CAR_IDX);
+
+  return (
+    <div className="flex w-96 flex-col gap-3 p-4 font-sans text-white">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-300">Raw RadioTransmitCarIdx</span>
+        <span
+          className={`font-mono text-sm ${
+            rawTransmitting ? 'text-amber-300' : 'text-slate-500'
+          }`}
+        >
+          {rawTransmitting ? `[${DEMO_CAR_IDX}]` : '[-1]'}
+        </span>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-slate-300">Debounced icon</span>
+        <span className="flex items-center gap-1.5">
+          <SpeakerHighIcon
+            size={16}
+            className={
+              iconLit ? 'animate-pulse text-amber-300' : 'text-slate-700'
+            }
+          />
+          <span
+            className={`text-sm ${iconLit ? 'text-amber-300' : 'text-slate-500'}`}
+          >
+            {iconLit ? 'lit' : 'off'}
+          </span>
+        </span>
+      </div>
+
+      <p className="text-xs text-slate-400">
+        {mode === 'flip-flap'
+          ? `Raw signal flips every 500ms, but the icon stays lit — each transmit frame re-arms the ${persistenceSeconds}s window.`
+          : `A single burst lights the icon, then it lingers for ${persistenceSeconds}s after the last transmit frame before clearing.`}
+      </p>
+    </div>
+  );
+};
+
+const meta: Meta<typeof RadioDebounceHarness> = {
+  title: 'widgets/Standings/hooks/useRadioActiveCarIdxs',
+  component: RadioDebounceHarness,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RadioDebounceHarness>;
+
+// The core regression: rapid on/off keying must not strobe the icon.
+export const FlipFlap: Story = {
+  name: 'Debounce - flip-flap',
+  args: { mode: 'flip-flap', persistenceSeconds: 3 },
+};
+
+// The other half of the window: lingers after a single burst, then clears.
+export const LingerThenClear: Story = {
+  name: 'Debounce - linger then clear',
+  args: { mode: 'single-burst', persistenceSeconds: 3 },
+};

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.tsx
@@ -1,98 +1,98 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef } from 'react';
 import { useTelemetryValues } from '@irdashies/context';
-
-export interface RadioActiveCarIdxs {
-  /** Cars whose speaker icon should be shown (currently transmitting OR within
-   * the persistence window after they stopped). */
-  active: number[];
-  /** Cars transmitting on the radio right now this telemetry frame. */
-  transmitting: number[];
-}
 
 /**
  * Tracks which car indices should show the radio/speaker icon.
  *
  * iRacing only reports a car as transmitting for the exact frames it holds the
- * push-to-talk, so the icon can flash and vanish before a driver looks up from
- * a corner. When `persistenceMs > 0`, a car stays in `active` for that long
- * after it stops transmitting, keeping the icon visible long enough to notice.
- * When `persistenceMs <= 0`, `active` equals the live `transmitting` set.
+ * push-to-talk, so the raw signal flickers — badly when a driver keys the radio
+ * on and off rapidly. To keep the icon stable we debounce: each car heard
+ * transmitting is kept active until `persistenceMs` has elapsed since its
+ * *last* transmit frame. Rapid on/off toggling just keeps pushing that deadline
+ * out, so the icon stays lit instead of strobing.
  *
- * `transmitting` always reflects the live telemetry, so callers can render the
- * lingering state (active but no longer transmitting) differently.
+ * When `persistenceMs <= 0` the live transmitting set is returned unchanged.
  */
-export const useRadioActiveCarIdxs = (
-  persistenceMs: number
-): RadioActiveCarIdxs => {
+export const useRadioActiveCarIdxs = (persistenceMs: number): number[] => {
   const radioTransmitCarIdx = useTelemetryValues<number[]>(
     'RadioTransmitCarIdx'
   );
-  const lastSeenRef = useRef<Map<number, number>>(new Map());
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined
-  );
-  const [persisted, setPersisted] = useState<number[]>([]);
 
   const transmitting = useMemo(
     () => radioTransmitCarIdx.filter((carIdx) => carIdx >= 0),
     [radioTransmitCarIdx]
   );
 
+  // carIdx -> timestamp the icon should clear (last transmit frame + window).
+  const expiryRef = useRef<Map<number, number>>(new Map());
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+  // Bumped to force a re-render when a window expires with no new telemetry.
+  const [renderTick, forceRender] = useReducer((n: number) => n + 1, 0);
+
   useEffect(() => {
+    const expiry = expiryRef.current;
+
     if (persistenceMs <= 0) {
-      lastSeenRef.current.clear();
+      expiry.clear();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
       return;
     }
 
-    const lastSeen = lastSeenRef.current;
+    // (Re)stamp each heard car's clear deadline. Seeing a car again before its
+    // deadline simply pushes it out — this is the debounce that keeps the icon
+    // solidly lit through rapid flip-flapping.
     const now = Date.now();
-
-    // Refresh the "last seen transmitting" timestamp for every active car.
     for (const carIdx of transmitting) {
-      lastSeen.set(carIdx, now);
+      expiry.set(carIdx, now + persistenceMs);
     }
 
-    const recompute = () => {
+    // Schedule a re-render at the soonest deadline so the icon clears even on an
+    // idle grid where no new telemetry arrives to trigger renders. Reschedules
+    // itself for the next deadline since the effect won't re-run while silent.
+    const scheduleNext = () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
       const t = Date.now();
-      let soonestExpiry = Infinity;
-      const active: number[] = [];
-      for (const [carIdx, seenAt] of lastSeen) {
-        const expiresAt = seenAt + persistenceMs;
-        if (t < expiresAt) {
-          active.push(carIdx);
-          soonestExpiry = Math.min(soonestExpiry, expiresAt);
-        } else {
-          lastSeen.delete(carIdx);
-        }
+      let soonest = Infinity;
+      for (const [carIdx, expiresAt] of expiry) {
+        if (expiresAt <= t) expiry.delete(carIdx);
+        else soonest = Math.min(soonest, expiresAt);
       }
-
-      active.sort((a, b) => a - b);
-      setPersisted((prev) =>
-        prev.length === active.length && prev.every((v, i) => v === active[i])
-          ? prev
-          : active
-      );
-
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      // Schedule a follow-up so the icon clears even when no new telemetry
-      // arrives to trigger a re-render (e.g. an idle, silent grid).
-      if (soonestExpiry !== Infinity) {
-        timeoutRef.current = setTimeout(recompute, soonestExpiry - t + 16);
+      if (soonest !== Infinity) {
+        timeoutRef.current = setTimeout(
+          () => {
+            forceRender();
+            scheduleNext();
+          },
+          soonest - t + 16
+        );
       }
     };
-
-    recompute();
-
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    };
+    scheduleNext();
   }, [transmitting, persistenceMs]);
 
-  return useMemo(
-    () => ({
-      active: persistenceMs > 0 ? persisted : transmitting,
-      transmitting,
-    }),
-    [persistenceMs, persisted, transmitting]
+  // Clear the pending timer on unmount.
+  useEffect(
+    () => () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    },
+    []
   );
+
+  return useMemo(() => {
+    if (persistenceMs <= 0) return transmitting;
+
+    // Currently-transmitting cars are always shown (covers the frame a car
+    // first keys up, before the effect has stamped its deadline). Recently-seen
+    // cars stay in until their window lapses.
+    const now = Date.now();
+    const active = new Set<number>(transmitting);
+    for (const [carIdx, expiresAt] of expiryRef.current) {
+      if (now < expiresAt) active.add(carIdx);
+    }
+    return [...active].sort((a, b) => a - b);
+    // renderTick forces recompute when a window expires with no telemetry change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [persistenceMs, transmitting, renderTick]);
 };


### PR DESCRIPTION
## Description

The radio/speaker icon in Standings and Relative was unreliable when a driver keyed their radio on and off rapidly ("flip-flapping"). iRacing only reports a car as transmitting for the exact frames it holds push-to-talk, so the raw `RadioTransmitCarIdx` signal flickers. The previous design tracked **two** states — a live `transmitting` set (driving `animate-pulse`) and a lingering `active` set (driving a dimmed `opacity-60`) — so under rapid toggling the icon strobed between pulsing and dimmed, and the per-frame effect churn made it unreliable.

This reworks `useRadioActiveCarIdxs` around a single **debounced** set: each car heard transmitting stays active until `persistenceMs` after its *last* transmit frame. Rapid on/off toggling simply keeps extending the window, so the icon stays solidly lit instead of strobing, and clears cleanly once the driver truly stops.

Per the goal of keeping it simple, the live-vs-lingering visual distinction is dropped — the icon now just pulses while active (the original pre-persistence behavior). The `radioTransmitting` field/prop is removed throughout (`createStandings`, `useDriverStandings`, `useDriverPositions`, `DriverInfoRow`, `DriverNameCell`). The existing `radio.persistenceSeconds` setting now controls the debounce window.

### How it was tested
- Unit tests for the hook, including a new flip-flap regression test (6 rapid on/off cycles must keep the icon lit, then clear after the full window).
- A dedicated `useRadioActiveCarIdxs` Storybook story that drives the **real** hook via the telemetry store (no `TelemetryDecorator`, since its 60Hz mock bridge would clobber injected values) — visually confirms the debounce.
- Not yet tested in a live iRacing session.

## Screenshots

### Before
Icon strobes between pulsing/dimmed and can flash-and-vanish when a driver flip-flaps the radio.

### After
Icon stays solidly lit through rapid toggling and clears cleanly after the persistence window. See the new `widgets/Standings/hooks/useRadioActiveCarIdxs` stories (`Debounce - flip-flap`, `Debounce - linger then clear`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (no functional changes)

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  - Updated radio indicator behavior in driver standings: the icon now displays active/inactive status with a pulsing animation during transmission, replacing the previous multi-state persistence display with simplified on/off logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->