### PR TITLE
fix: align battle player text styling

### DIFF
--- a/src/frontend/components/Battle/Battle.tsx
+++ b/src/frontend/components/Battle/Battle.tsx
@@ -131,11 +131,6 @@ const BattleRow = memo(
       .filter(Boolean)
       .join(' ');
     const mutedColor = 'text-white/55';
-    const highlightStyle =
-      isPlayer && highlightColor
-        ? { color: `#${highlightColor.toString(16).padStart(6, '0')}` }
-        : {};
-
     const tailwindStyles = useMemo(
       () =>
         getTailwindStyle(entry?.carClass?.color, highlightColor, isMultiClass),
@@ -164,12 +159,11 @@ const BattleRow = memo(
           : isPlayer
             ? tailwindStyles.classHeader
             : '';
-        const positionText = offTrack ? 'text-yellow-900' : '';
+        const positionText = offTrack ? 'text-yellow-900' : 'text-white';
         cols.push(
           <td
             key="pos"
             className={`w-auto text-center px-2 whitespace-nowrap ${positionBg} ${positionText}`}
-            style={highlightStyle}
           >
             {(() => {
               const p = liveClassPosition ?? entry?.classPosition;
@@ -188,11 +182,7 @@ const BattleRow = memo(
         );
       } else if (key === 'driverName' && settings?.driverName?.enabled) {
         cols.push(
-          <td
-            key="name"
-            className="px-1 py-0.5 w-full truncate max-w-0"
-            style={highlightStyle}
-          >
+          <td key="name" className="px-1 py-0.5 w-full truncate max-w-0">
             {entry?.driver?.name || '—'}
           </td>
         );


### PR DESCRIPTION
## Description

Fixes the Battle overlay's current-driver text styling. The name and position
cells no longer use the dashboard highlight colour, which could render them
blue and reduce contrast. The driver name now inherits the same gold row colour
as Standings and Relative, while the position keeps the shared white-on-highlight
treatment for readability.

This is a Phase 2 architectural-cleanup-adjacent widget styling consistency fix;
it does not alter data flow or telemetry subscriptions.

## Screenshots

### Before

The current driver's name and position could be overridden by the dashboard
highlight colour, and the position had insufficient contrast on its highlighted
background.

### After

The current driver's name uses the standard gold text treatment and the position
uses white text on its highlighted background, matching Standings and Relative.

<img width="483" height="109" alt="image" src="https://github.com/user-attachments/assets/7bad3ccb-ccde-4373-92ef-e495f6b2f6ca" />


## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
