### PR TITLE
fix: stabilize tachometer blink interval

### DIFF
--- a/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.spec.tsx
+++ b/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.spec.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import { Tachometer } from '../TachometerComponent/TachometerComponent';
 import type { ShiftPointSettings } from '@irdashies/types';
 
@@ -9,6 +9,10 @@ vi.mock('../../../context/TelemetryStore/TelemetryStore', () => ({
 }));
 
 describe('Tachometer', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   const mockCarData = {
     carName: 'Ferrari 296 GT3',
     carId: 'ferrari296gt3',
@@ -144,6 +148,44 @@ describe('Tachometer', () => {
     expect(ledElements.length).toBe(10);
     const firstLedColor = (ledElements[0] as HTMLElement).style.backgroundColor;
     expect(firstLedColor).toBeTruthy();
+  });
+
+  it('keeps the blink interval running while RPM changes above the threshold', () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(
+      <Tachometer rpm={8300} maxRpm={8500} blinkRpm={8200} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    rerender(<Tachometer rpm={8400} maxRpm={8500} blinkRpm={8200} />);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    const firstLed = container.querySelectorAll('.rounded-full.border')[0];
+    expect((firstLed as HTMLElement).style.backgroundColor).toBe(
+      'rgb(255, 255, 255)'
+    );
+  });
+
+  it('starts a new blink cycle on purple after RPM drops below the threshold', () => {
+    vi.useFakeTimers();
+    const { container, rerender } = render(
+      <Tachometer rpm={8300} maxRpm={8500} blinkRpm={8200} />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    rerender(<Tachometer rpm={8000} maxRpm={8500} blinkRpm={8200} />);
+    rerender(<Tachometer rpm={8300} maxRpm={8500} blinkRpm={8200} />);
+
+    const firstLed = container.querySelectorAll('.rounded-full.border')[0];
+    expect((firstLed as HTMLElement).style.backgroundColor).toBe(
+      'rgb(147, 51, 234)'
+    );
   });
 
   it('uses car-specific RPM thresholds when available', () => {

--- a/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.tsx
+++ b/src/frontend/components/Tachometer/TachometerComponent/TachometerComponent.tsx
@@ -83,6 +83,7 @@ export const Tachometer = ({
   const effectiveBlinkRpm = gearRpmThresholds
     ? gearRpmThresholds[0]
     : blinkRpm || maxRpm * 0.97; // Use redline from car data
+  const shouldBlink = clampedRpm >= effectiveBlinkRpm;
 
   // Use car-specific LED count if available
   const effectiveNumLights =
@@ -231,9 +232,6 @@ export const Tachometer = ({
 
   // Flash effect when RPM exceeds blink threshold
   useEffect(() => {
-    // Ensure we have a valid blinkRpm
-    const shouldBlink = clampedRpm >= effectiveBlinkRpm;
-
     if (shouldBlink) {
       // Set up flashing with a shorter interval for better visibility
       const interval = setInterval(() => {
@@ -242,9 +240,10 @@ export const Tachometer = ({
 
       return () => {
         clearInterval(interval);
+        setFlash(false);
       };
     }
-  }, [clampedRpm, effectiveBlinkRpm]);
+  }, [shouldBlink]);
 
   // Custom shift point flash effect
   useEffect(() => {
@@ -267,7 +266,7 @@ export const Tachometer = ({
     }
 
     // Phase 1: At or above blinkRpm - flash purple/white with stronger colors
-    if (clampedRpm >= effectiveBlinkRpm) {
+    if (shouldBlink) {
       return flash
         ? '#ffffff' /* Brighter white */
         : '#9333ea' /* More vivid purple */;


### PR DESCRIPTION
## Description

Fixes the Tachometer LED blink lifecycle related to #538. The blink interval now depends on whether the RPM is above the blink threshold instead of the continuously changing RPM value, preventing telemetry updates from repeatedly restarting the 200 ms timer. The flash phase is reset when blinking stops so the next blink cycle begins with the normal purple state.

Adds fake-timer regression coverage for RPM changes while blinking and for leaving and re-entering the blink range.

Architecture review reference: Phase 1 — Cheap perf wins. This is a scoped widget hot-path correction and does not change telemetry subscriptions, stores, IPC, or persistence.

Tested with the Tachometer Vitest suite (18 tests), repository-wide TypeScript/ESLint checks, Prettier, and git diff validation. Not tested in iRacing.

## Screenshots

### Before
The 200 ms blink interval was restarted whenever the RPM value changed, making blinking unreliable under continuous telemetry updates. A stopped cycle could also retain its white flash phase internally.

### After
The interval remains active while RPM stays above the threshold and resets to the purple phase after RPM drops below it. This timer behavior is covered by automated tests; no static screenshot is applicable.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tachometer LED blinking when RPM remains above the configured threshold.
  * Ensured a new blink cycle starts correctly after RPM drops below and then exceeds the threshold again.
  * Fixed LED color transitions during the blink cycle.
* **Tests**
  * Added coverage for sustained and restarted blink-cycle behavior.
  * Improved timer handling for more reliable test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->