### PR TITLE
fix: refine fuel strategy grid

### DIFF
--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -6,6 +6,7 @@ import {
   TelemetryDecorator,
 } from '@irdashies/storybook';
 import { useFuelStore } from './FuelStore';
+import { defaultFuelCalculatorSettings } from './defaults';
 import type { FuelCalculation, FuelLapData } from './types';
 import type { LayoutNode } from '@irdashies/types';
 
@@ -17,7 +18,7 @@ const OverlayFrame = ({
   height: 260 | 520;
 }) => (
   <div
-    className={`w-[300px] [&>div]:h-full ${height === 520 ? 'h-[520px]' : 'h-[260px]'}`}
+    className={`w-[300px] [&>div]:min-h-full ${height === 520 ? 'min-h-[520px]' : 'min-h-[260px]'}`}
   >
     {children}
   </div>
@@ -72,12 +73,10 @@ const fuelAtFinishLayout: LayoutNode = {
 };
 
 const baselineArgs = {
+  ...defaultFuelCalculatorSettings,
   showOnlyWhenOnTrack: false,
   layoutTree: strategyLayout,
   showFuelStatusBorder: false,
-  showMin: false,
-  showQualifyConsumption: false,
-  consumptionGridOrder: ['avg', 'last', 'max'],
 };
 
 const previewFuelData: FuelCalculation = {
@@ -153,6 +152,46 @@ export const Primary: Story = {
   args: { ...baselineArgs, previewData: previewFuelData },
 };
 
+/** Fuel required at the next stop fits within the car's usable tank capacity. */
+export const RefuelFitsTank: Story = {
+  decorators: [
+    (Story) => (
+      <MockFuelDataProvider>
+        <Story />
+      </MockFuelDataProvider>
+    ),
+    TelemetryDecorator(),
+  ],
+  args: { ...baselineArgs, previewData: previewFuelData },
+};
+
+/** Fuel required exceeds one tank, signalling that another stop is necessary. */
+export const RefuelExceedsTank: Story = {
+  decorators: [
+    (Story) => (
+      <MockFuelDataProvider>
+        <Story />
+      </MockFuelDataProvider>
+    ),
+    TelemetryDecorator(),
+  ],
+  args: {
+    ...baselineArgs,
+    previewData: {
+      ...previewFuelData,
+      fuelLevel: 8,
+      lapsWithFuel: 3.4,
+      fuelToAdd: 66.9,
+      pitWindowOpen: 4,
+      pitWindowClose: 5.4,
+      fuelAtFinish: -66.9,
+      stopsRemaining: 2,
+      earliestPitLap: 4,
+      fuelStatus: 'danger',
+    },
+  },
+};
+
 /** Verifies that the layout tree, grid order, and visibility settings are applied. */
 export const StrategyWithHistory: Story = {
   decorators: [
@@ -167,6 +206,16 @@ export const StrategyWithHistory: Story = {
     ...baselineArgs,
     layoutTree: strategyWithHistoryLayout,
     fuelHistoryType: 'histogram',
+    showLastLap: true,
+    consumptionGridOrder: [
+      'last',
+      'avg',
+      'max',
+      'min',
+      'avg10',
+      'curr',
+      'qual',
+    ],
     previewData: previewFuelData,
   },
 };

--- a/src/frontend/components/FuelCalculator/defaults.ts
+++ b/src/frontend/components/FuelCalculator/defaults.ts
@@ -24,11 +24,11 @@ export const defaultFuelCalculatorSettings: FuelCalculatorSettings = {
   showConsumption: true,
   showFuelLevel: true,
   showLapsRemaining: true,
-  showMin: false,
+  showMin: true,
   showCurrentLap: true,
-  showLastLap: true,
+  showLastLap: false,
   show3LapAvg: true,
-  show10LapAvg: true,
+  show10LapAvg: false,
   showMax: true,
   showPitWindow: true,
   showEnduranceStrategy: true,
@@ -53,7 +53,7 @@ export const defaultFuelCalculatorSettings: FuelCalculatorSettings = {
   },
   layoutConfig: [], // Default empty
   layoutTree: undefined, // Will be migrated on load
-  consumptionGridOrder: ['curr', 'avg', 'max', 'last', 'min', 'qual'],
+  consumptionGridOrder: ['curr', 'avg', 'max', 'min', 'last', 'avg10', 'qual'],
   avgLapsCount: 5,
   fuelStatusThresholds: { green: 35, amber: 15, red: 10 },
   fuelStatusBasis: 'avg',

--- a/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
+++ b/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
@@ -128,13 +128,16 @@ export const FuelCalculatorConsumptionGrid: React.FC<
   // BUT use predictiveUsage (passed from parent's throttled trigger) for the CURR column
   const currentUsage = predictiveUsage ?? displayData?.projectedLapUsage ?? 0;
   const tankCapacity = fuelData?.fuelTankCapacity ?? 0;
+  const frozenPitWindowOpen = displayData?.pitWindowOpen ?? currentLap;
 
   // Calculate derivates (Laps, Refuel, Finish)
   const calcCol = (
     usage: number,
     contextTotalLaps: number,
     contextLapsRemaining: number,
-    contextFuelLevel: number
+    contextFuelLevel: number,
+    contextCurrentLap: number,
+    contextPitWindowOpen: number
   ) => {
     if (usage <= 0)
       return {
@@ -164,7 +167,10 @@ export const FuelCalculatorConsumptionGrid: React.FC<
     // balance means no refuel is required; a deficit becomes a positive add.
     const refuelValue = Math.max(0, -balance);
     const isDeficit = balance < 0;
-    const fitsInTank = tankCapacity <= 0 || refuelValue <= tankCapacity;
+    const lapsUntilPit = Math.max(0, contextPitWindowOpen - contextCurrentLap);
+    const fuelAtPit = Math.max(0, contextFuelLevel - lapsUntilPit * usage);
+    const fitsInTank =
+      tankCapacity <= 0 || fuelAtPit + refuelValue <= tankCapacity;
 
     // If testing, hide Refuel and Finish (return 0/invalid)
     if (isTesting) {
@@ -214,37 +220,49 @@ export const FuelCalculatorConsumptionGrid: React.FC<
     avg,
     frozenTotalLaps,
     frozenLapsRemaining,
-    frozenFuelLevel
+    frozenFuelLevel,
+    currentLap,
+    frozenPitWindowOpen
   );
   const maxData = calcCol(
     max,
     frozenTotalLaps,
     frozenLapsRemaining,
-    frozenFuelLevel
+    frozenFuelLevel,
+    currentLap,
+    frozenPitWindowOpen
   );
   const avg10Data = calcCol(
     displayData?.avg10Laps || 0,
     frozenTotalLaps,
     frozenLapsRemaining,
-    frozenFuelLevel
+    frozenFuelLevel,
+    currentLap,
+    frozenPitWindowOpen
   );
   const lastData = calcCol(
     last,
     frozenTotalLaps,
     frozenLapsRemaining,
-    frozenFuelLevel
+    frozenFuelLevel,
+    currentLap,
+    frozenPitWindowOpen
   );
   const minData = calcCol(
     min,
     frozenTotalLaps,
     frozenLapsRemaining,
-    frozenFuelLevel
+    frozenFuelLevel,
+    currentLap,
+    frozenPitWindowOpen
   );
   const qualData = calcCol(
     qual,
     frozenTotalLaps,
     frozenLapsRemaining,
-    frozenFuelLevel
+    frozenFuelLevel,
+    currentLap,
+    frozenPitWindowOpen
   );
 
   // CURR uses LIVE context
@@ -252,7 +270,9 @@ export const FuelCalculatorConsumptionGrid: React.FC<
     currentUsage,
     liveTotalLaps,
     liveLapsRemaining,
-    dataLiveFuelLevel
+    dataLiveFuelLevel,
+    liveFuelData?.currentLap ?? currentLap,
+    liveFuelData?.pitWindowOpen ?? frozenPitWindowOpen
   );
   if (!fuelData) return null;
 
@@ -310,7 +330,7 @@ export const FuelCalculatorConsumptionGrid: React.FC<
   const recommendedRowCls = `${rowCls} bg-slate-700/50`;
   const actionCellCls = rowPadding;
   const avg10 = displayData?.avg10Laps || 0;
-  const pitWindowOpen = displayData?.pitWindowOpen ?? 0;
+  const pitWindowOpen = frozenPitWindowOpen;
   const pitWindowClose = displayData?.pitWindowClose ?? 0;
   const hasStrategy = isRace && avg > 0;
   const pitWindowStart = Math.ceil(pitWindowOpen);

--- a/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
+++ b/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
@@ -127,6 +127,7 @@ export const FuelCalculatorConsumptionGrid: React.FC<
   // Use frozen displayData for stable columns
   // BUT use predictiveUsage (passed from parent's throttled trigger) for the CURR column
   const currentUsage = predictiveUsage ?? displayData?.projectedLapUsage ?? 0;
+  const tankCapacity = fuelData?.fuelTankCapacity ?? 0;
 
   // Calculate derivates (Laps, Refuel, Finish)
   const calcCol = (
@@ -141,6 +142,7 @@ export const FuelCalculatorConsumptionGrid: React.FC<
         refuel: 0,
         totalReq: 0,
         isDeficit: false,
+        fitsInTank: true,
         isValid: false,
         hideRefuel: true,
       };
@@ -158,11 +160,11 @@ export const FuelCalculatorConsumptionGrid: React.FC<
     const fuelNeeded = contextLapsRemaining * usage;
     const balance = contextFuelLevel - fuelNeeded;
 
-    // Logic for Refuel Column:
-    // If Balance < 0 (Deficit): Show POSITIVE amount to ADD.
-    // If Balance >= 0 (Surplus): Show POSITIVE amount EXTRA.
-    const refuelValue = balance < 0 ? Math.abs(balance) : balance;
+    // Fuel to add is the actionable pit-stop amount. A positive finish
+    // balance means no refuel is required; a deficit becomes a positive add.
+    const refuelValue = Math.max(0, -balance);
     const isDeficit = balance < 0;
+    const fitsInTank = tankCapacity <= 0 || refuelValue <= tankCapacity;
 
     // If testing, hide Refuel and Finish (return 0/invalid)
     if (isTesting) {
@@ -171,6 +173,7 @@ export const FuelCalculatorConsumptionGrid: React.FC<
         refuel: 0,
         totalReq: 0,
         isDeficit: false,
+        fitsInTank: true,
         isValid: true,
         hideRefuel: true,
       };
@@ -181,6 +184,7 @@ export const FuelCalculatorConsumptionGrid: React.FC<
       refuel: refuelValue, // number (absolute value to show)
       totalReq: totalReq, // number
       isDeficit: isDeficit, // boolean
+      fitsInTank,
       isValid: true,
       hideRefuel: false,
     };
@@ -218,6 +222,12 @@ export const FuelCalculatorConsumptionGrid: React.FC<
     frozenLapsRemaining,
     frozenFuelLevel
   );
+  const avg10Data = calcCol(
+    displayData?.avg10Laps || 0,
+    frozenTotalLaps,
+    frozenLapsRemaining,
+    frozenFuelLevel
+  );
   const lastData = calcCol(
     last,
     frozenTotalLaps,
@@ -251,6 +261,7 @@ export const FuelCalculatorConsumptionGrid: React.FC<
 
   // Visibility Settings (Default to true if no settings provided, except Min which is optional in modern default layout)
   const showAvg = settings ? settings.show3LapAvg : true;
+  const showAvg10 = settings ? settings.show10LapAvg : true;
   const showMax = settings ? settings.showMax : true;
   const showLast = settings ? settings.showLastLap : true;
   const showCurrent = settings ? settings.showCurrentLap : true;
@@ -266,83 +277,118 @@ export const FuelCalculatorConsumptionGrid: React.FC<
     isValid ? num.toFixed(2) : '--';
   const fmtFuel = (liters: number, isValid = true) =>
     isValid ? fuelDisplayValue(liters, fuelUnits).toFixed(2) : '--';
-
-  const formatBalance = (data: {
-    isDeficit: boolean;
+  const formatFuelToAdd = (data: {
     refuel: number;
     isValid: boolean;
     hideRefuel?: boolean;
   }) => {
     if (!data.isValid || data.hideRefuel) return '--';
-    const value = fmtFuel(data.refuel);
-    return data.isDeficit ? `-${value}` : `+${value}`;
+    return `+${fmtFuel(data.refuel)}`;
   };
 
-  const getBalanceClass = (
-    data: { isDeficit: boolean },
-    isRecommended = false
-  ) => {
-    if (!isRecommended) return 'text-slate-300';
-    return data.isDeficit ? 'text-red-400' : 'text-emerald-400';
+  const getFuelToAddClass = (data: {
+    fitsInTank: boolean;
+    isValid: boolean;
+  }) => {
+    if (!data.isValid) return 'text-slate-300';
+    return data.fitsInTank ? 'text-emerald-400' : 'text-red-400';
   };
 
   // Helper for Refuel color
 
-  const rowPadding = compactMode === 'ultra' ? '' : 'px-1 py-0.5';
+  const rowPadding = compactMode === 'ultra' ? '' : 'px-1 py-px';
+  const headerPadding =
+    compactMode === 'ultra'
+      ? 'px-1'
+      : compactMode === 'compact'
+        ? 'px-1 py-0.5'
+        : 'px-1 py-1';
   const gridPadding =
     compactMode === 'ultra' ? '' : compactMode === 'compact' ? 'px-1' : 'px-2';
   const rowGap = '';
   const rowCls = 'col-span-4 grid grid-cols-subgrid';
   const recommendedRowCls = `${rowCls} bg-slate-700/50`;
-  const finishCellCls = `border-l border-slate-600/40 ${rowPadding}`;
+  const actionCellCls = rowPadding;
+  const avg10 = displayData?.avg10Laps || 0;
+  const pitWindowOpen = displayData?.pitWindowOpen ?? 0;
+  const pitWindowClose = displayData?.pitWindowClose ?? 0;
+  const hasStrategy = isRace && avg > 0;
+  const pitWindowStart = Math.ceil(pitWindowOpen);
+  const pitWindowEnd = Math.floor(pitWindowClose);
+  const pitWindowLabel = !hasStrategy
+    ? '--'
+    : pitWindowStart === pitWindowEnd
+      ? `L${pitWindowStart}`
+      : `L${pitWindowStart}–${pitWindowEnd}`;
+  const isPitWindowOpen =
+    hasStrategy && currentLap >= pitWindowStart && currentLap <= pitWindowEnd;
+  const isPastPitWindow = hasStrategy && currentLap > pitWindowEnd;
+  const pitWindowStatus = !hasStrategy
+    ? 'PIT WINDOW'
+    : isPastPitWindow
+      ? 'PIT NOW'
+      : isPitWindowOpen
+        ? 'OPEN'
+        : 'OPENS';
+  const pitWindowStatusClass = isPastPitWindow
+    ? 'text-red-400'
+    : isPitWindowOpen
+      ? 'text-emerald-400'
+      : 'text-amber-300';
 
   return (
     <div
       style={containerStyle}
-      className={`grid w-full grid-cols-[1.15fr_0.9fr_1.05fr_1.35fr] select-none overflow-hidden ${gridPadding} ${rowGap}`}
+      className={`grid w-full grid-cols-[2.75rem_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.15fr)] select-none overflow-hidden ${gridPadding} ${rowGap}`}
     >
       <div
-        className="col-span-4 flex justify-end pb-1 text-slate-500 font-semibold tracking-wide uppercase"
+        className="col-span-4 flex items-center justify-between pb-1 text-slate-500 font-semibold tracking-wide uppercase"
         style={{ fontSize: labelFontSize }}
       >
-        Race lap {currentLap}
-        {(displayData?.totalLaps ?? 0) > 0
-          ? ` / ${displayData?.totalLaps.toFixed(0)}`
-          : ''}
+        <span>
+          Race L{currentLap}
+          {(displayData?.totalLaps ?? 0) > 0
+            ? ` / ${displayData?.totalLaps.toFixed(0)}`
+            : ''}
+        </span>
+        <span>Fuel {fmtFuel(frozenFuelLevel)}</span>
       </div>
       {/* Grid Header */}
-      <div className="col-span-4 grid grid-cols-subgrid bg-slate-900 border-b border-slate-500/40">
+      <div className="col-span-4 mt-0.5 grid grid-cols-subgrid bg-slate-900/30">
+        <div aria-hidden="true" />
         <div
-          className={`font-bold text-slate-400 flex justify-center items-center leading-none ${compactMode === 'ultra' ? 'px-1 py-0' : compactMode === 'compact' ? 'px-1 py-1' : 'px-1 py-2'}`}
-          style={{ fontSize: labelFontSize }}
-        >
-          BASIS
-        </div>
-        <div
-          className={`font-bold text-slate-400 flex justify-center items-center leading-none ${compactMode === 'ultra' ? 'px-1 py-0' : compactMode === 'compact' ? 'px-1 py-1' : 'px-1 py-2'}`}
+          className={`font-bold text-slate-400 flex justify-center items-center leading-none ${headerPadding}`}
           style={{ fontSize: labelFontSize }}
         >
           USE/LAP
         </div>
         <div
-          className={`font-bold text-slate-400 flex justify-center items-center leading-none ${compactMode === 'ultra' ? 'px-1 py-0' : compactMode === 'compact' ? 'px-1 py-1' : 'px-1 py-2'}`}
+          className={`font-bold text-slate-400 flex justify-center items-center leading-none ${headerPadding}`}
           style={{ fontSize: labelFontSize }}
         >
-          IN TANK
+          LAPS
         </div>
         <div
-          className={`font-bold text-slate-400 flex justify-center items-center leading-none border-l border-slate-600/40 ${compactMode === 'ultra' ? 'px-1 py-0' : compactMode === 'compact' ? 'px-1 py-1' : 'px-1 py-2'}`}
+          className={`font-bold text-slate-400 flex justify-center items-center leading-none ${headerPadding}`}
           style={{ fontSize: labelFontSize }}
         >
-          AT FINISH
+          TO ADD
         </div>
       </div>
 
       {/* Dynamic Rows based on Order */}
       {(() => {
-        const defaultOrder = ['curr', 'avg', 'max', 'last', 'min', 'qual'];
+        const defaultOrder = [
+          'curr',
+          'avg',
+          'max',
+          'min',
+          'last',
+          'avg10',
+          'qual',
+        ];
         const savedOrder = settings?.consumptionGridOrder || defaultOrder;
-        const order = savedOrder;
+        const order = [...savedOrder];
 
         const renderRow = (type: string) => {
           switch (type) {
@@ -369,10 +415,10 @@ export const FuelCalculatorConsumptionGrid: React.FC<
                     {fmt(currentData.laps, isFinite(currentData.laps))}
                   </div>
                   <div
-                    className={`${getBalanceClass(currentData)} text-center ${finishCellCls}`}
+                    className={`${getFuelToAddClass(currentData)} text-center ${actionCellCls}`}
                     style={{ fontSize: valueFontSize }}
                   >
-                    {formatBalance(currentData)}
+                    {formatFuelToAdd(currentData)}
                   </div>
                 </div>
               );
@@ -400,14 +446,44 @@ export const FuelCalculatorConsumptionGrid: React.FC<
                     {fmt(avgData.laps, isFinite(avgData.laps))}
                   </div>
                   <div
-                    className={`${getBalanceClass(avgData, true)} text-center ${finishCellCls} font-bold`}
+                    className={`${getFuelToAddClass(avgData)} text-center ${actionCellCls} font-bold`}
                     style={{ fontSize: valueFontSize }}
                   >
-                    {formatBalance(avgData)}
+                    {formatFuelToAdd(avgData)}
                   </div>
                 </div>
               );
             }
+            case 'avg10':
+              if (!showAvg10 || avg10 <= 0) return null;
+              return (
+                <div key="avg10" className={rowCls}>
+                  <div
+                    className={`text-slate-400 ${rowPadding}`}
+                    style={{ fontSize: labelFontSize }}
+                  >
+                    AVG 10
+                  </div>
+                  <div
+                    className={`text-slate-300 text-center ${rowPadding}`}
+                    style={{ fontSize: valueFontSize }}
+                  >
+                    {fmtFuel(avg10)}
+                  </div>
+                  <div
+                    className={`text-slate-300 text-center ${rowPadding}`}
+                    style={{ fontSize: valueFontSize }}
+                  >
+                    {fmt(avg10Data.laps, isFinite(avg10Data.laps))}
+                  </div>
+                  <div
+                    className={`${getFuelToAddClass(avg10Data)} text-center ${actionCellCls}`}
+                    style={{ fontSize: valueFontSize }}
+                  >
+                    {formatFuelToAdd(avg10Data)}
+                  </div>
+                </div>
+              );
             case 'max':
               if (!showMax) return null;
               return (
@@ -431,10 +507,10 @@ export const FuelCalculatorConsumptionGrid: React.FC<
                     {fmt(maxData.laps, isFinite(maxData.laps))}
                   </div>
                   <div
-                    className={`${getBalanceClass(maxData)} text-center ${finishCellCls}`}
+                    className={`${getFuelToAddClass(maxData)} text-center ${actionCellCls}`}
                     style={{ fontSize: valueFontSize }}
                   >
-                    {formatBalance(maxData)}
+                    {formatFuelToAdd(maxData)}
                   </div>
                 </div>
               );
@@ -461,10 +537,10 @@ export const FuelCalculatorConsumptionGrid: React.FC<
                     {fmt(lastData.laps, isFinite(lastData.laps))}
                   </div>
                   <div
-                    className={`${getBalanceClass(lastData)} text-center ${finishCellCls}`}
+                    className={`${getFuelToAddClass(lastData)} text-center ${actionCellCls}`}
                     style={{ fontSize: valueFontSize }}
                   >
-                    {formatBalance(lastData)}
+                    {formatFuelToAdd(lastData)}
                   </div>
                 </div>
               );
@@ -491,10 +567,10 @@ export const FuelCalculatorConsumptionGrid: React.FC<
                     {fmt(minData.laps, isFinite(minData.laps))}
                   </div>
                   <div
-                    className={`${getBalanceClass(minData)} text-center ${finishCellCls}`}
+                    className={`${getFuelToAddClass(minData)} text-center ${actionCellCls}`}
                     style={{ fontSize: valueFontSize }}
                   >
-                    {formatBalance(minData)}
+                    {formatFuelToAdd(minData)}
                   </div>
                 </div>
               );
@@ -507,7 +583,7 @@ export const FuelCalculatorConsumptionGrid: React.FC<
                     className={`text-slate-400 ${rowPadding}`}
                     style={{ fontSize: labelFontSize }}
                   >
-                    QUAL MAX
+                    QUAL
                   </div>
                   <div
                     className={`text-slate-300 text-center ${rowPadding}`}
@@ -522,10 +598,10 @@ export const FuelCalculatorConsumptionGrid: React.FC<
                     {fmt(qualData.laps, isFinite(qualData.laps))}
                   </div>
                   <div
-                    className={`${getBalanceClass(qualData)} text-center ${finishCellCls}`}
+                    className={`${getFuelToAddClass(qualData)} text-center ${actionCellCls}`}
                     style={{ fontSize: valueFontSize }}
                   >
-                    {isRace && qual > 0 ? formatBalance(qualData) : '--'}
+                    {isRace && qual > 0 ? formatFuelToAdd(qualData) : '--'}
                   </div>
                 </div>
               );
@@ -537,6 +613,36 @@ export const FuelCalculatorConsumptionGrid: React.FC<
         const uniqueOrder = Array.from(new Set(order));
         return uniqueOrder.map((id) => renderRow(id));
       })()}
+      <div className="col-span-4 mt-1 grid grid-cols-[1fr_auto] items-center bg-slate-900/30 px-1 py-1 tabular-nums">
+        <div className="flex items-baseline gap-1">
+          <span
+            className={`font-bold tracking-wide ${pitWindowStatusClass}`}
+            style={{ fontSize: valueFontSize }}
+          >
+            {pitWindowStatus}
+          </span>
+          <span
+            className="font-bold text-white"
+            style={{ fontSize: valueFontSize }}
+          >
+            {pitWindowLabel}
+          </span>
+        </div>
+        <div className="flex items-baseline gap-1">
+          <span
+            className="font-semibold tracking-wide text-slate-500"
+            style={{ fontSize: labelFontSize }}
+          >
+            ADD
+          </span>
+          <strong
+            className={getFuelToAddClass(avgData)}
+            style={{ fontSize: valueFontSize }}
+          >
+            {hasStrategy ? `+${fmtFuel(avgData.refuel)} ${fuelUnits}` : '--'}
+          </strong>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/frontend/components/FuelCalculator/widgets/FuelCalculatorGauge.tsx
+++ b/src/frontend/components/FuelCalculator/widgets/FuelCalculatorGauge.tsx
@@ -101,7 +101,7 @@ export const FuelCalculatorGauge: React.FC<FuelCalculatorWidgetProps> = ({
       ? ''
       : compactMode === 'compact'
         ? 'px-1 pt-1 pb-0'
-        : 'px-2 pt-2 pb-0';
+        : 'px-2 pt-1 pb-0';
 
   return (
     <div className={`${paddingClass} mb-1`}>
@@ -119,7 +119,7 @@ export const FuelCalculatorGauge: React.FC<FuelCalculatorWidgetProps> = ({
           style={{ fontSize: valueFontSize }}
         >
           {fuelString} <span className="text-slate-500 font-medium">·</span>{' '}
-          {lapsString} laps in tank
+          {lapsString} laps
         </span>
         <span
           className="uppercase tracking-wide"

--- a/src/frontend/components/FuelCalculator/widgets/FuelCalculatorHeader.tsx
+++ b/src/frontend/components/FuelCalculator/widgets/FuelCalculatorHeader.tsx
@@ -79,12 +79,14 @@ export const FuelCalculatorHeader: React.FC<FuelCalculatorWidgetProps> = ({
   }
 
   const paddingClass =
-    compactMode === 'ultra' ? '' : compactMode === 'compact' ? 'p-1' : 'p-2';
+    compactMode === 'ultra'
+      ? ''
+      : compactMode === 'compact'
+        ? 'p-1'
+        : 'px-2 py-1';
 
   return (
-    <div
-      className={`border-b border-slate-600/50 ${paddingClass} ${compactMode !== 'off' ? 'mb-0' : 'mb-1'}`}
-    >
+    <div className={paddingClass}>
       <div className="grid grid-cols-[minmax(0,1fr)_auto_auto] items-end gap-x-3">
         <div>
           <div

--- a/src/frontend/components/Settings/sections/FuelSettings/GridOrderSettingsList.tsx
+++ b/src/frontend/components/Settings/sections/FuelSettings/GridOrderSettingsList.tsx
@@ -16,6 +16,7 @@ export const getSortableRows = (avgLapsCount: number): SortableRow[] => [
     label: `Average (${avgLapsCount} Lap)`,
     configKey: 'show3LapAvg',
   },
+  { id: 'avg10', label: 'Average (10 Lap)', configKey: 'show10LapAvg' },
   { id: 'max', label: 'Max Consumption', configKey: 'showMax' },
   { id: 'last', label: 'Last Lap', configKey: 'showLastLap' },
   { id: 'min', label: 'Min Consumption', configKey: 'showMin' },
@@ -60,6 +61,9 @@ export const GridOrderSettingsList = ({
             label={row.label}
             enabled={isEnabled}
             onToggle={(val) => {
+              if (val && !itemsOrder.includes(row.id)) {
+                onReorder([...itemsOrder, row.id]);
+              }
               handleConfigChange({ [row.configKey]: val });
             }}
             sortableProps={sortableProps}

--- a/src/types/defaultDashboard.spec.ts
+++ b/src/types/defaultDashboard.spec.ts
@@ -189,6 +189,16 @@ describe('getWidgetDefaultConfig', () => {
     expect(config).toBeDefined();
     expect(config.fuelUnits).toBeDefined();
     expect(config.safetyMargin).toBeDefined();
+    expect(config.showCurrentLap).toBe(true);
+    expect(config.consumptionGridOrder).toEqual([
+      'curr',
+      'avg',
+      'max',
+      'min',
+      'last',
+      'avg10',
+      'qual',
+    ]);
   });
 
   it('returns the flag config with doubleFlag field', () => {

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -823,15 +823,15 @@ export const defaultDashboard: {
         showLapsRemaining: true,
         showMin: true,
         showCurrentLap: true,
-        showLastLap: true,
+        showLastLap: false,
         show3LapAvg: true,
-        show10LapAvg: true,
+        show10LapAvg: false,
         showMax: true,
         showPitWindow: true,
         showEnduranceStrategy: true,
         showFuelScenarios: true,
         showFuelRequired: true,
-        showQualifyConsumption: true,
+        showQualifyConsumption: false,
         showFuelHistory: true,
         fuelHistoryType: 'histogram',
         safetyMargin: 0,
@@ -869,7 +869,15 @@ export const defaultDashboard: {
             },
           ],
         },
-        consumptionGridOrder: ['curr', 'avg', 'max', 'last', 'min', 'qual'],
+        consumptionGridOrder: [
+          'curr',
+          'avg',
+          'max',
+          'min',
+          'last',
+          'avg10',
+          'qual',
+        ],
         avgLapsCount: 5,
         fuelStatusThresholds: {
           green: 60,
@@ -1332,8 +1340,7 @@ export function getWidgetDefaultConfig<K extends keyof WidgetConfigMap>(
   id: K
 ): WidgetConfigMap[K] {
   const widget = defaultDashboard.widgets.find((w) => w.id === id) as
-    | TypedDashboardWidget<K>
-    | undefined;
+    TypedDashboardWidget<K> | undefined;
   if (!widget) throw new Error(`No default config found for widget: ${id}`);
   return widget.config;
 }


### PR DESCRIPTION
## Description

Refines the Fuel Calculator into an actionable pit-strategy view while restoring configuration-driven consumption row ordering.

- Shows `USE/LAP`, projected `LAPS`, and explicit `TO ADD` values for each enabled consumption basis.
- Colors refuel values green when the required addition fits in the tank and red when it exceeds capacity.
- Adds pit-window status and recommended fuel while keeping the panel styling consistent.
- Prevents the Storybook wrapper from cropping overflow and tightens gauge/header copy and spacing.
- Restores the default Racelab-style ordering: current lap, AVG 5, MAX, MIN, LAST, AVG 10, qualifying; only current lap, AVG 5, MAX, and MIN are visible by default.
- Ensures newly enabled rows append to `consumptionGridOrder` instead of being inserted unpredictably.
- Adds fit/exceeds-capacity stories and a regression assertion for default ordering.

Architecture phase: widget-local, Phase 2b-compatible refinement. No telemetry channel, store, IPC, bridge, processor, storage schema, native code, or security topology changes.

Architecture pre-PR checks:

- [x] Frontend remains isolated from the Electron main process.
- [x] No new telemetry subscriptions, stores, persistence paths, IPC channels, or settings migration are introduced.
- [x] Existing widget configuration remains backward compatible.
- [x] High-frequency fuel calculations retain full telemetry precision.

## Screenshots

### Before

The consumption grid used less actionable projections, could crop in constrained Storybook dimensions, and default row ordering did not reliably follow the configured order.

### After

The grid presents fuel use, laps remaining, and fuel to add; highlights whether refuel fits tank capacity; displays a consistent pit window; and follows the canonical default ordering without cropping.

<img width="322" height="274" alt="image" src="https://github.com/user-attachments/assets/b2a89dc6-5625-489d-8c1d-a4d4ca9cc33a" />

<img width="336" height="197" alt="image" src="https://github.com/user-attachments/assets/e8c39440-b6c8-43d8-894a-54060c7e8848" />

<img width="322" height="230" alt="image" src="https://github.com/user-attachments/assets/b6c88877-6128-48b2-b7da-edccdaf7b6d0" />
<img width="319" height="263" alt="image" src="https://github.com/user-attachments/assets/de6119f2-19c7-4310-85d2-181706221bf4" />


Verified visually in Storybook at constrained widget dimensions, including both refuel-capacity color variants.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 10-lap average (Avg 10) consumption data and included it in fuel grid ordering and settings.
  * Added “to add” fuel recommendations in the consumption grid, including tank-fit indication and pit-window status.
  * Added story scenarios for refueling that fits vs. exceeds tank capacity.

* **Updates**
  * Refined fuel widget defaults and metric visibility, including consumption display order and labels.
  * Improved fuel calculator spacing and responsive layout across display modes.
  * Updated strategy history display to show the last lap and adjusted ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->