### PR TITLE
fix: Class Sorting Bug

### DIFF
--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -447,7 +447,7 @@ export const groupStandingsByClass = (
         (d) =>
           d.position !== undefined &&
           d.fastestTime !== undefined &&
-          d.fastestTime > 0
+          d.fastestTime > 0 
       )
       .sort((a, b) => (a.position ?? 999) - (b.position ?? 999))
       .slice(0, 1); // Changed .slice(0,2) to .slice(0,1) to only compare leader of each class
@@ -459,7 +459,7 @@ export const groupStandingsByClass = (
     const positions = validDrivers.map((d) => d.position ?? 999);
 
     return {
-      average: positions.reduce((sum, pos) => sum + pos, 0) / positions.length,
+      //average: positions.reduce((sum, pos) => sum + pos, 0) / positions.length,
       bestPosition: positions[0], // lower is better
     };
   };
@@ -477,22 +477,9 @@ export const groupStandingsByClass = (
     const statsA = statsByClass.get(idA);
     const statsB = statsByClass.get(idB);
 
-    // Primary sort: average top-2 position
+    // Primary sort: average top-1 position
     if (statsA && statsB) {
-      // Prioritize the overall leader
-      if (statsA.bestPosition === 1 && statsB.bestPosition !== 1) {
-        return -1;
-      }
-      if (statsB.bestPosition === 1 && statsA.bestPosition !== 1) {
-        return 1;
-      }
-
-      // Better Class Average Position Overall
-      if (statsA.average !== statsB.average) {
-        return statsA.average - statsB.average;
-      }
-
-      // Tie-breaker: better leading position wins
+      // Better Class Leader Position Overall
       if (statsA.bestPosition !== statsB.bestPosition) {
         return statsA.bestPosition - statsB.bestPosition;
       }

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -450,7 +450,7 @@ export const groupStandingsByClass = (
           d.fastestTime > 0
       )
       .sort((a, b) => (a.position ?? 999) - (b.position ?? 999))
-      .slice(0, 2);
+      .slice(0, 1); // Changed .slice(0,2) to .slice(0,1) to only compare leader of each class
 
     if (validDrivers.length === 0) {
       return undefined;

--- a/src/frontend/components/Standings/createStandings.ts
+++ b/src/frontend/components/Standings/createStandings.ts
@@ -445,9 +445,9 @@ export const groupStandingsByClass = (
     const validDrivers = drivers
       .filter(
         (d) =>
-          d.position !== undefined &&
-          d.fastestTime !== undefined &&
-          d.fastestTime > 0 
+          d.position !== undefined &&  //Check for valid position
+          d.fastestTime !== undefined &&   //Check for valid time to filter qualifying positions with no set time
+          d.fastestTime > 0
       )
       .sort((a, b) => (a.position ?? 999) - (b.position ?? 999))
       .slice(0, 1); // Changed .slice(0,2) to .slice(0,1) to only compare leader of each class
@@ -459,7 +459,6 @@ export const groupStandingsByClass = (
     const positions = validDrivers.map((d) => d.position ?? 999);
 
     return {
-      //average: positions.reduce((sum, pos) => sum + pos, 0) / positions.length,
       bestPosition: positions[0], // lower is better
     };
   };


### PR DESCRIPTION
## Description

Previously used the average overall position of the top 2 cars in each class to sort classes. 
Bug: In small field sizes if p1 in class A is ahead of class B, but p2 in class A is behind 3+ cars in class B, class B would be considered faster than class A.
Fix: just use the overall position of the leader in each class, then sort by iracing's class relative speed. 

Bit of an odd visual, in qualifying if class B is faster than class A the order is Class B -> Class A. If grid by class is enabled iracing can switch the order to Class A -> Class B at the race start until p1 in Class B passes P1 in Class A.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

### After
<!-- Screenshot or description of the new behaviour -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ x] I have tested this in iRacing (either in an online session or with AI)
- [ x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run lint` and fixed any issues
- [ ] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated standings calculations to prioritize the single class leader’s position rather than averaging across the top multiple drivers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->