### PR TITLE
fix: settings window stuck on "Loading..." (missed dashboardUpdated broadcast)

### DIFF
--- a/src/app/bridge/dashboard/dashboardBridge.ts
+++ b/src/app/bridge/dashboard/dashboardBridge.ts
@@ -249,8 +249,12 @@ export async function publishDashboardUpdates(
   });
   ipcMain.on('reloadDashboard', () => {
     const currentProfileId = getCurrentProfileId();
-    const dashboard = getDashboard(currentProfileId);
-    if (!dashboard) return;
+    // Self-heal: if no dashboard is stored for the current profile, seed a
+    // default one instead of silently returning. A missing dashboard here
+    // means renderers never receive 'dashboardUpdated' and hang on "Loading...".
+    const dashboard =
+      getDashboard(currentProfileId) ??
+      getOrCreateDefaultDashboardForProfile(currentProfileId);
     const merged = mergeDriverTagsIntoLayout(dashboard, getDriverTagSettings());
     overlayManager.closeOrCreateWindows(merged);
     overlayManager.publishMessage('dashboardUpdated', merged);

--- a/src/frontend/context/DashboardContext/DashboardContext.spec.tsx
+++ b/src/frontend/context/DashboardContext/DashboardContext.spec.tsx
@@ -164,6 +164,49 @@ describe('DashboardContext', () => {
     });
   });
 
+  it('loads the dashboard directly when no dashboardUpdated broadcast arrives', async () => {
+    // Regression: the settings/overlay windows (no profileId) must not depend
+    // solely on the unbuffered dashboardUpdated broadcast, which can be missed
+    // if it is published before the renderer registers its listener — leaving
+    // the window stuck on "Loading...". Here dashboardUpdated never fires.
+    const mockDashboard: DashboardLayout = {
+      widgets: [
+        {
+          id: 'test',
+          enabled: true,
+          layout: { x: 0, y: 0, width: 1, height: 1 },
+        },
+      ],
+    };
+    mockBridge.dashboardUpdated = vi.fn(); // never invokes the callback
+    mockBridge.getCurrentProfile = vi.fn().mockResolvedValue({
+      id: 'active-profile',
+      name: 'Active',
+      createdAt: '',
+      lastModified: '',
+    });
+    mockBridge.getDashboardForProfile = vi
+      .fn()
+      .mockResolvedValue(mockDashboard);
+
+    act(() => {
+      render(
+        <DashboardProvider bridge={mockBridge}>
+          <TestComponent />
+        </DashboardProvider>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-dashboard').textContent).toBe(
+        JSON.stringify(mockDashboard)
+      );
+    });
+    expect(mockBridge.getDashboardForProfile).toHaveBeenCalledWith(
+      'active-profile'
+    );
+  });
+
   it('stops the bridge on unmount', () => {
     const { unmount } = render(
       <DashboardProvider bridge={mockBridge}>

--- a/src/frontend/context/DashboardContext/DashboardContext.tsx
+++ b/src/frontend/context/DashboardContext/DashboardContext.tsx
@@ -145,8 +145,28 @@ export const DashboardProvider: React.FC<{
           bridge.reloadDashboard();
         });
     } else {
-      // This is the path for the main Electron app, which doesn't have a profileId prop
-      bridge.reloadDashboard();
+      // Main Electron app windows (overlay + settings) have no profileId prop.
+      // Fetch the dashboard directly rather than relying solely on the
+      // reloadDashboard broadcast: 'dashboardUpdated' is delivered via an
+      // unbuffered ipcRenderer.on, so a broadcast published before this
+      // renderer has registered its listener is silently dropped — leaving the
+      // window stuck on "Loading...". The direct fetch is race-free (it mirrors
+      // the profileId path above). reloadDashboard is still sent for its
+      // main-side side effect of creating/refreshing the overlay windows.
+      bridge
+        .getCurrentProfile()
+        .then((profile) =>
+          profile?.id && bridge.getDashboardForProfile
+            ? bridge.getDashboardForProfile(profile.id)
+            : null
+        )
+        .then((dashboard) => {
+          if (dashboard) setDashboard(dashboard);
+        })
+        .catch((error) =>
+          logger.error('Error loading current dashboard:', error)
+        )
+        .finally(() => bridge.reloadDashboard());
     }
 
     const unsubEditMode = bridge.onEditModeToggled((editMode) =>


### PR DESCRIPTION
## Description

The settings window (and potentially an overlay window) can get stuck on a black **"Loading…"** screen indefinitely, surviving profile switches, while other windows load fine.

### Root cause
`Settings` renders "Loading…" until `currentDashboard` is set. For windows **without** a `profileId` prop (the main overlay + settings windows), `DashboardProvider` only fired `bridge.reloadDashboard()` and waited for the main process to broadcast `dashboardUpdated` back.

But `reloadDashboard` is a fire-and-forget `ipcRenderer.send`, and `dashboardUpdated` is delivered via an **unbuffered** `ipcRenderer.on`. If the main process broadcasts `dashboardUpdated` (e.g. triggered by another window's reload) *before* this renderer has registered its listener, the message is silently dropped — and since the renderer only requests once on mount, the window waits forever. Whichever window wins the race loads; the one that loses hangs.

### Fix
Two changes:

1. **`DashboardContext`** — for the no-`profileId` path, fetch the dashboard **directly** via `getCurrentProfile()` + `getDashboardForProfile()` (an `invoke` that returns the value), the same race-free pattern the `profileId` path already uses. `reloadDashboard()` is still sent afterward for its main-side side effect (creating/refreshing overlay windows). This makes initial load independent of broadcast timing.

2. **`dashboardBridge` (`reloadDashboard` handler)** — defensive: previously returned early (sending nothing) when no dashboard existed for the current profile, which would also leave renderers hanging. Now seeds a default via `getOrCreateDefaultDashboardForProfile`, mirroring `getDashboardForProfile`.

### Tests
Added a regression test in `DashboardContext.spec.tsx` that renders with **no** `dashboardUpdated` broadcast ever firing and asserts `currentDashboard` is still populated via the direct fetch. All 9 tests pass.

## Screenshots

N/A — recovers a stuck-loading window; no visual change when load succeeds.

### Before
Settings window stuck on black "Loading…" indefinitely (lost the broadcast race), persisting across profile switches.

### After
Window fetches the dashboard directly on mount and renders regardless of broadcast timing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)