### PR TITLE
fix: handle YAML mapping indicators in driver names

### DIFF
--- a/src/app/irsdk/node/irsdk-node.spec.ts
+++ b/src/app/irsdk/node/irsdk-node.spec.ts
@@ -169,4 +169,24 @@ DriverInfo:
     expect(result?.DriverInfo?.Drivers[0]?.UserName).toBe('? ?');
     expect(result?.DriverInfo?.Drivers[0]?.AbbrevName).toBe(null);
   });
+
+  it('should not consume the next key after a bare mapping indicator', () => {
+    const malformedYaml = `
+DriverInfo:
+  Drivers:
+    - CarIdx: 13
+      UserName: ?
+      AbbrevName: Anonymous
+      Initials: A
+`;
+
+    vi.mocked(mockSdk.getSessionData).mockReturnValue(malformedYaml);
+
+    const result = sdk.getSessionData();
+
+    expect(result).toBeDefined();
+    expect(result?.DriverInfo?.Drivers[0]?.UserName).toBe('?');
+    expect(result?.DriverInfo?.Drivers[0]?.AbbrevName).toBe('Anonymous');
+    expect(result?.DriverInfo?.Drivers[0]?.Initials).toBe('A');
+  });
 });

--- a/src/app/irsdk/node/irsdk-node.spec.ts
+++ b/src/app/irsdk/node/irsdk-node.spec.ts
@@ -150,4 +150,23 @@ DriverInfo:
     expect(result?.DriverInfo?.Drivers[0]?.TeamName).toBe("Mike's Team");
     expect(result?.DriverInfo?.Drivers[0]?.UserName).toBe("Coolio O'Brien");
   });
+
+  it('should handle names beginning with a YAML mapping indicator', () => {
+    const malformedYaml = `
+DriverInfo:
+  Drivers:
+    - CarIdx: 13
+      UserName: ? ?
+      AbbrevName:
+      Initials:
+`;
+
+    vi.mocked(mockSdk.getSessionData).mockReturnValue(malformedYaml);
+
+    const result = sdk.getSessionData();
+
+    expect(result).toBeDefined();
+    expect(result?.DriverInfo?.Drivers[0]?.UserName).toBe('? ?');
+    expect(result?.DriverInfo?.Drivers[0]?.AbbrevName).toBe(null);
+  });
 });

--- a/src/app/irsdk/node/irsdk-node.ts
+++ b/src/app/irsdk/node/irsdk-node.ts
@@ -221,7 +221,7 @@ export class IRacingSDK {
    */
   private static fixMappingIndicatorValues(yamlText: string): string {
     return yamlText.replace(
-      /^(\s*(?:-\s+)?\w+:\s*)(\?(?:\s.*)?)$/gm,
+      /^(\s*(?:-\s+)?\w+:\s*)(\?(?:[^\S\r\n]+[^\r\n]*)?)\r?$/gm,
       (_line, keyPart: string, value: string) =>
         `${keyPart}'${value.replace(/'/g, "''")}'`
     );

--- a/src/app/irsdk/node/irsdk-node.ts
+++ b/src/app/irsdk/node/irsdk-node.ts
@@ -215,6 +215,19 @@ export class IRacingSDK {
   }
 
   /**
+   * Quotes scalar values that iRacing emits with a leading YAML mapping
+   * indicator. For example, an anonymous driver's `UserName: ? ?` is not
+   * valid as an unquoted scalar because `? ` starts an explicit mapping key.
+   */
+  private static fixMappingIndicatorValues(yamlText: string): string {
+    return yamlText.replace(
+      /^(\s*(?:-\s+)?\w+:\s*)(\?(?:\s.*)?)$/gm,
+      (_line, keyPart: string, value: string) =>
+        `${keyPart}'${value.replace(/'/g, "''")}'`
+    );
+  }
+
+  /**
    * Starts the native iRacing SDK and begins subscribing for data.
    * @returns {boolean} If the SDK started successfully.
    */
@@ -269,7 +282,9 @@ export class IRacingSDK {
       // The multiline-value pass handles iRacing setup names that contain a literal
       // newline (e.g. corrupted DriverSetupName paths), which YAML would otherwise reject.
       const fixedYaml = seshString
-        ? IRacingSDK.fixMultilineValues(seshString)
+        ? IRacingSDK.fixMappingIndicatorValues(
+            IRacingSDK.fixMultilineValues(seshString)
+          )
             .replace(/(\w+: ) *, *\n/g, '$1 \n')
             .replace(/(\w+: )(,.*)/g, '$1"$2" \n')
         : seshString;


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

### After
<!-- Screenshot or description of the new behaviour -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run lint` and fixed any issues
- [ ] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed YAML session-data parsing when certain field values begin with the YAML mapping indicator (`?`).
  * These values are now preserved as literal text, avoiding misinterpretation as YAML structure.
* **Tests**
  * Added additional Vitest coverage for YAML parsing edge cases involving leading mapping indicators, including `UserName` values and ensuring subsequent keys still parse correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->