### PR TITLE
fix: Removed duplicate pit stop store updates (from Relative and Standings).

### DIFF
--- a/src/frontend/components/OverlayContainer/OverlayContainer.spec.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.spec.tsx
@@ -10,6 +10,7 @@ vi.mock('@irdashies/context', () => ({
   useRunningState: vi.fn(),
   usePushToPassStoreUpdater: vi.fn(),
   useResetOnDisconnect: vi.fn(),
+  usePitLapStoreUpdater: vi.fn(),
 }));
 vi.mock('../TrackMap/hooks/useSectorTiming', () => ({
   useSectorTiming: vi.fn(),

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -11,6 +11,7 @@ import { XIcon } from '@phosphor-icons/react';
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 import { SectorTimingUpdater } from './SectorTimingUpdater';
 import { PushToPassUpdater } from './PushToPassUpdater';
+import { PitLapUpdater } from './PitLapUpdater';
 
 export const OverlayContainer = memo(() => {
   const {
@@ -136,6 +137,7 @@ export const OverlayContainer = memo(() => {
     >
       <SectorTimingUpdater />
       <PushToPassUpdater />
+      <PitLapUpdater />
       {widgetsForThisDisplay.map((widget, index) => {
         const WidgetComponent = getWidget(widget.type || widget.id);
         if (!WidgetComponent) {

--- a/src/frontend/components/OverlayContainer/PitLapUpdater.tsx
+++ b/src/frontend/components/OverlayContainer/PitLapUpdater.tsx
@@ -1,0 +1,15 @@
+import { usePitLapStoreUpdater } from '@irdashies/context';
+import { useStandingsSettings, useRelativeSettings } from '../Standings/hooks';
+
+export const PitLapUpdater = () => {
+  const standingsSettings = useStandingsSettings();
+  const relativeSettings = useRelativeSettings();
+
+  const enabled = !!(
+    standingsSettings?.pitStatus?.enabled ||
+    relativeSettings?.pitStatus?.enabled
+  );
+
+  usePitLapStoreUpdater(enabled);
+  return null;
+};

--- a/src/frontend/components/Standings/Relative.stories.tsx
+++ b/src/frontend/components/Standings/Relative.stories.tsx
@@ -107,7 +107,7 @@ const RelativeWithoutHeaderFooter = () => {
   const numCarClasses = useWeekendInfoNumCarClasses();
   const isMultiClass = (numCarClasses ?? 0) > 1;
 
-  usePitLapStoreUpdater();
+  usePitLapStoreUpdater(true);
 
   // Always render 2 * buffer + 1 rows (buffer above + player + buffer below)
   const totalRows = 2 * buffer + 1;
@@ -554,7 +554,7 @@ const RelativeWithoutHeader = () => {
   const numCarClasses = useWeekendInfoNumCarClasses();
   const isMultiClass = (numCarClasses ?? 0) > 1;
 
-  usePitLapStoreUpdater();
+  usePitLapStoreUpdater(true);
 
   // Always render 2 * buffer + 1 rows (buffer above + player + buffer below)
   const totalRows = 2 * buffer + 1;
@@ -797,7 +797,7 @@ const RelativeWithoutFooter = () => {
   const numCarClasses = useWeekendInfoNumCarClasses();
   const isMultiClass = (numCarClasses ?? 0) > 1;
 
-  usePitLapStoreUpdater();
+  usePitLapStoreUpdater(true);
 
   // Always render 2 * buffer + 1 rows (buffer above + player + buffer below)
   const totalRows = 2 * buffer + 1;

--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -6,7 +6,6 @@ import {
   useWeekendInfoTeamRacing,
   useSessionVisibility,
   useGeneralSettings,
-  usePitLapStoreUpdater,
   useLapTimesStoreUpdater,
   useLapTimeHistory,
   useFocusCarIdx,
@@ -50,8 +49,8 @@ export const Relative = () => {
 
   const flagColor = getFlagColor(getFlag(sessionFlags).label);
 
-  usePitLapStoreUpdater();
   const p2pDisplayStates = useP2PDisplayStates();
+
 
   const lapTimeDeltasEnabled = settings?.lapTimeDeltas?.enabled ?? false;
   useLapTimesStoreUpdater(lapTimeDeltasEnabled);

--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -98,7 +98,7 @@ const StandingsWithoutHeaderFooter = () => {
   useLapTimesStoreUpdater(true);
 
   // Update pit laps
-  usePitLapStoreUpdater();
+  usePitLapStoreUpdater(true);
 
   const standings = useDriverStandings(settings);
   const classStats = useCarClassStats();
@@ -284,7 +284,7 @@ const StandingsWithIRatingCalculation = () => {
   const highlightColor = useHighlightColor();
 
   useLapTimesStoreUpdater(true);
-  usePitLapStoreUpdater();
+  usePitLapStoreUpdater(true);
 
   // Manually apply irating calculation for demo purposes
   const standingsWithIRating = useMemo(() => {
@@ -563,7 +563,7 @@ const StandingsWithoutHeader = () => {
   useLapTimesStoreUpdater(true);
 
   // Update pit laps
-  usePitLapStoreUpdater();
+  usePitLapStoreUpdater(true);
 
   const standings = useDriverStandings(settings);
   const classStats = useCarClassStats();
@@ -721,7 +721,7 @@ const StandingsWithoutFooter = () => {
   useLapTimesStoreUpdater(true);
 
   // Update pit laps
-  usePitLapStoreUpdater();
+  usePitLapStoreUpdater(true);
 
   const standings = useDriverStandings(settings);
   const classStats = useCarClassStats();
@@ -978,7 +978,7 @@ const StandingsWithFullHeader = () => {
   useLapTimesStoreUpdater(true);
 
   // Update pit laps
-  usePitLapStoreUpdater();
+  usePitLapStoreUpdater(true);
 
   const standings = useDriverStandings(settings);
   const classStats = useCarClassStats();

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -14,7 +14,6 @@ import {
 import {
   useGeneralSettings,
   useLapTimesStoreUpdater,
-  usePitLapStoreUpdater,
   useP2PDisplayStates,
   useDrivingState,
   useWeekendInfoNumCarClasses,
@@ -36,10 +35,8 @@ export const Standings = () => {
     !!(settings?.lapTimeDeltas?.enabled || settings?.avgLapTime?.enabled)
   );
 
-  // Update pit laps
-  usePitLapStoreUpdater();
-
   const p2pDisplayStates = useP2PDisplayStates();
+
 
   const standings = useDriverStandings(settings);
   const classStats = useCarClassStats();

--- a/src/frontend/context/PitLapStore/PitLapStoreUpdater.tsx
+++ b/src/frontend/context/PitLapStore/PitLapStoreUpdater.tsx
@@ -9,7 +9,7 @@ import { useStore } from 'zustand';
  *
  * Use this hook in components that need pit lap tracking (e.g., Standings overlay).
  */
-export const usePitLapStoreUpdater = () => {
+export const usePitLapStoreUpdater = (enabled: boolean) => {
   const carIdxOnPitRoad = useTelemetryValues<boolean[]>('CarIdxOnPitRoad');
   const carIdxLap = useTelemetryValues<number[]>('CarIdxLap');
   const sessionUniqueID = useTelemetryValue('SessionUniqueID');
@@ -24,6 +24,7 @@ export const usePitLapStoreUpdater = () => {
   });
 
   useEffect(() => {
+    if (!enabled) return;
     updatePitLapTimes(
       carIdxOnPitRoad ?? [],
       carIdxLap ?? [],
@@ -32,5 +33,5 @@ export const usePitLapStoreUpdater = () => {
       carIdxTrackSurface ?? [],
       sessionState ?? 0
     );
-  }, [carIdxOnPitRoad, carIdxLap, sessionUniqueID, throttledSessionTime, carIdxTrackSurface, sessionState, updatePitLapTimes]);
+  }, [enabled, carIdxOnPitRoad, carIdxLap, sessionUniqueID, throttledSessionTime, carIdxTrackSurface, sessionState, updatePitLapTimes]);
 };


### PR DESCRIPTION
## Description

Removed duplicate pit stop store updates (from Relative and Standings).

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

### After
<!-- Screenshot or description of the new behaviour -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pit-lap updater to the overlay so pit-lap updates are driven from overlay rendering.
* **Refactor**
  * Removed direct pit-lap update triggering from the Standings and Relative views.
* **Behavior Changes**
  * Pit-lap updates are now enable/disable controlled by overlay-related settings.
* **Tests**
  * Updated overlay container test mocks to match the updated pit-lap updater API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->