### PR TITLE
feat: add line graph option for lap history

### DIFF
--- a/src/frontend/components/LapTimeLog/LapTimeLog.stories.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.stories.tsx
@@ -197,6 +197,24 @@ export const HistoryView: Story = {
   },
 };
 
+export const HistoryChart: Story = {
+  name: 'History As Graph',
+  args: {
+    ...baseArgs,
+    history: [
+      ...baseHistory,
+      { lap: 5, time: 92.2, delta: 0.7 },
+      { lap: 4, time: 91.6, delta: 0.1 },
+      { lap: 3, time: 93.1, delta: 1.6 },
+      { lap: 2, time: 92.0, delta: 0.5 },
+      { lap: 1, time: 91.7, delta: 0.2 },
+    ],
+    settings: mockConfig({
+      history: { enabled: true, count: 10, style: 'chart' },
+    }),
+  },
+};
+
 export const NoDelta: Story = {
   name: 'Delta Disabled',
   args: {

--- a/src/frontend/components/LapTimeLog/LapTimeLog.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.tsx
@@ -14,6 +14,7 @@ import { useLapTimeLog } from './hooks/useLapTimeLog';
 import { getDemoLapTimeLogData, LapEntry } from './demoData';
 import { TimerIcon, TargetIcon, XIcon } from '@phosphor-icons/react';
 import { LapTimeRow } from './components/LapTimeRow';
+import { LapHistoryChart } from './components/LapHistoryChart';
 import type { LapTimeLogConfig } from '@irdashies/types';
 import { formatTime, formatDelta } from '@irdashies/utils/time';
 import { LapTimeCell } from './components/LapTimeCell';
@@ -268,24 +269,33 @@ export const LapTimeLogDisplay = ({
             )}
           </div>
 
-          {/* History List */}
-          {settings.history.enabled && (
-            <>
-              {sortedHistory.map((entry) => (
-                <LapTimeRow
-                  key={entry.lap} // Critical for React performance
-                  label={`LAP ${entry.lap}`}
-                  time={entry.time}
-                  delta={entry.delta}
-                  dirty={entry.dirty}
-                  best={bestlap}
-                  overall={overall}
-                  alltime={alltimelap}
-                  settings={settings}
-                />
-              ))}
-            </>
-          )}
+          {/* History List / Chart */}
+          {settings.history.enabled &&
+            (settings.history.style === 'chart' ? (
+              <LapHistoryChart
+                history={sortedHistory}
+                best={bestlap}
+                overall={overall}
+                alltime={alltimelap}
+                foregroundOpacity={settings.foreground.opacity}
+              />
+            ) : (
+              <>
+                {sortedHistory.map((entry) => (
+                  <LapTimeRow
+                    key={entry.lap} // Critical for React performance
+                    label={`LAP ${entry.lap}`}
+                    time={entry.time}
+                    delta={entry.delta}
+                    dirty={entry.dirty}
+                    best={bestlap}
+                    overall={overall}
+                    alltime={alltimelap}
+                    settings={settings}
+                  />
+                ))}
+              </>
+            ))}
         </div>
       </div>
     </div>

--- a/src/frontend/components/LapTimeLog/components/LapHistoryChart.tsx
+++ b/src/frontend/components/LapTimeLog/components/LapHistoryChart.tsx
@@ -47,7 +47,7 @@ export const LapHistoryChart = memo(
       const yScale = d3
         .scaleLinear()
         .domain([min - domainPad, max + domainPad])
-        .range([PADDING_Y, HEIGHT - PADDING_Y]);
+        .range([HEIGHT - PADDING_Y, PADDING_Y]);
 
       const line = d3
         .line<LapEntry>()

--- a/src/frontend/components/LapTimeLog/components/LapHistoryChart.tsx
+++ b/src/frontend/components/LapTimeLog/components/LapHistoryChart.tsx
@@ -1,0 +1,139 @@
+import { memo, useMemo } from 'react';
+import * as d3 from 'd3';
+import { formatTime } from '@irdashies/utils/time';
+import { getColor } from '@irdashies/utils/colors';
+import type { LapEntry } from '../demoData';
+
+interface LapHistoryChartProps {
+  history: LapEntry[];
+  best?: number;
+  overall?: number;
+  alltime?: number;
+  foregroundOpacity?: number;
+}
+
+const WIDTH = 240;
+const HEIGHT = 60;
+const PADDING_X = 6;
+const PADDING_Y = 8;
+
+const isSameLapTime = (left?: number, right?: number) =>
+  left !== undefined &&
+  right !== undefined &&
+  left > 0 &&
+  Math.abs(left - right) < 0.001;
+
+export const LapHistoryChart = memo(
+  ({ history, best, overall, alltime, foregroundOpacity }: LapHistoryChartProps) => {
+    // chronological order: oldest lap on the left, newest on the right
+    const laps = useMemo(
+      () => [...history].sort((a, b) => a.lap - b.lap),
+      [history]
+    );
+
+    const chart = useMemo(() => {
+      if (laps.length === 0) return undefined;
+
+      const times = laps.map((lap) => lap.time);
+      const min = Math.min(...times);
+      const max = Math.max(...times);
+      const domainPad = (max - min) * 0.15 || 0.5;
+
+      const xScale = d3
+        .scalePoint<number>()
+        .domain(laps.map((_, i) => i) as unknown as number[])
+        .range([PADDING_X, WIDTH - PADDING_X]);
+
+      const yScale = d3
+        .scaleLinear()
+        .domain([min - domainPad, max + domainPad])
+        .range([PADDING_Y, HEIGHT - PADDING_Y]);
+
+      const line = d3
+        .line<LapEntry>()
+        .x((_, i) => xScale(i) ?? 0)
+        .y((d) => yScale(d.time))
+        .curve(d3.curveMonotoneX);
+
+      const average = times.reduce((sum, t) => sum + t, 0) / times.length;
+
+      return {
+        pathD: line(laps) ?? '',
+        yScale,
+        average,
+        points: laps.map((entry, i) => ({
+          x: xScale(i) ?? 0,
+          y: yScale(entry.time),
+          entry,
+        })),
+      };
+    }, [laps]);
+
+    const pointColor = (entry: LapEntry) => {
+      if (entry.dirty) return getColor('zinc', 400);
+      if (isSameLapTime(entry.time, alltime)) return getColor('yellow', 400);
+      if (isSameLapTime(entry.time, overall)) return getColor('purple', 400);
+      if (isSameLapTime(entry.time, best)) return getColor('green', 400);
+      if (chart && entry.time > chart.average) return getColor('red', 400);
+      return getColor('slate', 200);
+    };
+
+    if (!chart) return null;
+
+    const opacity = foregroundOpacity ?? 70;
+
+    return (
+      <div
+        className="w-full p-1 bg-slate-900/[var(--fg-alpha)] rounded-sm"
+        style={{ '--fg-alpha': `${opacity / 3}%` } as React.CSSProperties}
+      >
+        <svg
+          width="100%"
+          viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+          preserveAspectRatio="none"
+        >
+          {best !== undefined && best > 0 && (
+            <line
+              x1={0}
+              x2={WIDTH}
+              y1={chart.yScale(best)}
+              y2={chart.yScale(best)}
+              stroke={getColor('green', 400)}
+              strokeDasharray="2,2"
+              strokeOpacity={0.5}
+            />
+          )}
+          <line
+            x1={0}
+            x2={WIDTH}
+            y1={chart.yScale(chart.average)}
+            y2={chart.yScale(chart.average)}
+            stroke={getColor('sky', 400)}
+            strokeDasharray="4,3"
+            strokeOpacity={0.5}
+          />
+          <path
+            d={chart.pathD}
+            fill="none"
+            stroke={getColor('slate', 300)}
+            strokeWidth={1.5}
+          />
+          {chart.points.map(({ x, y, entry }) => (
+            <circle key={entry.lap} cx={x} cy={y} r={2.5} fill={pointColor(entry)} />
+          ))}
+        </svg>
+        <div className="flex justify-between text-[0.65em] text-zinc-400 tabular-nums px-1">
+          <span>
+            L{laps[0].lap} · {formatTime(laps[0].time)}
+          </span>
+          <span className="text-sky-400">AVG {formatTime(chart.average)}</span>
+          <span>
+            L{laps[laps.length - 1].lap} · {formatTime(laps[laps.length - 1].time)}
+          </span>
+        </div>
+      </div>
+    );
+  }
+);
+
+LapHistoryChart.displayName = 'LapHistoryChart';

--- a/src/frontend/components/Settings/sections/LapTimeLogSettings.tsx
+++ b/src/frontend/components/Settings/sections/LapTimeLogSettings.tsx
@@ -182,6 +182,24 @@ export const LapTimeLogSettings = () => {
 
                   {settings.config.history?.enabled && (
                     <SettingsSection>
+                      <SettingButtonGroupRow<'list' | 'chart'>
+                        title="History Style"
+                        value={settings.config.history?.style ?? 'list'}
+                        options={[
+                          { label: 'List', value: 'list' },
+                          { label: 'Graph', value: 'chart' },
+                        ]}
+                        onChange={(v) =>
+                          handleConfigChange({
+                            ...settings.config,
+                            history: {
+                              ...settings.config.history,
+                              style: v,
+                            },
+                          })
+                        }
+                      />
+
                       <SettingSelectRow
                         title="Number Of Laps To Show"
                         value={(

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1017,6 +1017,7 @@ export const defaultDashboard: {
         history: {
           enabled: true,
           count: 10,
+          style: 'list',
         },
         background: {
           opacity: 80,

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -559,6 +559,7 @@ export interface LapTimeLogConfig {
   history: {
     enabled: boolean;
     count: number;
+    style?: 'list' | 'chart';
   };
   scale: number;
   alignment: 'top' | 'bottom';


### PR DESCRIPTION
## Description

Adds a "Graph" display style for the Lap Timer widget's lap history, as an alternative to the existing scrolling list. The chart plots past lap times as a connected line (oldest → newest, left to right), with:

- A dashed green reference line for the session-best lap time
- A dashed blue reference line for the average of the displayed laps
- Lap dots colored yellow/purple/green for personal-best/overall-best/session-best matches, gray for dirty laps, and red for laps slower than the average

A new "History Style" toggle (List / Graph) was added to the widget's settings under the existing "Show Lap History" section. Defaults to "List" so existing saved dashboards are unaffected.

Tested via Storybook with demo data (no iRacing session available in this environment) — see the new "History As Graph" story under `widgets/LapTimeLog`.

## Screenshots

### Before
<img width="323" height="367" alt="before" src="https://github.com/user-attachments/assets/7d0a0f71-7e97-40dd-be4d-9f0745eb4034" />

### After
New graph view of lap history:
<img width="310" height="271" alt="after" src="https://github.com/user-attachments/assets/c83884a4-80f7-44ee-be4f-88b478cb4690" />




## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)