### PR TITLE
feat: Add support for game controller "keybinds" via WebHID

### DIFF
--- a/index-hid-host.html
+++ b/index-hid-host.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>irDashies HID Host</title>
+  </head>
+  <body>
+    <script type="module" src="/src/hidHost.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "@types/jsdom": "^28.0.3",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
+        "@types/w3c-web-hid": "^1.0.7",
         "@types/ws": "^8.18.1",
         "@vitejs/plugin-react": "^6.0.2",
         "@vitest/coverage-v8": "^4.1.7",
@@ -5239,6 +5240,13 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/w3c-web-hid": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-hid/-/w3c-web-hid-1.0.7.tgz",
+      "integrity": "sha512-/y97wBH7fYB5vKoDIn11O1ZDMNFLCAVqZ9af0OWDN7VSO2ClErEN2HlGbBuPgHBTUmZOVx1og2ZHX1U2gEJM4Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/jsdom": "^28.0.3",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
+    "@types/w3c-web-hid": "^1.0.7",
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.7",

--- a/src/app/bridge/keybindingsBridge.spec.ts
+++ b/src/app/bridge/keybindingsBridge.spec.ts
@@ -125,6 +125,34 @@ describe('keybindingsBridge keybindings:update', () => {
     expect(mockReloadBindings).toHaveBeenCalledOnce();
   });
 
+  it('accepts a valid gamepad token without keyboard validation', () => {
+    const next = sampleBindings();
+    mockUpdateKeybinding.mockReturnValue(next);
+
+    const result = invokeUpdate('toggle-edit-mode', 'gamepad:btn0');
+
+    expect(result).toBe(next);
+    // Gamepad tokens skip the Electron accelerator check entirely.
+    expect(mockIsValidAccelerator).not.toHaveBeenCalled();
+    expect(mockUpdateKeybinding).toHaveBeenCalledWith(
+      'toggle-edit-mode',
+      'gamepad:btn0'
+    );
+    expect(mockReloadBindings).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an unknown gamepad token without persisting', () => {
+    expect(() => invokeUpdate('toggle-edit-mode', 'gamepad:nope')).toThrow(
+      'not a valid controller button'
+    );
+    expect(mockUpdateKeybinding).not.toHaveBeenCalled();
+    expect(mockReloadBindings).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'Failed to update keybinding:',
+      expect.any(Error)
+    );
+  });
+
   it('surfaces storage conflict errors to the caller', () => {
     mockIsValidAccelerator.mockReturnValue(true);
     mockUpdateKeybinding.mockImplementation(() => {

--- a/src/app/bridge/keybindingsBridge.ts
+++ b/src/app/bridge/keybindingsBridge.ts
@@ -1,5 +1,6 @@
-import { ipcMain } from 'electron';
+import { ipcMain, webContents } from 'electron';
 import type { KeybindingActionId } from '@irdashies/types';
+import { isGamepadBinding, parseGamepadToken } from '@irdashies/shared';
 import {
   getKeybindings,
   updateKeybinding,
@@ -10,6 +11,22 @@ import { KeybindingManager } from '../keybindingManager';
 import { rebuildTaskbarMenu } from '../setupTaskbar';
 import logger from '../logger';
 
+/** Throw if `accelerator` is not a valid binding of its kind. */
+function assertValidAccelerator(accelerator: string): void {
+  if (isGamepadBinding(accelerator)) {
+    if (!parseGamepadToken(accelerator)) {
+      throw new Error(`"${accelerator}" is not a valid controller button`);
+    }
+  } else if (!KeybindingManager.isValidAccelerator(accelerator)) {
+    throw new Error(`"${accelerator}" is not a valid keyboard shortcut`);
+  }
+}
+
+/**
+ * Register the IPC handlers backing the keybindings settings UI: read/update/
+ * reset bindings and the record-mode lifecycle that captures keyboard or gamepad
+ * input for rebinding.
+ */
 export function setupKeybindingsBridge(
   keybindingManager: KeybindingManager
 ): void {
@@ -21,12 +38,12 @@ export function setupKeybindingsBridge(
     'keybindings:update',
     (_, actionId: KeybindingActionId, accelerator: string) => {
       try {
-        if (!KeybindingManager.isValidAccelerator(accelerator)) {
-          throw new Error(`"${accelerator}" is not a valid keyboard shortcut`);
-        }
+        assertValidAccelerator(accelerator);
+
         const result = updateKeybinding(actionId, accelerator);
         keybindingManager.reloadBindings();
         rebuildTaskbarMenu();
+
         return result;
       } catch (err) {
         logger.error('Failed to update keybinding:', err);
@@ -50,10 +67,18 @@ export function setupKeybindingsBridge(
   });
 
   ipcMain.handle('keybindings:startRecording', () => {
+    // Free keyboard shortcuts so presses reach the settings window, and route
+    // captured pad presses to the renderer instead of triggering actions.
     keybindingManager.unregisterAll();
+    keybindingManager.startGamepadCapture((token) => {
+      for (const wc of webContents.getAllWebContents()) {
+        wc.send('keybindings:gamepadCaptured', token);
+      }
+    });
   });
 
   ipcMain.handle('keybindings:stopRecording', () => {
+    keybindingManager.stopGamepadCapture();
     keybindingManager.registerAll();
   });
 }

--- a/src/app/bridge/rendererExposeBridge.ts
+++ b/src/app/bridge/rendererExposeBridge.ts
@@ -14,6 +14,7 @@ import type {
   ReferenceLapBridge,
   KeybindingsBridge,
   KeybindingActionId,
+  GamepadHostBridge,
   PersonalBestLapBridge,
   ChromiumFlagsBridge,
   ChromiumFlagsType,
@@ -256,7 +257,20 @@ export function exposeBridge() {
     resetAllKeybindings: () => ipcRenderer.invoke('keybindings:resetAll'),
     startRecording: () => ipcRenderer.invoke('keybindings:startRecording'),
     stopRecording: () => ipcRenderer.invoke('keybindings:stopRecording'),
+    onGamepadCaptured: (callback: (token: string) => void) => {
+      const handler = (_: Electron.IpcRendererEvent, token: string) =>
+        callback(token);
+      ipcRenderer.on('keybindings:gamepadCaptured', handler);
+      return () =>
+        ipcRenderer.removeListener('keybindings:gamepadCaptured', handler);
+    },
   } as KeybindingsBridge);
+
+  // Used only by the hidden WebHID host renderer (src/hidHost.ts) to forward
+  // controller button presses to the main process.
+  contextBridge.exposeInMainWorld('gamepadHost', {
+    sendButton: (token: string) => ipcRenderer.send('gamepad:button', token),
+  } satisfies GamepadHostBridge);
 
   contextBridge.exposeInMainWorld('personalBestBridge', {
     getPersonalBest: (trackId: string | number, carName: string) =>
@@ -265,7 +279,7 @@ export function exposeBridge() {
       trackId: string | number,
       carName: string,
       time: number
-    ) => ipcRenderer.invoke('personalBest:set', trackId, carName, time),  
+    ) => ipcRenderer.invoke('personalBest:set', trackId, carName, time),
   } as PersonalBestLapBridge);
 
   contextBridge.exposeInMainWorld('chromiumFlagsBridge', {

--- a/src/app/gamepad/README.md
+++ b/src/app/gamepad/README.md
@@ -1,0 +1,32 @@
+# Gamepad input (WebHID)
+
+Any keybinding fire from controller button too, not just keyboard. Bindings live in **Settings → Key Bindings**. Click binding to record, press key _or_ pad button.
+
+Code-level detail (token grammar, permissions, parsing, hat decoding) live in the file-header JSDoc of `hidHost.ts`, `gamepadHost.ts`, `gamepadToken.ts`, `hidReport.ts`. This file only keep the design rationale that isn't obvious from the code.
+
+## Why WebHID (not other Electron options)
+
+iRacing overlay never hold focus — sim hold it. Input source must deliver presses while app unfocused:
+
+- Main process `globalShortcut`: keyboard only.
+- Renderer **W3C Gamepad API** (`navigator.getGamepads()`): delivers input only while window focused → useless for overlay.
+- **WebHID** (`navigator.hid`): keeps delivering input reports while unfocused. Built into Chromium (no extra dependency / native build). Hotplug via `connect` / `disconnect` events.
+
+So one hidden, always-alive window host the HID reader and forward presses to the main process, which fire the bound action through the same `triggerAction` path as keyboard shortcuts.
+
+## Why single-bit-only, no usage-page filter
+
+`parseButtons` keep **every non-constant, single-bit field** — no usage-page filter.
+
+- Many controllers and sim wheel bases (Thrustmaster, Fanatec, Simucube) declare buttons on a **vendor-defined** page (`0xFF00`+), not the standard Button page (`0x09`). Filtering by page drop those — exactly what broke a real Thrustmaster wheel. An unbound bit fire nothing (`GamepadManager` only trigger mapped tokens), so no need to guess which bits are "real" buttons.
+- Single-bit is the safety line. Analog axes are multi-bit (`reportSize > 1`), so a turned wheel or pressed pedal can't reach the binding map. The overlay run during a race — firing an action by accident (analog drift, a status flag toggling mid-corner) is worse than a missing feature.
+
+## Hat switch (d-pad)
+
+Pads report the d-pad as one multi-bit **hat switch** (Generic Desktop usage `0x39`), not four bits, so `parseButtons` never see it. `parseHats` find it; `hatEdges` decode directions clockwise from the descriptor's logical minimum (= up), which handles both `0-7` and `1-8` pads.
+
+> **Assumption left:** directions read clockwise from `logicalMin`. Matches every pad seen. A device ordering its hat differently would map wrong — fix point is the `HAT_DIRECTIONS` order in `hidReport.ts`.
+
+## Future
+
+Analog-axis binding need a different contract (threshold/deadzone/hysteresis + new token grammar e.g. `gamepad:axisRx+>0.5`). Deferred until concrete need — mapping a continuous axis to a discrete action is mostly an accidental-trigger generator.

--- a/src/app/gamepad/gamepadHost.ts
+++ b/src/app/gamepad/gamepadHost.ts
@@ -1,0 +1,108 @@
+import { BrowserWindow, ipcMain, session } from 'electron';
+import path from 'node:path';
+import logger from '../logger';
+
+declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;
+declare const MAIN_WINDOW_VITE_NAME: string;
+
+/** IPC channel the hidden WebHID host renderer uses to forward button presses. */
+const BUTTON_CHANNEL = 'gamepad:button';
+
+/**
+ * In-memory session partition for the HID host window. Scoping the auto-grant
+ * permission handlers to this partition keeps them off the default session that
+ * every other window shares.
+ */
+const HID_PARTITION = 'hid-host';
+
+/**
+ * Owns the hidden renderer that reads controllers via WebHID. Mirrors the small
+ * start/stop surface the KeybindingManager expects: it creates an always-alive,
+ * never-shown window, auto-grants HID access for that window's session, and
+ * relays each `gamepad:btn<N>` token to the supplied callback.
+ */
+export class GamepadHost {
+  private window?: BrowserWindow;
+  private onButton?: (token: string) => void;
+  private permissionsGranted = false;
+  private readonly handleButton = (
+    event: Electron.IpcMainEvent,
+    token: string
+  ): void => {
+    // Only the HID-host window may emit; reject any other renderer spoofing tokens.
+    if (event.sender.id !== this.window?.webContents.id) return;
+    this.onButton?.(token);
+  };
+
+  start(onButton: (token: string) => void): void {
+    this.onButton = onButton;
+    if (this.window && !this.window.isDestroyed()) return;
+
+    this.grantHidPermissions();
+    ipcMain.removeListener(BUTTON_CHANNEL, this.handleButton);
+    ipcMain.on(BUTTON_CHANNEL, this.handleButton);
+
+    this.window = new BrowserWindow({
+      show: false,
+      width: 1,
+      height: 1,
+      webPreferences: {
+        preload: path.join(__dirname, 'preload.js'),
+        backgroundThrottling: false,
+        partition: HID_PARTITION,
+      },
+    });
+
+    this.window.webContents.on('did-fail-load', (_e, code, desc, url) =>
+      logger.error(`[Gamepad] HID host failed to load ${url}: ${code} ${desc}`)
+    );
+
+    if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
+      const base = MAIN_WINDOW_VITE_DEV_SERVER_URL.replace(/\/$/, '');
+      this.window.loadURL(`${base}/index-hid-host.html`);
+    } else {
+      this.window.loadFile(
+        path.join(
+          __dirname,
+          `../renderer/${MAIN_WINDOW_VITE_NAME}/index-hid-host.html`
+        )
+      );
+    }
+
+    logger.info('[Gamepad] WebHID host window started');
+  }
+
+  stop(): void {
+    ipcMain.removeListener(BUTTON_CHANNEL, this.handleButton);
+    if (this.window && !this.window.isDestroyed()) {
+      this.window.destroy();
+    }
+    this.window = undefined;
+  }
+
+  /**
+   * Auto-grant HID access for the host window's session so the renderer can
+   * enumerate controllers via `navigator.hid.getDevices()` without a chooser or
+   * a user gesture.
+   *
+   * The handlers grant unconditionally: this is a dedicated in-memory partition
+   * that only this app's own hidden HID-host renderer ever loads, so there is no
+   * untrusted origin to guard against. (Filtering on `permission === 'hid'` or
+   * `details.deviceType === 'hid'` risks silently denying enumeration if those
+   * fields differ across call contexts — which would leave getDevices() empty.)
+   */
+  private grantHidPermissions(): void {
+    if (this.permissionsGranted) return;
+    this.permissionsGranted = true;
+
+    const ses = session.fromPartition(HID_PARTITION);
+    ses.setPermissionCheckHandler(() => true);
+    ses.setDevicePermissionHandler(() => true);
+    ses.on('select-hid-device', (event, details, callback) => {
+      // Only fires if the renderer ever calls requestDevice(); auto-pick the
+      // first match so no picker UI is shown.
+      event.preventDefault();
+      callback(details.deviceList[0]?.deviceId);
+    });
+  }
+}

--- a/src/app/gamepad/gamepadManager.spec.ts
+++ b/src/app/gamepad/gamepadManager.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { KeybindingsMap } from '@irdashies/types';
+
+const mockLoggerError = vi.hoisted(() => vi.fn());
+
+vi.mock('../logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: mockLoggerError,
+    debug: vi.fn(),
+  },
+}));
+
+// Keep electron (pulled in transitively by gamepadHost) out of the test graph;
+// these tests drive the manager's logic, never the host window.
+vi.mock('./gamepadHost', () => ({ GamepadHost: vi.fn() }));
+
+import { GamepadManager } from './gamepadManager';
+
+const gamepadBinding = (): KeybindingsMap =>
+  ({
+    'toggle-edit-mode': {
+      accelerator: 'gamepad:btn0',
+      label: 'Edit Layout',
+      description: '',
+      isDefault: false,
+    },
+  }) as unknown as KeybindingsMap;
+
+// handleButton is private; the WebHID host callback is its only caller,
+// passing a ready-made gamepad token.
+const fireButton = (manager: GamepadManager, token: string) =>
+  (
+    manager as unknown as {
+      handleButton: (token: string) => void;
+    }
+  ).handleButton(token);
+
+describe('GamepadManager', () => {
+  beforeEach(() => {
+    mockLoggerError.mockReset();
+  });
+
+  it('triggers the mapped action when its bound pad button is pressed', () => {
+    const trigger = vi.fn();
+    const manager = new GamepadManager(trigger);
+    manager.syncBindings(gamepadBinding());
+
+    fireButton(manager, 'gamepad:btn0');
+
+    expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
+  });
+
+  it('does not trigger an action for an unbound pad button', () => {
+    const trigger = vi.fn();
+    const manager = new GamepadManager(trigger);
+    manager.syncBindings(gamepadBinding());
+
+    fireButton(manager, 'gamepad:btn1');
+
+    expect(trigger).not.toHaveBeenCalled();
+  });
+
+  it('forwards to the capture callback instead of triggering while recording', () => {
+    const trigger = vi.fn();
+    const manager = new GamepadManager(trigger);
+    manager.syncBindings(gamepadBinding());
+
+    const captured: string[] = [];
+    manager.startCapture((token) => captured.push(token));
+    fireButton(manager, 'gamepad:btn0');
+
+    expect(captured).toEqual(['gamepad:btn0']);
+    expect(trigger).not.toHaveBeenCalled();
+
+    manager.stopCapture();
+    fireButton(manager, 'gamepad:btn0');
+    expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
+  });
+
+  it('rebuilds the token map on syncBindings, dropping stale tokens', () => {
+    const trigger = vi.fn();
+    const manager = new GamepadManager(trigger);
+    manager.syncBindings(gamepadBinding());
+
+    // Rebind the action to a different button.
+    manager.syncBindings({
+      'toggle-edit-mode': {
+        accelerator: 'gamepad:btn5',
+        label: 'Edit Layout',
+        description: '',
+        isDefault: false,
+      },
+    } as unknown as KeybindingsMap);
+
+    fireButton(manager, 'gamepad:btn0');
+    expect(trigger).not.toHaveBeenCalled();
+
+    fireButton(manager, 'gamepad:btn5');
+    expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
+  });
+
+  it('maps device-specific tokens (gamepad:<device>:btn<N>)', () => {
+    const trigger = vi.fn();
+    const manager = new GamepadManager(trigger);
+    manager.syncBindings({
+      'toggle-edit-mode': {
+        accelerator: 'gamepad:B66E:btn10',
+        label: 'Edit Layout',
+        description: '',
+        isDefault: false,
+      },
+    } as unknown as KeybindingsMap);
+
+    fireButton(manager, 'gamepad:B66E:btn10');
+
+    expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
+  });
+});

--- a/src/app/gamepad/gamepadManager.ts
+++ b/src/app/gamepad/gamepadManager.ts
@@ -1,0 +1,78 @@
+import type { KeybindingActionId, KeybindingsMap } from '@irdashies/types';
+import { isGamepadBinding } from '@irdashies/shared';
+import logger from '../logger';
+import { GamepadHost } from './gamepadHost';
+
+/**
+ * Owns the runtime side of gamepad bindings: the token -> action lookup, the
+ * record/capture mode used while rebinding, and the WebHID host lifecycle.
+ *
+ * It does not own the bindings themselves — the {@link KeybindingManager} pushes
+ * the current map in via {@link GamepadManager.syncBindings} — and it triggers
+ * actions through the `triggerAction` callback supplied at construction, so it
+ * stays decoupled from how those actions are implemented.
+ */
+export class GamepadManager {
+  /** Gamepad token (e.g. "gamepad:btn0") -> action it triggers. */
+  private map = new Map<string, KeybindingActionId>();
+  /** Lazily-created WebHID host window manager (see start). */
+  private host?: GamepadHost;
+  /** When set, captured pad presses are reported here instead of triggering actions (rebinding). */
+  private onCapture?: (token: string) => void;
+
+  constructor(private triggerAction: (actionId: KeybindingActionId) => void) {}
+
+  /** Rebuild the gamepad token -> action lookup from the current bindings. */
+  public syncBindings(bindings: KeybindingsMap): void {
+    this.map.clear();
+    for (const [actionId, entry] of Object.entries(bindings)) {
+      if (isGamepadBinding(entry.accelerator)) {
+        this.map.set(entry.accelerator, actionId as KeybindingActionId);
+      }
+    }
+  }
+
+  /**
+   * Route a gamepad button-down (a `gamepad:btn<N>` token from the WebHID host)
+   * to capture (rebinding) or to its bound action.
+   */
+  private handleButton(token: string): void {
+    if (this.onCapture) {
+      this.onCapture(token);
+      return;
+    }
+    const actionId = this.map.get(token);
+    if (actionId) this.triggerAction(actionId);
+  }
+
+  /**
+   * Start reading game controllers via the hidden WebHID host window. Failures
+   * are logged and leave keyboard bindings working.
+   */
+  public start(): void {
+    try {
+      if (!this.host) this.host = new GamepadHost();
+      this.host.start((token) => this.handleButton(token));
+    } catch (err) {
+      logger.error(
+        '[Gamepad] host unavailable, controller bindings disabled',
+        err
+      );
+    }
+  }
+
+  /** Tear down the WebHID host window (call on shutdown). */
+  public stop(): void {
+    this.host?.stop();
+  }
+
+  /** Enter capture mode: the next pad presses are reported to `onCapture` for rebinding. */
+  public startCapture(onCapture: (token: string) => void): void {
+    this.onCapture = onCapture;
+  }
+
+  /** Leave capture mode; pad presses resume triggering actions. */
+  public stopCapture(): void {
+    this.onCapture = undefined;
+  }
+}

--- a/src/app/gamepad/hidReport.spec.ts
+++ b/src/app/gamepad/hidReport.spec.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect } from 'vitest';
+import type { ButtonBit, HatField, HatDirection } from '@irdashies/types';
+import {
+  parseButtons,
+  parseHats,
+  buttonEdges,
+  hatEdges,
+  itemUsagePage,
+} from './hidReport';
+
+/** Build a collections tree from input-report item lists (one report each). */
+const collections = (
+  ...reports: { reportId?: number; items: Partial<HIDReportItem>[] }[]
+): HIDCollectionInfo[] =>
+  [
+    {
+      inputReports: reports.map((r) => ({
+        reportId: r.reportId,
+        items: r.items,
+      })),
+    },
+  ] as unknown as HIDCollectionInfo[];
+
+const view = (...bytes: number[]) => new DataView(new Uint8Array(bytes).buffer);
+
+/** Encode a HID usage page into the high 16 bits of a usage value, as WebHID reports it. */
+const page = (p: number) => p * 0x10000;
+
+describe('parseButtons', () => {
+  it('locates a simple block of buttons at byte 0', () => {
+    const buttons = parseButtons(
+      collections({
+        items: [{ usageMinimum: page(0x09), reportSize: 1, reportCount: 8 }],
+      })
+    );
+
+    expect(buttons).toHaveLength(8);
+    expect(buttons[0]).toEqual({
+      reportId: 0,
+      byteOffset: 0,
+      bitMask: 0b00000001,
+      index: 0,
+    });
+    expect(buttons[5]).toEqual({
+      reportId: 0,
+      byteOffset: 0,
+      bitMask: 0b00100000,
+      index: 5,
+    });
+  });
+
+  it('skips axis fields and keeps the button bit offsets aligned', () => {
+    // 8-bit axis, then 8 buttons -> buttons start at bit 8 (byte 1).
+    const buttons = parseButtons(
+      collections({
+        items: [
+          { usageMinimum: page(0x01), reportSize: 8, reportCount: 1 }, // X axis
+          { usageMinimum: page(0x09), reportSize: 1, reportCount: 8 },
+        ],
+      })
+    );
+
+    expect(buttons).toHaveLength(8);
+    expect(buttons[0]).toMatchObject({ byteOffset: 1, bitMask: 0b1 });
+    expect(buttons[7]).toMatchObject({ byteOffset: 1, bitMask: 0b10000000 });
+  });
+
+  it('ignores wide (non-1-bit) fields on the button page', () => {
+    // A hat switch is reported on the button page in some descriptors but as a
+    // multi-bit field; only true 1-bit buttons are captured.
+    const buttons = parseButtons(
+      collections({
+        items: [{ usageMinimum: page(0x09), reportSize: 4, reportCount: 1 }],
+      })
+    );
+    expect(buttons).toHaveLength(0);
+  });
+
+  it('includes single-bit controls on any usage page (Button + Generic Desktop d-pad)', () => {
+    // Real buttons on the Button page (0x09) plus a d-pad as four on/off bits on
+    // Generic Desktop (0x01, usages 0x90-0x93). Both are single-bit controls, so
+    // both are bindable — selection does not filter by usage page.
+    const buttons = parseButtons(
+      collections({
+        items: [
+          { usageMinimum: page(0x09) + 1, reportSize: 1, reportCount: 4 },
+          {
+            usageMinimum: page(0x01) + 0x90, // D-pad Up..Left
+            reportSize: 1,
+            reportCount: 4,
+          },
+        ],
+      })
+    );
+
+    expect(buttons).toHaveLength(8);
+  });
+
+  it('collects buttons declared on a vendor-defined usage page', () => {
+    // Most sim wheel bases (e.g. Thrustmaster) declare buttons on a vendor page.
+    const buttons = parseButtons(
+      collections({
+        items: [
+          {
+            usageMinimum: page(0xff00),
+            reportSize: 1,
+            reportCount: 6,
+            isConstant: false,
+          },
+          { usageMinimum: page(0x01), reportSize: 8, reportCount: 2 }, // axes
+        ],
+      })
+    );
+
+    expect(buttons).toHaveLength(6);
+    expect(buttons[0]).toMatchObject({ byteOffset: 0, bitMask: 0b1, index: 0 });
+  });
+
+  it('excludes constant padding', () => {
+    const buttons = parseButtons(
+      collections({
+        items: [
+          {
+            usageMinimum: page(0xff00),
+            reportSize: 1,
+            reportCount: 4,
+            isConstant: false,
+          },
+          {
+            usageMinimum: page(0x00),
+            reportSize: 1,
+            reportCount: 4,
+            isConstant: true,
+          }, // padding
+        ],
+      })
+    );
+    expect(buttons).toHaveLength(4);
+  });
+
+  it('indexes buttons continuously across multiple reports', () => {
+    const buttons = parseButtons(
+      collections(
+        {
+          reportId: 1,
+          items: [{ usageMinimum: page(0x09), reportSize: 1, reportCount: 4 }],
+        },
+        {
+          reportId: 2,
+          items: [{ usageMinimum: page(0x09), reportSize: 1, reportCount: 4 }],
+        }
+      )
+    );
+
+    expect(buttons.map((b) => b.index)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+    expect(buttons[0].reportId).toBe(1);
+    expect(buttons[4].reportId).toBe(2);
+  });
+});
+
+// Selection no longer depends on the usage page, but `itemUsagePage` still
+// feeds the diagnostic dump (describeCollections), and its derivation is
+// non-obvious: WebHID has no `usagePage` field on a report item — the page is
+// the high 16 bits of each 32-bit usage value (`usageMinimum` for ranges,
+// `usages[]` for enumerated, chosen by `isRange`).
+describe('itemUsagePage (diagnostic page derivation)', () => {
+  it('reads the page from the high 16 bits of usageMinimum for range items', () => {
+    expect(itemUsagePage({ isRange: true, usageMinimum: page(0x09) + 1 })).toBe(
+      0x09
+    );
+    expect(itemUsagePage({ isRange: true, usageMinimum: page(0xff00) })).toBe(
+      0xff00
+    );
+  });
+
+  it('does not confuse a low-word usage id with the page', () => {
+    // 0x0009 is page 0x00, usage id 9 — not the Button page.
+    expect(itemUsagePage({ isRange: true, usageMinimum: 0x0009 })).toBe(0x00);
+  });
+
+  it('reads usages[] for enumerated items, even when usageMinimum is present as 0', () => {
+    // isRange false -> the usages live in `usages[]`; Chromium may still surface
+    // usageMinimum as 0, which must not be read as page 0.
+    expect(
+      itemUsagePage({
+        isRange: false,
+        usages: [page(0x09) + 1],
+        usageMinimum: 0,
+      })
+    ).toBe(0x09);
+  });
+
+  it('returns 0 when the item declares no usage', () => {
+    expect(itemUsagePage({})).toBe(0);
+  });
+});
+
+describe('parseHats', () => {
+  it('locates a 4-bit hat switch and skips axes and buttons', () => {
+    const hats = parseHats(
+      collections({
+        items: [
+          { usageMinimum: page(0x01) + 0x30, reportSize: 16, reportCount: 1 }, // X axis, bits 0-15
+          { usageMinimum: page(0x09) + 1, reportSize: 1, reportCount: 8 }, // 8 buttons, bits 16-23
+          { usages: [page(0x01) + 0x39], reportSize: 4, reportCount: 1 }, // hat switch, bits 24-27
+        ],
+      })
+    );
+
+    expect(hats).toEqual([
+      {
+        reportId: 0,
+        bitOffset: 24,
+        bitWidth: 4,
+        logicalMin: 0,
+        logicalMax: 7,
+        index: 0,
+      },
+    ]);
+  });
+
+  it('captures the declared logical range (e.g. a 1-8 numbered hat)', () => {
+    const hats = parseHats(
+      collections({
+        items: [
+          {
+            usages: [page(0x01) + 0x39],
+            reportSize: 4,
+            reportCount: 1,
+            logicalMinimum: 1,
+            logicalMaximum: 8,
+          },
+        ],
+      })
+    );
+
+    expect(hats[0]).toMatchObject({ logicalMin: 1, logicalMax: 8 });
+  });
+
+  it('does not treat other Generic Desktop fields as hats', () => {
+    // Usage 0x30 (X axis) on the same page is not a hat switch (0x39).
+    const hats = parseHats(
+      collections({
+        items: [
+          { usageMinimum: page(0x01) + 0x30, reportSize: 4, reportCount: 1 },
+        ],
+      })
+    );
+    expect(hats).toHaveLength(0);
+  });
+});
+
+describe('hatEdges', () => {
+  const hat = (over: Partial<HatField> = {}): HatField => ({
+    reportId: 0,
+    bitOffset: 0,
+    bitWidth: 4,
+    logicalMin: 0,
+    logicalMax: 7,
+    index: 0,
+    ...over,
+  });
+  const hats: HatField[] = [hat()];
+
+  it('fires once on entering a direction, ignoring held frames', () => {
+    const state = new Map<number, HatDirection | null>();
+
+    expect(hatEdges(view(0x0f), hats, 0, state)).toEqual([]); // 15 = centered
+    expect(hatEdges(view(0x00), hats, 0, state)).toEqual([
+      { index: 0, direction: 'up' }, // 0 = up
+    ]);
+    expect(hatEdges(view(0x00), hats, 0, state)).toEqual([]); // held
+    expect(hatEdges(view(0x02), hats, 0, state)).toEqual([
+      { index: 0, direction: 'right' }, // roll straight to 2 = right
+    ]);
+    expect(hatEdges(view(0x0f), hats, 0, state)).toEqual([]); // centered
+    expect(hatEdges(view(0x00), hats, 0, state)).toEqual([
+      { index: 0, direction: 'up' }, // press again
+    ]);
+  });
+
+  it('respects a 1-8 numbered hat (logicalMin 1, 0 = centered)', () => {
+    // The real bug: a pad whose hat reads 1=up..8=upleft, 0=centered. Without
+    // the logicalMin base, raw 1 decoded as "upright" and raw 7 as "upleft".
+    const state = new Map<number, HatDirection | null>();
+    const oneBased: HatField[] = [hat({ logicalMin: 1, logicalMax: 8 })];
+
+    expect(hatEdges(view(0x00), oneBased, 0, state)).toEqual([]); // 0 = centered
+    expect(hatEdges(view(0x01), oneBased, 0, state)).toEqual([
+      { index: 0, direction: 'up' }, // 1 = up
+    ]);
+    expect(hatEdges(view(0x07), oneBased, 0, state)).toEqual([
+      { index: 0, direction: 'left' }, // 7 = left
+    ]);
+    expect(hatEdges(view(0x08), oneBased, 0, state)).toEqual([
+      { index: 0, direction: 'upleft' }, // 8 = upleft
+    ]);
+  });
+
+  it('reads a hat packed in the high nibble (bit offset 4)', () => {
+    const state = new Map<number, HatDirection | null>();
+    const hi: HatField[] = [hat({ bitOffset: 4 })];
+    // high nibble of 0x40 is 4 -> down
+    expect(hatEdges(view(0x40), hi, 0, state)).toEqual([
+      { index: 0, direction: 'down' },
+    ]);
+  });
+
+  it('treats values outside the range as centered', () => {
+    const state = new Map<number, HatDirection | null>();
+    expect(hatEdges(view(0x08), hats, 0, state)).toEqual([]); // 8 (> logicalMax 7)
+    expect(hatEdges(view(0x09), hats, 0, state)).toEqual([]); // 9
+  });
+
+  it('only reads hats whose reportId matches the incoming report', () => {
+    const state = new Map<number, HatDirection | null>();
+    const idHats: HatField[] = [hat({ reportId: 2 })];
+
+    expect(hatEdges(view(0x00), idHats, 1, state)).toEqual([]); // wrong report
+    expect(hatEdges(view(0x00), idHats, 2, state)).toEqual([
+      { index: 0, direction: 'up' },
+    ]);
+  });
+});
+
+describe('buttonEdges', () => {
+  const buttons: ButtonBit[] = [
+    { reportId: 0, byteOffset: 0, bitMask: 0b001, index: 0 },
+    { reportId: 0, byteOffset: 0, bitMask: 0b010, index: 1 },
+    { reportId: 0, byteOffset: 0, bitMask: 0b100, index: 2 },
+  ];
+
+  it('reports a press once on the rising edge, ignoring held frames', () => {
+    const state = new Map<number, boolean>();
+
+    expect(buttonEdges(view(0b000), buttons, 0, state)).toEqual([]);
+    expect(buttonEdges(view(0b101), buttons, 0, state)).toEqual([0, 2]);
+    // Held: no new edges.
+    expect(buttonEdges(view(0b101), buttons, 0, state)).toEqual([]);
+    // Release then press again -> new edge.
+    expect(buttonEdges(view(0b000), buttons, 0, state)).toEqual([]);
+    expect(buttonEdges(view(0b001), buttons, 0, state)).toEqual([0]);
+  });
+
+  it('only reads buttons whose reportId matches the incoming report', () => {
+    const state = new Map<number, boolean>();
+    const idBtns: ButtonBit[] = [
+      { reportId: 1, byteOffset: 0, bitMask: 0b1, index: 0 },
+      { reportId: 2, byteOffset: 0, bitMask: 0b1, index: 1 },
+    ];
+
+    // A report with id 2 must not read the id-1 button's bits.
+    expect(buttonEdges(view(0b1), idBtns, 2, state)).toEqual([1]);
+    expect(state.has(0)).toBe(false);
+  });
+
+  it('guards against a byte offset past the end of the report', () => {
+    const state = new Map<number, boolean>();
+    const wide: ButtonBit[] = [
+      { reportId: 0, byteOffset: 4, bitMask: 0b1, index: 0 },
+    ];
+    expect(buttonEdges(view(0b1), wide, 0, state)).toEqual([]);
+  });
+});

--- a/src/app/gamepad/hidReport.ts
+++ b/src/app/gamepad/hidReport.ts
@@ -1,0 +1,293 @@
+/**
+ * Pure helpers for locating button bits inside a WebHID device's input reports
+ * and detecting button-press edges. Kept free of DOM/Electron so it can be unit
+ * tested directly. The renderer host (src/hidHost.ts) wires these to live
+ * `navigator.hid` devices.
+ *
+ * HID input reports are bit-packed: each report item occupies
+ * `reportSize * reportCount` bits, laid out sequentially (LSB-first within each
+ * byte). Buttons are 1-bit fields; hat switches (d-pads) are a small multi-bit
+ * value handled separately (see parseHats); axes and padding are wider or
+ * constant and ignored. By walking every item and advancing a bit cursor we can
+ * pick out just the controls we want — so a wheel base's analog axes never
+ * masquerade as button presses.
+ */
+
+import {
+  HAT_DIRECTIONS,
+  type ButtonBit,
+  type HatDirection,
+  type HatField,
+  type HatPress,
+} from '@irdashies/types';
+
+/**
+ * A HID usage value packs a 16-bit usage page in the high half and a 16-bit
+ * usage id in the low half (WebHID surfaces only this combined value).
+ */
+const USAGE_PAGE_SHIFT = 16;
+const USAGE_ID_MASK = 0xffff;
+
+/** Usage pages and the usages within them that this parser recognises. */
+const HID_USAGE = {
+  /** Generic Desktop page. */
+  GENERIC_DESKTOP_PAGE: 0x01,
+  /** Hat Switch usage id, on the Generic Desktop page. */
+  HAT_SWITCH: 0x39,
+} as const;
+
+/**
+ * The 32-bit usage value of a report item: usage page in the high 16 bits,
+ * usage id in the low 16. WebHID has no separate `usagePage` field.
+ *
+ * `isRange` selects where the usages live: range items (e.g. Button 1..N) use
+ * `usageMinimum`/`usageMaximum`, enumerated items use the `usages` array. Read
+ * whichever the item declares — for an enumerated item `usageMinimum` may be
+ * surfaced as 0, so it must not be trusted as the source.
+ */
+function itemUsage(item: HIDReportItem): number {
+  const usage = item.isRange
+    ? (item.usageMinimum ?? item.usages?.[0])
+    : (item.usages?.[0] ?? item.usageMinimum);
+  return usage ?? 0;
+}
+
+/** Usage page (high 16 bits) of a report item. Used for diagnostics and hat detection. */
+export function itemUsagePage(item: HIDReportItem): number {
+  return itemUsage(item) >>> USAGE_PAGE_SHIFT;
+}
+
+/** A single 1-bit field located in a report. Constant fields are padding. */
+interface BitField {
+  reportId: number;
+  byteOffset: number;
+  bitMask: number;
+  isConstant: boolean;
+}
+
+/** Flatten a collection tree into its input reports (reports can nest in children). */
+function collectInputReports(
+  collections: readonly HIDCollectionInfo[]
+): HIDReportInfo[] {
+  const reports: HIDReportInfo[] = [];
+  for (const collection of collections) {
+    if (collection.inputReports) reports.push(...collection.inputReports);
+    if (collection.children) {
+      reports.push(...collectInputReports(collection.children));
+    }
+  }
+  return reports;
+}
+
+/** Walk every input-report item and record the bit location of each 1-bit field. */
+function collectBitFields(
+  collections: readonly HIDCollectionInfo[]
+): BitField[] {
+  const fields: BitField[] = [];
+
+  for (const report of collectInputReports(collections)) {
+    const reportId = report.reportId ?? 0;
+    let bit = 0;
+
+    for (const item of report.items ?? []) {
+      const size = item.reportSize ?? 0;
+      const count = item.reportCount ?? 0;
+
+      if (size === 1) {
+        for (let k = 0; k < count; k++) {
+          const position = bit + k;
+          fields.push({
+            reportId,
+            byteOffset: position >> 3,
+            bitMask: 1 << (position & 7),
+            isConstant: item.isConstant ?? false,
+          });
+        }
+      }
+
+      // Advance past this item regardless of type so offsets stay aligned.
+      bit += size * count;
+    }
+  }
+
+  return fields;
+}
+
+/**
+ * Locate every bindable control in a device's input reports, indexed in
+ * declaration order.
+ *
+ * A bindable control is any non-constant single-bit field. Analog axes are
+ * multi-bit (reportSize > 1) so they never appear here; constant fields are
+ * padding. We deliberately do NOT filter by usage page — many controllers and
+ * sim wheel bases (e.g. Thrustmaster) declare their buttons on vendor-defined
+ * pages, and an unbound bit triggers nothing (GamepadManager only fires mapped
+ * tokens), so there is no need to guess which 1-bit fields are "real" buttons.
+ */
+export function parseButtons(
+  collections: readonly HIDCollectionInfo[]
+): ButtonBit[] {
+  const fields = collectBitFields(collections).filter((f) => !f.isConstant);
+
+  return fields.map((field, index) => ({
+    reportId: field.reportId,
+    byteOffset: field.byteOffset,
+    bitMask: field.bitMask,
+    index,
+  }));
+}
+
+/**
+ * Locate every hat switch (d-pad / point-of-view) in a device's input reports.
+ *
+ * A hat is the Hat Switch usage (0x39) on the Generic Desktop page, declared as
+ * a small multi-bit value (almost always 4 bits) rather than individual bits —
+ * which is exactly why {@link parseButtons} never sees a d-pad. We walk the same
+ * bit cursor as collectBitFields so the offset lines up with the live report.
+ */
+export function parseHats(
+  collections: readonly HIDCollectionInfo[]
+): HatField[] {
+  const hats: HatField[] = [];
+  let index = 0;
+
+  for (const report of collectInputReports(collections)) {
+    const reportId = report.reportId ?? 0;
+    let bit = 0;
+
+    for (const item of report.items ?? []) {
+      const size = item.reportSize ?? 0;
+      const count = item.reportCount ?? 0;
+      const usage = itemUsage(item);
+      const isHat =
+        usage >>> USAGE_PAGE_SHIFT === HID_USAGE.GENERIC_DESKTOP_PAGE &&
+        (usage & USAGE_ID_MASK) === HID_USAGE.HAT_SWITCH;
+
+      if (isHat && size >= 2 && size <= 8) {
+        // Pads number their hat 0-7 or 1-8; the descriptor's logical range tells
+        // us which, and which raw value means "up".
+        const logicalMin = item.logicalMinimum ?? 0;
+        const logicalMax =
+          item.logicalMaximum ?? logicalMin + HAT_DIRECTIONS.length - 1;
+        for (let k = 0; k < count; k++) {
+          hats.push({
+            reportId,
+            bitOffset: bit + k * size,
+            bitWidth: size,
+            logicalMin,
+            logicalMax,
+            index: index++,
+          });
+        }
+      }
+
+      bit += size * count;
+    }
+  }
+
+  return hats;
+}
+
+/**
+ * Read button states from an input report and return the indices that
+ * transitioned from up to down (rising edge). `state` is mutated in place to
+ * hold the latest pressed/released value for each button index.
+ */
+export function buttonEdges(
+  data: DataView,
+  buttons: readonly ButtonBit[],
+  reportId: number,
+  state: Map<number, boolean>
+): number[] {
+  const pressed: number[] = [];
+
+  for (const button of buttons) {
+    if (button.reportId !== reportId) continue;
+    if (button.byteOffset >= data.byteLength) continue;
+
+    const isDown = (data.getUint8(button.byteOffset) & button.bitMask) !== 0;
+    if (isDown && !(state.get(button.index) ?? false)) {
+      pressed.push(button.index);
+    }
+    state.set(button.index, isDown);
+  }
+
+  return pressed;
+}
+
+/** Read `bitWidth` bits starting at `bitOffset` (LSB-first), or null if out of range. */
+function readBits(
+  data: DataView,
+  bitOffset: number,
+  bitWidth: number
+): number | null {
+  let value = 0;
+  for (let i = 0; i < bitWidth; i++) {
+    const position = bitOffset + i;
+    const byteOffset = position >> 3;
+    if (byteOffset >= data.byteLength) return null;
+    value |= ((data.getUint8(byteOffset) >> (position & 7)) & 1) << i;
+  }
+  return value;
+}
+
+/**
+ * Read hat values from an input report and return the hats that just entered a
+ * new direction (the d-pad equivalent of a rising edge). Holding a direction
+ * fires once; rolling straight from one direction to another fires the new one;
+ * centering (value outside 0-7) fires nothing. `state` is mutated in place.
+ */
+export function hatEdges(
+  data: DataView,
+  hats: readonly HatField[],
+  reportId: number,
+  state: Map<number, HatDirection | null>
+): HatPress[] {
+  const pressed: HatPress[] = [];
+
+  for (const hat of hats) {
+    if (hat.reportId !== reportId) continue;
+
+    const value = readBits(data, hat.bitOffset, hat.bitWidth);
+    // Directions run from logicalMin (= up) clockwise; a value outside the
+    // [logicalMin, logicalMax] range (commonly 0, 8 or 15) means centered.
+    const offset = value === null ? -1 : value - hat.logicalMin;
+    const direction =
+      value !== null &&
+      value >= hat.logicalMin &&
+      value <= hat.logicalMax &&
+      offset < HAT_DIRECTIONS.length
+        ? HAT_DIRECTIONS[offset]
+        : null;
+    const previous = state.get(hat.index) ?? null;
+
+    if (direction && direction !== previous) {
+      pressed.push({ index: hat.index, direction });
+    }
+    state.set(hat.index, direction);
+  }
+
+  return pressed;
+}
+
+/** Human-readable dump of a device's input-report layout, for diagnostics. */
+export function describeCollections(
+  collections: readonly HIDCollectionInfo[]
+): string {
+  const hex = (n: number) => `0x${n.toString(16).padStart(2, '0')}`;
+  const lines: string[] = [];
+
+  for (const report of collectInputReports(collections)) {
+    lines.push(`  report id=${report.reportId ?? 0}`);
+    for (const item of report.items ?? []) {
+      lines.push(
+        `    usagePage=${hex(itemUsagePage(item))} ` +
+          `usages=${item.usageMinimum ?? '?'}..${item.usageMaximum ?? '?'} ` +
+          `size=${item.reportSize ?? 0}x${item.reportCount ?? 0} ` +
+          `const=${item.isConstant ?? false}`
+      );
+    }
+  }
+
+  return lines.join('\n') || '  (no input reports)';
+}

--- a/src/app/keybindingManager.spec.ts
+++ b/src/app/keybindingManager.spec.ts
@@ -170,6 +170,32 @@ describe('KeybindingManager', () => {
     });
   });
 
+  describe('gamepad bindings', () => {
+    const gamepadBinding = (): KeybindingsMap =>
+      ({
+        'toggle-edit-mode': {
+          accelerator: 'gamepad:btn0',
+          label: 'Edit Layout',
+          description: '',
+          isDefault: false,
+        },
+      }) as unknown as KeybindingsMap;
+
+    // The token -> action routing, capture mode, and host lifecycle now live in
+    // GamepadManager (see gamepadManager.spec.ts). KeybindingManager only has to
+    // keep gamepad bindings out of the global keyboard-shortcut registry.
+    it('does not register gamepad bindings as global keyboard shortcuts', () => {
+      mockGetKeybindings.mockReturnValue(gamepadBinding());
+      mockIsRegistered.mockReturnValue(false);
+      mockRegister.mockReturnValue(true);
+
+      const manager = new KeybindingManager(fakeOverlayManager);
+      manager.registerAll();
+
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+  });
+
   describe('isValidAccelerator', () => {
     it('returns true when registration succeeds and unregisters the trial', () => {
       mockRegister.mockReturnValue(true);

--- a/src/app/keybindingManager.ts
+++ b/src/app/keybindingManager.ts
@@ -2,19 +2,27 @@ import { globalShortcut, desktopCapturer } from 'electron';
 import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import type { KeybindingActionId, KeybindingsMap } from '@irdashies/types';
+import { isGamepadBinding } from '@irdashies/shared';
 import { getKeybindings } from './storage/keybindings';
 import { OverlayManager } from './overlayManager';
 import logger from './logger';
+import { GamepadManager } from './gamepad/gamepadManager';
 
 export class KeybindingManager {
   private bindings: KeybindingsMap;
   private actionHandlers: Map<KeybindingActionId, () => void>;
   private hideState = false;
 
+  /** Owns the gamepad token -> action map, capture mode, and WebHID host. */
+  private gamepad: GamepadManager;
+
   constructor(private overlayManager: OverlayManager) {
     this.bindings = getKeybindings();
     this.actionHandlers = new Map();
     this.setupActionHandlers();
+    this.gamepad = new GamepadManager((actionId) =>
+      this.triggerAction(actionId)
+    );
   }
 
   private setupActionHandlers(): void {
@@ -76,9 +84,14 @@ export class KeybindingManager {
   }
 
   public registerAll(): void {
+    this.gamepad.syncBindings(this.bindings);
     for (const [actionId, entry] of Object.entries(this.bindings)) {
       const handler = this.actionHandlers.get(actionId as KeybindingActionId);
       if (!handler) continue;
+
+      // Gamepad bindings aren't global keyboard shortcuts; the GamepadManager
+      // routes them via syncBindings() above.
+      if (isGamepadBinding(entry.accelerator)) continue;
 
       try {
         // Skip if already registered (idempotent — safe to call after reloadBindings)
@@ -103,6 +116,7 @@ export class KeybindingManager {
 
   public unregisterAll(): void {
     for (const entry of Object.values(this.bindings)) {
+      if (isGamepadBinding(entry.accelerator)) continue;
       try {
         if (globalShortcut.isRegistered(entry.accelerator)) {
           globalShortcut.unregister(entry.accelerator);
@@ -114,6 +128,26 @@ export class KeybindingManager {
         );
       }
     }
+  }
+
+  /** Start reading game controllers (see {@link GamepadManager.start}). */
+  public startGamepad(): void {
+    this.gamepad.start();
+  }
+
+  /** Tear down the WebHID host window (call on shutdown). */
+  public stopGamepad(): void {
+    this.gamepad.stop();
+  }
+
+  /** Enter capture mode: the next pad presses are reported to `onCapture` for rebinding. */
+  public startGamepadCapture(onCapture: (token: string) => void): void {
+    this.gamepad.startCapture(onCapture);
+  }
+
+  /** Leave capture mode; pad presses resume triggering actions. */
+  public stopGamepadCapture(): void {
+    this.gamepad.stopCapture();
   }
 
   /**

--- a/src/frontend/components/Settings/sections/KeybindingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/KeybindingsSettings.tsx
@@ -5,7 +5,49 @@ import type {
   KeybindingEntry,
   KeybindingsMap,
 } from '@irdashies/types';
+import { isGamepadBinding, parseGamepadToken } from '@irdashies/shared';
 import logger from '@irdashies/utils/logger';
+
+const HAT_DIRECTION_LABELS: Record<string, string> = {
+  up: 'Up',
+  upright: 'Up Right',
+  right: 'Right',
+  downright: 'Down Right',
+  down: 'Down',
+  downleft: 'Down Left',
+  left: 'Left',
+  upleft: 'Up Left',
+};
+
+/** Format a gamepad control id ("btn5", "hat0_up") into a human label. */
+function formatGamepadControl(control: string): string {
+  const button = /^btn(\d+)$/.exec(control);
+  if (button) return `Button ${button[1]}`;
+
+  const hat = /^hat(\d+)_([a-z]+)$/.exec(control);
+  if (hat) {
+    const label = HAT_DIRECTION_LABELS[hat[2]] ?? hat[2];
+    // Hat 0 is the d-pad on every controller seen so far; name it as such.
+    return hat[1] === '0' ? `D-pad ${label}` : `Hat ${hat[1]} ${label}`;
+  }
+
+  return control;
+}
+
+/**
+ * Formats a gamepad token for display, prefixed with the device name when known
+ * and falling back to "Pad" otherwise, e.g.
+ *   "gamepad:Logitech%20G29:btn5" -> "Logitech G29: Button 5"
+ *   "gamepad:btn5"                -> "Pad: Button 5"
+ *   "gamepad:hat0_up"             -> "Pad: D-pad Up"
+ */
+function formatGamepadToken(token: string): string {
+  const parsed = parseGamepadToken(token);
+  if (!parsed) return 'Pad: ?';
+
+  const prefix = parsed.device || 'Pad';
+  return `${prefix}: ${formatGamepadControl(parsed.button)}`;
+}
 
 /**
  * Maps a browser KeyboardEvent into an Electron accelerator string.
@@ -60,6 +102,10 @@ function keyEventToAccelerator(e: KeyboardEvent): string | null {
  * Formats an accelerator string for display, e.g. "CommandOrControl" -> "Ctrl".
  */
 function formatAccelerator(accelerator: string): string {
+  if (isGamepadBinding(accelerator)) {
+    return formatGamepadToken(accelerator);
+  }
+
   const isMac =
     typeof navigator !== 'undefined' &&
     navigator.platform.toUpperCase().includes('MAC');
@@ -91,28 +137,24 @@ const KeyRecorder = ({ actionId, entry, onUpdated }: KeyRecorderProps) => {
   const [recording, setRecording] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const recorderRef = useRef<HTMLButtonElement>(null);
+  // First input (key or pad) during recording wins; later ones are ignored until
+  // recording restarts. Guards the async gap before listeners are torn down.
+  const bindingInProgressRef = useRef(false);
 
   const stopRecording = useCallback(async () => {
     setRecording(false);
+    bindingInProgressRef.current = false;
     await window.keybindingsBridge?.stopRecording();
   }, []);
 
   useEffect(() => {
     if (!recording) return;
 
-    const handleKeyDown = async (e: KeyboardEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-
-      // Escape cancels recording
-      if (e.key === 'Escape') {
-        await stopRecording();
-        return;
-      }
-
-      const accelerator = keyEventToAccelerator(e);
-      if (!accelerator) return; // Only modifiers pressed, keep waiting
-
+    // Persist whichever input arrives first — a key combo or a controller button.
+    const applyBinding = async (accelerator: string) => {
+      // check-then-set is atomic (no await between); blocks a second concurrent input.
+      if (bindingInProgressRef.current) return;
+      bindingInProgressRef.current = true;
       try {
         const result = await window.keybindingsBridge.updateKeybinding(
           actionId,
@@ -128,9 +170,34 @@ const KeyRecorder = ({ actionId, entry, onUpdated }: KeyRecorderProps) => {
       await stopRecording();
     };
 
+    const handleKeyDown = async (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      // Escape cancels recording
+      if (e.key === 'Escape') {
+        await stopRecording();
+        return;
+      }
+
+      const accelerator = keyEventToAccelerator(e);
+      if (!accelerator) return; // Only modifiers pressed, keep waiting
+
+      await applyBinding(accelerator);
+    };
+
     window.addEventListener('keydown', handleKeyDown, true);
+    // Controllers have no focus/DOM events; the main process captures pad
+    // presses via the WebHID host and forwards the token here while recording.
+    const unsubscribeGamepad = window.keybindingsBridge?.onGamepadCaptured(
+      (token) => {
+        void applyBinding(token);
+      }
+    );
+
     return () => {
       window.removeEventListener('keydown', handleKeyDown, true);
+      unsubscribeGamepad?.();
     };
   }, [recording, actionId, onUpdated, stopRecording]);
 

--- a/src/hidHost.ts
+++ b/src/hidHost.ts
@@ -1,0 +1,109 @@
+/**
+ * Hidden renderer that reads game-controller input via the WebHID API and
+ * forwards button presses to the main process. WebHID (unlike the focus-gated
+ * Gamepad API) keeps delivering input reports while the app is unfocused, which
+ * is what an iRacing overlay needs.
+ *
+ * This runs in its own always-alive, never-shown BrowserWindow (see
+ * src/app/gamepad/gamepadHost.ts). The main process auto-grants HID permission
+ * for that window's session, so `navigator.hid.getDevices()` returns the
+ * connected devices without a chooser or a user gesture.
+ */
+import logger from '@irdashies/utils/logger';
+import { gamepadTokenFromIndex, gamepadTokenFromHat } from '@irdashies/shared';
+import type { ButtonBit, HatField, HatDirection } from '@irdashies/types';
+import {
+  parseButtons,
+  parseHats,
+  buttonEdges,
+  hatEdges,
+  describeCollections,
+} from './app/gamepad/hidReport';
+
+interface DeviceState {
+  buttons: ButtonBit[];
+  hats: HatField[];
+  pressed: Map<number, boolean>;
+  hatState: Map<number, HatDirection | null>;
+}
+
+const devices = new Map<HIDDevice, DeviceState>();
+
+/** Open a HID device (if not already), parse its controls, and relay press edges. */
+async function openDevice(device: HIDDevice): Promise<void> {
+  if (devices.has(device)) return;
+
+  try {
+    if (!device.opened) await device.open();
+  } catch (err) {
+    logger.error(`[Gamepad] failed to open ${device.productName}`, err);
+    return;
+  }
+
+  const buttons = parseButtons(device.collections);
+  const hats = parseHats(device.collections);
+  const state: DeviceState = {
+    buttons,
+    hats,
+    pressed: new Map(),
+    hatState: new Map(),
+  };
+  devices.set(device, state);
+
+  if (buttons.length === 0 && hats.length === 0) {
+    logger.warn(
+      `[Gamepad] ${device.productName} opened but no controls detected. ` +
+        `Report layout:\n${describeCollections(device.collections)}`
+    );
+  }
+
+  device.addEventListener('inputreport', (event) => {
+    for (const index of buttonEdges(
+      event.data,
+      state.buttons,
+      event.reportId,
+      state.pressed
+    )) {
+      window.gamepadHost?.sendButton(
+        gamepadTokenFromIndex(index, device.productName)
+      );
+    }
+
+    for (const { index, direction } of hatEdges(
+      event.data,
+      state.hats,
+      event.reportId,
+      state.hatState
+    )) {
+      window.gamepadHost?.sendButton(
+        gamepadTokenFromHat(index, direction, device.productName)
+      );
+    }
+  });
+}
+
+/** Wire hotplug listeners and open every controller already connected at startup. */
+async function start(): Promise<void> {
+  if (!navigator.hid) {
+    logger.error('[Gamepad] WebHID (navigator.hid) is unavailable');
+    return;
+  }
+
+  navigator.hid.addEventListener('connect', (event) => {
+    logger.info(`[Gamepad] hid device connected: ${event.device.productName}`);
+    void openDevice(event.device);
+  });
+  navigator.hid.addEventListener('disconnect', (event) => {
+    devices.delete(event.device);
+  });
+
+  const available = await navigator.hid.getDevices();
+  if (available.length === 0) {
+    logger.info('[Gamepad] getDevices() returned no controllers');
+  }
+  for (const device of available) {
+    await openDevice(device);
+  }
+}
+
+void start();

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -6,6 +6,7 @@ import type {
   ReferenceLapBridge,
   LogBridge,
   KeybindingsBridge,
+  GamepadHostBridge,
   ChromiumFlagsBridge,
 } from '@irdashies/types';
 
@@ -18,6 +19,8 @@ declare global {
     referenceLapsBridge: ReferenceLapBridge;
     logBridge: LogBridge;
     keybindingsBridge: KeybindingsBridge;
+    /** Present only in the hidden WebHID host renderer (src/hidHost.ts). */
+    gamepadHost?: GamepadHostBridge;
     chromiumFlagsBridge: ChromiumFlagsBridge;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,9 @@ overlayManager.setupHardwareAcceleration();
 overlayManager.setupSingleInstanceLock();
 overlayManager.setupAutoStart();
 
+// Hoisted so the quit handler can tear down the WebHID host window cleanly.
+let keybindingManager: KeybindingManager | undefined;
+
 app.on('ready', async () => {
   // Don't start services if we don't have the single instance lock
   // (this instance should be quitting)
@@ -75,8 +78,10 @@ app.on('ready', async () => {
 
   overlayManager.createOverlays(dashboard);
 
-  const keybindingManager = new KeybindingManager(overlayManager);
+  keybindingManager = new KeybindingManager(overlayManager);
   keybindingManager.registerAll();
+  // Start the WebHID host window that reads game controllers for gamepad bindings.
+  keybindingManager.startGamepad();
 
   setupTaskbar(overlayManager, keybindingManager);
   publishDashboardUpdates(overlayManager, analytics);
@@ -107,6 +112,7 @@ app.on('quit', () => {
 
 app.on('before-quit', () => {
   overlayManager.markQuitting();
+  keybindingManager?.stopGamepad();
   // Synchronous flush so any pending debounced reference-lap write completes
   // before the process exits.
   flushReferenceLapsOnShutdown();

--- a/src/shared/gamepadToken.spec.ts
+++ b/src/shared/gamepadToken.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isGamepadBinding,
+  gamepadTokenFromIndex,
+  gamepadTokenFromHat,
+  parseGamepadToken,
+} from './gamepadToken';
+
+describe('gamepad binding token helpers', () => {
+  it('detects gamepad tokens vs keyboard accelerators', () => {
+    expect(isGamepadBinding('gamepad:btn0')).toBe(true);
+    expect(isGamepadBinding('gamepad:Logitech%20G29:btn3')).toBe(true);
+    expect(isGamepadBinding('Alt+H')).toBe(false);
+    expect(isGamepadBinding('F8')).toBe(false);
+  });
+
+  it('builds button and hat tokens with and without a device name', () => {
+    expect(gamepadTokenFromIndex(5)).toBe('gamepad:btn5');
+    expect(gamepadTokenFromIndex(5, 'Logitech G29')).toBe(
+      'gamepad:Logitech%20G29:btn5'
+    );
+    expect(gamepadTokenFromHat(0, 'up')).toBe('gamepad:hat0_up');
+    expect(gamepadTokenFromHat(0, 'downright', 'Xbox Pad')).toBe(
+      'gamepad:Xbox%20Pad:hat0_downright'
+    );
+  });
+
+  it('parses tokens back into device + control parts', () => {
+    expect(parseGamepadToken('gamepad:btn5')).toEqual({ button: 'btn5' });
+    expect(parseGamepadToken('gamepad:Logitech%20G29:btn5')).toEqual({
+      device: 'Logitech G29',
+      button: 'btn5',
+    });
+    expect(parseGamepadToken('gamepad:hat0_up')).toEqual({ button: 'hat0_up' });
+    expect(
+      parseGamepadToken(gamepadTokenFromHat(1, 'left', 'My:Wheel'))
+    ).toEqual({ device: 'My:Wheel', button: 'hat1_left' });
+    expect(parseGamepadToken('Alt+H')).toBeNull();
+    expect(parseGamepadToken('gamepad:btn')).toBeNull();
+    expect(parseGamepadToken('gamepad:Dev:nope')).toBeNull();
+  });
+
+  it('validates button and hat tokens with or without a device name', () => {
+    expect(parseGamepadToken('gamepad:btn0')).not.toBeNull();
+    expect(parseGamepadToken('gamepad:btn27')).not.toBeNull();
+    expect(parseGamepadToken('gamepad:Fanatec%20CSL:btn12')).not.toBeNull();
+    expect(parseGamepadToken('gamepad:hat0_up')).not.toBeNull();
+    expect(
+      parseGamepadToken('gamepad:Xbox%20Pad:hat0_downright')
+    ).not.toBeNull();
+    // Malformed / non-control tokens
+    expect(parseGamepadToken('gamepad:btn')).toBeNull();
+    expect(parseGamepadToken('gamepad:a')).toBeNull();
+    expect(parseGamepadToken('gamepad:hat0')).toBeNull();
+    expect(parseGamepadToken('gamepad:hat_up')).toBeNull();
+    expect(parseGamepadToken('gamepad:hat0_unknown')).toBeNull();
+    expect(parseGamepadToken('Alt+H')).toBeNull();
+  });
+});

--- a/src/shared/gamepadToken.ts
+++ b/src/shared/gamepadToken.ts
@@ -1,0 +1,81 @@
+import { HAT_DIRECTIONS, type ParsedGamepadToken } from '@irdashies/types';
+
+/** Prefix marking a binding value as a gamepad button rather than a keyboard accelerator. */
+export const GAMEPAD_TOKEN_PREFIX = 'gamepad:';
+
+/**
+ * Gamepad control token grammar:
+ *
+ *   gamepad:btn<N>                 button index N, device unknown
+ *   gamepad:<device>:btn<N>        button index N on a named device
+ *   gamepad:hat<N>_<dir>           hat (d-pad) N in direction <dir>
+ *   gamepad:<device>:hat<N>_<dir>  hat N on a named device
+ *
+ * N is the control's zero-based index within the device's HID input report
+ * (WebHID exposes controls by index, not name). `<dir>` is a hat direction such
+ * as `up` or `downright`. The control id never contains a raw ':' (hats use
+ * '_'), and `<device>` is the URL-encoded product name — so a single ':' always
+ * separates the optional device from the control.
+ */
+// Hat suffix restricted to the 8 known HID directions — rejects junk like `hat0_unknown`.
+const GAMEPAD_CONTROL_RE = new RegExp(
+  `^(btn\\d+|hat\\d+_(?:${HAT_DIRECTIONS.join('|')}))$`
+);
+
+/** True when a binding value refers to a gamepad control. */
+export function isGamepadBinding(accelerator: string): boolean {
+  return accelerator.startsWith(GAMEPAD_TOKEN_PREFIX);
+}
+
+function gamepadToken(control: string, deviceName?: string): string {
+  return deviceName
+    ? `${GAMEPAD_TOKEN_PREFIX}${encodeURIComponent(deviceName)}:${control}`
+    : `${GAMEPAD_TOKEN_PREFIX}${control}`;
+}
+
+/**
+ * Build a gamepad token from a button index and (optionally) the device's
+ * product name, e.g. (5, "Logitech G29") -> "gamepad:Logitech%20G29:btn5",
+ * or (5) -> "gamepad:btn5".
+ */
+export function gamepadTokenFromIndex(
+  index: number,
+  deviceName?: string
+): string {
+  return gamepadToken(`btn${index}`, deviceName);
+}
+
+/**
+ * Build a gamepad token from a hat index + direction and (optionally) the
+ * device's product name, e.g. (0, "up", "Xbox") -> "gamepad:Xbox:hat0_up".
+ */
+export function gamepadTokenFromHat(
+  index: number,
+  direction: string,
+  deviceName?: string
+): string {
+  return gamepadToken(`hat${index}_${direction}`, deviceName);
+}
+
+/** Parse a gamepad token into its device + control parts, or null if invalid. */
+export function parseGamepadToken(token: string): ParsedGamepadToken | null {
+  if (!isGamepadBinding(token)) return null;
+  const body = token.slice(GAMEPAD_TOKEN_PREFIX.length);
+
+  const sep = body.lastIndexOf(':');
+  if (sep === -1) {
+    return GAMEPAD_CONTROL_RE.test(body) ? { button: body } : null;
+  }
+
+  const button = body.slice(sep + 1);
+  if (!GAMEPAD_CONTROL_RE.test(button)) return null;
+
+  const encoded = body.slice(0, sep);
+  let device: string | undefined;
+  try {
+    device = decodeURIComponent(encoded) || undefined;
+  } catch {
+    device = encoded || undefined;
+  }
+  return { device, button };
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './gamepadToken';

--- a/src/types/gamepadToken.ts
+++ b/src/types/gamepadToken.ts
@@ -1,0 +1,57 @@
+/** Parsed device + control parts of a gamepad token. */
+export interface ParsedGamepadToken {
+  /** Decoded device product name, or undefined when the token carries none. */
+  device?: string;
+  /** Control id, e.g. "btn5" or "hat0_up". */
+  button: string;
+}
+
+/** Location of a single button bit within a device's HID input report. */
+export interface ButtonBit {
+  /** Report ID the bit belongs to (0 when the device uses no report IDs). */
+  reportId: number;
+  /** Byte offset within the report's data (the report-ID prefix is excluded). */
+  byteOffset: number;
+  /** Bit mask within that byte. */
+  bitMask: number;
+  /** Stable zero-based ordinal across all of the device's buttons. */
+  index: number;
+}
+
+/**
+ * The eight hat (point-of-view / d-pad) positions in HID order: value 0 is up,
+ * incrementing clockwise. Any value outside 0-7 means the hat is centered.
+ */
+export const HAT_DIRECTIONS = [
+  'up',
+  'upright',
+  'right',
+  'downright',
+  'down',
+  'downleft',
+  'left',
+  'upleft',
+] as const;
+
+export type HatDirection = (typeof HAT_DIRECTIONS)[number];
+
+/** Location of a hat-switch (d-pad / POV) value within a device's HID input report. */
+export interface HatField {
+  reportId: number;
+  /** Absolute bit offset of the value within the report's data. */
+  bitOffset: number;
+  /** Width of the value in bits (typically 4). */
+  bitWidth: number;
+  /** Raw value of the first ("up") position. Pads number 0-7 or 1-8. */
+  logicalMin: number;
+  /** Raw value of the last valid position; anything outside the range is centered. */
+  logicalMax: number;
+  /** Stable zero-based ordinal across all of the device's hats. */
+  index: number;
+}
+
+/** A hat that just entered a new direction — the d-pad equivalent of a press. */
+export interface HatPress {
+  index: number;
+  direction: HatDirection;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,3 +15,4 @@ export * from './logBridge';
 export * from './keybindings';
 export * from './personalBestLapBridge';
 export * from './chromiumFlags';
+export * from './gamepadToken';

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -5,7 +5,11 @@ export type KeybindingActionId =
   | 'save-telemetry';
 
 export interface KeybindingEntry {
-  /** Electron accelerator string, e.g. "Alt+H", "CommandOrControl+Shift+F6" */
+  /**
+   * The bound input. Either an Electron keyboard accelerator
+   * (e.g. "Alt+H", "CommandOrControl+Shift+F6") or a gamepad token
+   * (e.g. "gamepad:btn0"). Use `isGamepadBinding` to tell them apart.
+   */
   accelerator: string;
   /** Human-readable label for the settings UI */
   label: string;
@@ -26,10 +30,26 @@ export interface KeybindingsBridge {
   ) => Promise<KeybindingsMap>;
   resetKeybinding: (actionId: KeybindingActionId) => Promise<KeybindingsMap>;
   resetAllKeybindings: () => Promise<KeybindingsMap>;
-  /** Temporarily unregister all global shortcuts so key presses reach the settings window */
+  /**
+   * Temporarily unregister keyboard shortcuts (so key presses reach the
+   * settings window) and put the gamepad into capture mode.
+   */
   startRecording: () => Promise<void>;
-  /** Re-register all global shortcuts after recording completes */
+  /** Re-register keyboard shortcuts and leave gamepad capture mode. */
   stopRecording: () => Promise<void>;
+  /**
+   * Subscribe to gamepad button presses captured while recording. The callback
+   * receives a gamepad token (e.g. "gamepad:btn0"). Returns an unsubscribe fn.
+   */
+  onGamepadCaptured: (callback: (token: string) => void) => () => void;
+}
+
+/**
+ * Bridge exposed only to the hidden WebHID host window. Forwards a controller
+ * button press (already encoded as a `gamepad:btn<N>` token) to the main process.
+ */
+export interface GamepadHostBridge {
+  sendButton: (token: string) => void;
 }
 
 export const DEFAULT_KEYBINDINGS: KeybindingsMap = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,10 @@
       "@irdashies/storybook": ["./.storybook"],
       "@irdashies/utils/*": ["./src/frontend/utils/*"],
       "@irdashies/context": ["./src/frontend/context"],
-      "@irdashies/types": ["./src/types"]
+      "@irdashies/types": ["./src/types"],
+      "@irdashies/shared": ["./src/shared"]
     },
-    "types": ["vite/client"]
+    "types": ["vite/client", "w3c-web-hid"]
   },
   "exclude": ["site"]
 }

--- a/vite.renderer.config.ts
+++ b/vite.renderer.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       input: {
         main: path.resolve(__dirname, 'index.html'),
         'dashboard-view': path.resolve(__dirname, 'index-dashboard-view.html'),
+        'hid-host': path.resolve(__dirname, 'index-hid-host.html'),
       },
       output: {
         chunkFileNames: 'assets/[name]-[hash].js',


### PR DESCRIPTION
Any keybinding can now be triggered by a controller button as well as a keyboard shortcut. Recording a binding accepts whichever arrives first.

WebHID is used because it keeps delivering input reports while the app is unfocused (the sim holds focus), unlike the W3C Gamepad API. A hidden, always-alive renderer hosts the HID reader and forwards button tokens to the main process, where GamepadManager routes them to the bound action through the same triggerAction path as keyboard shortcuts.

Bindings store either a keyboard accelerator or a gamepad token (`gamepad:[device:]btn<N>`) helpers and validation live in `@irdashies/shared`.

## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

## Screenshots

<img width="919" height="245" alt="image" src="https://github.com/user-attachments/assets/011b2758-b379-4936-9a89-971191f32874" />

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added gamepad/controller button bindings with human-readable labels in keybinding settings.
  * Gamepad input is now captured even when the app is unfocused.
  * Added d-pad (hat switch) support and recording for both buttons and hats.

* **Bug Fixes**
  * Improved validation for controller binding updates, rejecting invalid controller button tokens without changing saved bindings.

* **Tests**
  * Added comprehensive unit tests covering gamepad token parsing, HID report parsing, input capture/dispatch, and keybinding bridge behavior.

* **Chores**
  * Added WebHID design documentation and build/dev setup for the hidden HID host.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->