### PR TITLE
feat: Layout profile cycling/switching keybind + some optimizations

### DIFF
--- a/src/app/bridge/dashboard/dashboardBridge.ts
+++ b/src/app/bridge/dashboard/dashboardBridge.ts
@@ -408,12 +408,10 @@ export async function publishDashboardUpdates(
   });
 
   ipcMain.handle('switchProfile', (_, profileId: string) => {
+    // setCurrentProfile emits dashboardUpdated → publishDashboardUpdates
+    // live-updates overlays (closeOrCreateWindows + publishMessage). No
+    // destroy/recreate, so the switch is near-instant.
     setCurrentProfile(profileId);
-    // Force refresh overlays with the new profile's dashboard
-    const dashboard = getDashboard(profileId);
-    if (dashboard) {
-      overlayManager.forceRefreshOverlays(dashboard);
-    }
   });
 
   ipcMain.handle('getCurrentProfile', () => {

--- a/src/app/bridge/dashboard/dashboardBridge.ts
+++ b/src/app/bridge/dashboard/dashboardBridge.ts
@@ -37,6 +37,12 @@ import {
   getAnalyticsOptOut as getAnalyticsOptOutStorage,
   setAnalyticsOptOut as setAnalyticsOptOutStorage,
 } from '../../storage/analytics';
+import {
+  getCycleProfiles as getCycleProfilesStorage,
+  setCycleProfiles as setCycleProfilesStorage,
+  getShowProfileBanner as getShowProfileBannerStorage,
+  setShowProfileBanner as setShowProfileBannerStorage,
+} from '../../storage/appSettings';
 import { Analytics } from '../../analytics';
 import logger from '../../logger';
 
@@ -212,9 +218,11 @@ export async function publishDashboardUpdates(
   overlayManager: OverlayManager,
   analytics: Analytics
 ) {
-  onDashboardUpdated((dashboard) => {
-    const merged = mergeDriverTagsIntoLayout(dashboard, getDriverTagSettings());
-    const profileId = getCurrentProfileId();
+  let lastProfileId = getCurrentProfileId();
+  let hideTimer: ReturnType<typeof setTimeout> | undefined;
+  let settleTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const applyDashboard = (merged: DashboardLayout, profileId: string) => {
     overlayManager.closeOrCreateWindows(merged);
     overlayManager.publishMessage('dashboardUpdated', merged);
     // Notify component server bridge subscribers
@@ -225,6 +233,40 @@ export async function publishDashboardUpdates(
         logger.error('Error in dashboard update callback:', err);
       }
     });
+  };
+
+  onDashboardUpdated((dashboard) => {
+    const merged = mergeDriverTagsIntoLayout(dashboard, getDriverTagSettings());
+    const profileId = getCurrentProfileId();
+
+    if (profileId === lastProfileId) {
+      applyDashboard(merged, profileId);
+      return;
+    }
+
+    // Profile switch: the overlay windows resize to the new layout, which is
+    // visible if it happens on screen. So hide the widgets, resize while
+    // hidden, then reveal and show the name. The renderer just toggles
+    // visibility on command; main sequences the timing.
+    clearTimeout(hideTimer);
+    clearTimeout(settleTimer);
+    lastProfileId = profileId;
+    const name = getProfile(profileId)?.name ?? '';
+    // Banner is cosmetic; the hide/reveal still runs to mask the resize.
+    const showBanner = getShowProfileBannerStorage();
+    const HIDE_MS = 120; // let the renderer hide before we resize
+    const SETTLE_MS = 80; // let the new layout settle before revealing
+    overlayManager.publishMessage('profileTransition', { hidden: true, name });
+    hideTimer = setTimeout(() => {
+      applyDashboard(merged, profileId);
+      settleTimer = setTimeout(() => {
+        overlayManager.publishMessage('profileTransition', {
+          hidden: false,
+          name,
+          showBanner,
+        });
+      }, SETTLE_MS);
+    }, HIDE_MS);
   });
   ipcMain.on('saveDashboard', (_, dashboard, options) => {
     // For layout-only changes (drag/resize), skip the window refresh
@@ -331,6 +373,18 @@ export async function publishDashboardUpdates(
       },
     });
   });
+
+  ipcMain.handle('getCycleProfiles', () => getCycleProfilesStorage());
+
+  ipcMain.handle('setCycleProfiles', (_, enabled: boolean) =>
+    setCycleProfilesStorage(enabled)
+  );
+
+  ipcMain.handle('getShowProfileBanner', () => getShowProfileBannerStorage());
+
+  ipcMain.handle('setShowProfileBanner', (_, enabled: boolean) =>
+    setShowProfileBannerStorage(enabled)
+  );
 
   // Profile management IPC handlers
   ipcMain.handle('listProfiles', () => {

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -152,6 +152,14 @@ export async function publishIRacingSDKEvents(
   sdk.autoEnableTelemetry = true;
   await sdk.ready();
 
+  // Seed the running state immediately so the renderer doesn't sit on the
+  // previous bridge's last value (e.g. a stale demo frame) until the first
+  // interval tick 5s later — this is what made exiting demo mode feel slow.
+  const initialRunningState = sdk.sessionStatusOK;
+  lastRunningState = initialRunningState;
+  overlayManager.publishMessage('runningState', initialRunningState);
+  runningStateCallbacks.forEach((callback) => callback(initialRunningState));
+
   const runningStateInterval = setInterval(() => {
     const isSimRunning = sdk.sessionStatusOK;
     if (isSimRunning === lastRunningState) {

--- a/src/app/bridge/iracingSdk/setup.ts
+++ b/src/app/bridge/iracingSdk/setup.ts
@@ -42,13 +42,16 @@ export async function iRacingSDKSetup(overlayManager: OverlayManager) {
       currentBridge.stop();
       currentBridge = undefined;
     }
-    await setupBridge(overlayManager);
 
+    // Flip the UI immediately; the data source swaps underneath. Otherwise the
+    // mode change is gated behind the full bridge teardown/rebuild below
+    // (dynamic import, native SDK load, sdk.ready()).
     overlayManager.publishMessage('demoModeChanged', value);
-
     const { notifyDemoModeChanged } =
       await import('../dashboard/dashboardBridge');
     notifyDemoModeChanged(value);
+
+    await setupBridge(overlayManager);
   });
 
   await setupBridge(overlayManager);

--- a/src/app/bridge/keybindingsBridge.spec.ts
+++ b/src/app/bridge/keybindingsBridge.spec.ts
@@ -75,6 +75,18 @@ const sampleBindings = (): KeybindingsMap => ({
     description: '',
     isDefault: true,
   },
+  'prev-profile': {
+    accelerator: 'Alt+PageUp',
+    label: '',
+    description: '',
+    isDefault: true,
+  },
+  'next-profile': {
+    accelerator: 'Alt+PageDown',
+    label: '',
+    description: '',
+    isDefault: true,
+  },
 });
 
 const invokeUpdate = (

--- a/src/app/bridge/rendererExposeBridge.ts
+++ b/src/app/bridge/rendererExposeBridge.ts
@@ -114,6 +114,18 @@ export function exposeBridge() {
     setAnalyticsOptOut: (optOut: boolean) => {
       return ipcRenderer.invoke('setAnalyticsOptOut', optOut);
     },
+    getCycleProfiles: () => {
+      return ipcRenderer.invoke('getCycleProfiles');
+    },
+    setCycleProfiles: (enabled: boolean) => {
+      return ipcRenderer.invoke('setCycleProfiles', enabled);
+    },
+    getShowProfileBanner: () => {
+      return ipcRenderer.invoke('getShowProfileBanner');
+    },
+    setShowProfileBanner: (enabled: boolean) => {
+      return ipcRenderer.invoke('setShowProfileBanner', enabled);
+    },
     // Profile management
     listProfiles: () => {
       return ipcRenderer.invoke('listProfiles');

--- a/src/app/keybindingManager.spec.ts
+++ b/src/app/keybindingManager.spec.ts
@@ -61,6 +61,18 @@ const bindingsWithBadAccelerator = (): KeybindingsMap => ({
     description: '',
     isDefault: true,
   },
+  'prev-profile': {
+    accelerator: 'Alt+PageUp',
+    label: 'Previous Profile',
+    description: '',
+    isDefault: true,
+  },
+  'next-profile': {
+    accelerator: 'Alt+PageDown',
+    label: 'Next Profile',
+    description: '',
+    isDefault: true,
+  },
 });
 
 describe('KeybindingManager', () => {

--- a/src/app/keybindingManager.ts
+++ b/src/app/keybindingManager.ts
@@ -5,6 +5,7 @@ import type { KeybindingActionId, KeybindingsMap } from '@irdashies/types';
 import {
   isGamepadBinding,
   isWidgetToggleActionId,
+  nextProfileIndex,
   widgetIdFromToggleActionId,
 } from '@irdashies/shared';
 import { getKeybindings } from './storage/keybindings';
@@ -46,6 +47,54 @@ export class KeybindingManager {
     this.actionHandlers.set('save-telemetry', () => {
       this.saveTelemetry();
     });
+
+    this.actionHandlers.set('prev-profile', () => {
+      this.cycleProfile(-1);
+    });
+
+    this.actionHandlers.set('next-profile', () => {
+      this.cycleProfile(1);
+    });
+  }
+
+  // ponytail: dynamic import keeps storage/dashboards out of the constructor's
+  // module graph (electron isn't fully mocked in keybinding unit tests).
+  private async cycleProfile(direction: 1 | -1): Promise<void> {
+    try {
+      const {
+        listProfiles,
+        getCurrentProfileId,
+        setCurrentProfile,
+        getDashboard,
+      } = await import('./storage/dashboards');
+      const { getCycleProfiles } = await import('./storage/appSettings');
+
+      const profiles = listProfiles();
+      if (profiles.length < 2) return;
+
+      const currentId = getCurrentProfileId();
+      const currentIndex = profiles.findIndex((p) => p.id === currentId);
+      const cycle = getCycleProfiles();
+
+      const targetIndex = nextProfileIndex(
+        currentIndex,
+        profiles.length,
+        direction,
+        cycle
+      );
+      if (targetIndex === -1) return;
+
+      const target = profiles[targetIndex];
+      if (!target || target.id === currentId) return;
+
+      setCurrentProfile(target.id);
+      const dashboard = getDashboard(target.id);
+      if (dashboard) {
+        this.overlayManager.forceRefreshOverlays(dashboard);
+      }
+    } catch (error) {
+      logger.error('Error switching profile via keybind:', error);
+    }
   }
 
   private async saveTelemetry(): Promise<void> {

--- a/src/app/keybindingManager.ts
+++ b/src/app/keybindingManager.ts
@@ -61,12 +61,8 @@ export class KeybindingManager {
   // module graph (electron isn't fully mocked in keybinding unit tests).
   private async cycleProfile(direction: 1 | -1): Promise<void> {
     try {
-      const {
-        listProfiles,
-        getCurrentProfileId,
-        setCurrentProfile,
-        getDashboard,
-      } = await import('./storage/dashboards');
+      const { listProfiles, getCurrentProfileId, setCurrentProfile } =
+        await import('./storage/dashboards');
       const { getCycleProfiles } = await import('./storage/appSettings');
 
       const profiles = listProfiles();
@@ -87,11 +83,10 @@ export class KeybindingManager {
       const target = profiles[targetIndex];
       if (!target || target.id === currentId) return;
 
+      // setCurrentProfile emits dashboardUpdated, which live-updates the
+      // existing overlay windows (closeOrCreateWindows + publishMessage). No
+      // destroy/recreate — see publishDashboardUpdates in dashboardBridge.
       setCurrentProfile(target.id);
-      const dashboard = getDashboard(target.id);
-      if (dashboard) {
-        this.overlayManager.forceRefreshOverlays(dashboard);
-      }
     } catch (error) {
       logger.error('Error switching profile via keybind:', error);
     }

--- a/src/app/rendererExpose.ts
+++ b/src/app/rendererExpose.ts
@@ -32,6 +32,23 @@ export function exposeInMainWorld() {
     },
   });
 
+  contextBridge.exposeInMainWorld('profileSwitch', {
+    onTransition: (
+      cb: (data: {
+        hidden: boolean;
+        name: string;
+        showBanner?: boolean;
+      }) => void
+    ) => {
+      const listener = (
+        _: Electron.IpcRendererEvent,
+        data: { hidden: boolean; name: string; showBanner?: boolean }
+      ) => cb(data);
+      ipcRenderer.on('profileTransition', listener);
+      return () => ipcRenderer.removeListener('profileTransition', listener);
+    },
+  });
+
   const pitLaneBridge: PitLaneBridge = {
     getPitLaneData: (trackId: string) =>
       ipcRenderer.invoke('pitLane:getData', trackId),

--- a/src/app/storage/appSettings.ts
+++ b/src/app/storage/appSettings.ts
@@ -1,0 +1,20 @@
+import { readData, writeData } from './storage';
+
+const CYCLE_PROFILES_KEY = 'cycleProfiles';
+const SHOW_PROFILE_BANNER_KEY = 'showProfileBanner';
+
+export const getCycleProfiles = (): boolean => {
+  return readData<boolean>(CYCLE_PROFILES_KEY) ?? false;
+};
+
+export const setCycleProfiles = (enabled: boolean): void => {
+  writeData(CYCLE_PROFILES_KEY, enabled);
+};
+
+export const getShowProfileBanner = (): boolean => {
+  return readData<boolean>(SHOW_PROFILE_BANNER_KEY) ?? true;
+};
+
+export const setShowProfileBanner = (enabled: boolean): void => {
+  writeData(SHOW_PROFILE_BANNER_KEY, enabled);
+};

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -12,6 +12,7 @@ import {
 import { Settings } from './components/Settings/Settings';
 import { ThemeManager } from './components/ThemeManager/ThemeManager';
 import { HideUIWrapper } from './components/HideUIWrapper/HideUIWrapper';
+import { ProfileSwitchOverlay } from './components/ProfileSwitchOverlay/ProfileSwitchOverlay';
 import { OverlayContainer } from './components/OverlayContainer';
 import { ErrorBoundary } from './components/ErrorBoundary/ErrorBoundary';
 
@@ -44,9 +45,11 @@ const SettingsApp = () => {
 const OverlayApp = () => {
   return (
     <HideUIWrapper>
-      <ThemeManager>
-        <OverlayContainer />
-      </ThemeManager>
+      <ProfileSwitchOverlay>
+        <ThemeManager>
+          <OverlayContainer />
+        </ThemeManager>
+      </ProfileSwitchOverlay>
     </HideUIWrapper>
   );
 };

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -195,7 +195,7 @@ export const OverlayContainer = memo(() => {
       {editMode && (
         <button
           onClick={handleExitEditMode}
-          className="pointer-events-auto fixed top-12.5 left-1/2 -translate-x-1/2 z-9999 flex items-center gap-2 px-3 py-2 bg-sky-500 hover:bg-sky-600 text-white rounded shadow-lg transition-colors cursor-pointer"
+          className="pointer-events-auto fixed top-12.5 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-2 px-3 py-2 bg-sky-500 hover:bg-sky-600 text-white rounded shadow-lg transition-colors cursor-pointer"
         >
           <XIcon size={18} weight="bold" />
           <span className="text-sm font-medium">Exit Edit Mode</span>

--- a/src/frontend/components/ProfileSwitchOverlay/ProfileSwitchOverlay.tsx
+++ b/src/frontend/components/ProfileSwitchOverlay/ProfileSwitchOverlay.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useDashboard } from '@irdashies/context';
+
+declare global {
+  interface Window {
+    profileSwitch?: {
+      onTransition: (
+        cb: (data: {
+          hidden: boolean;
+          name: string;
+          showBanner?: boolean;
+        }) => void
+      ) => () => void;
+    };
+  }
+}
+
+interface ProfileSwitchOverlayProps {
+  children: ReactNode;
+}
+
+// How long the profile name stays on screen after a switch.
+const BANNER_MS = 1500;
+
+/**
+ * On a profile switch the main process hides the widgets, resizes the overlay
+ * windows off-screen, then reveals them and shows the new profile name. This
+ * component just toggles visibility on command and renders the name. `hidden`
+ * uses visibility:hidden (Tailwind `invisible`) so the widget subtree isn't
+ * painted while the windows resize — opacity alone doesn't reliably hide a
+ * fixed-position subtree on a transparent overlay window, and visibility (vs
+ * display:none) keeps layout so widgets don't re-measure on reveal.
+ */
+export const ProfileSwitchOverlay = ({
+  children,
+}: ProfileSwitchOverlayProps) => {
+  const { containerBoundsInfo } = useDashboard();
+  const [name, setName] = useState('');
+  const [hidden, setHidden] = useState(false);
+  const [bannerVisible, setBannerVisible] = useState(false);
+  const bannerTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  // Windows shrink-wrap to their widget bounding box, so the renderer viewport
+  // isn't the full screen. Center the banner on the display in window-local px:
+  // display center (screen coords) minus the window's screen x. Fall back to
+  // viewport-center if bounds aren't known yet.
+  const display = containerBoundsInfo?.displayBounds;
+  const win = containerBoundsInfo?.expected;
+  const bannerLeft =
+    display && win ? display.x + display.width / 2 - win.x : undefined;
+
+  useEffect(() => {
+    if (!window.profileSwitch?.onTransition) return;
+    const unsub = window.profileSwitch.onTransition((data) => {
+      if (data.name) setName(data.name);
+      setHidden(data.hidden);
+      if (!data.hidden && data.showBanner !== false) {
+        setBannerVisible(true);
+        clearTimeout(bannerTimer.current);
+        bannerTimer.current = setTimeout(
+          () => setBannerVisible(false),
+          BANNER_MS
+        );
+      }
+    });
+    return () => {
+      clearTimeout(bannerTimer.current);
+      unsub();
+    };
+  }, []);
+
+  return (
+    <>
+      <div className={hidden ? 'invisible' : ''}>{children}</div>
+      {bannerVisible && (
+        <div
+          className="pointer-events-none fixed top-6 -translate-x-1/2 z-[9999]"
+          style={{ left: bannerLeft ?? '50%' }}
+        >
+          <div className="px-8 py-4 rounded-xl bg-slate-900/85 text-white text-5xl font-bold tracking-wide shadow-2xl">
+            {name}
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/src/frontend/components/Settings/sections/KeybindingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/KeybindingsSettings.tsx
@@ -56,6 +56,25 @@ function formatGamepadToken(token: string): string {
   return `${prefix}: ${formatGamepadControl(parsed.button)}`;
 }
 
+// Every modifier KeyboardEvent.key value (W3C UI Events). A bare modifier press
+// can't be a main key, and none are valid standalone Electron accelerators.
+const MODIFIER_KEYS = new Set([
+  'Alt',
+  'AltGraph',
+  'CapsLock',
+  'Control',
+  'Fn',
+  'FnLock',
+  'Hyper',
+  'Meta',
+  'NumLock',
+  'ScrollLock',
+  'Shift',
+  'Super',
+  'Symbol',
+  'SymbolLock',
+]);
+
 /**
  * Maps a browser KeyboardEvent into an Electron accelerator string.
  * Returns null if only modifier keys are pressed (waiting for a main key).
@@ -68,7 +87,7 @@ function keyEventToAccelerator(e: KeyboardEvent): string | null {
   if (e.shiftKey) parts.push('Shift');
 
   // Ignore standalone modifier presses
-  if (['Control', 'Meta', 'Alt', 'Shift'].includes(e.key)) {
+  if (MODIFIER_KEYS.has(e.key)) {
     return null;
   }
 

--- a/src/frontend/components/Settings/sections/ProfileSettings.tsx
+++ b/src/frontend/components/Settings/sections/ProfileSettings.tsx
@@ -14,6 +14,7 @@ export const ProfileSettings = () => {
   const {
     currentProfile,
     profiles,
+    bridge,
     createProfile,
     cloneProfile,
     deleteProfile,
@@ -21,6 +22,26 @@ export const ProfileSettings = () => {
     switchProfile,
     refreshProfiles,
   } = useDashboard();
+
+  const [cycleProfiles, setCycleProfiles] = useState(false);
+  const [showProfileBanner, setShowProfileBanner] = useState(true);
+
+  useEffect(() => {
+    bridge.getCycleProfiles?.().then((v) => setCycleProfiles(v ?? false));
+    bridge
+      .getShowProfileBanner?.()
+      .then((v) => setShowProfileBanner(v ?? true));
+  }, [bridge]);
+
+  const handleToggleCycleProfiles = async (checked: boolean) => {
+    await bridge.setCycleProfiles?.(checked);
+    setCycleProfiles(checked);
+  };
+
+  const handleToggleShowProfileBanner = async (checked: boolean) => {
+    await bridge.setShowProfileBanner?.(checked);
+    setShowProfileBanner(checked);
+  };
 
   const [newProfileName, setNewProfileName] = useState('');
   const [editingProfileId, setEditingProfileId] = useState<string | null>(null);
@@ -396,6 +417,61 @@ export const ProfileSettings = () => {
                 );
               })
             )}
+          </div>
+        </div>
+
+        {/* Profile Switching Options */}
+        <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4 space-y-4">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h4
+                id="cycle-profiles-label"
+                className="text-md font-medium text-slate-300"
+              >
+                Cycle Profiles
+              </h4>
+              <p className="text-sm text-slate-400">
+                When switching profiles with the keyboard shortcut, wrap around
+                from the last profile back to the first (and vice versa).
+              </p>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={cycleProfiles}
+                onChange={(e) => handleToggleCycleProfiles(e.target.checked)}
+                aria-labelledby="cycle-profiles-label"
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-slate-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+            </label>
+          </div>
+
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <h4
+                id="show-profile-banner-label"
+                className="text-md font-medium text-slate-300"
+              >
+                Show Profile Name Banner
+              </h4>
+              <p className="text-sm text-slate-400">
+                Briefly display the profile name on the overlay when switching
+                profiles.
+              </p>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={showProfileBanner}
+                onChange={(e) =>
+                  handleToggleShowProfileBanner(e.target.checked)
+                }
+                aria-labelledby="show-profile-banner-label"
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-slate-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+            </label>
           </div>
         </div>
 

--- a/src/shared/keybindingActions.spec.ts
+++ b/src/shared/keybindingActions.spec.ts
@@ -5,6 +5,7 @@ import {
   isValidWidgetToggleActionId,
   widgetToggleActionId,
   widgetIdFromToggleActionId,
+  nextProfileIndex,
 } from './keybindingActions';
 
 describe('widget toggle action id helpers', () => {
@@ -36,5 +37,26 @@ describe('widget toggle action id helpers', () => {
     expect(isValidWidgetToggleActionId('toggle-widget:fuel')).toBe(true);
     expect(isValidWidgetToggleActionId('toggle-widget:')).toBe(false);
     expect(isValidWidgetToggleActionId('toggle-hide-ui')).toBe(false);
+  });
+});
+
+describe('nextProfileIndex', () => {
+  it('advances and goes back without wrapping when loop is off', () => {
+    expect(nextProfileIndex(0, 3, 1, false)).toBe(1);
+    expect(nextProfileIndex(1, 3, -1, false)).toBe(0);
+  });
+
+  it('returns -1 at the edges when loop is off', () => {
+    expect(nextProfileIndex(2, 3, 1, false)).toBe(-1); // last -> next
+    expect(nextProfileIndex(0, 3, -1, false)).toBe(-1); // first -> prev
+  });
+
+  it('wraps around at the edges when loop is on', () => {
+    expect(nextProfileIndex(2, 3, 1, true)).toBe(0); // last -> first
+    expect(nextProfileIndex(0, 3, -1, true)).toBe(2); // first -> last
+  });
+
+  it('treats an unknown current index as the start', () => {
+    expect(nextProfileIndex(-1, 3, 1, false)).toBe(1);
   });
 });

--- a/src/shared/keybindingActions.ts
+++ b/src/shared/keybindingActions.ts
@@ -35,3 +35,21 @@ export function isValidWidgetToggleActionId(actionId: string): boolean {
     widgetIdFromToggleActionId(actionId).length > 0
   );
 }
+
+/**
+ * Target index when cycling profiles. Returns -1 when at an edge and cycle is
+ * off (i.e. no switch should happen).
+ */
+export const nextProfileIndex = (
+  currentIndex: number,
+  length: number,
+  direction: 1 | -1,
+  cycle: boolean
+): number => {
+  if (length === 0) return -1;
+  const start = currentIndex === -1 ? 0 : currentIndex;
+  const next = start + direction;
+  if (cycle) return (next + length) % length;
+  if (next < 0 || next >= length) return -1;
+  return next;
+};

--- a/src/types/dashboardBridge.ts
+++ b/src/types/dashboardBridge.ts
@@ -58,6 +58,10 @@ export interface DashboardBridge {
   getPlayerIconImageAsDataUrl: (imagePath: string) => Promise<string | null>;
   getAnalyticsOptOut: () => Promise<boolean>;
   setAnalyticsOptOut: (optOut: boolean) => Promise<void>;
+  getCycleProfiles?: () => Promise<boolean>;
+  setCycleProfiles?: (enabled: boolean) => Promise<void>;
+  getShowProfileBanner?: () => Promise<boolean>;
+  setShowProfileBanner?: (enabled: boolean) => Promise<void>;
   listProfiles: () => Promise<DashboardProfile[]>;
   createProfile: (name: string) => Promise<DashboardProfile>;
   cloneProfile: (profileId: string) => Promise<DashboardProfile>;

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -2,7 +2,9 @@
 export type StaticKeybindingActionId =
   | 'toggle-hide-ui'
   | 'toggle-edit-mode'
-  | 'save-telemetry';
+  | 'save-telemetry'
+  | 'prev-profile'
+  | 'next-profile';
 
 /**
  * Dynamic per-widget show/hide action, keyed by the widget instance id, e.g.
@@ -86,6 +88,18 @@ export const DEFAULT_KEYBINDINGS: KeybindingsMap = {
     accelerator: 'F7',
     label: 'Save Telemetry',
     description: 'Capture current telemetry data and screenshots',
+    isDefault: true,
+  },
+  'prev-profile': {
+    accelerator: 'Alt+PageUp',
+    label: 'Previous Profile',
+    description: 'Switch to the previous configuration profile',
+    isDefault: true,
+  },
+  'next-profile': {
+    accelerator: 'Alt+PageDown',
+    label: 'Next Profile',
+    description: 'Switch to the next configuration profile',
     isDefault: true,
   },
 };


### PR DESCRIPTION
## Description

Adds a keybind for switching to next/previous layout profile with an optional layout name "banner" shown after switching.
Also reduces time between layout switches and demo mode toggling.

## Screenshots


https://github.com/user-attachments/assets/97b98974-d4e5-43a0-9823-ca97d81a51da


<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added profile cycling via keyboard shortcuts (Alt+PageUp/PageDown) and new profile transition overlay.
  * Added Profile Switching options: cycle profiles and show profile name banner.

* **Improvements**
  * Improved profile transition behavior to apply only when needed and coordinate overlay timing.
  * Improved startup synchronization by sending the initial iRacing “running” state immediately.
  * Expanded modifier-key detection for more reliable keybinding capture.

* **Bug Fixes**
  * Demo mode notifications now show immediately when toggled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->