### PR TITLE
feat: Add support for controller combo keybindings

### DIFF
--- a/src/app/bridge/keybindingsBridge.ts
+++ b/src/app/bridge/keybindingsBridge.ts
@@ -4,7 +4,7 @@ import { DEFAULT_KEYBINDINGS } from '@irdashies/types';
 import {
   isGamepadBinding,
   isValidWidgetToggleActionId,
-  parseGamepadToken,
+  parseGamepadTokens,
 } from '@irdashies/shared';
 import {
   getKeybindings,
@@ -24,10 +24,10 @@ function assertSupportedAction(actionId: KeybindingActionId): void {
   }
 }
 
-/** Throw if `accelerator` is not a valid binding of its kind. */
+/** Throw if `accelerator` is not a valid binding of its kind (single token or combo). */
 function assertValidAccelerator(accelerator: string): void {
   if (isGamepadBinding(accelerator)) {
-    if (!parseGamepadToken(accelerator)) {
+    if (!parseGamepadTokens(accelerator)) {
       throw new Error(`"${accelerator}" is not a valid controller button`);
     }
   } else if (!KeybindingManager.isValidAccelerator(accelerator)) {

--- a/src/app/bridge/rendererExposeBridge.ts
+++ b/src/app/bridge/rendererExposeBridge.ts
@@ -284,7 +284,8 @@ export function exposeBridge() {
   // Used only by the hidden WebHID host renderer (src/hidHost.ts) to forward
   // controller button presses to the main process.
   contextBridge.exposeInMainWorld('gamepadHost', {
-    sendButton: (token: string) => ipcRenderer.send('gamepad:button', token),
+    sendButton: (token: string, down: boolean) =>
+      ipcRenderer.send('gamepad:button', token, down),
   } satisfies GamepadHostBridge);
 
   contextBridge.exposeInMainWorld('personalBestBridge', {

--- a/src/app/gamepad/README.md
+++ b/src/app/gamepad/README.md
@@ -21,9 +21,19 @@ So one hidden, always-alive window host the HID reader and forward presses to th
 - Many controllers and sim wheel bases (Thrustmaster, Fanatec, Simucube) declare buttons on a **vendor-defined** page (`0xFF00`+), not the standard Button page (`0x09`). Filtering by page drop those — exactly what broke a real Thrustmaster wheel. An unbound bit fire nothing (`GamepadManager` only trigger mapped tokens), so no need to guess which bits are "real" buttons.
 - Single-bit is the safety line. Analog axes are multi-bit (`reportSize > 1`), so a turned wheel or pressed pedal can't reach the binding map. The overlay run during a race — firing an action by accident (analog drift, a status flag toggling mid-corner) is worse than a missing feature.
 
+## Button & d-pad combos (chords)
+
+A binding can be two or more controls held together — buttons, d-pad directions, or a mix, e.g. `gamepad:btn0+gamepad:hat0_up`. `GamepadManager` tracks every currently-held control token in a `Set`; on each press it canonicalizes the held set (sorted, joined by `+` — see `gamepadComboToken` in `gamepadToken.ts`) and looks that up directly. So a combo fires the instant its exact set of controls is held, and pressing one more unrelated control breaks the match — it is not "any superset", deliberately, to avoid one combo accidentally swallowing another that shares controls.
+
+To record one: hold the controls together, then release any one of them — that release commits whatever was held as the new binding. A single press+release still binds a plain single-control accelerator (the one-control case of the same canonical-join logic), so existing single bindings are unaffected.
+
+This needs a release edge per control to know what's still held: `buttonChanges` in `hidReport.ts` reports both press and release for buttons; `hatChanges` does the same for hat directions — rolling from one direction straight to another emits a release of the old direction and a press of the new one in the same report, and centering emits a release with no matching press.
+
+One consequence worth knowing: **no subset firing.** Holding A+B+C when only A+B is bound does not fire A+B. This keeps a 2-control and a 3-control combo that share controls unambiguous, at the cost of needing an exact match.
+
 ## Hat switch (d-pad)
 
-Pads report the d-pad as one multi-bit **hat switch** (Generic Desktop usage `0x39`), not four bits, so `parseButtons` never see it. `parseHats` find it; `hatEdges` decode directions clockwise from the descriptor's logical minimum (= up), which handles both `0-7` and `1-8` pads.
+Pads report the d-pad as one multi-bit **hat switch** (Generic Desktop usage `0x39`), not four bits, so `parseButtons` never see it. `parseHats` find it; `hatChanges` decode directions clockwise from the descriptor's logical minimum (= up), which handles both `0-7` and `1-8` pads.
 
 > **Assumption left:** directions read clockwise from `logicalMin`. Matches every pad seen. A device ordering its hat differently would map wrong — fix point is the `HAT_DIRECTIONS` order in `hidReport.ts`.
 

--- a/src/app/gamepad/gamepadHost.ts
+++ b/src/app/gamepad/gamepadHost.ts
@@ -23,18 +23,19 @@ const HID_PARTITION = 'hid-host';
  */
 export class GamepadHost {
   private window?: BrowserWindow;
-  private onButton?: (token: string) => void;
+  private onButton?: (token: string, down: boolean) => void;
   private permissionsGranted = false;
   private readonly handleButton = (
     event: Electron.IpcMainEvent,
-    token: string
+    token: string,
+    down: boolean
   ): void => {
     // Only the HID-host window may emit; reject any other renderer spoofing tokens.
     if (event.sender.id !== this.window?.webContents.id) return;
-    this.onButton?.(token);
+    this.onButton?.(token, down);
   };
 
-  start(onButton: (token: string) => void): void {
+  start(onButton: (token: string, down: boolean) => void): void {
     this.onButton = onButton;
     if (this.window && !this.window.isDestroyed()) return;
 

--- a/src/app/gamepad/gamepadManager.spec.ts
+++ b/src/app/gamepad/gamepadManager.spec.ts
@@ -29,13 +29,18 @@ const gamepadBinding = (): KeybindingsMap =>
   }) as unknown as KeybindingsMap;
 
 // handleButton is private; the WebHID host callback is its only caller,
-// passing a ready-made gamepad token.
-const fireButton = (manager: GamepadManager, token: string) =>
+// passing a ready-made gamepad token and its press/release state.
+const fireButton = (manager: GamepadManager, token: string, down = true) =>
   (
     manager as unknown as {
-      handleButton: (token: string) => void;
+      handleButton: (token: string, down: boolean) => void;
     }
-  ).handleButton(token);
+  ).handleButton(token, down);
+
+const press = (manager: GamepadManager, token: string) =>
+  fireButton(manager, token, true);
+const release = (manager: GamepadManager, token: string) =>
+  fireButton(manager, token, false);
 
 describe('GamepadManager', () => {
   beforeEach(() => {
@@ -47,7 +52,7 @@ describe('GamepadManager', () => {
     const manager = new GamepadManager(trigger);
     manager.syncBindings(gamepadBinding());
 
-    fireButton(manager, 'gamepad:btn0');
+    press(manager, 'gamepad:btn0');
 
     expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
   });
@@ -57,25 +62,27 @@ describe('GamepadManager', () => {
     const manager = new GamepadManager(trigger);
     manager.syncBindings(gamepadBinding());
 
-    fireButton(manager, 'gamepad:btn1');
+    press(manager, 'gamepad:btn1');
 
     expect(trigger).not.toHaveBeenCalled();
   });
 
-  it('forwards to the capture callback instead of triggering while recording', () => {
+  it('forwards the captured combo to the capture callback on first release, instead of triggering', () => {
     const trigger = vi.fn();
     const manager = new GamepadManager(trigger);
     manager.syncBindings(gamepadBinding());
 
     const captured: string[] = [];
     manager.startCapture((token) => captured.push(token));
-    fireButton(manager, 'gamepad:btn0');
+    press(manager, 'gamepad:btn0');
+    expect(captured).toEqual([]); // not yet committed — waiting for a release
+    release(manager, 'gamepad:btn0');
 
     expect(captured).toEqual(['gamepad:btn0']);
     expect(trigger).not.toHaveBeenCalled();
 
     manager.stopCapture();
-    fireButton(manager, 'gamepad:btn0');
+    press(manager, 'gamepad:btn0');
     expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
   });
 
@@ -94,10 +101,11 @@ describe('GamepadManager', () => {
       },
     } as unknown as KeybindingsMap);
 
-    fireButton(manager, 'gamepad:btn0');
+    press(manager, 'gamepad:btn0');
+    release(manager, 'gamepad:btn0');
     expect(trigger).not.toHaveBeenCalled();
 
-    fireButton(manager, 'gamepad:btn5');
+    press(manager, 'gamepad:btn5');
     expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
   });
 
@@ -113,8 +121,108 @@ describe('GamepadManager', () => {
       },
     } as unknown as KeybindingsMap);
 
-    fireButton(manager, 'gamepad:B66E:btn10');
+    press(manager, 'gamepad:B66E:btn10');
 
     expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
+  });
+
+  describe('combos (chords)', () => {
+    const comboBinding = (): KeybindingsMap =>
+      ({
+        'toggle-edit-mode': {
+          accelerator: 'gamepad:btn0+gamepad:btn1',
+          label: 'Edit Layout',
+          description: '',
+          isDefault: false,
+        },
+      }) as unknown as KeybindingsMap;
+
+    it('fires when the second button completes the bound chord, regardless of press order', () => {
+      const trigger = vi.fn();
+      const manager = new GamepadManager(trigger);
+      manager.syncBindings(comboBinding());
+
+      press(manager, 'gamepad:btn1');
+      expect(trigger).not.toHaveBeenCalled();
+      press(manager, 'gamepad:btn0');
+      expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
+    });
+
+    it('does not fire on a 2-of-3 subset — an extra held button breaks the exact match', () => {
+      const trigger = vi.fn();
+      const manager = new GamepadManager(trigger);
+      manager.syncBindings(comboBinding());
+
+      press(manager, 'gamepad:btn2');
+      press(manager, 'gamepad:btn0');
+      press(manager, 'gamepad:btn1');
+
+      expect(trigger).not.toHaveBeenCalled();
+    });
+
+    it('re-fires after releasing and re-pressing one button of the chord', () => {
+      const trigger = vi.fn();
+      const manager = new GamepadManager(trigger);
+      manager.syncBindings(comboBinding());
+
+      press(manager, 'gamepad:btn0');
+      press(manager, 'gamepad:btn1');
+      expect(trigger).toHaveBeenCalledTimes(1);
+
+      release(manager, 'gamepad:btn1');
+      press(manager, 'gamepad:btn1');
+      expect(trigger).toHaveBeenCalledTimes(2);
+    });
+
+    it('captures a chord and commits it as a canonical, order-independent combo', () => {
+      const trigger = vi.fn();
+      const manager = new GamepadManager(trigger);
+
+      const captured: string[] = [];
+      manager.startCapture((token) => captured.push(token));
+      press(manager, 'gamepad:btn1');
+      press(manager, 'gamepad:btn0');
+      release(manager, 'gamepad:btn1');
+
+      expect(captured).toEqual(['gamepad:btn0+gamepad:btn1']);
+    });
+
+    it('fires a button + hat-direction combo once both are held', () => {
+      const trigger = vi.fn();
+      const manager = new GamepadManager(trigger);
+      manager.syncBindings({
+        'toggle-edit-mode': {
+          accelerator: 'gamepad:btn0+gamepad:hat0_up',
+          label: 'Edit Layout',
+          description: '',
+          isDefault: false,
+        },
+      } as unknown as KeybindingsMap);
+
+      press(manager, 'gamepad:btn0');
+      expect(trigger).not.toHaveBeenCalled();
+      press(manager, 'gamepad:hat0_up');
+
+      expect(trigger).toHaveBeenCalledWith('toggle-edit-mode');
+    });
+
+    it('releasing a hat direction (centering) drops it from the held set', () => {
+      const trigger = vi.fn();
+      const manager = new GamepadManager(trigger);
+      manager.syncBindings({
+        'toggle-edit-mode': {
+          accelerator: 'gamepad:btn0+gamepad:hat0_up',
+          label: 'Edit Layout',
+          description: '',
+          isDefault: false,
+        },
+      } as unknown as KeybindingsMap);
+
+      press(manager, 'gamepad:hat0_up');
+      release(manager, 'gamepad:hat0_up'); // centered
+      press(manager, 'gamepad:btn0');
+
+      expect(trigger).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/gamepad/gamepadManager.ts
+++ b/src/app/gamepad/gamepadManager.ts
@@ -1,5 +1,5 @@
 import type { KeybindingActionId, KeybindingsMap } from '@irdashies/types';
-import { isGamepadBinding } from '@irdashies/shared';
+import { gamepadComboToken, isGamepadBinding } from '@irdashies/shared';
 import logger from '../logger';
 import { GamepadHost } from './gamepadHost';
 
@@ -11,14 +11,24 @@ import { GamepadHost } from './gamepadHost';
  * the current map in via {@link GamepadManager.syncBindings} — and it triggers
  * actions through the `triggerAction` callback supplied at construction, so it
  * stays decoupled from how those actions are implemented.
+ *
+ * Buttons and d-pad directions both support combos (chords): a binding can be
+ * a single token ("gamepad:btn0", "gamepad:hat0_up") or several joined with
+ * '+' in canonical (sorted) order ("gamepad:btn0+gamepad:hat0_up"). A combo
+ * fires the moment its exact set of controls is held — pressing an extra,
+ * unrelated control breaks the match, it does not fire a 2-of-3 subset.
  */
 export class GamepadManager {
-  /** Gamepad token (e.g. "gamepad:btn0") -> action it triggers. */
+  /** Canonical accelerator (single token or sorted combo) -> action it triggers. */
   private map = new Map<string, KeybindingActionId>();
+  /** Controls (buttons and hat directions) currently held down. */
+  private held = new Set<string>();
   /** Lazily-created WebHID host window manager (see start). */
   private host?: GamepadHost;
   /** When set, captured pad presses are reported here instead of triggering actions (rebinding). */
   private onCapture?: (token: string) => void;
+  /** Tokens pressed since capture started, committed as a combo on first release. */
+  private captureHeld = new Set<string>();
 
   constructor(private triggerAction: (actionId: KeybindingActionId) => void) {}
 
@@ -30,18 +40,34 @@ export class GamepadManager {
         this.map.set(entry.accelerator, actionId as KeybindingActionId);
       }
     }
+    // Rebinding invalidates whatever was held under the old map — start the
+    // new map's held-set tracking from a clean slate.
+    this.held.clear();
   }
 
   /**
-   * Route a gamepad button-down (a `gamepad:btn<N>` token from the WebHID host)
-   * to capture (rebinding) or to its bound action.
+   * Route a gamepad control transition (a token from the WebHID host, `down`
+   * true on press / false on release) to capture (rebinding) or to its bound
+   * action.
    */
-  private handleButton(token: string): void {
+  private handleButton(token: string, down: boolean): void {
     if (this.onCapture) {
-      this.onCapture(token);
+      if (down) {
+        this.captureHeld.add(token);
+      } else if (this.captureHeld.size > 0) {
+        const combo = gamepadComboToken(this.captureHeld);
+        this.captureHeld.clear();
+        this.onCapture(combo);
+      }
       return;
     }
-    const actionId = this.map.get(token);
+
+    if (!down) {
+      this.held.delete(token);
+      return;
+    }
+    this.held.add(token);
+    const actionId = this.map.get(gamepadComboToken(this.held));
     if (actionId) this.triggerAction(actionId);
   }
 
@@ -52,7 +78,7 @@ export class GamepadManager {
   public start(): void {
     try {
       if (!this.host) this.host = new GamepadHost();
-      this.host.start((token) => this.handleButton(token));
+      this.host.start((token, down) => this.handleButton(token, down));
     } catch (err) {
       logger.error(
         '[Gamepad] host unavailable, controller bindings disabled',
@@ -68,11 +94,16 @@ export class GamepadManager {
 
   /** Enter capture mode: the next pad presses are reported to `onCapture` for rebinding. */
   public startCapture(onCapture: (token: string) => void): void {
+    this.captureHeld.clear();
     this.onCapture = onCapture;
   }
 
   /** Leave capture mode; pad presses resume triggering actions. */
   public stopCapture(): void {
     this.onCapture = undefined;
+    this.captureHeld.clear();
+    // Buttons held while recording may never have reached a release edge
+    // here (focus, timing) — start the next non-capture run from a clean slate.
+    this.held.clear();
   }
 }

--- a/src/app/gamepad/hidReport.spec.ts
+++ b/src/app/gamepad/hidReport.spec.ts
@@ -3,8 +3,8 @@ import type { ButtonBit, HatField, HatDirection } from '@irdashies/types';
 import {
   parseButtons,
   parseHats,
-  buttonEdges,
-  hatEdges,
+  buttonChanges,
+  hatChanges,
   itemUsagePage,
 } from './hidReport';
 
@@ -250,7 +250,7 @@ describe('parseHats', () => {
   });
 });
 
-describe('hatEdges', () => {
+describe('hatChanges', () => {
   const hat = (over: Partial<HatField> = {}): HatField => ({
     reportId: 0,
     bitOffset: 0,
@@ -262,20 +262,36 @@ describe('hatEdges', () => {
   });
   const hats: HatField[] = [hat()];
 
-  it('fires once on entering a direction, ignoring held frames', () => {
+  it('fires a press once on entering a direction, ignoring held frames', () => {
     const state = new Map<number, HatDirection | null>();
 
-    expect(hatEdges(view(0x0f), hats, 0, state)).toEqual([]); // 15 = centered
-    expect(hatEdges(view(0x00), hats, 0, state)).toEqual([
-      { index: 0, direction: 'up' }, // 0 = up
+    expect(hatChanges(view(0x0f), hats, 0, state)).toEqual([]); // 15 = centered
+    expect(hatChanges(view(0x00), hats, 0, state)).toEqual([
+      { index: 0, direction: 'up', down: true }, // 0 = up
     ]);
-    expect(hatEdges(view(0x00), hats, 0, state)).toEqual([]); // held
-    expect(hatEdges(view(0x02), hats, 0, state)).toEqual([
-      { index: 0, direction: 'right' }, // roll straight to 2 = right
+    expect(hatChanges(view(0x00), hats, 0, state)).toEqual([]); // held
+  });
+
+  it('rolling straight to a new direction releases the old one and presses the new one', () => {
+    const state = new Map<number, HatDirection | null>();
+
+    hatChanges(view(0x00), hats, 0, state); // press up
+    expect(hatChanges(view(0x02), hats, 0, state)).toEqual([
+      { index: 0, direction: 'up', down: false },
+      { index: 0, direction: 'right', down: true },
     ]);
-    expect(hatEdges(view(0x0f), hats, 0, state)).toEqual([]); // centered
-    expect(hatEdges(view(0x00), hats, 0, state)).toEqual([
-      { index: 0, direction: 'up' }, // press again
+  });
+
+  it('centering releases the held direction with no matching press', () => {
+    const state = new Map<number, HatDirection | null>();
+
+    hatChanges(view(0x00), hats, 0, state); // press up
+    expect(hatChanges(view(0x0f), hats, 0, state)).toEqual([
+      { index: 0, direction: 'up', down: false },
+    ]);
+    // press again after centering
+    expect(hatChanges(view(0x00), hats, 0, state)).toEqual([
+      { index: 0, direction: 'up', down: true },
     ]);
   });
 
@@ -285,15 +301,17 @@ describe('hatEdges', () => {
     const state = new Map<number, HatDirection | null>();
     const oneBased: HatField[] = [hat({ logicalMin: 1, logicalMax: 8 })];
 
-    expect(hatEdges(view(0x00), oneBased, 0, state)).toEqual([]); // 0 = centered
-    expect(hatEdges(view(0x01), oneBased, 0, state)).toEqual([
-      { index: 0, direction: 'up' }, // 1 = up
+    expect(hatChanges(view(0x00), oneBased, 0, state)).toEqual([]); // 0 = centered
+    expect(hatChanges(view(0x01), oneBased, 0, state)).toEqual([
+      { index: 0, direction: 'up', down: true }, // 1 = up
     ]);
-    expect(hatEdges(view(0x07), oneBased, 0, state)).toEqual([
-      { index: 0, direction: 'left' }, // 7 = left
+    expect(hatChanges(view(0x07), oneBased, 0, state)).toEqual([
+      { index: 0, direction: 'up', down: false },
+      { index: 0, direction: 'left', down: true }, // 7 = left
     ]);
-    expect(hatEdges(view(0x08), oneBased, 0, state)).toEqual([
-      { index: 0, direction: 'upleft' }, // 8 = upleft
+    expect(hatChanges(view(0x08), oneBased, 0, state)).toEqual([
+      { index: 0, direction: 'left', down: false },
+      { index: 0, direction: 'upleft', down: true }, // 8 = upleft
     ]);
   });
 
@@ -301,29 +319,29 @@ describe('hatEdges', () => {
     const state = new Map<number, HatDirection | null>();
     const hi: HatField[] = [hat({ bitOffset: 4 })];
     // high nibble of 0x40 is 4 -> down
-    expect(hatEdges(view(0x40), hi, 0, state)).toEqual([
-      { index: 0, direction: 'down' },
+    expect(hatChanges(view(0x40), hi, 0, state)).toEqual([
+      { index: 0, direction: 'down', down: true },
     ]);
   });
 
   it('treats values outside the range as centered', () => {
     const state = new Map<number, HatDirection | null>();
-    expect(hatEdges(view(0x08), hats, 0, state)).toEqual([]); // 8 (> logicalMax 7)
-    expect(hatEdges(view(0x09), hats, 0, state)).toEqual([]); // 9
+    expect(hatChanges(view(0x08), hats, 0, state)).toEqual([]); // 8 (> logicalMax 7)
+    expect(hatChanges(view(0x09), hats, 0, state)).toEqual([]); // 9
   });
 
   it('only reads hats whose reportId matches the incoming report', () => {
     const state = new Map<number, HatDirection | null>();
     const idHats: HatField[] = [hat({ reportId: 2 })];
 
-    expect(hatEdges(view(0x00), idHats, 1, state)).toEqual([]); // wrong report
-    expect(hatEdges(view(0x00), idHats, 2, state)).toEqual([
-      { index: 0, direction: 'up' },
+    expect(hatChanges(view(0x00), idHats, 1, state)).toEqual([]); // wrong report
+    expect(hatChanges(view(0x00), idHats, 2, state)).toEqual([
+      { index: 0, direction: 'up', down: true },
     ]);
   });
 });
 
-describe('buttonEdges', () => {
+describe('buttonChanges', () => {
   const buttons: ButtonBit[] = [
     { reportId: 0, byteOffset: 0, bitMask: 0b001, index: 0 },
     { reportId: 0, byteOffset: 0, bitMask: 0b010, index: 1 },
@@ -333,13 +351,21 @@ describe('buttonEdges', () => {
   it('reports a press once on the rising edge, ignoring held frames', () => {
     const state = new Map<number, boolean>();
 
-    expect(buttonEdges(view(0b000), buttons, 0, state)).toEqual([]);
-    expect(buttonEdges(view(0b101), buttons, 0, state)).toEqual([0, 2]);
+    expect(buttonChanges(view(0b000), buttons, 0, state)).toEqual([]);
+    expect(buttonChanges(view(0b101), buttons, 0, state)).toEqual([
+      { index: 0, down: true },
+      { index: 2, down: true },
+    ]);
     // Held: no new edges.
-    expect(buttonEdges(view(0b101), buttons, 0, state)).toEqual([]);
-    // Release then press again -> new edge.
-    expect(buttonEdges(view(0b000), buttons, 0, state)).toEqual([]);
-    expect(buttonEdges(view(0b001), buttons, 0, state)).toEqual([0]);
+    expect(buttonChanges(view(0b101), buttons, 0, state)).toEqual([]);
+    // Release then press again -> new edges both ways.
+    expect(buttonChanges(view(0b000), buttons, 0, state)).toEqual([
+      { index: 0, down: false },
+      { index: 2, down: false },
+    ]);
+    expect(buttonChanges(view(0b001), buttons, 0, state)).toEqual([
+      { index: 0, down: true },
+    ]);
   });
 
   it('only reads buttons whose reportId matches the incoming report', () => {
@@ -350,7 +376,9 @@ describe('buttonEdges', () => {
     ];
 
     // A report with id 2 must not read the id-1 button's bits.
-    expect(buttonEdges(view(0b1), idBtns, 2, state)).toEqual([1]);
+    expect(buttonChanges(view(0b1), idBtns, 2, state)).toEqual([
+      { index: 1, down: true },
+    ]);
     expect(state.has(0)).toBe(false);
   });
 
@@ -359,6 +387,6 @@ describe('buttonEdges', () => {
     const wide: ButtonBit[] = [
       { reportId: 0, byteOffset: 4, bitMask: 0b1, index: 0 },
     ];
-    expect(buttonEdges(view(0b1), wide, 0, state)).toEqual([]);
+    expect(buttonChanges(view(0b1), wide, 0, state)).toEqual([]);
   });
 });

--- a/src/app/gamepad/hidReport.ts
+++ b/src/app/gamepad/hidReport.ts
@@ -188,31 +188,40 @@ export function parseHats(
   return hats;
 }
 
+/** A button that transitioned this report: `down: true` on press, `false` on release. */
+export interface ButtonChange {
+  index: number;
+  down: boolean;
+}
+
 /**
- * Read button states from an input report and return the indices that
- * transitioned from up to down (rising edge). `state` is mutated in place to
- * hold the latest pressed/released value for each button index.
+ * Read button states from an input report and return every button that
+ * transitioned (pressed or released) this report. Combo (chord) bindings need
+ * both edges to know which buttons are still held alongside a newly-pressed
+ * one. `state` is mutated in place to hold the latest pressed/released value
+ * for each button index.
  */
-export function buttonEdges(
+export function buttonChanges(
   data: DataView,
   buttons: readonly ButtonBit[],
   reportId: number,
   state: Map<number, boolean>
-): number[] {
-  const pressed: number[] = [];
+): ButtonChange[] {
+  const changes: ButtonChange[] = [];
 
   for (const button of buttons) {
     if (button.reportId !== reportId) continue;
     if (button.byteOffset >= data.byteLength) continue;
 
     const isDown = (data.getUint8(button.byteOffset) & button.bitMask) !== 0;
-    if (isDown && !(state.get(button.index) ?? false)) {
-      pressed.push(button.index);
+    const wasDown = state.get(button.index) ?? false;
+    if (isDown !== wasDown) {
+      changes.push({ index: button.index, down: isDown });
     }
     state.set(button.index, isDown);
   }
 
-  return pressed;
+  return changes;
 }
 
 /** Read `bitWidth` bits starting at `bitOffset` (LSB-first), or null if out of range. */
@@ -231,19 +240,27 @@ function readBits(
   return value;
 }
 
+/** A hat direction that transitioned this report: released, pressed, or both (rolling to a new direction). */
+export interface HatChange extends HatPress {
+  down: boolean;
+}
+
 /**
- * Read hat values from an input report and return the hats that just entered a
- * new direction (the d-pad equivalent of a rising edge). Holding a direction
- * fires once; rolling straight from one direction to another fires the new one;
- * centering (value outside 0-7) fires nothing. `state` is mutated in place.
+ * Read hat values from an input report and return every direction transition
+ * this report: holding fires nothing further, rolling straight from one
+ * direction to another fires a release of the old one followed by a press of
+ * the new one (same report, two entries), and centering (value outside the
+ * logical range) fires a release with no matching press. `state` is mutated
+ * in place. Releases let a d-pad direction be tracked as held, same as a
+ * button, so it can be a combo (chord) member.
  */
-export function hatEdges(
+export function hatChanges(
   data: DataView,
   hats: readonly HatField[],
   reportId: number,
   state: Map<number, HatDirection | null>
-): HatPress[] {
-  const pressed: HatPress[] = [];
+): HatChange[] {
+  const changes: HatChange[] = [];
 
   for (const hat of hats) {
     if (hat.reportId !== reportId) continue;
@@ -261,13 +278,15 @@ export function hatEdges(
         : null;
     const previous = state.get(hat.index) ?? null;
 
-    if (direction && direction !== previous) {
-      pressed.push({ index: hat.index, direction });
+    if (direction !== previous) {
+      if (previous)
+        changes.push({ index: hat.index, direction: previous, down: false });
+      if (direction) changes.push({ index: hat.index, direction, down: true });
     }
     state.set(hat.index, direction);
   }
 
-  return pressed;
+  return changes;
 }
 
 /** Human-readable dump of a device's input-report layout, for diagnostics. */

--- a/src/frontend/components/Settings/sections/KeybindingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/KeybindingsSettings.tsx
@@ -9,6 +9,7 @@ import {
   isGamepadBinding,
   isWidgetToggleActionId,
   parseGamepadToken,
+  parseGamepadTokens,
   widgetToggleActionId,
 } from '@irdashies/shared';
 import { useDashboard } from '@irdashies/context';
@@ -126,9 +127,13 @@ function keyEventToAccelerator(e: KeyboardEvent): string | null {
 
 /**
  * Formats an accelerator string for display, e.g. "CommandOrControl" -> "Ctrl".
+ * A gamepad combo (chord) renders each button joined by " + ", e.g.
+ * "Pad: Button 0 + Pad: Button 5".
  */
 function formatAccelerator(accelerator: string): string {
   if (isGamepadBinding(accelerator)) {
+    const tokens = parseGamepadTokens(accelerator);
+    if (tokens) return tokens.map(formatGamepadToken).join(' + ');
     return formatGamepadToken(accelerator);
   }
 
@@ -375,7 +380,8 @@ export const KeybindingsSettings = () => {
             <h2 className="text-xl mb-1">Key Bindings</h2>
             <p className="text-slate-400 text-sm">
               Customize keyboard shortcuts. Click a binding then press a new key
-              combination.
+              combination, or hold two or more controller buttons together for a
+              combo.
             </p>
           </div>
           <button

--- a/src/hidHost.ts
+++ b/src/hidHost.ts
@@ -15,8 +15,8 @@ import type { ButtonBit, HatField, HatDirection } from '@irdashies/types';
 import {
   parseButtons,
   parseHats,
-  buttonEdges,
-  hatEdges,
+  buttonChanges,
+  hatChanges,
   describeCollections,
 } from './app/gamepad/hidReport';
 
@@ -58,25 +58,27 @@ async function openDevice(device: HIDDevice): Promise<void> {
   }
 
   device.addEventListener('inputreport', (event) => {
-    for (const index of buttonEdges(
+    for (const change of buttonChanges(
       event.data,
       state.buttons,
       event.reportId,
       state.pressed
     )) {
       window.gamepadHost?.sendButton(
-        gamepadTokenFromIndex(index, device.productName)
+        gamepadTokenFromIndex(change.index, device.productName),
+        change.down
       );
     }
 
-    for (const { index, direction } of hatEdges(
+    for (const change of hatChanges(
       event.data,
       state.hats,
       event.reportId,
       state.hatState
     )) {
       window.gamepadHost?.sendButton(
-        gamepadTokenFromHat(index, direction, device.productName)
+        gamepadTokenFromHat(change.index, change.direction, device.productName),
+        change.down
       );
     }
   });

--- a/src/shared/gamepadToken.spec.ts
+++ b/src/shared/gamepadToken.spec.ts
@@ -93,4 +93,11 @@ describe('gamepad combo (chord) helpers', () => {
     expect(parseGamepadTokens('gamepad:btn0+Alt')).toBeNull();
     expect(parseGamepadTokens('Alt+H')).toBeNull();
   });
+
+  it('rejects a non-canonical combo that could never fire at runtime', () => {
+    // Unsorted and duplicate combos validate part-by-part but the runtime
+    // lookup keys on gamepadComboToken form, so they would never match.
+    expect(parseGamepadTokens('gamepad:btn5+gamepad:btn0')).toBeNull();
+    expect(parseGamepadTokens('gamepad:btn0+gamepad:btn0')).toBeNull();
+  });
 });

--- a/src/shared/gamepadToken.spec.ts
+++ b/src/shared/gamepadToken.spec.ts
@@ -3,7 +3,9 @@ import {
   isGamepadBinding,
   gamepadTokenFromIndex,
   gamepadTokenFromHat,
+  gamepadComboToken,
   parseGamepadToken,
+  parseGamepadTokens,
 } from './gamepadToken';
 
 describe('gamepad binding token helpers', () => {
@@ -55,5 +57,40 @@ describe('gamepad binding token helpers', () => {
     expect(parseGamepadToken('gamepad:hat_up')).toBeNull();
     expect(parseGamepadToken('gamepad:hat0_unknown')).toBeNull();
     expect(parseGamepadToken('Alt+H')).toBeNull();
+  });
+});
+
+describe('gamepad combo (chord) helpers', () => {
+  it('builds a canonical, sorted combo regardless of input order', () => {
+    expect(gamepadComboToken(['gamepad:btn5', 'gamepad:btn0'])).toBe(
+      'gamepad:btn0+gamepad:btn5'
+    );
+    expect(gamepadComboToken(['gamepad:btn0', 'gamepad:btn5'])).toBe(
+      'gamepad:btn0+gamepad:btn5'
+    );
+  });
+
+  it('de-duplicates tokens when building a combo', () => {
+    expect(gamepadComboToken(['gamepad:btn0', 'gamepad:btn0'])).toBe(
+      'gamepad:btn0'
+    );
+  });
+
+  it('round-trips a single token unchanged', () => {
+    expect(gamepadComboToken(['gamepad:btn0'])).toBe('gamepad:btn0');
+  });
+
+  it('parses a combo into its individual valid tokens', () => {
+    expect(parseGamepadTokens('gamepad:btn0+gamepad:btn1')).toEqual([
+      'gamepad:btn0',
+      'gamepad:btn1',
+    ]);
+    expect(parseGamepadTokens('gamepad:btn0')).toEqual(['gamepad:btn0']);
+  });
+
+  it('rejects a combo containing an invalid or non-gamepad part', () => {
+    expect(parseGamepadTokens('gamepad:btn0+gamepad:nope')).toBeNull();
+    expect(parseGamepadTokens('gamepad:btn0+Alt')).toBeNull();
+    expect(parseGamepadTokens('Alt+H')).toBeNull();
   });
 });

--- a/src/shared/gamepadToken.ts
+++ b/src/shared/gamepadToken.ts
@@ -91,12 +91,17 @@ const COMBO_SEPARATOR = '+';
 /**
  * Split a gamepad accelerator (single token or combo) into its individual
  * tokens, validating each one. Returns null if `accelerator` isn't a gamepad
- * binding, or if any part fails to parse as a gamepad token.
+ * binding, any part fails to parse, or the combo isn't in canonical form.
+ *
+ * The runtime lookup keys actions by `gamepadComboToken` (sorted + deduped),
+ * so a non-canonical combo like "gamepad:btn5+gamepad:btn0" or a duplicate
+ * "gamepad:btn0+gamepad:btn0" would validate here yet never fire — reject it.
  */
 export function parseGamepadTokens(accelerator: string): string[] | null {
   if (!isGamepadBinding(accelerator)) return null;
   const parts = accelerator.split(COMBO_SEPARATOR);
-  return parts.every((part) => parseGamepadToken(part)) ? parts : null;
+  if (!parts.every((part) => parseGamepadToken(part))) return null;
+  return gamepadComboToken(parts) === accelerator ? parts : null;
 }
 
 /**

--- a/src/shared/gamepadToken.ts
+++ b/src/shared/gamepadToken.ts
@@ -79,3 +79,32 @@ export function parseGamepadToken(token: string): ParsedGamepadToken | null {
   }
   return { device, button };
 }
+
+/**
+ * Separator joining individual gamepad tokens into a combo (chord) accelerator,
+ * e.g. "gamepad:btn0+gamepad:btn5". Safe to split on: every token's encoded
+ * device segment runs through `encodeURIComponent`, which escapes '+' (it is
+ * not in the unreserved set), so a literal '+' never appears inside a token.
+ */
+const COMBO_SEPARATOR = '+';
+
+/**
+ * Split a gamepad accelerator (single token or combo) into its individual
+ * tokens, validating each one. Returns null if `accelerator` isn't a gamepad
+ * binding, or if any part fails to parse as a gamepad token.
+ */
+export function parseGamepadTokens(accelerator: string): string[] | null {
+  if (!isGamepadBinding(accelerator)) return null;
+  const parts = accelerator.split(COMBO_SEPARATOR);
+  return parts.every((part) => parseGamepadToken(part)) ? parts : null;
+}
+
+/**
+ * Build a canonical combo accelerator from a set of gamepad tokens, sorted so
+ * the binding is independent of press order (the same chord always produces
+ * the same string, however its buttons were pressed). A single token round
+ * -trips unchanged, so this also covers plain (non-combo) bindings.
+ */
+export function gamepadComboToken(tokens: Iterable<string>): string {
+  return [...new Set(tokens)].sort().join(COMBO_SEPARATOR);
+}

--- a/src/types/keybindings.ts
+++ b/src/types/keybindings.ts
@@ -21,8 +21,11 @@ export type KeybindingActionId =
 export interface KeybindingEntry {
   /**
    * The bound input. Either an Electron keyboard accelerator
-   * (e.g. "Alt+H", "CommandOrControl+Shift+F6") or a gamepad token
-   * (e.g. "gamepad:btn0"). Use `isGamepadBinding` to tell them apart.
+   * (e.g. "Alt+H", "CommandOrControl+Shift+F6"), a single gamepad token
+   * (e.g. "gamepad:btn0"), or a multi-button gamepad combo/chord — gamepad
+   * tokens joined by '+' in sorted order (e.g. "gamepad:btn0+gamepad:btn5").
+   * Use `isGamepadBinding` to tell them apart, `parseGamepadTokens` to split
+   * a combo into its individual tokens.
    */
   accelerator: string;
   /** Human-readable label for the settings UI */
@@ -65,10 +68,13 @@ export interface KeybindingsBridge {
 
 /**
  * Bridge exposed only to the hidden WebHID host window. Forwards a controller
- * button press (already encoded as a `gamepad:btn<N>` token) to the main process.
+ * button transition (already encoded as a `gamepad:btn<N>` token) to the main
+ * process: `down: true` on press, `false` on release. Releases let the main
+ * process track which buttons and hat directions are held together for
+ * combo (chord) bindings.
  */
 export interface GamepadHostBridge {
-  sendButton: (token: string) => void;
+  sendButton: (token: string, down: boolean) => void;
 }
 
 export const DEFAULT_KEYBINDINGS: KeybindingsMap = {


### PR DESCRIPTION
## Description

Buttons and hat directions can now be bound together as a chord (gamepad:btn0+gamepad:hat0_up), not just single controls.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

### After
<!-- Screenshot or description of the new behaviour -->

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [x] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [x] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for gamepad combo/chord bindings by holding multiple controller controls together.
  * Improved combo handling to trigger based on exact held-set matches and include press/release state.

* **Bug Fixes**
  * Updated gamepad and HID input processing to correctly emit both button and d-pad direction releases/presses for more reliable chord behavior.

* **Documentation**
  * Updated keybindings settings and gamepad README to clarify how multi-button combinations and d-pad directions work.

* **Tests**
  * Expanded coverage for combos, capture/rebind flows, and button/hat transition parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->