### PR TITLE
[perf] Add throttled telemetry values hook and prevent driver standings memo from recalculation on each re-render

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,10 @@ jobs:
     - name: Run tests with coverage
       run: npm test
 
+    - name: Run benchmarks
+      run: npm run bench
+      continue-on-error: true
+
     - name: Upload coverage report
       uses: actions/upload-artifact@v7
       with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,15 @@ npm run test -- --no-coverage
 
 ---
 
+## Benchmarks & Perf Testing
+
+Validate perf fixes with a quantitative test, not eyeballing.
+
+- **`*.perf.spec.ts`** — normal Vitest assertion test, counts renders/calls under simulated load, asserts before/after. Gates CI via `npm test`. Wrap each simulated tick in its own `act()` (one `act()` around a whole loop batches it into a single render). Use `vi.useFakeTimers()` for time-based throttles.
+- **`*.bench.ts`** — `vitest bench()`, compares wall-clock cost. Run via `npm run bench`. Not part of `npm test`; CI runs it after tests but `continue-on-error` (wall-clock too noisy on shared runners to gate on). Call `cleanup()` (`@testing-library/react`) at the end of each bench body or subscriptions leak across sampling rounds and corrupt results. Use top-level `import { bench, describe } from 'vitest'` (this repo is on Vitest 4, not the v5 fixture style).
+
+---
+
 ## Storybook
 
 Every component needs `.stories.tsx`:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "vitest --coverage",
+    "bench": "vitest bench --run",
     "ensure-tracks": "npx tsx ./tools/ensure-tracks.ts",
     "fetch-lovely-data": "npx tsx ./tools/fetch-lovely-data.ts",
     "fetch-lovely-track-data": "npx tsx ./tools/fetch-lovely-track-data.ts",

--- a/src/frontend/components/Standings/hooks/useDriverLivePositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverLivePositions.tsx
@@ -6,7 +6,7 @@ import {
   useSessionStore,
   useTelemetryValue,
   useTelemetryValues,
-  useTelemetryValuesRounded,
+  useTelemetryValuesThrottled,
 } from '@irdashies/context';
 import { SessionState, TrackLocation } from '@irdashies/types';
 
@@ -36,8 +36,14 @@ interface DriverData {
  */
 export const useDriverLivePositions = ({
   enabled,
+  carIdxLapDistPct: carIdxLapDistPctOverride,
+  carIdxTrackSurface: carIdxTrackSurfaceOverride,
 }: {
   enabled: boolean;
+  /** Pass an already-subscribed array to avoid a duplicate store subscription
+   * when the caller already holds this telemetry key. */
+  carIdxLapDistPct?: number[];
+  carIdxTrackSurface?: number[];
 }): Record<number, number> => {
   // Old variables, not used anymore. Left here for reference.
   // const carIdxClassPosition = useTelemetryValues<number[]>('CarIdxClassPosition');
@@ -75,9 +81,12 @@ export const useDriverLivePositions = ({
   const sessionPositions = useSessionPositions(sessionNum);
   const sessionState = useTelemetryValue('SessionState') ?? 0;
   const carIdxLapCompleted = useTelemetryValues<number[]>('CarIdxLapCompleted');
-  const carIdxLapDistPct = useTelemetryValuesRounded('CarIdxLapDistPct', 3);
+  const ownCarIdxLapDistPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+  const carIdxLapDistPct = carIdxLapDistPctOverride ?? ownCarIdxLapDistPct;
   const carIdxClass = useTelemetryValues<number[]>('CarIdxClass');
-  const carIdxTrackSurface = useTelemetryValues<number[]>('CarIdxTrackSurface');
+  const ownCarIdxTrackSurface =
+    useTelemetryValues<number[]>('CarIdxTrackSurface');
+  const carIdxTrackSurface = carIdxTrackSurfaceOverride ?? ownCarIdxTrackSurface;
   const paceCarIdx =
     useSessionStore((s) => s.session?.DriverInfo?.PaceCarIdx) ?? -1;
   const p1Car = sessionPositions?.find((pos) => pos.Position === 1); // Position is 1-based

--- a/src/frontend/components/Standings/hooks/useDriverLivePositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverLivePositions.tsx
@@ -81,12 +81,13 @@ export const useDriverLivePositions = ({
   const sessionPositions = useSessionPositions(sessionNum);
   const sessionState = useTelemetryValue('SessionState') ?? 0;
   const carIdxLapCompleted = useTelemetryValues<number[]>('CarIdxLapCompleted');
-  const ownCarIdxLapDistPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+  const ownCarIdxLapDistPct = useTelemetryValuesThrottled('CarIdxLapDistPct');
   const carIdxLapDistPct = carIdxLapDistPctOverride ?? ownCarIdxLapDistPct;
   const carIdxClass = useTelemetryValues<number[]>('CarIdxClass');
   const ownCarIdxTrackSurface =
     useTelemetryValues<number[]>('CarIdxTrackSurface');
-  const carIdxTrackSurface = carIdxTrackSurfaceOverride ?? ownCarIdxTrackSurface;
+  const carIdxTrackSurface =
+    carIdxTrackSurfaceOverride ?? ownCarIdxTrackSurface;
   const paceCarIdx =
     useSessionStore((s) => s.session?.DriverInfo?.PaceCarIdx) ?? -1;
   const p1Car = sessionPositions?.find((pos) => pos.Position === 1); // Position is 1-based

--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -13,6 +13,7 @@ import {
   useSessionPositions,
   useSessionFastestLaps,
   useTelemetryValuesRounded,
+  useTelemetryValuesThrottled,
 } from '@irdashies/context';
 
 import {
@@ -41,7 +42,11 @@ const getLastTimeState = (
   return undefined;
 };
 
-export const useDriverPositions = () => {
+export const useDriverPositions = (overrides?: {
+  /** Pass an already-subscribed array to avoid a duplicate store subscription
+   * when the caller already holds this telemetry key. */
+  carIdxLapDstPct?: number[];
+}) => {
   const carIdxPosition = useTelemetry('CarIdxPosition');
   const carIdxClassPosition = useTelemetry('CarIdxClassPosition');
   const carIdxBestLap = useTelemetry('CarIdxBestLapTime');
@@ -52,7 +57,11 @@ export const useDriverPositions = () => {
   const prevCarTrackSurface = usePrevCarTrackSurface();
   const lastPitLap = usePitLap();
   const lastLap = useCarLap();
-  const carIdxLapDstPct = useTelemetryValuesRounded('CarIdxLapDistPct', 3);
+  // Sampled by time, not value delta: with a full grid, some car's lap
+  // distance crosses any rounding threshold almost every tick, so value
+  // rounding alone doesn't throttle the recompute below.
+  const ownCarIdxLapDstPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+  const carIdxLapDstPct = overrides?.carIdxLapDstPct ?? ownCarIdxLapDstPct;
 
   const positions = useMemo(() => {
     return (
@@ -112,8 +121,14 @@ export const useDrivers = () => {
   return drivers;
 };
 
-export const useCarState = () => {
-  const carIdxTrackSurface = useTelemetry('CarIdxTrackSurface');
+export const useCarState = (overrides?: {
+  /** Pass an already-subscribed value to avoid a duplicate store subscription
+   * when the caller already holds this telemetry key. */
+  carIdxTrackSurface?: ReturnType<typeof useTelemetry<number[]>>;
+}) => {
+  const ownCarIdxTrackSurface = useTelemetry('CarIdxTrackSurface');
+  const carIdxTrackSurface =
+    overrides?.carIdxTrackSurface ?? ownCarIdxTrackSurface;
   const carIdxOnPitRoad = useTelemetry<boolean[]>('CarIdxOnPitRoad');
   const carIdxTireCompound = useTelemetry<number[]>('CarIdxTireCompound');
   const carIdxSessionFlags = useTelemetry<number[]>('CarIdxSessionFlags');
@@ -150,17 +165,25 @@ export const useCarState = () => {
 // TODO: this should eventually replace the useDriverStandings hook
 // currently there's still a few bugs to handle but is only used in relative right now
 export const useDriverStandings = () => {
-  const driverPositions = useDriverPositions();
+  // Shared once here and passed down so useDriverPositions, useCarState and
+  // useDriverLivePositions don't each open their own subscription to the
+  // same telemetry key.
+  const carIdxTrackSurface = useTelemetry('CarIdxTrackSurface');
+  const carIdxLapDstPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+
+  const driverPositions = useDriverPositions({ carIdxLapDstPct });
   const relativeSettings = useRelativeSettings();
   const useLivePositionStandings = relativeSettings?.useLivePosition ?? false;
   const driverLivePositions = useDriverLivePositions({
     enabled: useLivePositionStandings,
+    carIdxLapDistPct: carIdxLapDstPct,
+    carIdxTrackSurface: carIdxTrackSurface?.value,
   });
   const drivers = useDrivers();
   const radioActiveCarIdxs = useRadioActiveCarIdxs(
     (relativeSettings?.radio?.persistenceSeconds ?? 3) * 1000
   );
-  const carStates = useCarState();
+  const carStates = useCarState({ carIdxTrackSurface });
   // Use focus car index which handles spectator mode (uses CamCarIdx when spectating)
   const playerCarIdx = useFocusCarIdx();
   const sessionType = useCurrentSessionType();

--- a/src/frontend/components/Standings/hooks/useDriverPositions.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverPositions.tsx
@@ -60,7 +60,7 @@ export const useDriverPositions = (overrides?: {
   // Sampled by time, not value delta: with a full grid, some car's lap
   // distance crosses any rounding threshold almost every tick, so value
   // rounding alone doesn't throttle the recompute below.
-  const ownCarIdxLapDstPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+  const ownCarIdxLapDstPct = useTelemetryValuesThrottled('CarIdxLapDistPct');
   const carIdxLapDstPct = overrides?.carIdxLapDstPct ?? ownCarIdxLapDstPct;
 
   const positions = useMemo(() => {
@@ -169,7 +169,7 @@ export const useDriverStandings = () => {
   // useDriverLivePositions don't each open their own subscription to the
   // same telemetry key.
   const carIdxTrackSurface = useTelemetry('CarIdxTrackSurface');
-  const carIdxLapDstPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+  const carIdxLapDstPct = useTelemetryValuesThrottled('CarIdxLapDistPct');
 
   const driverPositions = useDriverPositions({ carIdxLapDstPct });
   const relativeSettings = useRelativeSettings();

--- a/src/frontend/components/Standings/hooks/useDriverRelatives.spec.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverRelatives.spec.tsx
@@ -19,6 +19,7 @@ vi.mock('@irdashies/context', async (importOriginal) => {
     useFocusCarIdx: vi.fn(),
     useTelemetryValues: vi.fn(),
     useTelemetryValuesRounded: vi.fn(),
+    useTelemetryValuesThrottled: vi.fn(),
     useSessionStore: vi.fn(),
     REFERENCE_INTERVAL: 0.0025,
   };
@@ -69,6 +70,7 @@ const {
   useFocusCarIdx,
   useTelemetryValues,
   useTelemetryValuesRounded,
+  useTelemetryValuesThrottled,
   useSessionStore,
 } = await import('@irdashies/context');
 const { useDriverStandings } = await import('./useDriverPositions');
@@ -175,8 +177,12 @@ describe('useDriverRelatives', () => {
     vi.clearAllMocks();
 
     vi.mocked(useFocusCarIdx).mockReturnValue(0);
-    // Delegate rounded calls to the same mock — precision is irrelevant for static test data
+    // Delegate rounded/throttled calls to the same mock — precision/cadence is irrelevant for static test data
     vi.mocked(useTelemetryValuesRounded).mockImplementation(
+      (key: keyof TelemetryVarList) =>
+        vi.mocked(useTelemetryValues)(key) as number[]
+    );
+    vi.mocked(useTelemetryValuesThrottled).mockImplementation(
       (key: keyof TelemetryVarList) =>
         vi.mocked(useTelemetryValues)(key) as number[]
     );

--- a/src/frontend/components/Standings/hooks/useDriverRelatives.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverRelatives.tsx
@@ -3,6 +3,7 @@ import {
   useSessionStore,
   useTelemetryValues,
   useTelemetryValuesRounded,
+  useTelemetryValuesThrottled,
   useFocusCarIdx,
   useReferenceLapStore,
 } from '@irdashies/context';
@@ -16,7 +17,8 @@ import { Standings } from '../createStandings';
 
 export const useDriverRelatives = ({ buffer }: { buffer: number }) => {
   const drivers = useDriverStandings();
-  const carIdxLapDistPct = useTelemetryValuesRounded('CarIdxLapDistPct', 4);
+  // Sampled by time, not value delta - see useDriverPositions.tsx for why.
+  const carIdxLapDistPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
   const carIdxIsOnPitRoad = useTelemetryValues('CarIdxOnPitRoad');
   const carIdxEstTime = useTelemetryValuesRounded('CarIdxEstTime', 2);
   // Use focus car index which handles spectator mode (uses CamCarIdx when spectating)

--- a/src/frontend/components/Standings/hooks/useDriverRelatives.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverRelatives.tsx
@@ -18,7 +18,7 @@ import { Standings } from '../createStandings';
 export const useDriverRelatives = ({ buffer }: { buffer: number }) => {
   const drivers = useDriverStandings();
   // Sampled by time, not value delta - see useDriverPositions.tsx for why.
-  const carIdxLapDistPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+  const carIdxLapDistPct = useTelemetryValuesThrottled('CarIdxLapDistPct');
   const carIdxIsOnPitRoad = useTelemetryValues('CarIdxOnPitRoad');
   const carIdxEstTime = useTelemetryValuesRounded('CarIdxEstTime', 2);
   // Use focus car index which handles spectator mode (uses CamCarIdx when spectating)

--- a/src/frontend/components/Standings/hooks/useDriverStandings.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverStandings.tsx
@@ -67,22 +67,22 @@ export const useDriverStandings = (
     qualifyingResultsRaw?.length
       ? qualifyingResultsRaw
       : sessionQualifyPositions?.map((q) => ({
-        Position: q.Position + 1,
-        ClassPosition: q.ClassPosition,
-        CarIdx: q.CarIdx,
-        Lap: q.FastestLap,
-        Time: q.FastestTime,
-        FastestLap: q.FastestLap,
-        FastestTime: q.FastestTime,
-        LastTime: -1,
-        LapsLed: 0,
-        LapsComplete: 0,
-        JokerLapsComplete: 0,
-        LapsDriven: 0,
-        Incidents: 0,
-        ReasonOutId: 0,
-        ReasonOutStr: 'Running',
-      }));
+          Position: q.Position + 1,
+          ClassPosition: q.ClassPosition,
+          CarIdx: q.CarIdx,
+          Lap: q.FastestLap,
+          Time: q.FastestTime,
+          FastestLap: q.FastestLap,
+          FastestTime: q.FastestTime,
+          LastTime: -1,
+          LapsLed: 0,
+          LapsComplete: 0,
+          JokerLapsComplete: 0,
+          LapsDriven: 0,
+          Incidents: 0,
+          ReasonOutId: 0,
+          ReasonOutStr: 'Running',
+        }));
   const standingsSettings = useStandingsSettings();
   const useLivePositionStandings = standingsSettings?.useLivePosition ?? false;
   const fastestLaps = useSessionFastestLaps(sessionNum);
@@ -93,7 +93,7 @@ export const useDriverStandings = (
   // Sampled by time, not value delta: with a full grid, some car's lap
   // distance crosses any rounding threshold almost every tick, so value
   // rounding alone doesn't throttle the recompute below.
-  const carIdxLapDistPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+  const carIdxLapDistPct = useTelemetryValuesThrottled('CarIdxLapDistPct');
   const carIdxTrackSurface =
     useTelemetryValues<TrackLocation[]>('CarIdxTrackSurface');
   // Pass already-subscribed arrays down so this doesn't also re-subscribe
@@ -187,14 +187,14 @@ export const useDriverStandings = (
     const gapAugmentedGroupedByClass =
       gapEnabled || intervalEnabled
         ? augmentStandingsWithGap(
-          iratingAugmentedGroupedByClass,
-          carIdxLap,
-          carIdxLapDistPct,
-          carIdxOnPitRoad,
-          carIdxEstTime,
-          useLivePositionStandings,
-          sessionType
-        )
+            iratingAugmentedGroupedByClass,
+            carIdxLap,
+            carIdxLapDistPct,
+            carIdxOnPitRoad,
+            carIdxEstTime,
+            useLivePositionStandings,
+            sessionType
+          )
         : iratingAugmentedGroupedByClass;
 
     // Calculate interval to player when enabled

--- a/src/frontend/components/Standings/hooks/useDriverStandings.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverStandings.tsx
@@ -11,6 +11,7 @@ import {
   useFocusCarIdx,
   useTelemetryValues,
   useTelemetryValuesRounded,
+  useTelemetryValuesThrottled,
   useCarLap,
   usePitLap,
   usePrevCarTrackSurface,
@@ -66,35 +67,42 @@ export const useDriverStandings = (
     qualifyingResultsRaw?.length
       ? qualifyingResultsRaw
       : sessionQualifyPositions?.map((q) => ({
-          Position: q.Position + 1,
-          ClassPosition: q.ClassPosition,
-          CarIdx: q.CarIdx,
-          Lap: q.FastestLap,
-          Time: q.FastestTime,
-          FastestLap: q.FastestLap,
-          FastestTime: q.FastestTime,
-          LastTime: -1,
-          LapsLed: 0,
-          LapsComplete: 0,
-          JokerLapsComplete: 0,
-          LapsDriven: 0,
-          Incidents: 0,
-          ReasonOutId: 0,
-          ReasonOutStr: 'Running',
-        }));
+        Position: q.Position + 1,
+        ClassPosition: q.ClassPosition,
+        CarIdx: q.CarIdx,
+        Lap: q.FastestLap,
+        Time: q.FastestTime,
+        FastestLap: q.FastestLap,
+        FastestTime: q.FastestTime,
+        LastTime: -1,
+        LapsLed: 0,
+        LapsComplete: 0,
+        JokerLapsComplete: 0,
+        LapsDriven: 0,
+        Incidents: 0,
+        ReasonOutId: 0,
+        ReasonOutStr: 'Running',
+      }));
   const standingsSettings = useStandingsSettings();
   const useLivePositionStandings = standingsSettings?.useLivePosition ?? false;
-  const driverLivePositions = useDriverLivePositions({
-    enabled: useLivePositionStandings,
-  });
   const fastestLaps = useSessionFastestLaps(sessionNum);
   const carIdxF2Time = useTelemetryValuesRounded('CarIdxF2Time', 2);
   const carIdxEstTime = useTelemetryValuesRounded('CarIdxEstTime', 2);
   const carIdxOnPitRoad = useTelemetryValues<boolean[]>('CarIdxOnPitRoad');
   const carIdxLap = useTelemetryValues<number[]>('CarIdxLap');
-  const carIdxLapDistPct = useTelemetryValuesRounded('CarIdxLapDistPct', 3);
+  // Sampled by time, not value delta: with a full grid, some car's lap
+  // distance crosses any rounding threshold almost every tick, so value
+  // rounding alone doesn't throttle the recompute below.
+  const carIdxLapDistPct = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
   const carIdxTrackSurface =
     useTelemetryValues<TrackLocation[]>('CarIdxTrackSurface');
+  // Pass already-subscribed arrays down so this doesn't also re-subscribe
+  // to the same telemetry keys internally.
+  const driverLivePositions = useDriverLivePositions({
+    enabled: useLivePositionStandings,
+    carIdxLapDistPct,
+    carIdxTrackSurface,
+  });
   const radioTransmitCarIdx = useRadioActiveCarIdxs(
     (settings?.radio?.persistenceSeconds ?? 3) * 1000
   );
@@ -179,14 +187,14 @@ export const useDriverStandings = (
     const gapAugmentedGroupedByClass =
       gapEnabled || intervalEnabled
         ? augmentStandingsWithGap(
-            iratingAugmentedGroupedByClass,
-            carIdxLap,
-            carIdxLapDistPct,
-            carIdxOnPitRoad,
-            carIdxEstTime,
-            useLivePositionStandings,
-            sessionType
-          )
+          iratingAugmentedGroupedByClass,
+          carIdxLap,
+          carIdxLapDistPct,
+          carIdxOnPitRoad,
+          carIdxEstTime,
+          useLivePositionStandings,
+          sessionType
+        )
         : iratingAugmentedGroupedByClass;
 
     // Calculate interval to player when enabled

--- a/src/frontend/context/TelemetryStore/TelemetryStore.spec.tsx
+++ b/src/frontend/context/TelemetryStore/TelemetryStore.spec.tsx
@@ -1,10 +1,11 @@
-import { renderHook } from '@testing-library/react';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   useTelemetryStore,
   useTelemetry,
   useTelemetryValue,
   useTelemetryValues,
+  useTelemetryValuesThrottled,
 } from './TelemetryStore';
 import type { Telemetry } from '@irdashies/types';
 
@@ -68,6 +69,73 @@ describe('TelemetryStore', () => {
       useTelemetryStore.getState().setTelemetry(emptyTelemetry);
       const { result } = renderHook(() => useTelemetryValues('RPM'));
       expect(result.current).toEqual([]);
+    });
+  });
+
+  describe('useTelemetryValuesThrottled', () => {
+    // Regression test for the Standings perf fix: a full-grid array (e.g.
+    // CarIdxLapDistPct) changes on nearly every 60Hz tick once enough cars
+    // are on track, so value-based rounding alone never throttles
+    // re-renders. This proves the time-based gate actually caps render
+    // count regardless of how often the underlying value changes.
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('ignores changes between samples and picks up the latest value at the next tick', () => {
+      useTelemetryStore
+        .getState()
+        .setTelemetry({ ...mockTelemetry, Speed: { value: [1, 2] } } as Telemetry);
+
+      const { result } = renderHook(() =>
+        useTelemetryValuesThrottled('Speed', 100)
+      );
+      expect(result.current).toEqual([1, 2]);
+
+      // Several rapid changes within one sampling window.
+      act(() => {
+        useTelemetryStore
+          .getState()
+          .setTelemetry({ ...mockTelemetry, Speed: { value: [3, 4] } } as Telemetry);
+        useTelemetryStore
+          .getState()
+          .setTelemetry({ ...mockTelemetry, Speed: { value: [5, 6] } } as Telemetry);
+        useTelemetryStore
+          .getState()
+          .setTelemetry({ ...mockTelemetry, Speed: { value: [7, 8] } } as Telemetry);
+      });
+      // No re-render has happened yet — the sampler hasn't ticked.
+      expect(result.current).toEqual([1, 2]);
+
+      // Once the interval elapses, only the latest value is picked up.
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(result.current).toEqual([7, 8]);
+    });
+
+    it('does not change reference when the sampled value is unchanged', () => {
+      useTelemetryStore
+        .getState()
+        .setTelemetry({ ...mockTelemetry, Speed: { value: [1, 2] } } as Telemetry);
+
+      const { result } = renderHook(() =>
+        useTelemetryValuesThrottled('Speed', 100)
+      );
+      const firstValue = result.current;
+
+      act(() => {
+        // Same values, new array reference.
+        useTelemetryStore
+          .getState()
+          .setTelemetry({ ...mockTelemetry, Speed: { value: [1, 2] } } as Telemetry);
+        vi.advanceTimersByTime(100);
+      });
+      expect(result.current).toBe(firstValue);
     });
   });
 });

--- a/src/frontend/context/TelemetryStore/TelemetryStore.tsx
+++ b/src/frontend/context/TelemetryStore/TelemetryStore.tsx
@@ -107,10 +107,11 @@ export const useTelemetryValueRounded = (
  */
 export const useTelemetryValuesThrottled = (
   key: keyof Telemetry,
-  intervalMs: number
+  intervalMs = 66
 ): number[] => {
   const [sampled, setSampled] = useState<number[]>(
-    () => (useTelemetryStore.getState().telemetry?.[key]?.value ?? []) as number[]
+    () =>
+      (useTelemetryStore.getState().telemetry?.[key]?.value ?? []) as number[]
   );
 
   useEffect(() => {

--- a/src/frontend/context/TelemetryStore/TelemetryStore.tsx
+++ b/src/frontend/context/TelemetryStore/TelemetryStore.tsx
@@ -1,6 +1,7 @@
 import type { Telemetry, TelemetryVar } from '@irdashies/types';
 import { create, useStore } from 'zustand';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
+import { useEffect, useState } from 'react';
 import {
   arrayCompare,
   arrayCompareRounded,
@@ -87,3 +88,52 @@ export const useTelemetryValueRounded = (
     (state) => state.telemetry?.[key]?.value?.[0] as number | undefined,
     (a, b) => scalarCompareRounded(precision, a, b)
   );
+
+/**
+ * Returns telemetry values for a given key, sampled at most once per
+ * intervalMs. Unlike *Rounded variants, this throttles by time, not value
+ * delta — needed for full-grid arrays (e.g. CarIdxLapDistPct) where, with
+ * enough cars, some element crosses any rounding threshold almost every
+ * tick, making value-based rounding a no-op for re-render cadence.
+ *
+ * Schedules a flush only when the store actually changes, and only if one
+ * isn't already pending — leading-edge throttle, not a poll. No timer runs
+ * while telemetry is idle (sim disconnected, etc).
+ *
+ * Not implemented via a stateful equalityFn: useSyncExternalStoreWithSelector
+ * (which backs useStoreWithEqualityFn) can invoke equalityFn more than once
+ * per store update, so a comparator with a time-based side effect can
+ * suppress the very change it just accepted.
+ */
+export const useTelemetryValuesThrottled = (
+  key: keyof Telemetry,
+  intervalMs: number
+): number[] => {
+  const [sampled, setSampled] = useState<number[]>(
+    () => (useTelemetryStore.getState().telemetry?.[key]?.value ?? []) as number[]
+  );
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const flush = () => {
+      timer = undefined;
+      const latest = (useTelemetryStore.getState().telemetry?.[key]?.value ??
+        []) as number[];
+      setSampled((prev) => (arrayCompare(prev, latest) ? prev : latest));
+    };
+
+    const unsubscribe = useTelemetryStore.subscribe(() => {
+      if (timer === undefined) {
+        timer = setTimeout(flush, intervalMs);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      if (timer !== undefined) clearTimeout(timer);
+    };
+  }, [key, intervalMs]);
+
+  return sampled;
+};

--- a/src/frontend/context/TelemetryStore/standingsThrottle.bench.ts
+++ b/src/frontend/context/TelemetryStore/standingsThrottle.bench.ts
@@ -1,0 +1,94 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { bench, describe, vi } from 'vitest';
+import {
+  useTelemetryStore,
+  useTelemetryValuesRounded,
+  useTelemetryValuesThrottled,
+} from './TelemetryStore';
+import type { Telemetry } from '@irdashies/types';
+
+/**
+ * Wall-clock companion to standingsThrottle.perf.spec.ts. That test proves
+ * render counts; this measures the actual time cost of driving the same
+ * simulated race through each subscription strategy, including a stand-in
+ * for the Standings recompute work each render triggers (sort + map over
+ * the grid), since fewer renders only matters if the work they trigger is
+ * non-trivial — which createStandings' grouping/sorting/iRating pass is.
+ *
+ * Run with: npx vitest bench src/frontend/context/TelemetryStore/standingsThrottle.bench.ts
+ */
+const CAR_COUNT = 24;
+const TICK_MS = 1000 / 60;
+const TICK_COUNT = 120; // shorter than the perf spec — bench repeats this many times per round
+
+const buildTelemetry = (lapDistPct: number[]): Telemetry =>
+  ({ CarIdxLapDistPct: { value: lapDistPct } }) as Telemetry;
+
+const tickDeltas = Array.from(
+  { length: CAR_COUNT },
+  (_, carIdx) => 0.005 + (carIdx % 5) * 0.003
+);
+
+/** Stand-in for createStandings' per-render work: sort + map over the grid. */
+const simulateStandingsRecompute = (lapDistPct: number[]) =>
+  lapDistPct
+    .map((pct, carIdx) => ({ carIdx, pct }))
+    .sort((a, b) => b.pct - a.pct);
+
+describe('Standings telemetry subscription cost: rounding vs throttling', () => {
+  bench('before — useTelemetryValuesRounded(key, 3)', () => {
+    vi.useFakeTimers();
+    useTelemetryStore
+      .getState()
+      .setTelemetry(buildTelemetry(new Array(CAR_COUNT).fill(0)));
+    const lapDistPct = new Array(CAR_COUNT).fill(0);
+
+    renderHook(() => {
+      const values = useTelemetryValuesRounded('CarIdxLapDistPct', 3);
+      simulateStandingsRecompute(values);
+      return values;
+    });
+
+    for (let tick = 0; tick < TICK_COUNT; tick++) {
+      for (let carIdx = 0; carIdx < CAR_COUNT; carIdx++) {
+        lapDistPct[carIdx] = (lapDistPct[carIdx] + tickDeltas[carIdx]) % 1;
+      }
+      act(() => {
+        useTelemetryStore
+          .getState()
+          .setTelemetry(buildTelemetry([...lapDistPct]));
+        vi.advanceTimersByTime(TICK_MS);
+      });
+    }
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  bench('after — useTelemetryValuesThrottled(key, 66)', () => {
+    vi.useFakeTimers();
+    useTelemetryStore
+      .getState()
+      .setTelemetry(buildTelemetry(new Array(CAR_COUNT).fill(0)));
+    const lapDistPct = new Array(CAR_COUNT).fill(0);
+
+    renderHook(() => {
+      const values = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+      simulateStandingsRecompute(values);
+      return values;
+    });
+
+    for (let tick = 0; tick < TICK_COUNT; tick++) {
+      for (let carIdx = 0; carIdx < CAR_COUNT; carIdx++) {
+        lapDistPct[carIdx] = (lapDistPct[carIdx] + tickDeltas[carIdx]) % 1;
+      }
+      act(() => {
+        useTelemetryStore
+          .getState()
+          .setTelemetry(buildTelemetry([...lapDistPct]));
+        vi.advanceTimersByTime(TICK_MS);
+      });
+    }
+    vi.useRealTimers();
+    cleanup();
+  });
+});

--- a/src/frontend/context/TelemetryStore/standingsThrottle.bench.ts
+++ b/src/frontend/context/TelemetryStore/standingsThrottle.bench.ts
@@ -72,7 +72,7 @@ describe('Standings telemetry subscription cost: rounding vs throttling', () => 
     const lapDistPct = new Array(CAR_COUNT).fill(0);
 
     renderHook(() => {
-      const values = useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+      const values = useTelemetryValuesThrottled('CarIdxLapDistPct');
       simulateStandingsRecompute(values);
       return values;
     });

--- a/src/frontend/context/TelemetryStore/standingsThrottle.perf.spec.ts
+++ b/src/frontend/context/TelemetryStore/standingsThrottle.perf.spec.ts
@@ -34,7 +34,7 @@ const buildTelemetry = (lapDistPct: number[]): Telemetry =>
  * race-speed cars (200kph on a 5km track ≈ 0.011/tick). */
 const tickDeltas = Array.from(
   { length: CAR_COUNT },
-  (_, carIdx) => 0.005 + ((carIdx % 5) * 0.003) // varied speeds, all comfortably > 0.001
+  (_, carIdx) => 0.005 + (carIdx % 5) * 0.003 // varied speeds, all comfortably > 0.001
 );
 
 const driveSimulatedRace = (onTick: (lapDistPct: number[]) => void) => {
@@ -55,7 +55,9 @@ const driveSimulatedRace = (onTick: (lapDistPct: number[]) => void) => {
 describe('Standings telemetry subscription: rounding vs throttling under realistic load', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    useTelemetryStore.getState().setTelemetry(buildTelemetry(new Array(CAR_COUNT).fill(0)));
+    useTelemetryStore
+      .getState()
+      .setTelemetry(buildTelemetry(new Array(CAR_COUNT).fill(0)));
   });
 
   afterEach(() => {
@@ -72,7 +74,7 @@ describe('Standings telemetry subscription: rounding vs throttling under realist
     let throttledRenders = 0;
     renderHook(() => {
       throttledRenders++;
-      return useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+      return useTelemetryValuesThrottled('CarIdxLapDistPct');
     });
 
     // Both hooks render once on mount before any ticks are driven.

--- a/src/frontend/context/TelemetryStore/standingsThrottle.perf.spec.ts
+++ b/src/frontend/context/TelemetryStore/standingsThrottle.perf.spec.ts
@@ -1,0 +1,105 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  useTelemetryStore,
+  useTelemetryValuesRounded,
+  useTelemetryValuesThrottled,
+} from './TelemetryStore';
+import type { Telemetry } from '@irdashies/types';
+
+/**
+ * Quantifies the Standings perf fix instead of eyeballing Task Manager.
+ *
+ * Simulates a 24-car grid at 60Hz for 6 simulated seconds (360 ticks) with
+ * realistic per-car speed deltas on CarIdxLapDistPct, and counts how many
+ * times each subscription strategy actually accepts a new value (the
+ * render/recompute trigger for the Standings aggregation hooks):
+ *
+ * - "before": useTelemetryValuesRounded(key, 3) — value-based rounding
+ * - "after":  useTelemetryValuesThrottled(key, 66) — time-based sampling
+ *
+ * Claim under test: with a full grid, some car crosses any reasonable
+ * rounding threshold almost every tick, so rounding alone barely reduces
+ * render count versus the raw 60Hz feed. The throttle should cap renders to
+ * roughly simulatedDurationMs / intervalMs regardless of grid size/speed.
+ */
+const CAR_COUNT = 24;
+const TICK_MS = 1000 / 60;
+const TICK_COUNT = 360; // 6 simulated seconds
+
+const buildTelemetry = (lapDistPct: number[]): Telemetry =>
+  ({ CarIdxLapDistPct: { value: lapDistPct } }) as Telemetry;
+
+/** Per-car per-tick movement: ~0.005-0.02 of the track per tick, matching
+ * race-speed cars (200kph on a 5km track ≈ 0.011/tick). */
+const tickDeltas = Array.from(
+  { length: CAR_COUNT },
+  (_, carIdx) => 0.005 + ((carIdx % 5) * 0.003) // varied speeds, all comfortably > 0.001
+);
+
+const driveSimulatedRace = (onTick: (lapDistPct: number[]) => void) => {
+  const lapDistPct = new Array(CAR_COUNT).fill(0);
+  for (let tick = 0; tick < TICK_COUNT; tick++) {
+    for (let carIdx = 0; carIdx < CAR_COUNT; carIdx++) {
+      lapDistPct[carIdx] = (lapDistPct[carIdx] + tickDeltas[carIdx]) % 1;
+    }
+    // Each tick flushed on its own — mirrors discrete IPC pushes from the
+    // main process, not a batch of 360 updates collapsed into one render.
+    act(() => {
+      onTick([...lapDistPct]);
+      vi.advanceTimersByTime(TICK_MS);
+    });
+  }
+};
+
+describe('Standings telemetry subscription: rounding vs throttling under realistic load', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useTelemetryStore.getState().setTelemetry(buildTelemetry(new Array(CAR_COUNT).fill(0)));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports render counts for both strategies over the same simulated race', () => {
+    let roundedRenders = 0;
+    renderHook(() => {
+      roundedRenders++;
+      return useTelemetryValuesRounded('CarIdxLapDistPct', 3);
+    });
+
+    let throttledRenders = 0;
+    renderHook(() => {
+      throttledRenders++;
+      return useTelemetryValuesThrottled('CarIdxLapDistPct', 66);
+    });
+
+    // Both hooks render once on mount before any ticks are driven.
+    const initialRounded = roundedRenders;
+    const initialThrottled = throttledRenders;
+
+    driveSimulatedRace((lapDistPct) => {
+      useTelemetryStore.getState().setTelemetry(buildTelemetry(lapDistPct));
+    });
+
+    const roundedTickRenders = roundedRenders - initialRounded;
+    const throttledTickRenders = throttledRenders - initialThrottled;
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `[perf] ${TICK_COUNT} ticks @ 60Hz, ${CAR_COUNT} cars: ` +
+        `rounded(3dp)=${roundedTickRenders} renders, throttled(66ms)=${throttledTickRenders} renders`
+    );
+
+    // "before": rounding barely throttles anything — some car crosses the
+    // threshold on nearly every tick with a full moving grid.
+    expect(roundedTickRenders).toBeGreaterThan(TICK_COUNT * 0.9);
+
+    // "after": capped to roughly simulated-duration / interval, independent
+    // of grid size or speed.
+    const expectedThrottledRenders = (TICK_COUNT * TICK_MS) / 66;
+    expect(throttledTickRenders).toBeLessThan(expectedThrottledRenders * 1.5);
+    expect(throttledTickRenders).toBeLessThan(roundedTickRenders * 0.5);
+  });
+});


### PR DESCRIPTION
## Description

Plus add benchmark testing, not sure about integration into CI, tho.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

### After
<!-- Screenshot or description of the new behaviour -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added benchmarks measuring telemetry subscription performance
  * Added performance specifications for standings display updates

* **Chores**
  * CI pipeline now executes benchmarks after tests
  * Added npm bench script for local performance testing

* **Documentation**
  * Added guidance on benchmarking and performance testing best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->