### PR TITLE
fix: omit trailing zero from estimated lap totals

### DIFF
--- a/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/SessionBar.tsx
@@ -27,6 +27,7 @@ import { SessionBarConfig } from '@irdashies/types';
 import { useSessionCurrentTime } from '../../hooks/useSessionCurrentTime';
 import { SessionState } from '@irdashies/types';
 import { WindArrow } from '../../../shared/WindArrow';
+import { formatLapTotal } from './formatLapTotal';
 import { getIncidentDisplay } from './getIncidentDisplay';
 
 // compact=true (total time): trims trailing zero components, never shows seconds
@@ -282,7 +283,7 @@ export const SessionBar = ({
             return (
               <div className="flex justify-center">
                 L{lapValue} /{' '}
-                {overrun ? effectiveTotal.toFixed(0) : lapsTotal.toFixed(1)}
+                {overrun ? effectiveTotal.toFixed(0) : formatLapTotal(lapsTotal)}
               </div>
             );
         else return <div className="flex justify-center">L{lapDisplay}</div>;

--- a/src/frontend/components/Standings/components/SessionBar/formatLapTotal.spec.ts
+++ b/src/frontend/components/Standings/components/SessionBar/formatLapTotal.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatLapTotal } from './formatLapTotal';
+
+describe('formatLapTotal', () => {
+  it('omits a trailing zero for whole lap totals', () => {
+    expect(formatLapTotal(55)).toBe('55');
+  });
+
+  it('keeps one decimal place for fractional lap totals', () => {
+    expect(formatLapTotal(33.8)).toBe('33.8');
+  });
+
+  it('omits the decimal when the displayed value rounds to a whole lap', () => {
+    expect(formatLapTotal(54.999999)).toBe('55');
+  });
+});

--- a/src/frontend/components/Standings/components/SessionBar/formatLapTotal.ts
+++ b/src/frontend/components/Standings/components/SessionBar/formatLapTotal.ts
@@ -1,0 +1,2 @@
+export const formatLapTotal = (laps: number) =>
+  laps.toFixed(1).replace(/\.0$/, '');


### PR DESCRIPTION
## Description

Formats estimated race lap totals with up to one decimal place, omitting the trailing decimal when the displayed value is a whole number. For example, `L24 / 55.0` now displays as `L24 / 55`, while `L11 / 33.8` remains unchanged.

Architecture phase: no topology change; presentation-only fix within the Standings widget.

Tested with the focused Vitest spec and the full TypeScript/ESLint lint command. Not tested in iRacing.

## Screenshots

### Before

Whole-number estimates display with a trailing decimal, for example: `L24 / 55.0`.

### After

Whole-number estimates omit the trailing decimal: `L24 / 55`. Fractional estimates such as `L11 / 33.8` are unchanged.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session lap totals in standings by displaying whole numbers without unnecessary decimal places.
  * Fractional lap totals continue to display one decimal place, with near-whole values rounded appropriately.

* **Tests**
  * Added coverage for whole, fractional, and rounded lap-total formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->