### PR TITLE
fix: honor "Start minimized" so the settings window stays hidden on launch

### DIFF
--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -128,7 +128,8 @@ export class OverlayManager {
       this.createWindowForDisplay(display, isPrimary);
     }
 
-    this.createSettingsWindow();
+    const startMinimized = generalSettings?.startMinimized ?? false;
+    this.createSettingsWindow(undefined, { startHidden: startMinimized });
   }
 
   /**
@@ -835,7 +836,10 @@ export class OverlayManager {
     return this.hasSingleInstanceLock;
   }
 
-  public createSettingsWindow(widgetType?: string): BrowserWindow {
+  public createSettingsWindow(
+    widgetType?: string,
+    options?: { startHidden?: boolean }
+  ): BrowserWindow {
     if (this.currentSettingsWindow) {
       if (this.currentSettingsWindow.isMinimized()) {
         this.currentSettingsWindow.restore();
@@ -844,6 +848,8 @@ export class OverlayManager {
       this.currentSettingsWindow.focus();
       return this.currentSettingsWindow;
     }
+
+    const startHidden = options?.startHidden ?? false;
 
     // Load saved window bounds
     const savedBounds = loadWindowBounds();
@@ -855,6 +861,11 @@ export class OverlayManager {
       autoHideMenuBar: true,
       acceptFirstMouse: true,
       icon: getIconPath(),
+      // Start hidden and reveal on ready-to-show (same pattern as overlay
+      // windows). This avoids a race where a window created with the default
+      // show:true is auto-shown by Electron on first paint even after an early
+      // hide() call — which is what broke the "Start minimized" setting.
+      show: false,
       webPreferences: {
         preload: path.join(__dirname, 'preload.js'),
         backgroundThrottling: false,
@@ -867,6 +878,14 @@ export class OverlayManager {
     );
 
     this.currentSettingsWindow = browserWindow;
+
+    // Reveal the window once its content is ready, unless it should start
+    // minimized to the system tray (the "Start minimized" general setting).
+    browserWindow.once('ready-to-show', () => {
+      if (browserWindow.isDestroyed() || startHidden) return;
+      browserWindow.show();
+      browserWindow.focus();
+    });
 
     // During edit mode, raise settings window above overlay windows (layer 1).
     // Outside edit mode, use normal window layering.

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,16 +88,6 @@ app.on('ready', async () => {
   setupKeybindingsBridge(keybindingManager);
 
   await analytics.init(overlayManager.getVersion(), dashboard);
-
-  // Check if settings window should start minimized
-  const shouldStartMinimized =
-    dashboard?.generalSettings?.startMinimized ?? false;
-  if (shouldStartMinimized) {
-    // Create the settings window but don't show it immediately
-    const settingsWindow = overlayManager.createSettingsWindow();
-    // Minimize it to system tray
-    settingsWindow.hide();
-  }
 });
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Description

When launching irDashies (e.g. via iRacing Manager) with **Start minimized** enabled, the settings/program window would still open instead of staying minimized to the system tray.

**Root cause:** The settings window was created unconditionally in `createOverlays()` (`overlayManager.ts`) using Electron's default `show: true` and **no `ready-to-show` handler** — unlike the overlay windows, which correctly use `show: false` + `ready-to-show`. The `startMinimized` → `hide()` logic lived in `main.ts` and only ran **after `await analytics.init()`**. That raced against Electron auto-showing the window on first paint: depending on timing (Electron version, how fast `analytics.init` resolves), the paint landed *after* the late `.hide()`, so the window opened anyway. It also re-entered `createSettingsWindow`, which `.show()`+`.focus()`'d the window right before hiding it.

This is why it appeared to regress — `createSettingsWindow()` was added to `createOverlays` ("open settings on startup", Apr 2025) before the start-minimized feature existed, so start-minimized has always been fighting an already-visible window, and any timing shift tipped it from "usually works" to "never works."

**Fix:** Create the settings window with `show: false` and reveal it on `ready-to-show` *unless* it should start hidden — the same pattern the overlay windows already use. `createOverlays` reads `startMinimized` and passes the intent through. Removed the redundant, racy post-`await` `hide()` block from `main.ts`. The minimize intent is now honored at creation time, so the window never paints when minimized (also eliminates a brief flash that occurred even when it "worked").

## Screenshots

### Before
With "Start minimized" enabled, the settings window opens on launch (instead of going to the tray).

### After
With "Start minimized" enabled, the app starts with the settings window hidden in the system tray; opening it from the tray works as before.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings window now supports starting in a hidden state when the "start minimized" preference is enabled, providing improved control over application startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->