### PR TITLE
fix: normalize P2P count encodings

### DIFF
--- a/src/frontend/components/Standings/Standings.stories.tsx
+++ b/src/frontend/components/Standings/Standings.stories.tsx
@@ -18,6 +18,8 @@ import {
   useTelemetryValue,
   useSessionName,
   useSessionLaps,
+  usePushToPassStoreUpdater,
+  useSessionDrivers,
   type P2PDisplayState,
 } from '@irdashies/context';
 import { generateMockDataFromPath } from '../../../app/bridge/iracingSdk/mock-data/generateMockData';
@@ -1597,6 +1599,36 @@ const StandingsPushToPassComponent = () => (
 export const PushToPass: Story = {
   decorators: [TelemetryDecorator()],
   render: () => <StandingsPushToPassComponent />,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+const RecordedIL15P2PStandings = () => {
+  usePushToPassStoreUpdater(true);
+
+  const sessionDrivers = useSessionDrivers();
+
+  if (!sessionDrivers?.length) {
+    return (
+      <div className="p-4 text-sm text-white">Loading recorded telemetry…</div>
+    );
+  }
+
+  return <Standings />;
+};
+
+export const RecordedIL15P2P: Story = {
+  name: 'Recorded IL-15 P2P telemetry',
+  decorators: [
+    TelemetryDecoratorWithConfig('/test-data/1783998516193', {
+      standings: {
+        pushToPass: { enabled: true },
+        displayOrder: P2P_STANDINGS_DISPLAY_ORDER,
+      },
+    }),
+  ],
+  render: () => <RecordedIL15P2PStandings />,
   parameters: {
     layout: 'padded',
   },

--- a/src/frontend/context/PushToPassStore/PushToPassStore.spec.ts
+++ b/src/frontend/context/PushToPassStore/PushToPassStore.spec.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { usePushToPassStore } from './PushToPassStore';
+
+describe('PushToPassStore', () => {
+  beforeEach(() => {
+    usePushToPassStore.getState().reset();
+  });
+
+  it('keeps IL-15 opponent counts as integers', () => {
+    usePushToPassStore
+      .getState()
+      .update(
+        [false, false, false],
+        [65, 65, 65],
+        { 0: 205, 1: 205, 2: 205 },
+        100,
+        1,
+        1
+      );
+
+    expect(usePushToPassStore.getState().displayStates).toEqual([
+      { status: 'inactive', count: 65 },
+      { status: 'inactive', count: 65 },
+      { status: 'inactive', count: 65 },
+    ]);
+  });
+
+  it('keeps IR18 opponent counts as integers', () => {
+    usePushToPassStore
+      .getState()
+      .update([false, false], [65, 65], { 0: 99, 1: 99 }, 100, 1, 1);
+
+    expect(usePushToPassStore.getState().displayStates).toEqual([
+      { status: 'inactive', count: 65 },
+      { status: 'inactive', count: 65 },
+    ]);
+  });
+});

--- a/src/frontend/context/PushToPassStore/PushToPassStore.spec.ts
+++ b/src/frontend/context/PushToPassStore/PushToPassStore.spec.ts
@@ -36,6 +36,17 @@ describe('PushToPassStore', () => {
     ]);
   });
 
+  it('does not add a cooldown after IR18 P2P deactivates', () => {
+    const store = usePushToPassStore.getState();
+
+    store.update([true], [65], { 0: 99 }, 100, 1, 0);
+    store.update([false], [65], { 0: 99 }, 101, 1, 0);
+
+    expect(usePushToPassStore.getState().displayStates).toEqual([
+      { status: 'inactive', count: 65 },
+    ]);
+  });
+
   it('decodes Super Formula opponent counts from float32 tenths', () => {
     const encodedCount = new DataView(new ArrayBuffer(4));
     encodedCount.setFloat32(0, 12.5);

--- a/src/frontend/context/PushToPassStore/PushToPassStore.spec.ts
+++ b/src/frontend/context/PushToPassStore/PushToPassStore.spec.ts
@@ -35,4 +35,25 @@ describe('PushToPassStore', () => {
       { status: 'inactive', count: 65 },
     ]);
   });
+
+  it('decodes Super Formula opponent counts from float32 tenths', () => {
+    const encodedCount = new DataView(new ArrayBuffer(4));
+    encodedCount.setFloat32(0, 12.5);
+
+    usePushToPassStore
+      .getState()
+      .update(
+        [false, false],
+        [encodedCount.getInt32(0), 65],
+        { 0: 171, 1: 171 },
+        100,
+        1,
+        1
+      );
+
+    expect(usePushToPassStore.getState().displayStates).toEqual([
+      { status: 'inactive', count: 125 },
+      { status: 'inactive', count: 65 },
+    ]);
+  });
 });

--- a/src/frontend/context/PushToPassStore/PushToPassStore.ts
+++ b/src/frontend/context/PushToPassStore/PushToPassStore.ts
@@ -1,13 +1,18 @@
 import { create } from 'zustand';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
-import { getCarP2PConfig } from './carP2PConfigs';
+import { getCarP2PConfig, type CarP2PConfig } from './carP2PConfigs';
 import { arrayShallowCompare } from '../SessionStore/arrayShallowCompare';
 
 // Other cars report CarIdxP2P_Count as IEEE-754 float32 bits despite varType=2 (int).
 // The decoded float is in 0.1s units, so multiply by 10 to get seconds.
 // The player's own car reports it as a plain integer (already in seconds) — no conversion needed.
-const parseP2PCount = (bits: number, isPlayer: boolean): number => {
+const parseP2PCount = (
+  bits: number,
+  isPlayer: boolean,
+  config: CarP2PConfig
+): number => {
   if (isPlayer) return bits;
+  if (config.countEncoding === 'integer') return bits;
   const view = new DataView(new ArrayBuffer(4));
   view.setInt32(0, bits, true);
   return Math.round(view.getFloat32(0, true) * 10);
@@ -77,10 +82,6 @@ export const usePushToPassStore = create<PushToPassState>((set, get) => ({
 
     p2pStatus.forEach((isActive, carIdx) => {
       const wasActive = prevP2PStatus[carIdx] ?? false;
-      const count = parseP2PCount(
-        p2pCount[carIdx] ?? 0,
-        carIdx === playerCarIdx
-      );
       const carId = carIdxToCarId[carIdx];
       const config = carId !== undefined ? getCarP2PConfig(carId) : undefined;
 
@@ -88,6 +89,12 @@ export const usePushToPassStore = create<PushToPassState>((set, get) => ({
         newPrevP2PStatus[carIdx] = isActive;
         return;
       }
+
+      const count = parseP2PCount(
+        p2pCount[carIdx] ?? 0,
+        carIdx === playerCarIdx,
+        config
+      );
 
       // Transition active → inactive: start cooldown (only if P2P not exhausted)
       if (wasActive && !isActive && count > 0) {
@@ -125,7 +132,7 @@ export const usePushToPassStore = create<PushToPassState>((set, get) => ({
         continue;
       }
 
-      const count = parseP2PCount(rawCount, carIdx === playerCarIdx);
+      const count = parseP2PCount(rawCount, carIdx === playerCarIdx, config);
       const isActive = p2pStatus[carIdx] ?? false;
       const cooldownEnd = newCooldownEndTimes[carIdx] ?? null;
 

--- a/src/frontend/context/PushToPassStore/carP2PConfigs.ts
+++ b/src/frontend/context/PushToPassStore/carP2PConfigs.ts
@@ -1,5 +1,7 @@
 export interface CarP2PConfig {
   carId: number;
+  /** Encoding used by CarIdxP2P_Count for opponent cars. */
+  countEncoding: 'integer' | 'float32-tenths';
   /** Cooldown interval in seconds after deactivation before P2P can be reactivated */
   cooldownInterval: number;
 }
@@ -11,15 +13,13 @@ export interface CarP2PConfig {
  */
 export const CAR_P2P_CONFIGS: CarP2PConfig[] = [
   // Dallara IR18 (IndyCar)
-  { carId: 99, cooldownInterval: 10 },
-  // Dallara F3
-  { carId: 106, cooldownInterval: 10 },
+  { carId: 99, countEncoding: 'integer', cooldownInterval: 10 },
   // Super Formula - Toyota
-  { carId: 171, cooldownInterval: 100 },
+  { carId: 171, countEncoding: 'float32-tenths', cooldownInterval: 100 },
   // Super Formula - Honda
-  { carId: 172, cooldownInterval: 100 },
+  { carId: 172, countEncoding: 'float32-tenths', cooldownInterval: 100 },
   // IL-15
-  { carId: 205, cooldownInterval: 0 },
+  { carId: 205, countEncoding: 'integer', cooldownInterval: 0 },
 ];
 
 export const getCarP2PConfig = (carId: number): CarP2PConfig | undefined =>

--- a/src/frontend/context/PushToPassStore/carP2PConfigs.ts
+++ b/src/frontend/context/PushToPassStore/carP2PConfigs.ts
@@ -13,7 +13,7 @@ export interface CarP2PConfig {
  */
 export const CAR_P2P_CONFIGS: CarP2PConfig[] = [
   // Dallara IR18 (IndyCar)
-  { carId: 99, countEncoding: 'integer', cooldownInterval: 10 },
+  { carId: 99, countEncoding: 'integer', cooldownInterval: 0 },
   // Super Formula - Toyota
   { carId: 171, countEncoding: 'float32-tenths', cooldownInterval: 100 },
   // Super Formula - Honda

--- a/test-data/1783998516193/session.json
+++ b/test-data/1783998516193/session.json
@@ -1,0 +1,3403 @@
+{
+  "WeekendInfo": {
+    "Encoding": "ISO_8859_1",
+    "TrackName": "nurburgring nordschleife",
+    "TrackID": 249,
+    "TrackLength": "20.6383 km",
+    "TrackLengthOfficial": "22.81 km",
+    "TrackDisplayName": "Nordschleife Industriefahrten",
+    "TrackDisplayShortName": "Nordschleife",
+    "TrackConfigName": null,
+    "TrackCity": "Nürburg",
+    "TrackState": "Rhineland-Palatinate",
+    "TrackCountry": "Germany",
+    "TrackAltitude": "620.72 m",
+    "TrackLatitude": "50.337805 m",
+    "TrackLongitude": "6.950717 m",
+    "TrackNorthOffset": "1.5446 rad",
+    "TrackNumTurns": 154,
+    "TrackPitSpeedLimit": "60.00 kph",
+    "TrackPaceSpeed": "23.61 kph",
+    "TrackNumPitStalls": 19,
+    "TrackType": "road course",
+    "TrackDirection": "neutral",
+    "TrackWeatherType": "Realistic",
+    "TrackSkies": "Dynamic",
+    "TrackSurfaceTemp": "22.82 C",
+    "TrackSurfaceTempCrew": "22.82 C",
+    "TrackAirTemp": "19.82 C",
+    "TrackAirPressure": "27.98 Hg",
+    "TrackAirDensity": "1.12 kg/m^3",
+    "TrackWindVel": "3.26 m/s",
+    "TrackWindDir": "4.36 rad",
+    "TrackRelativeHumidity": "71 %",
+    "TrackFogLevel": "0 %",
+    "TrackPrecipitation": "0 %",
+    "TrackCleanup": 0,
+    "TrackDynamicTrack": 1,
+    "TrackVersion": "2026.05.28.02",
+    "SeriesID": 526,
+    "SeasonID": 6278,
+    "SessionID": 315421076,
+    "SubSessionID": 87185137,
+    "LeagueID": 0,
+    "Official": 1,
+    "RaceWeek": 4,
+    "EventType": "Race",
+    "Category": "Formula",
+    "SimMode": "full",
+    "TeamRacing": 0,
+    "MinDrivers": 0,
+    "MaxDrivers": 1,
+    "DCRuleSet": "None",
+    "QualifierMustStartRace": 0,
+    "NumCarClasses": 1,
+    "NumCarTypes": 2,
+    "HeatRacing": 0,
+    "BuildType": "Release",
+    "BuildTarget": "Members",
+    "BuildVersion": "2026.06.24.02",
+    "RaceFarm": "US-East-OH",
+    "WeekendOptions": {
+      "NumStarters": 30,
+      "StartingGrid": "2x2 inline pole on left",
+      "QualifyScoring": "best lap",
+      "CourseCautions": "advisory",
+      "StandingStart": 0,
+      "ShortParadeLap": 0,
+      "Restarts": "double file lapped cars behind",
+      "WeatherType": "Realistic",
+      "Skies": "Dynamic",
+      "WindDirection": "N",
+      "WindSpeed": "3.22 km/h",
+      "WeatherTemp": "25.56 C",
+      "RelativeHumidity": "45 %",
+      "FogLevel": "0 %",
+      "TimeOfDay": "12:00 pm",
+      "Date": "2026-07-18T00:00:00.000Z",
+      "EarthRotationSpeedupFactor": 1,
+      "Unofficial": 0,
+      "CommercialMode": "consumer",
+      "NightMode": "variable",
+      "IsFixedSetup": 1,
+      "StrictLapsChecking": "default",
+      "HasOpenRegistration": 0,
+      "HardcoreLevel": 1,
+      "NumJokerLaps": 0,
+      "IncidentLimit": 25,
+      "IncidentWarningInitialLimit": 17,
+      "IncidentWarningSubsequentLimit": 17,
+      "FastRepairsLimit": 0,
+      "GreenWhiteCheckeredLimit": 0
+    },
+    "TelemetryOptions": {
+      "TelemetryDiskFile": "C /Users/tarik/Documents/iRacing/telemetry/dallarail15_nurburgring nordschleife 2026-07-14 15-08-01.ibt"
+    }
+  },
+  "SessionInfo": {
+    "CurrentSessionNum": 1,
+    "Sessions": [
+      {
+        "SessionNum": 0,
+        "SessionLaps": "unlimited",
+        "SessionTime": "420.0000 sec",
+        "SessionNumLapsToAvg": 0,
+        "SessionType": "Warmup",
+        "SessionTrackRubberState": "moderately high usage",
+        "SessionName": "PRACTICE",
+        "SessionSubType": null,
+        "SessionSkipped": 0,
+        "SessionRunGroupsUsed": 0,
+        "SessionEnforceTireCompoundChange": 0,
+        "ResultsPositions": [
+          {
+            "Position": 1,
+            "ClassPosition": 0,
+            "CarIdx": 1,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 2,
+            "ClassPosition": 1,
+            "CarIdx": 0,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.7,
+            "Incidents": 2,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 3,
+            "ClassPosition": 2,
+            "CarIdx": 2,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.786,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 4,
+            "ClassPosition": 3,
+            "CarIdx": 3,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 5,
+            "ClassPosition": 4,
+            "CarIdx": 4,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 6,
+            "ClassPosition": 5,
+            "CarIdx": 5,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 7,
+            "ClassPosition": 6,
+            "CarIdx": 6,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.53,
+            "Incidents": 2,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 8,
+            "ClassPosition": 7,
+            "CarIdx": 7,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.889,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 9,
+            "ClassPosition": 8,
+            "CarIdx": 8,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.956,
+            "Incidents": 1,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 10,
+            "ClassPosition": 9,
+            "CarIdx": 9,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 11,
+            "ClassPosition": 10,
+            "CarIdx": 10,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 12,
+            "ClassPosition": 11,
+            "CarIdx": 11,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 13,
+            "ClassPosition": 12,
+            "CarIdx": 12,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 14,
+            "ClassPosition": 13,
+            "CarIdx": 13,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.051,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 15,
+            "ClassPosition": 14,
+            "CarIdx": 14,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.646,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 16,
+            "ClassPosition": 15,
+            "CarIdx": 15,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.621,
+            "Incidents": 3,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 17,
+            "ClassPosition": 16,
+            "CarIdx": 16,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 18,
+            "ClassPosition": 17,
+            "CarIdx": 17,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.819,
+            "Incidents": 1,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 19,
+            "ClassPosition": 18,
+            "CarIdx": 18,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 20,
+            "ClassPosition": 19,
+            "CarIdx": 19,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.888,
+            "Incidents": 1,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 21,
+            "ClassPosition": 20,
+            "CarIdx": 20,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0,
+            "Incidents": 0,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 22,
+            "ClassPosition": 21,
+            "CarIdx": 21,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.251,
+            "Incidents": 1,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 23,
+            "ClassPosition": 22,
+            "CarIdx": 22,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 1.045,
+            "Incidents": 1,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          },
+          {
+            "Position": 24,
+            "ClassPosition": 23,
+            "CarIdx": 23,
+            "Lap": 0,
+            "Time": -1,
+            "FastestLap": -1,
+            "FastestTime": -1,
+            "LastTime": -1,
+            "LapsLed": 0,
+            "LapsComplete": 0,
+            "JokerLapsComplete": 0,
+            "LapsDriven": 0.335,
+            "Incidents": 2,
+            "ReasonOutId": 0,
+            "ReasonOutStr": "Running"
+          }
+        ],
+        "ResultsFastestLap": [
+          {
+            "CarIdx": 255,
+            "FastestLap": 0,
+            "FastestTime": -1
+          }
+        ],
+        "ResultsAverageLapTime": -1,
+        "ResultsNumCautionFlags": 0,
+        "ResultsNumCautionLaps": 0,
+        "ResultsNumLeadChanges": 0,
+        "ResultsLapsComplete": -1,
+        "ResultsOfficial": 1
+      },
+      {
+        "SessionNum": 1,
+        "SessionLaps": 3,
+        "SessionTime": "unlimited",
+        "SessionNumLapsToAvg": 0,
+        "SessionType": "Race",
+        "SessionTrackRubberState": "carry over",
+        "SessionName": "RACE",
+        "SessionSubType": null,
+        "SessionSkipped": 0,
+        "SessionRunGroupsUsed": 0,
+        "SessionEnforceTireCompoundChange": 0,
+        "ResultsPositions": null,
+        "ResultsFastestLap": [
+          {
+            "CarIdx": 255,
+            "FastestLap": 0,
+            "FastestTime": -1
+          }
+        ],
+        "ResultsAverageLapTime": -1,
+        "ResultsNumCautionFlags": 0,
+        "ResultsNumCautionLaps": 0,
+        "ResultsNumLeadChanges": 0,
+        "ResultsLapsComplete": -1,
+        "ResultsOfficial": 0
+      }
+    ]
+  },
+  "QualifyResultsInfo": {
+    "Results": [
+      {
+        "Position": 0,
+        "ClassPosition": 0,
+        "CarIdx": 0,
+        "FastestLap": 0,
+        "FastestTime": 357.3616
+      },
+      {
+        "Position": 1,
+        "ClassPosition": 1,
+        "CarIdx": 1,
+        "FastestLap": 0,
+        "FastestTime": 358.8356
+      },
+      {
+        "Position": 2,
+        "ClassPosition": 2,
+        "CarIdx": 2,
+        "FastestLap": 0,
+        "FastestTime": 359.5048
+      },
+      {
+        "Position": 3,
+        "ClassPosition": 3,
+        "CarIdx": 3,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 4,
+        "ClassPosition": 4,
+        "CarIdx": 4,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 5,
+        "ClassPosition": 5,
+        "CarIdx": 5,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 6,
+        "ClassPosition": 6,
+        "CarIdx": 6,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 7,
+        "ClassPosition": 7,
+        "CarIdx": 7,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 8,
+        "ClassPosition": 8,
+        "CarIdx": 8,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 9,
+        "ClassPosition": 9,
+        "CarIdx": 9,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 10,
+        "ClassPosition": 10,
+        "CarIdx": 10,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 11,
+        "ClassPosition": 11,
+        "CarIdx": 11,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 12,
+        "ClassPosition": 12,
+        "CarIdx": 12,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 13,
+        "ClassPosition": 13,
+        "CarIdx": 13,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 14,
+        "ClassPosition": 14,
+        "CarIdx": 14,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 15,
+        "ClassPosition": 15,
+        "CarIdx": 15,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 16,
+        "ClassPosition": 16,
+        "CarIdx": 16,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 17,
+        "ClassPosition": 17,
+        "CarIdx": 17,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 18,
+        "ClassPosition": 18,
+        "CarIdx": 18,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 19,
+        "ClassPosition": 19,
+        "CarIdx": 19,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 20,
+        "ClassPosition": 20,
+        "CarIdx": 20,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 21,
+        "ClassPosition": 21,
+        "CarIdx": 21,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 22,
+        "ClassPosition": 22,
+        "CarIdx": 22,
+        "FastestLap": 0,
+        "FastestTime": 0
+      },
+      {
+        "Position": 23,
+        "ClassPosition": 23,
+        "CarIdx": 23,
+        "FastestLap": 0,
+        "FastestTime": 0
+      }
+    ]
+  },
+  "CameraInfo": {
+    "Groups": [
+      {
+        "GroupNum": 1,
+        "GroupName": "Nose",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamNose"
+          }
+        ]
+      },
+      {
+        "GroupNum": 2,
+        "GroupName": "Gearbox",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamGearbox"
+          }
+        ]
+      },
+      {
+        "GroupNum": 3,
+        "GroupName": "Roll Bar",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamRoll Bar"
+          }
+        ]
+      },
+      {
+        "GroupNum": 4,
+        "GroupName": "LF Susp",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamLF Susp"
+          }
+        ]
+      },
+      {
+        "GroupNum": 5,
+        "GroupName": "LR Susp",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamLR Susp"
+          }
+        ]
+      },
+      {
+        "GroupNum": 6,
+        "GroupName": "Gyro",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamGyro"
+          }
+        ]
+      },
+      {
+        "GroupNum": 7,
+        "GroupName": "RF Susp",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamRF Susp"
+          }
+        ]
+      },
+      {
+        "GroupNum": 8,
+        "GroupName": "RR Susp",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamRR Susp"
+          }
+        ]
+      },
+      {
+        "GroupNum": 9,
+        "GroupName": "Cockpit",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamCockpit"
+          }
+        ]
+      },
+      {
+        "GroupNum": 10,
+        "GroupName": "Scenic",
+        "IsScenic": true,
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "Cam_Scenic_00"
+          },
+          {
+            "CameraNum": 2,
+            "CameraName": "Cam_Scenic_01"
+          },
+          {
+            "CameraNum": 3,
+            "CameraName": "Cam_Scenic_02"
+          },
+          {
+            "CameraNum": 4,
+            "CameraName": "Cam_Scenic_03"
+          },
+          {
+            "CameraNum": 5,
+            "CameraName": "Cam_Scenic_04"
+          },
+          {
+            "CameraNum": 6,
+            "CameraName": "Cam_Scenic_05"
+          },
+          {
+            "CameraNum": 7,
+            "CameraName": "Cam_Scenic_06"
+          },
+          {
+            "CameraNum": 8,
+            "CameraName": "Cam_Scenic_07"
+          },
+          {
+            "CameraNum": 9,
+            "CameraName": "Cam_Scenic_08"
+          },
+          {
+            "CameraNum": 10,
+            "CameraName": "Cam_Scenic_09"
+          },
+          {
+            "CameraNum": 11,
+            "CameraName": "Cam_Scenic_10"
+          }
+        ]
+      },
+      {
+        "GroupNum": 11,
+        "GroupName": "TV1",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamTV1_00"
+          },
+          {
+            "CameraNum": 2,
+            "CameraName": "CamTV1_01"
+          },
+          {
+            "CameraNum": 3,
+            "CameraName": "CamTV1_02"
+          },
+          {
+            "CameraNum": 4,
+            "CameraName": "CamTV1_03"
+          },
+          {
+            "CameraNum": 5,
+            "CameraName": "CamTV1_04"
+          },
+          {
+            "CameraNum": 6,
+            "CameraName": "CamTV1_05"
+          },
+          {
+            "CameraNum": 7,
+            "CameraName": "CamTV1_06"
+          },
+          {
+            "CameraNum": 8,
+            "CameraName": "CamTV1_07"
+          },
+          {
+            "CameraNum": 9,
+            "CameraName": "CamTV1_08"
+          },
+          {
+            "CameraNum": 10,
+            "CameraName": "CamTV1_09"
+          },
+          {
+            "CameraNum": 11,
+            "CameraName": "CamTV1_10"
+          },
+          {
+            "CameraNum": 12,
+            "CameraName": "CamTV1_11"
+          },
+          {
+            "CameraNum": 13,
+            "CameraName": "CamTV1_12"
+          },
+          {
+            "CameraNum": 14,
+            "CameraName": "CamTV1_13"
+          },
+          {
+            "CameraNum": 15,
+            "CameraName": "CamTV1_14"
+          },
+          {
+            "CameraNum": 16,
+            "CameraName": "CamTV1_15"
+          },
+          {
+            "CameraNum": 17,
+            "CameraName": "CamTV1_16"
+          },
+          {
+            "CameraNum": 18,
+            "CameraName": "CamTV1_17"
+          },
+          {
+            "CameraNum": 19,
+            "CameraName": "CamTV1_18"
+          },
+          {
+            "CameraNum": 20,
+            "CameraName": "CamTV1_19"
+          },
+          {
+            "CameraNum": 21,
+            "CameraName": "CamTV1_20"
+          },
+          {
+            "CameraNum": 22,
+            "CameraName": "CamTV1_21"
+          },
+          {
+            "CameraNum": 23,
+            "CameraName": "CamTV1_22"
+          },
+          {
+            "CameraNum": 24,
+            "CameraName": "CamTV1_23"
+          },
+          {
+            "CameraNum": 25,
+            "CameraName": "CamTV1_24"
+          },
+          {
+            "CameraNum": 26,
+            "CameraName": "CamTV1_25"
+          },
+          {
+            "CameraNum": 27,
+            "CameraName": "CamTV1_26"
+          },
+          {
+            "CameraNum": 28,
+            "CameraName": "CamTV1_27"
+          },
+          {
+            "CameraNum": 29,
+            "CameraName": "CamTV1_28"
+          },
+          {
+            "CameraNum": 30,
+            "CameraName": "CamTV1_29"
+          },
+          {
+            "CameraNum": 31,
+            "CameraName": "CamTV1_30"
+          },
+          {
+            "CameraNum": 32,
+            "CameraName": "CamTV1_31"
+          },
+          {
+            "CameraNum": 33,
+            "CameraName": "CamTV1_32"
+          },
+          {
+            "CameraNum": 34,
+            "CameraName": "CamTV1_33"
+          },
+          {
+            "CameraNum": 35,
+            "CameraName": "CamTV1_34"
+          },
+          {
+            "CameraNum": 36,
+            "CameraName": "CamTV1_35"
+          },
+          {
+            "CameraNum": 37,
+            "CameraName": "CamTV1_36"
+          },
+          {
+            "CameraNum": 38,
+            "CameraName": "CamTV1_37"
+          },
+          {
+            "CameraNum": 39,
+            "CameraName": "CamTV1_38"
+          },
+          {
+            "CameraNum": 40,
+            "CameraName": "CamTV1_39"
+          },
+          {
+            "CameraNum": 41,
+            "CameraName": "CamTV1_40"
+          },
+          {
+            "CameraNum": 42,
+            "CameraName": "CamTV1_41"
+          },
+          {
+            "CameraNum": 43,
+            "CameraName": "CamTV1_42"
+          },
+          {
+            "CameraNum": 44,
+            "CameraName": "CamTV1_43"
+          },
+          {
+            "CameraNum": 45,
+            "CameraName": "CamTV1_44"
+          },
+          {
+            "CameraNum": 46,
+            "CameraName": "CamTV1_45"
+          },
+          {
+            "CameraNum": 47,
+            "CameraName": "CamTV1_46"
+          },
+          {
+            "CameraNum": 48,
+            "CameraName": "CamTV1_47"
+          },
+          {
+            "CameraNum": 49,
+            "CameraName": "CamTV1_48"
+          },
+          {
+            "CameraNum": 50,
+            "CameraName": "CamTV1_49"
+          },
+          {
+            "CameraNum": 51,
+            "CameraName": "CamTV1_50"
+          },
+          {
+            "CameraNum": 52,
+            "CameraName": "CamTV1_51"
+          },
+          {
+            "CameraNum": 53,
+            "CameraName": "CamTV1_52"
+          },
+          {
+            "CameraNum": 54,
+            "CameraName": "CamTV1_53"
+          },
+          {
+            "CameraNum": 55,
+            "CameraName": "CamTV1_54"
+          },
+          {
+            "CameraNum": 56,
+            "CameraName": "CamTV1_55"
+          },
+          {
+            "CameraNum": 57,
+            "CameraName": "CamTV1_56"
+          },
+          {
+            "CameraNum": 58,
+            "CameraName": "CamTV1_57"
+          },
+          {
+            "CameraNum": 59,
+            "CameraName": "CamTV1_58"
+          }
+        ]
+      },
+      {
+        "GroupNum": 12,
+        "GroupName": "TV2",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamTV2_04"
+          },
+          {
+            "CameraNum": 2,
+            "CameraName": "CamTV2_58"
+          },
+          {
+            "CameraNum": 3,
+            "CameraName": "CamTV2_57"
+          },
+          {
+            "CameraNum": 4,
+            "CameraName": "CamTV2_56"
+          },
+          {
+            "CameraNum": 5,
+            "CameraName": "CamTV2_55"
+          },
+          {
+            "CameraNum": 6,
+            "CameraName": "CamTV2_54"
+          },
+          {
+            "CameraNum": 7,
+            "CameraName": "CamTV2_53"
+          },
+          {
+            "CameraNum": 8,
+            "CameraName": "CamTV2_52"
+          },
+          {
+            "CameraNum": 9,
+            "CameraName": "CamTV2_51"
+          },
+          {
+            "CameraNum": 10,
+            "CameraName": "CamTV2_50"
+          },
+          {
+            "CameraNum": 11,
+            "CameraName": "CamTV2_49"
+          },
+          {
+            "CameraNum": 12,
+            "CameraName": "CamTV2_48"
+          },
+          {
+            "CameraNum": 13,
+            "CameraName": "CamTV2_47"
+          },
+          {
+            "CameraNum": 14,
+            "CameraName": "CamTV2_46"
+          },
+          {
+            "CameraNum": 15,
+            "CameraName": "CamTV2_45"
+          },
+          {
+            "CameraNum": 16,
+            "CameraName": "CamTV2_44"
+          },
+          {
+            "CameraNum": 17,
+            "CameraName": "CamTV2_43"
+          },
+          {
+            "CameraNum": 18,
+            "CameraName": "CamTV2_42"
+          },
+          {
+            "CameraNum": 19,
+            "CameraName": "CamTV2_41"
+          },
+          {
+            "CameraNum": 20,
+            "CameraName": "CamTV2_40"
+          },
+          {
+            "CameraNum": 21,
+            "CameraName": "CamTV2_39"
+          },
+          {
+            "CameraNum": 22,
+            "CameraName": "CamTV2_38"
+          },
+          {
+            "CameraNum": 23,
+            "CameraName": "CamTV2_37"
+          },
+          {
+            "CameraNum": 24,
+            "CameraName": "CamTV2_36"
+          },
+          {
+            "CameraNum": 25,
+            "CameraName": "CamTV2_35"
+          },
+          {
+            "CameraNum": 26,
+            "CameraName": "CamTV2_34"
+          },
+          {
+            "CameraNum": 27,
+            "CameraName": "CamTV2_33"
+          },
+          {
+            "CameraNum": 28,
+            "CameraName": "CamTV2_32"
+          },
+          {
+            "CameraNum": 29,
+            "CameraName": "CamTV2_31"
+          },
+          {
+            "CameraNum": 30,
+            "CameraName": "CamTV2_30"
+          },
+          {
+            "CameraNum": 31,
+            "CameraName": "CamTV2_29"
+          },
+          {
+            "CameraNum": 32,
+            "CameraName": "CamTV2_28"
+          },
+          {
+            "CameraNum": 33,
+            "CameraName": "CamTV2_27"
+          },
+          {
+            "CameraNum": 34,
+            "CameraName": "CamTV2_26"
+          },
+          {
+            "CameraNum": 35,
+            "CameraName": "CamTV2_25"
+          },
+          {
+            "CameraNum": 36,
+            "CameraName": "CamTV2_24"
+          },
+          {
+            "CameraNum": 37,
+            "CameraName": "CamTV2_23"
+          },
+          {
+            "CameraNum": 38,
+            "CameraName": "CamTV2_22"
+          },
+          {
+            "CameraNum": 39,
+            "CameraName": "CamTV2_21"
+          },
+          {
+            "CameraNum": 40,
+            "CameraName": "CamTV2_20"
+          },
+          {
+            "CameraNum": 41,
+            "CameraName": "CamTV2_19"
+          },
+          {
+            "CameraNum": 42,
+            "CameraName": "CamTV2_18"
+          },
+          {
+            "CameraNum": 43,
+            "CameraName": "CamTV2_17"
+          },
+          {
+            "CameraNum": 44,
+            "CameraName": "CamTV2_16"
+          },
+          {
+            "CameraNum": 45,
+            "CameraName": "CamTV2_15"
+          },
+          {
+            "CameraNum": 46,
+            "CameraName": "CamTV2_14"
+          },
+          {
+            "CameraNum": 47,
+            "CameraName": "CamTV2_13"
+          },
+          {
+            "CameraNum": 48,
+            "CameraName": "CamTV2_12"
+          },
+          {
+            "CameraNum": 49,
+            "CameraName": "CamTV2_11"
+          },
+          {
+            "CameraNum": 50,
+            "CameraName": "CamTV2_10"
+          },
+          {
+            "CameraNum": 51,
+            "CameraName": "CamTV2_09"
+          },
+          {
+            "CameraNum": 52,
+            "CameraName": "CamTV2_08"
+          },
+          {
+            "CameraNum": 53,
+            "CameraName": "CamTV2_07"
+          },
+          {
+            "CameraNum": 54,
+            "CameraName": "CamTV2_06"
+          },
+          {
+            "CameraNum": 55,
+            "CameraName": "CamTV2_05"
+          },
+          {
+            "CameraNum": 56,
+            "CameraName": "CamTV2_03"
+          },
+          {
+            "CameraNum": 57,
+            "CameraName": "CamTV2_02"
+          },
+          {
+            "CameraNum": 58,
+            "CameraName": "CamTV2_01"
+          },
+          {
+            "CameraNum": 59,
+            "CameraName": "CamTV2_00"
+          }
+        ]
+      },
+      {
+        "GroupNum": 13,
+        "GroupName": "TV3",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamTV3_00"
+          },
+          {
+            "CameraNum": 2,
+            "CameraName": "CamTV3_01"
+          },
+          {
+            "CameraNum": 3,
+            "CameraName": "CamTV3_02"
+          },
+          {
+            "CameraNum": 4,
+            "CameraName": "CamTV3_03"
+          },
+          {
+            "CameraNum": 5,
+            "CameraName": "CamTV3_04"
+          },
+          {
+            "CameraNum": 6,
+            "CameraName": "CamTV3_05"
+          },
+          {
+            "CameraNum": 7,
+            "CameraName": "CamTV3_06"
+          },
+          {
+            "CameraNum": 8,
+            "CameraName": "CamTV3_07"
+          },
+          {
+            "CameraNum": 9,
+            "CameraName": "CamTV3_08"
+          },
+          {
+            "CameraNum": 10,
+            "CameraName": "CamTV3_09"
+          },
+          {
+            "CameraNum": 11,
+            "CameraName": "CamTV3_10"
+          },
+          {
+            "CameraNum": 12,
+            "CameraName": "CamTV3_11"
+          },
+          {
+            "CameraNum": 13,
+            "CameraName": "CamTV3_12"
+          },
+          {
+            "CameraNum": 14,
+            "CameraName": "CamTV3_13"
+          },
+          {
+            "CameraNum": 15,
+            "CameraName": "CamTV3_14"
+          },
+          {
+            "CameraNum": 16,
+            "CameraName": "CamTV3_15"
+          },
+          {
+            "CameraNum": 17,
+            "CameraName": "CamTV3_16"
+          },
+          {
+            "CameraNum": 18,
+            "CameraName": "CamTV3_17"
+          },
+          {
+            "CameraNum": 19,
+            "CameraName": "CamTV3_18"
+          },
+          {
+            "CameraNum": 20,
+            "CameraName": "CamTV3_19"
+          },
+          {
+            "CameraNum": 21,
+            "CameraName": "CamTV3_20"
+          },
+          {
+            "CameraNum": 22,
+            "CameraName": "CamTV3_21"
+          },
+          {
+            "CameraNum": 23,
+            "CameraName": "CamTV3_22"
+          },
+          {
+            "CameraNum": 24,
+            "CameraName": "CamTV3_23"
+          },
+          {
+            "CameraNum": 25,
+            "CameraName": "CamTV3_24"
+          },
+          {
+            "CameraNum": 26,
+            "CameraName": "CamTV3_25"
+          },
+          {
+            "CameraNum": 27,
+            "CameraName": "CamTV3_26"
+          },
+          {
+            "CameraNum": 28,
+            "CameraName": "CamTV3_27"
+          },
+          {
+            "CameraNum": 29,
+            "CameraName": "CamTV3_28"
+          },
+          {
+            "CameraNum": 30,
+            "CameraName": "CamTV3_29"
+          },
+          {
+            "CameraNum": 31,
+            "CameraName": "CamTV3_30"
+          },
+          {
+            "CameraNum": 32,
+            "CameraName": "CamTV3_31"
+          },
+          {
+            "CameraNum": 33,
+            "CameraName": "CamTV3_32"
+          },
+          {
+            "CameraNum": 34,
+            "CameraName": "CamTV3_33"
+          },
+          {
+            "CameraNum": 35,
+            "CameraName": "CamTV3_34"
+          },
+          {
+            "CameraNum": 36,
+            "CameraName": "CamTV3_35"
+          },
+          {
+            "CameraNum": 37,
+            "CameraName": "CamTV3_36"
+          },
+          {
+            "CameraNum": 38,
+            "CameraName": "CamTV3_37"
+          },
+          {
+            "CameraNum": 39,
+            "CameraName": "CamTV3_38"
+          },
+          {
+            "CameraNum": 40,
+            "CameraName": "CamTV3_39"
+          },
+          {
+            "CameraNum": 41,
+            "CameraName": "CamTV3_40"
+          },
+          {
+            "CameraNum": 42,
+            "CameraName": "CamTV3_41"
+          },
+          {
+            "CameraNum": 43,
+            "CameraName": "CamTV3_42"
+          },
+          {
+            "CameraNum": 44,
+            "CameraName": "CamTV3_43"
+          },
+          {
+            "CameraNum": 45,
+            "CameraName": "CamTV3_44"
+          },
+          {
+            "CameraNum": 46,
+            "CameraName": "CamTV3_45"
+          },
+          {
+            "CameraNum": 47,
+            "CameraName": "CamTV3_46"
+          },
+          {
+            "CameraNum": 48,
+            "CameraName": "CamTV3_47"
+          },
+          {
+            "CameraNum": 49,
+            "CameraName": "CamTV3_48"
+          },
+          {
+            "CameraNum": 50,
+            "CameraName": "CamTV3_49"
+          },
+          {
+            "CameraNum": 51,
+            "CameraName": "CamTV3_50"
+          },
+          {
+            "CameraNum": 52,
+            "CameraName": "CamTV3_51"
+          },
+          {
+            "CameraNum": 53,
+            "CameraName": "CamTV3_52"
+          },
+          {
+            "CameraNum": 54,
+            "CameraName": "CamTV3_53"
+          },
+          {
+            "CameraNum": 55,
+            "CameraName": "CamTV3_54"
+          },
+          {
+            "CameraNum": 56,
+            "CameraName": "CamTV3_55"
+          },
+          {
+            "CameraNum": 57,
+            "CameraName": "CamTV3_56"
+          },
+          {
+            "CameraNum": 58,
+            "CameraName": "CamTV3_57"
+          },
+          {
+            "CameraNum": 59,
+            "CameraName": "CamTV3_58"
+          },
+          {
+            "CameraNum": 60,
+            "CameraName": "CamTV3_59"
+          },
+          {
+            "CameraNum": 61,
+            "CameraName": "CamTV3_60"
+          },
+          {
+            "CameraNum": 62,
+            "CameraName": "CamTV3_61"
+          }
+        ]
+      },
+      {
+        "GroupNum": 14,
+        "GroupName": "Pit Lane",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamPit Lane"
+          }
+        ]
+      },
+      {
+        "GroupNum": 15,
+        "GroupName": "Pit Lane 2",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamPit Lane 2"
+          }
+        ]
+      },
+      {
+        "GroupNum": 16,
+        "GroupName": "Chopper",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamChopper"
+          }
+        ]
+      },
+      {
+        "GroupNum": 17,
+        "GroupName": "Blimp",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamBlimp_00"
+          },
+          {
+            "CameraNum": 2,
+            "CameraName": "CamBlimp_01"
+          },
+          {
+            "CameraNum": 3,
+            "CameraName": "CamBlimp_02"
+          },
+          {
+            "CameraNum": 4,
+            "CameraName": "CamBlimp_03"
+          },
+          {
+            "CameraNum": 5,
+            "CameraName": "CamBlimp_04"
+          },
+          {
+            "CameraNum": 6,
+            "CameraName": "CamBlimp_05"
+          },
+          {
+            "CameraNum": 7,
+            "CameraName": "CamBlimp_06"
+          },
+          {
+            "CameraNum": 8,
+            "CameraName": "CamBlimp_07"
+          },
+          {
+            "CameraNum": 9,
+            "CameraName": "CamBlimp_08"
+          }
+        ]
+      },
+      {
+        "GroupNum": 18,
+        "GroupName": "Chase",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamChase"
+          }
+        ]
+      },
+      {
+        "GroupNum": 19,
+        "GroupName": "Far Chase",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamFar Chase"
+          }
+        ]
+      },
+      {
+        "GroupNum": 20,
+        "GroupName": "Rear Chase",
+        "Cameras": [
+          {
+            "CameraNum": 1,
+            "CameraName": "CamRear Chase"
+          }
+        ]
+      }
+    ]
+  },
+  "RadioInfo": {
+    "SelectedRadioNum": 0,
+    "Radios": [
+      {
+        "RadioNum": 0,
+        "HopCount": 2,
+        "NumFrequencies": 5,
+        "TunedToFrequencyNum": 1,
+        "ScanningIsOn": 1,
+        "Frequencies": [
+          {
+            "FrequencyNum": 0,
+            "FrequencyName": "@ALLTEAMS",
+            "Priority": 12,
+            "CarIdx": -1,
+            "EntryIdx": -1,
+            "ClubID": 0,
+            "CanScan": 1,
+            "CanSquawk": 1,
+            "Muted": 0,
+            "IsMutable": 1,
+            "IsDeletable": 0
+          },
+          {
+            "FrequencyNum": 1,
+            "FrequencyName": "@DRIVERS",
+            "Priority": 15,
+            "CarIdx": -1,
+            "EntryIdx": -1,
+            "ClubID": 0,
+            "CanScan": 1,
+            "CanSquawk": 1,
+            "Muted": 0,
+            "IsMutable": 1,
+            "IsDeletable": 0
+          },
+          {
+            "FrequencyNum": 2,
+            "FrequencyName": "@TEAM",
+            "Priority": 60,
+            "CarIdx": 14,
+            "EntryIdx": -1,
+            "ClubID": 0,
+            "CanScan": 1,
+            "CanSquawk": 1,
+            "Muted": 0,
+            "IsMutable": 0,
+            "IsDeletable": 0
+          },
+          {
+            "FrequencyNum": 3,
+            "FrequencyName": "@RACECONTROL",
+            "Priority": 80,
+            "CarIdx": -1,
+            "EntryIdx": -1,
+            "ClubID": 0,
+            "CanScan": 1,
+            "CanSquawk": 0,
+            "Muted": 0,
+            "IsMutable": 0,
+            "IsDeletable": 0
+          },
+          {
+            "FrequencyNum": 4,
+            "FrequencyName": "@PRIVATE",
+            "Priority": 70,
+            "CarIdx": -1,
+            "EntryIdx": 15,
+            "ClubID": 0,
+            "CanScan": 1,
+            "CanSquawk": 1,
+            "Muted": 0,
+            "IsMutable": 0,
+            "IsDeletable": 0
+          }
+        ]
+      }
+    ]
+  },
+  "DriverInfo": {
+    "DriverCarIdx": 14,
+    "DriverUserID": 968989,
+    "PaceCarIdx": 64,
+    "DriverIsAdmin": 0,
+    "DriverHeadPosX": 0.226,
+    "DriverHeadPosY": 0,
+    "DriverHeadPosZ": 0.43,
+    "DriverCarIsElectric": 0,
+    "DriverCarIdleRPM": 2500,
+    "DriverCarRedLine": 7750,
+    "DriverCarEngCylinderCount": 4,
+    "DriverCarFuelKgPerLtr": 0.75,
+    "DriverCarFuelMaxLtr": 76,
+    "DriverCarMaxFuelPct": 1,
+    "DriverCarGearNumForward": 6,
+    "DriverCarGearNeutral": 1,
+    "DriverCarGearReverse": 1,
+    "DriverGearboxType": "Sequential",
+    "DriverGearboxControlType": "Sequential",
+    "DriverCarShiftAid": "Antistall_Clutch_Throttle",
+    "DriverCarSLFirstRPM": 6560,
+    "DriverCarSLShiftRPM": 7150,
+    "DriverCarSLLastRPM": 7270,
+    "DriverCarSLBlinkRPM": 7700,
+    "DriverCarVersion": "2026.06.01.01",
+    "DriverPitTrkPct": 0.001221,
+    "DriverCarEstLapTime": 339.915,
+    "DriverSetupName": "ringmeister.sto",
+    "DriverSetupIsModified": 0,
+    "DriverSetupLoadTypeName": "fixed",
+    "DriverSetupPassedTech": 1,
+    "DriverIncidentCount": 0,
+    "DriverBrakeCurvingFactor": 0.001,
+    "DriverTires": [
+      {
+        "TireIndex": 0,
+        "TireCompoundType": "Hard"
+      },
+      {
+        "TireIndex": 1,
+        "TireCompoundType": "Wet"
+      }
+    ],
+    "Drivers": [
+      {
+        "CarIdx": 0,
+        "UserName": "Sebastian Trubitz",
+        "AbbrevName": "Trubitz, S",
+        "Initials": "ST",
+        "UserID": 1121073,
+        "TeamID": 0,
+        "TeamName": "Sebastian Trubitz",
+        "CarNumber": "2",
+        "CarNumberRaw": 2,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 4853,
+        "LicLevel": 18,
+        "LicSubLevel": 255,
+        "LicString": "A 2.55",
+        "LicColor": 87003,
+        "IsSpectator": 0,
+        "CarDesignStr": "25,ff0000,000000,ffe500",
+        "HelmetDesignStr": "22,ff0000,000000,ffe500",
+        "SuitDesignStr": "1,111111,391c83,ccff00",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Germany",
+        "FlairID": 77,
+        "DivisionName": "Division 1",
+        "DivisionID": 0,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 1,
+        "UserName": "Henry Pinto",
+        "AbbrevName": "Pinto, H",
+        "Initials": "HP",
+        "UserID": 1181109,
+        "TeamID": 0,
+        "TeamName": "Henry Pinto",
+        "CarNumber": "1",
+        "CarNumberRaw": 1,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 5139,
+        "LicLevel": 16,
+        "LicSubLevel": 499,
+        "LicString": "B 4.99",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "10,000000,a6a6a6,ffffff,ffffff",
+        "HelmetDesignStr": "57,ffffff,a6a6a6,000000",
+        "SuitDesignStr": "1,000000,040405,ffffff",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 3",
+        "DivisionID": 2,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 2,
+        "UserName": "Marcello Olindo",
+        "AbbrevName": "Olindo, M",
+        "Initials": "MO",
+        "UserID": 392220,
+        "TeamID": 0,
+        "TeamName": "Marcello Olindo",
+        "CarNumber": "3",
+        "CarNumberRaw": 3,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 3708,
+        "LicLevel": 15,
+        "LicSubLevel": 358,
+        "LicString": "B 3.58",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "5,000000,4dc7aa,575757",
+        "HelmetDesignStr": "26,000000,4dc7aa,575757",
+        "SuitDesignStr": "10,000000,44c7b7,061809",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Canada",
+        "FlairID": 39,
+        "DivisionName": "Division 3",
+        "DivisionID": 2,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 3,
+        "UserName": "Angela Rodrigues",
+        "AbbrevName": "Rodrigues, A",
+        "Initials": "AR",
+        "UserID": 773486,
+        "TeamID": 0,
+        "TeamName": "Angela Rodrigues",
+        "CarNumber": "4",
+        "CarNumberRaw": 4,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 3150,
+        "LicLevel": 15,
+        "LicSubLevel": 372,
+        "LicString": "B 3.72",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "10,ff00fc,ff00fc,ff00fc",
+        "HelmetDesignStr": "0,ff00fc,ff00fc,ff00fc",
+        "SuitDesignStr": "33,004f0f,00ff1e,ff00fc",
+        "BodyType": 0,
+        "FaceType": 7,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Monaco",
+        "FlairID": 137,
+        "DivisionName": "Division 2",
+        "DivisionID": 1,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 4,
+        "UserName": "Guillermo Siguenza",
+        "AbbrevName": "Siguenza, G",
+        "Initials": "GS",
+        "UserID": 807943,
+        "TeamID": 0,
+        "TeamName": "Guillermo Siguenza",
+        "CarNumber": "5",
+        "CarNumberRaw": 5,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 2570,
+        "LicLevel": 18,
+        "LicSubLevel": 253,
+        "LicString": "A 2.53",
+        "LicColor": 87003,
+        "IsSpectator": 0,
+        "CarDesignStr": "5,e4e6f0,1122e5,0ce6ed",
+        "HelmetDesignStr": "68,e4e6f0,1122e5,2d0bed",
+        "SuitDesignStr": "8,4a11de,e7d6d6,dccec7",
+        "BodyType": 1,
+        "FaceType": 4,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 324,
+        "CarSponsor_2": 243,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Argentina",
+        "FlairID": 13,
+        "DivisionName": "Division 2",
+        "DivisionID": 1,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 5,
+        "UserName": "Bernardo De Castro",
+        "AbbrevName": "Castro, B",
+        "Initials": "BC",
+        "UserID": 1234512,
+        "TeamID": 0,
+        "TeamName": "Bernardo De Castro",
+        "CarNumber": "6",
+        "CarNumberRaw": 6,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 2371,
+        "LicLevel": 10,
+        "LicSubLevel": 231,
+        "LicString": "C 2.31",
+        "LicColor": 16706564,
+        "IsSpectator": 0,
+        "CarDesignStr": "15,ffffff,0280cc,1a599d",
+        "HelmetDesignStr": "1,ffffff,0280cc,1a599d",
+        "SuitDesignStr": "1,ffffff,0280cc,1a599d",
+        "BodyType": 0,
+        "FaceType": 5,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Brazil",
+        "FlairID": 31,
+        "DivisionName": "Division 3",
+        "DivisionID": 2,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 6,
+        "UserName": "Franco Battistelli",
+        "AbbrevName": "Battistelli, F",
+        "Initials": "FB",
+        "UserID": 856192,
+        "TeamID": 0,
+        "TeamName": "Franco Battistelli",
+        "CarNumber": "7",
+        "CarNumberRaw": 7,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 2100,
+        "LicLevel": 14,
+        "LicSubLevel": 276,
+        "LicString": "B 2.76",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "11,930f3f,ff0000,5a00ff",
+        "HelmetDesignStr": "35,000000,000000,521cb8",
+        "SuitDesignStr": "7,000000,000000,321683",
+        "BodyType": 1,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Chile",
+        "FlairID": 44,
+        "DivisionName": "Division 3",
+        "DivisionID": 2,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 7,
+        "UserName": "Hugo Poulin",
+        "AbbrevName": "Poulin, H",
+        "Initials": "HP",
+        "UserID": 993300,
+        "TeamID": 0,
+        "TeamName": "Hugo Poulin",
+        "CarNumber": "8",
+        "CarNumberRaw": 8,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 2059,
+        "LicLevel": 18,
+        "LicSubLevel": 228,
+        "LicString": "A 2.28",
+        "LicColor": 87003,
+        "IsSpectator": 0,
+        "CarDesignStr": "3,1fdb00,0031ad,dd6300",
+        "HelmetDesignStr": "2,1fdb00,0031ad,dd6300",
+        "SuitDesignStr": "21,000000,000000,000000",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Canada",
+        "FlairID": 39,
+        "DivisionName": "Division 6",
+        "DivisionID": 5,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 8,
+        "UserName": "Jesse M Nelson",
+        "AbbrevName": "Nelson, J",
+        "Initials": "JN",
+        "UserID": 1220159,
+        "TeamID": 0,
+        "TeamName": "Jesse M Nelson",
+        "CarNumber": "9",
+        "CarNumberRaw": 9,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1808,
+        "LicLevel": 14,
+        "LicSubLevel": 247,
+        "LicString": "B 2.47",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "21,f70a0a,000000,000000,ffffff",
+        "HelmetDesignStr": "10,f70a0a,ffffff,000000",
+        "SuitDesignStr": "33,f60000,000000,000000",
+        "BodyType": 1,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "3,0,ffffff,ff0000,000000",
+        "CarSponsor_1": 363,
+        "CarSponsor_2": 367,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 5",
+        "DivisionID": 4,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 9,
+        "UserName": "Kelly McQueen IV",
+        "AbbrevName": "McQueen, K IV",
+        "Initials": "KM",
+        "UserID": 1253258,
+        "TeamID": 0,
+        "TeamName": "Kelly McQueen IV",
+        "CarNumber": "10",
+        "CarNumberRaw": 10,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1765,
+        "LicLevel": 18,
+        "LicSubLevel": 229,
+        "LicString": "A 2.29",
+        "LicColor": 87003,
+        "IsSpectator": 0,
+        "CarDesignStr": "12,06d4e1,6325e6,bfa600",
+        "HelmetDesignStr": "57,06d4e1,6325e6,bfa600",
+        "SuitDesignStr": "33,7817f4,009eec,bba200",
+        "BodyType": 0,
+        "FaceType": 10,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 5",
+        "DivisionID": 4,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 10,
+        "UserName": "Mauricio Vaz",
+        "AbbrevName": "Vaz, M",
+        "Initials": "MV",
+        "UserID": 1127416,
+        "TeamID": 0,
+        "TeamName": "Mauricio Vaz",
+        "CarNumber": "11",
+        "CarNumberRaw": 11,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1721,
+        "LicLevel": 14,
+        "LicSubLevel": 242,
+        "LicString": "B 2.42",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "12,e3ff2b,0006ab,00eb17",
+        "HelmetDesignStr": "58,e3ff2b,0006ab,00eb17",
+        "SuitDesignStr": "24,010057,e0f406,0011a6",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Brazil",
+        "FlairID": 31,
+        "DivisionName": "Division 6",
+        "DivisionID": 5,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 11,
+        "UserName": "Spencer Clowry",
+        "AbbrevName": "Clowry, S",
+        "Initials": "SC",
+        "UserID": 846592,
+        "TeamID": 0,
+        "TeamName": "Spencer Clowry",
+        "CarNumber": "12",
+        "CarNumberRaw": 12,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1715,
+        "LicLevel": 15,
+        "LicSubLevel": 329,
+        "LicString": "B 3.29",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "15,f1732e,372a75,ffffff",
+        "HelmetDesignStr": "1,f1732e,372a75,ffffff",
+        "SuitDesignStr": "1,f1732e,372a75,ffffff",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Canada",
+        "FlairID": 39,
+        "DivisionName": "Division 10",
+        "DivisionID": 9,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 12,
+        "UserName": "Carlton Halford",
+        "AbbrevName": "Halford, C",
+        "Initials": "CH",
+        "UserID": 1470271,
+        "TeamID": 0,
+        "TeamName": "Carlton Halford",
+        "CarNumber": "13",
+        "CarNumberRaw": 13,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1653,
+        "LicLevel": 12,
+        "LicSubLevel": 417,
+        "LicString": "C 4.17",
+        "LicColor": 16706564,
+        "IsSpectator": 0,
+        "CarDesignStr": "15,ffffff,ffffff,0e00ae",
+        "HelmetDesignStr": "1,2e358f,ec232d,0a0a0a",
+        "SuitDesignStr": "1,2e358f,ec232d,0a0a0a",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 3",
+        "DivisionID": 2,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 13,
+        "UserName": "Omid Zadeh",
+        "AbbrevName": "Zadeh, O",
+        "Initials": "OZ",
+        "UserID": 1104971,
+        "TeamID": 0,
+        "TeamName": "Omid Zadeh",
+        "CarNumber": "14",
+        "CarNumberRaw": 14,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1607,
+        "LicLevel": 10,
+        "LicSubLevel": 293,
+        "LicString": "C 2.93",
+        "LicColor": 16706564,
+        "IsSpectator": 0,
+        "CarDesignStr": "23,000000,000000,2900ff.2b00ff",
+        "HelmetDesignStr": "12,ff0000,00fffa,ff0000",
+        "SuitDesignStr": "24,000000,2e00ff,000000",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,000000,3800ff,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Canada",
+        "FlairID": 39,
+        "DivisionName": "Division 7",
+        "DivisionID": 6,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 14,
+        "UserName": "Tarik Alani",
+        "AbbrevName": "Alani, T",
+        "Initials": "TA",
+        "UserID": 968989,
+        "TeamID": 0,
+        "TeamName": "Tarik Alani",
+        "CarNumber": "15",
+        "CarNumberRaw": 15,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1600,
+        "LicLevel": 15,
+        "LicSubLevel": 324,
+        "LicString": "B 3.24",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "4,000000,ffffff,00107c",
+        "HelmetDesignStr": "7,000000,ffffff,00107c",
+        "SuitDesignStr": "30,000000,ffffff,00015d",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "New Zealand",
+        "FlairID": 149,
+        "DivisionName": "Division 5",
+        "DivisionID": 4,
+        "CurDriverIncidentCount": 0,
+        "TeamIncidentCount": 0
+      },
+      {
+        "CarIdx": 15,
+        "UserName": "Briant Huynh2",
+        "AbbrevName": "Huynh2, B",
+        "Initials": "BH",
+        "UserID": 1281819,
+        "TeamID": 0,
+        "TeamName": "Briant Huynh2",
+        "CarNumber": "16",
+        "CarNumberRaw": 16,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1578,
+        "LicLevel": 7,
+        "LicSubLevel": 353,
+        "LicString": "D 3.53",
+        "LicColor": 16550439,
+        "IsSpectator": 0,
+        "CarDesignStr": "13,fafafa,2400b4,bf05cf",
+        "HelmetDesignStr": "36,fafafa,2400b4,bf05cf",
+        "SuitDesignStr": "1,0a0a0a,545859,06c4de",
+        "BodyType": 0,
+        "FaceType": 6,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Vietnam",
+        "FlairID": 229,
+        "DivisionName": "Division 6",
+        "DivisionID": 5,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 16,
+        "UserName": "Lucas Polson",
+        "AbbrevName": "Polson, L",
+        "Initials": "LP",
+        "UserID": 1427857,
+        "TeamID": 0,
+        "TeamName": "Lucas Polson",
+        "CarNumber": "17",
+        "CarNumberRaw": 17,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1577,
+        "LicLevel": 14,
+        "LicSubLevel": 261,
+        "LicString": "B 2.61",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "10,ffffff,001dff,e90000",
+        "HelmetDesignStr": "35,ffffff,001dff,e90000",
+        "SuitDesignStr": "22,000000,ffffff,ffed00",
+        "BodyType": 0,
+        "FaceType": 4,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 7",
+        "DivisionID": 6,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 17,
+        "UserName": "Tyler Hovestadt",
+        "AbbrevName": "Hovestadt, T",
+        "Initials": "TH",
+        "UserID": 1251103,
+        "TeamID": 0,
+        "TeamName": "Tyler Hovestadt",
+        "CarNumber": "18",
+        "CarNumberRaw": 18,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1567,
+        "LicLevel": 18,
+        "LicSubLevel": 234,
+        "LicString": "A 2.34",
+        "LicColor": 87003,
+        "IsSpectator": 0,
+        "CarDesignStr": "7,000000,ff0000,2bff00",
+        "HelmetDesignStr": "61,000000,ff0000,2bff00",
+        "SuitDesignStr": "2,000000,ff0000,4aff00",
+        "BodyType": 0,
+        "FaceType": 8,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 9",
+        "DivisionID": 8,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 18,
+        "UserName": "Stefan Roehrig",
+        "AbbrevName": "Roehrig, S",
+        "Initials": "SR",
+        "UserID": 378037,
+        "TeamID": 0,
+        "TeamName": "Stefan Roehrig",
+        "CarNumber": "19",
+        "CarNumberRaw": 19,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1532,
+        "LicLevel": 18,
+        "LicSubLevel": 248,
+        "LicString": "A 2.48",
+        "LicColor": 87003,
+        "IsSpectator": 0,
+        "CarDesignStr": "11,00d113,111111,000000",
+        "HelmetDesignStr": "63,00d113,111111,000000",
+        "SuitDesignStr": "15,000000,000000,2df800",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "Germany",
+        "FlairID": 77,
+        "DivisionName": "Division 7",
+        "DivisionID": 6,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 19,
+        "UserName": "John Reichenbach",
+        "AbbrevName": "Reichenbach, J",
+        "Initials": "JR",
+        "UserID": 1445144,
+        "TeamID": 0,
+        "TeamName": "John Reichenbach",
+        "CarNumber": "20",
+        "CarNumberRaw": 20,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1522,
+        "LicLevel": 10,
+        "LicSubLevel": 239,
+        "LicString": "C 2.39",
+        "LicColor": 16706564,
+        "IsSpectator": 0,
+        "CarDesignStr": "18,2f3e59,464249,000000",
+        "HelmetDesignStr": "60,2f3e59,464249,000000",
+        "SuitDesignStr": "3,2f3e59,464249,000000",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 6",
+        "DivisionID": 5,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 20,
+        "UserName": "Cameron Tackman",
+        "AbbrevName": "Tackman, C",
+        "Initials": "CT",
+        "UserID": 1022016,
+        "TeamID": 0,
+        "TeamName": "Cameron Tackman",
+        "CarNumber": "21",
+        "CarNumberRaw": 21,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1520,
+        "LicLevel": 14,
+        "LicSubLevel": 227,
+        "LicString": "B 2.27",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "9,55155d,111111,22ff46",
+        "HelmetDesignStr": "21,55155d,111111,22ff46",
+        "SuitDesignStr": "3,55155d,111111,22ff46",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 6",
+        "DivisionID": 5,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 21,
+        "UserName": "Xin Wan",
+        "AbbrevName": "Wan, X",
+        "Initials": "XW",
+        "UserID": 1254401,
+        "TeamID": 0,
+        "TeamName": "Xin Wan",
+        "CarNumber": "22",
+        "CarNumberRaw": 22,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1451,
+        "LicLevel": 17,
+        "LicSubLevel": 188,
+        "LicString": "A 1.88",
+        "LicColor": 87003,
+        "IsSpectator": 0,
+        "CarDesignStr": "2,ff0000,00ff00,0000ff",
+        "HelmetDesignStr": "64,2a3795,ed2229,eeeeee",
+        "SuitDesignStr": "1,0b3559,969799,0a0a0a",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "China",
+        "FlairID": 45,
+        "DivisionName": "Division 9",
+        "DivisionID": 8,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 22,
+        "UserName": "Vincent Viscioni",
+        "AbbrevName": "Viscioni, V",
+        "Initials": "VV",
+        "UserID": 897516,
+        "TeamID": 0,
+        "TeamName": "Vincent Viscioni",
+        "CarNumber": "23",
+        "CarNumberRaw": 23,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1408,
+        "LicLevel": 18,
+        "LicSubLevel": 200,
+        "LicString": "A 2.00",
+        "LicColor": 87003,
+        "IsSpectator": 0,
+        "CarDesignStr": "2,ff0000,00ff00,0000ff",
+        "HelmetDesignStr": "65,000000,ed2129,ffffff",
+        "SuitDesignStr": "3,000000,ed2129,ececec",
+        "BodyType": 1,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 4",
+        "DivisionID": 3,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 23,
+        "UserName": "James Deonier",
+        "AbbrevName": "Deonier, J",
+        "Initials": "JD",
+        "UserID": 869399,
+        "TeamID": 0,
+        "TeamName": "James Deonier",
+        "CarNumber": "24",
+        "CarNumberRaw": 24,
+        "CarPath": "dallarail15",
+        "CarClassID": 4089,
+        "CarID": 205,
+        "CarIsPaceCar": 0,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "Dallara IL15 Indy NXT",
+        "CarScreenNameShort": "Dallara IL15",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": "Dallara IL15",
+        "CarClassRelSpeed": 105,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 339.915,
+        "IRating": 1381,
+        "LicLevel": 14,
+        "LicSubLevel": 261,
+        "LicString": "B 2.61",
+        "LicColor": 50946,
+        "IsSpectator": 0,
+        "CarDesignStr": "10,cedc00,00665e,000000",
+        "HelmetDesignStr": "22,cedc00,00665e,000000",
+        "SuitDesignStr": "2,00665e,000000,cedc00",
+        "BodyType": 0,
+        "FaceType": 8,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,777777,000000",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "United States",
+        "FlairID": 223,
+        "DivisionName": "Division 5",
+        "DivisionID": 4,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      },
+      {
+        "CarIdx": 64,
+        "UserName": "Pace Car",
+        "AbbrevName": null,
+        "Initials": null,
+        "UserID": -1,
+        "TeamID": 0,
+        "TeamName": "Pace Car",
+        "CarNumber": "0",
+        "CarNumberRaw": 0,
+        "CarPath": "safety pcporsche911cup",
+        "CarClassID": 11,
+        "CarID": 108,
+        "CarIsPaceCar": 1,
+        "CarIsAI": 0,
+        "CarIsElectric": 0,
+        "CarScreenName": "safety pcporsche911cup",
+        "CarScreenNameShort": "safety pcporsche911cup",
+        "CarCfg": -1,
+        "CarCfgName": null,
+        "CarCfgCustomPaintExt": null,
+        "CarClassShortName": null,
+        "CarClassRelSpeed": 0,
+        "CarClassLicenseLevel": 0,
+        "CarClassMaxFuelPct": "1.000 %",
+        "CarClassWeightPenalty": "0.000 kg",
+        "CarClassPowerAdjust": "0.000 %",
+        "CarClassDryTireSetLimit": "0 %",
+        "CarClassColor": 16777215,
+        "CarClassEstLapTime": 408.7477,
+        "IRating": 0,
+        "LicLevel": 1,
+        "LicSubLevel": 0,
+        "LicString": "R 0.00",
+        "LicColor": 16777215,
+        "IsSpectator": 0,
+        "CarDesignStr": "0,ffffff,ffffff,ffffff",
+        "HelmetDesignStr": "0,ffffff,ffffff,ffffff",
+        "SuitDesignStr": "0,ffffff,ffffff,ffffff",
+        "BodyType": 0,
+        "FaceType": 0,
+        "HelmetType": 0,
+        "CarNumberDesignStr": "0,0,ffffff,ffffff,ffffff",
+        "CarSponsor_1": 0,
+        "CarSponsor_2": 0,
+        "ClubName": "None",
+        "ClubID": 0,
+        "FlairName": "-none-",
+        "FlairID": 0,
+        "DivisionName": "Division 1",
+        "DivisionID": 0,
+        "CurDriverIncidentCount": -1,
+        "TeamIncidentCount": -1
+      }
+    ]
+  },
+  "SplitTimeInfo": {
+    "Sectors": [
+      {
+        "SectorNum": 0,
+        "SectorStartPct": 0
+      },
+      {
+        "SectorNum": 1,
+        "SectorStartPct": 0.102182
+      },
+      {
+        "SectorNum": 2,
+        "SectorStartPct": 0.232163
+      },
+      {
+        "SectorNum": 3,
+        "SectorStartPct": 0.308586
+      },
+      {
+        "SectorNum": 4,
+        "SectorStartPct": 0.410256
+      },
+      {
+        "SectorNum": 5,
+        "SectorStartPct": 0.505824
+      },
+      {
+        "SectorNum": 6,
+        "SectorStartPct": 0.598813
+      },
+      {
+        "SectorNum": 7,
+        "SectorStartPct": 0.690796
+      },
+      {
+        "SectorNum": 8,
+        "SectorStartPct": 0.788933
+      },
+      {
+        "SectorNum": 9,
+        "SectorStartPct": 0.952591
+      }
+    ]
+  },
+  "CarSetup": {
+    "UpdateCount": 5,
+    "TiresAero": {
+      "TireType": {
+        "TireType": "Dry"
+      },
+      "LeftFront": {
+        "ColdPressure": "124 kPa",
+        "LastHotPressure": "124 kPa",
+        "LastTempsOMI": "41C, 41C, 41C",
+        "TreadRemaining": "100%, 100%, 100%"
+      },
+      "LeftRear": {
+        "ColdPressure": "124 kPa",
+        "LastHotPressure": "124 kPa",
+        "LastTempsOMI": "41C, 41C, 41C",
+        "TreadRemaining": "100%, 100%, 100%"
+      },
+      "AeroCalculator": {
+        "FrontRhAtSpeed": "10.0 mm",
+        "RearRhAtSpeed": "15.0 mm",
+        "DragTrim": "0.5 pts",
+        "DownforceTrim": "3.4 pts",
+        "BalanceTrim": "0.6%",
+        "DownforceToDrag": "2.546:1",
+        "AeroBalance": "41.2%"
+      },
+      "RightFront": {
+        "ColdPressure": "124 kPa",
+        "LastHotPressure": "124 kPa",
+        "LastTempsIMO": "41C, 41C, 41C",
+        "TreadRemaining": "100%, 100%, 100%"
+      },
+      "RightRear": {
+        "ColdPressure": "124 kPa",
+        "LastHotPressure": "124 kPa",
+        "LastTempsIMO": "41C, 41C, 41C",
+        "TreadRemaining": "100%, 100%, 100%"
+      },
+      "AeroSetup": {
+        "AeroPackage": "High DF",
+        "FrontMainplaneAngle": "4 deg",
+        "FrontFlapAngle": "18.0 deg",
+        "FrontFlapGurney": "12.7mm",
+        "RearFlapAngle": "43.5 deg",
+        "RearWingGurney": "12.7mm",
+        "DiffuserGurney": "25.0mm"
+      }
+    },
+    "Chassis": {
+      "Front": {
+        "ArbSize": "Stiff",
+        "ArbArmLength": "Narrow",
+        "ArbBlades": "3-5",
+        "ArbPreloadAdj": 0,
+        "ArbPreload": "0.0 Nm",
+        "CrossWeight": "50.0%"
+      },
+      "LeftFront": {
+        "CornerWeight": "1683 N",
+        "RideHeight": "23.7 mm",
+        "PRodLengthOffset": "22.0 mm",
+        "SpringDefl": "5.7 mm 54.4 mm",
+        "ShockDefl": "11.7 mm 72.0 mm",
+        "SpringPerchOffset": "61.0 mm",
+        "SpringRate": "245 N/mm",
+        "Camber": "-4.0 deg",
+        "ToeIn": "-1.4 mm"
+      },
+      "LeftRear": {
+        "CornerWeight": "2008 N",
+        "RideHeight": "31.8 mm",
+        "PRodLengthOffset": "-10.0 mm",
+        "SpringDefl": "8.8 mm 62.5 mm",
+        "ShockDefl": "16.6 mm 69.0 mm",
+        "SpringPerchOffset": "91.2 mm",
+        "SpringRate": "219 N/mm",
+        "Camber": "-2.9 deg",
+        "ToeIn": "+1.1 mm"
+      },
+      "Rear": {
+        "ArbSize": "Soft",
+        "ArbArmLength": "Position 2",
+        "ArbBlades": "2-5",
+        "ArbPreloadAdj": 0,
+        "ArbPreload": "-0.0 Nm",
+        "FuelLevel": "42.0 L"
+      },
+      "BrakesInCarMisc": {
+        "DisplayPage": "Race 1",
+        "FrontMasterCyl": "19.1 mm",
+        "RearMasterCyl": "20.6 mm",
+        "BrakePressureBias": "53.8%",
+        "SteeringRatio": "8 tooth",
+        "ThrottleSetting": "Linear"
+      },
+      "RightFront": {
+        "CornerWeight": "1683 N",
+        "RideHeight": "23.7 mm",
+        "PRodLengthOffset": "22.0 mm",
+        "SpringDefl": "5.7 mm 54.4 mm",
+        "ShockDefl": "11.7 mm 72.0 mm",
+        "SpringPerchOffset": "61.0 mm",
+        "SpringRate": "245 N/mm",
+        "Camber": "-4.0 deg",
+        "ToeIn": "-1.4 mm"
+      },
+      "RightRear": {
+        "CornerWeight": "2008 N",
+        "RideHeight": "31.8 mm",
+        "PRodLengthOffset": "-10.0 mm",
+        "SpringDefl": "8.8 mm 62.5 mm",
+        "ShockDefl": "16.6 mm 69.0 mm",
+        "SpringPerchOffset": "91.2 mm",
+        "SpringRate": "219 N/mm",
+        "Camber": "-2.9 deg",
+        "ToeIn": "+1.1 mm"
+      }
+    },
+    "Dampers": {
+      "LeftFrontDamper": {
+        "LowSpeedComp": "3 clicks",
+        "HighSpeedComp": "5 clicks",
+        "LowSpeedRbd": "1 clicks",
+        "HighSpeedRbd": "3 clicks"
+      },
+      "LeftRearDamper": {
+        "LowSpeedComp": "4 clicks",
+        "HighSpeedComp": "7 clicks",
+        "LowSpeedRbd": "1 clicks",
+        "HighSpeedRbd": "1 clicks"
+      },
+      "RightFrontDamper": {
+        "LowSpeedComp": "3 clicks",
+        "HighSpeedComp": "5 clicks",
+        "LowSpeedRbd": "1 clicks",
+        "HighSpeedRbd": "3 clicks"
+      },
+      "RightRearDamper": {
+        "LowSpeedComp": "4 clicks",
+        "HighSpeedComp": "7 clicks",
+        "LowSpeedRbd": "1 clicks",
+        "HighSpeedRbd": "1 clicks"
+      }
+    },
+    "Drivetrain": {
+      "Drivetrain": {
+        "SecondGear": 1.875,
+        "At": "315.4 Km/h",
+        "ThirdGear": 1.5,
+        "FourthGear": 1.25,
+        "FifthGear": 1.0833,
+        "SixthGear": 0.9474
+      },
+      "Diff": {
+        "DiffRampAngles": "80 coast/45 drive",
+        "DiffClutchFrictionFaces": 8,
+        "DiffPreload": "25 Nm"
+      }
+    }
+  }
+}

--- a/test-data/1783998516193/telemetry.json
+++ b/test-data/1783998516193/telemetry.json
@@ -1,0 +1,3649 @@
+{
+  "SessionTime": {
+    "value": [
+      43.899999988077866
+    ]
+  },
+  "SessionTick": {
+    "value": [
+      74645
+    ]
+  },
+  "SessionNum": {
+    "value": [
+      1
+    ]
+  },
+  "SessionState": {
+    "value": [
+      1
+    ]
+  },
+  "SessionUniqueID": {
+    "value": [
+      2
+    ]
+  },
+  "SessionFlags": {
+    "value": [
+      268698112
+    ]
+  },
+  "SessionTimeRemain": {
+    "value": [
+      604800
+    ]
+  },
+  "SessionLapsRemain": {
+    "value": [
+      3
+    ]
+  },
+  "SessionLapsRemainEx": {
+    "value": [
+      3
+    ]
+  },
+  "SessionTimeTotal": {
+    "value": [
+      604800
+    ]
+  },
+  "SessionLapsTotal": {
+    "value": [
+      3
+    ]
+  },
+  "SessionJokerLapsRemain": {
+    "value": [
+      0
+    ]
+  },
+  "SessionOnJokerLap": {
+    "value": [
+      false
+    ]
+  },
+  "SessionTimeOfDay": {
+    "value": [
+      44443
+    ]
+  },
+  "RadioTransmitCarIdx": {
+    "value": [
+      2
+    ]
+  },
+  "RadioTransmitRadioIdx": {
+    "value": [
+      0
+    ]
+  },
+  "RadioTransmitFrequencyIdx": {
+    "value": [
+      1
+    ]
+  },
+  "DisplayUnits": {
+    "value": [
+      1
+    ]
+  },
+  "DriverMarker": {
+    "value": [
+      false
+    ]
+  },
+  "PushToTalk": {
+    "value": [
+      false
+    ]
+  },
+  "PushToPass": {
+    "value": [
+      false
+    ]
+  },
+  "ManualBoost": {
+    "value": [
+      false
+    ]
+  },
+  "ManualNoBoost": {
+    "value": [
+      false
+    ]
+  },
+  "IsOnTrack": {
+    "value": [
+      true
+    ]
+  },
+  "IsReplayPlaying": {
+    "value": [
+      false
+    ]
+  },
+  "ReplayFrameNum": {
+    "value": [
+      0
+    ]
+  },
+  "ReplayFrameNumEnd": {
+    "value": [
+      19943
+    ]
+  },
+  "IsDiskLoggingEnabled": {
+    "value": [
+      true
+    ]
+  },
+  "IsDiskLoggingActive": {
+    "value": [
+      true
+    ]
+  },
+  "FrameRate": {
+    "value": [
+      79.76591491699219
+    ]
+  },
+  "CpuUsageFG": {
+    "value": [
+      0.29075440764427185
+    ]
+  },
+  "GpuUsage": {
+    "value": [
+      0.6625882387161255
+    ]
+  },
+  "ChanAvgLatency": {
+    "value": [
+      0.2339962273836136
+    ]
+  },
+  "ChanLatency": {
+    "value": [
+      0.23333333432674408
+    ]
+  },
+  "ChanQuality": {
+    "value": [
+      1.0001001358032227
+    ]
+  },
+  "ChanPartnerQuality": {
+    "value": [
+      1
+    ]
+  },
+  "CpuUsageBG": {
+    "value": [
+      0.22999940812587738
+    ]
+  },
+  "ChanClockSkew": {
+    "value": [
+      0
+    ]
+  },
+  "MemPageFaultSec": {
+    "value": [
+      1
+    ]
+  },
+  "MemSoftPageFaultSec": {
+    "value": [
+      4079
+    ]
+  },
+  "PlayerCarPosition": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerCarClassPosition": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerCarClass": {
+    "value": [
+      4089
+    ]
+  },
+  "PlayerTrackSurface": {
+    "value": [
+      3
+    ]
+  },
+  "PlayerTrackSurfaceMaterial": {
+    "value": [
+      1
+    ]
+  },
+  "PlayerCarIdx": {
+    "value": [
+      14
+    ]
+  },
+  "PlayerCarTeamIncidentCount": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerCarMyIncidentCount": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerCarDriverIncidentCount": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerCarWeightPenalty": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerCarPowerAdjust": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerCarDryTireSetLimit": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerCarTowTime": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerCarInPitStall": {
+    "value": [
+      false
+    ]
+  },
+  "PlayerCarPitSvStatus": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerTireCompound": {
+    "value": [
+      0
+    ]
+  },
+  "PlayerFastRepairsUsed": {
+    "value": [
+      0
+    ]
+  },
+  "OnPitRoad": {
+    "value": [
+      false
+    ]
+  },
+  "PaceMode": {
+    "value": [
+      1
+    ]
+  },
+  "CarIdxLap": {
+    "value": [
+      0,
+      0,
+      0,
+      -1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      -1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      -1,
+      0,
+      -1,
+      0,
+      -1,
+      -1,
+      -1,
+      0,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      0,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxLapCompleted": {
+    "value": [
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxLapDistPct": {
+    "value": [
+      0.9265385866165161,
+      0.926537036895752,
+      0.926150918006897,
+      -1,
+      0.9257631897926331,
+      0.9257614016532898,
+      0.9253754019737244,
+      0.9253736734390259,
+      0.9249878525733948,
+      0.924985945224762,
+      -1,
+      0.9245984554290771,
+      0.9242129921913147,
+      0.9242110252380371,
+      0.9238255620002747,
+      0.9238236546516418,
+      -1,
+      0.9234361052513123,
+      -1,
+      0.9230486750602722,
+      -1,
+      -1,
+      -1,
+      0.9222736954689026,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      0.9269611835479736,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxTrackSurface": {
+    "value": [
+      3,
+      3,
+      3,
+      -1,
+      3,
+      3,
+      3,
+      3,
+      3,
+      3,
+      -1,
+      3,
+      3,
+      3,
+      3,
+      3,
+      -1,
+      3,
+      -1,
+      3,
+      -1,
+      -1,
+      -1,
+      3,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      3,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxTrackSurfaceMaterial": {
+    "value": [
+      1,
+      1,
+      1,
+      -1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      -1,
+      1,
+      1,
+      1,
+      1,
+      1,
+      -1,
+      1,
+      -1,
+      1,
+      -1,
+      -1,
+      -1,
+      1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxOnPitRoad": {
+    "value": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "CarIdxPosition": {
+    "value": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxClassPosition": {
+    "value": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxClass": {
+    "value": [
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      4089,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      4089,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxF2Time": {
+    "value": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxEstTime": {
+    "value": [
+      317.0901184082031,
+      317.0897521972656,
+      316.9902038574219,
+      0,
+      316.8902282714844,
+      316.8897705078125,
+      316.7902526855469,
+      316.7898254394531,
+      316.6903381347656,
+      316.6898498535156,
+      0,
+      316.5899353027344,
+      316.4905700683594,
+      316.49005126953125,
+      316.39068603515625,
+      316.39019775390625,
+      0,
+      316.290283203125,
+      0,
+      316.1904602050781,
+      0,
+      0,
+      0,
+      315.9908447265625,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      383.1430358886719,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  "CarIdxLastLapTime": {
+    "value": [
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxBestLapTime": {
+    "value": [
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxBestLapNum": {
+    "value": [
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxTireCompound": {
+    "value": [
+      0,
+      0,
+      0,
+      -1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      -1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      -1,
+      0,
+      -1,
+      0,
+      -1,
+      -1,
+      -1,
+      0,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxQualTireCompound": {
+    "value": [
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxQualTireCompoundLocked": {
+    "value": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "CarIdxFastRepairsUsed": {
+    "value": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  "CarIdxSessionFlags": {
+    "value": [
+      262144,
+      262144,
+      262144,
+      262144,
+      262144,
+      262144,
+      262144,
+      262144,
+      262144,
+      262144,
+      0,
+      262144,
+      262144,
+      262144,
+      262144,
+      262144,
+      0,
+      262144,
+      0,
+      262144,
+      0,
+      0,
+      0,
+      262144,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      262144,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  "CarIdxPaceLine": {
+    "value": [
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      0,
+      1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxPaceRow": {
+    "value": [
+      0,
+      0,
+      1,
+      1,
+      2,
+      2,
+      3,
+      3,
+      4,
+      4,
+      5,
+      5,
+      6,
+      6,
+      7,
+      7,
+      8,
+      8,
+      9,
+      9,
+      10,
+      10,
+      11,
+      11,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxPaceFlags": {
+    "value": [
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  "CarIdxSteer": {
+    "value": [
+      -0.000006171541826915927,
+      -3.35655414573921e-8,
+      0.0000014607410321332281,
+      0,
+      0.0000014275954072218155,
+      4.452697623946733e-7,
+      -7.196146611931908e-8,
+      3.9115226968533534e-7,
+      -1.2024142570510321e-8,
+      6.776957661713823e-7,
+      0,
+      6.783244543839828e-8,
+      1.4071167342422086e-8,
+      -6.334893498660676e-8,
+      0.31497153639793396,
+      -3.1078505458026484e-7,
+      0,
+      -6.6530412290433105e-9,
+      0,
+      -2.7110744205138815e-10,
+      0,
+      0,
+      0,
+      1.2826394168996558e-8,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      3.7828023380370723e-8,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0
+    ]
+  },
+  "CarIdxRPM": {
+    "value": [
+      7621.494140625,
+      2497.64892578125,
+      3439.26953125,
+      -1,
+      2497.64892578125,
+      2497.649169921875,
+      2511.2001953125,
+      2497.649169921875,
+      2497.648681640625,
+      2497.649169921875,
+      -1,
+      2755.35009765625,
+      2497.649169921875,
+      2628.90771484375,
+      2499.760009765625,
+      2497.64892578125,
+      -1,
+      2497.64892578125,
+      -1,
+      2497.648681640625,
+      -1,
+      -1,
+      -1,
+      2497.648681640625,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      2000,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "CarIdxGear": {
+    "value": [
+      0,
+      0,
+      0,
+      -1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      -1,
+      0,
+      0,
+      0,
+      0,
+      0,
+      -1,
+      0,
+      -1,
+      0,
+      -1,
+      -1,
+      -1,
+      0,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "SteeringWheelAngle": {
+    "value": [
+      0.31497153639793396
+    ]
+  },
+  "Throttle": {
+    "value": [
+      0
+    ]
+  },
+  "Brake": {
+    "value": [
+      1
+    ]
+  },
+  "Clutch": {
+    "value": [
+      0
+    ]
+  },
+  "Gear": {
+    "value": [
+      0
+    ]
+  },
+  "RPM": {
+    "value": [
+      2499.760009765625
+    ]
+  },
+  "PlayerCarSLFirstRPM": {
+    "value": [
+      6560
+    ]
+  },
+  "PlayerCarSLShiftRPM": {
+    "value": [
+      7150
+    ]
+  },
+  "PlayerCarSLLastRPM": {
+    "value": [
+      7270
+    ]
+  },
+  "PlayerCarSLBlinkRPM": {
+    "value": [
+      7700
+    ]
+  },
+  "Lap": {
+    "value": [
+      0
+    ]
+  },
+  "LapCompleted": {
+    "value": [
+      -1
+    ]
+  },
+  "LapDist": {
+    "value": [
+      19066.189453125
+    ]
+  },
+  "LapDistPct": {
+    "value": [
+      0.9238255620002747
+    ]
+  },
+  "RaceLaps": {
+    "value": [
+      0
+    ]
+  },
+  "CarDistAhead": {
+    "value": [
+      7.955078125
+    ]
+  },
+  "CarDistBehind": {
+    "value": [
+      0.0390625
+    ]
+  },
+  "LapBestLap": {
+    "value": [
+      0
+    ]
+  },
+  "LapBestLapTime": {
+    "value": [
+      0
+    ]
+  },
+  "LapLastLapTime": {
+    "value": [
+      0
+    ]
+  },
+  "LapCurrentLapTime": {
+    "value": [
+      0
+    ]
+  },
+  "LapLasNLapSeq": {
+    "value": [
+      0
+    ]
+  },
+  "LapLastNLapTime": {
+    "value": [
+      0
+    ]
+  },
+  "LapBestNLapLap": {
+    "value": [
+      0
+    ]
+  },
+  "LapBestNLapTime": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToBestLap": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToBestLap_DD": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToBestLap_OK": {
+    "value": [
+      false
+    ]
+  },
+  "LapDeltaToOptimalLap": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToOptimalLap_DD": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToOptimalLap_OK": {
+    "value": [
+      false
+    ]
+  },
+  "LapDeltaToSessionBestLap": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToSessionBestLap_DD": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToSessionBestLap_OK": {
+    "value": [
+      false
+    ]
+  },
+  "LapDeltaToSessionOptimalLap": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToSessionOptimalLap_DD": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToSessionOptimalLap_OK": {
+    "value": [
+      false
+    ]
+  },
+  "LapDeltaToSessionLastlLap": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToSessionLastlLap_DD": {
+    "value": [
+      0
+    ]
+  },
+  "LapDeltaToSessionLastlLap_OK": {
+    "value": [
+      false
+    ]
+  },
+  "Speed": {
+    "value": [
+      0.00005718558531953022
+    ]
+  },
+  "Yaw": {
+    "value": [
+      -2.608140230178833
+    ]
+  },
+  "YawNorth": {
+    "value": [
+      4.152705192565918
+    ]
+  },
+  "Pitch": {
+    "value": [
+      -0.05162113904953003
+    ]
+  },
+  "Roll": {
+    "value": [
+      0.012961162254214287
+    ]
+  },
+  "EnterExitReset": {
+    "value": [
+      1
+    ]
+  },
+  "TrackTemp": {
+    "value": [
+      25.555572509765625
+    ]
+  },
+  "TrackTempCrew": {
+    "value": [
+      25.555572509765625
+    ]
+  },
+  "AirTemp": {
+    "value": [
+      19.91712188720703
+    ]
+  },
+  "TrackWetness": {
+    "value": [
+      1
+    ]
+  },
+  "Skies": {
+    "value": [
+      3
+    ]
+  },
+  "AirDensity": {
+    "value": [
+      1.1182819604873657
+    ]
+  },
+  "AirPressure": {
+    "value": [
+      94691.140625
+    ]
+  },
+  "WindVel": {
+    "value": [
+      2.9940478801727295
+    ]
+  },
+  "WindDir": {
+    "value": [
+      4.458711624145508
+    ]
+  },
+  "RelativeHumidity": {
+    "value": [
+      0.7030566334724426
+    ]
+  },
+  "FogLevel": {
+    "value": [
+      0
+    ]
+  },
+  "Precipitation": {
+    "value": [
+      0
+    ]
+  },
+  "SolarAltitude": {
+    "value": [
+      0.9964755177497864
+    ]
+  },
+  "SolarAzimuth": {
+    "value": [
+      2.5369699001312256
+    ]
+  },
+  "WeatherDeclaredWet": {
+    "value": [
+      false
+    ]
+  },
+  "SteeringFFBEnabled": {
+    "value": [
+      true
+    ]
+  },
+  "DCLapStatus": {
+    "value": [
+      2
+    ]
+  },
+  "DCDriversSoFar": {
+    "value": [
+      1
+    ]
+  },
+  "OkToReloadTextures": {
+    "value": [
+      true
+    ]
+  },
+  "LoadNumTextures": {
+    "value": [
+      false
+    ]
+  },
+  "CarLeftRight": {
+    "value": [
+      1
+    ]
+  },
+  "PitsOpen": {
+    "value": [
+      true
+    ]
+  },
+  "VidCapEnabled": {
+    "value": [
+      false
+    ]
+  },
+  "VidCapActive": {
+    "value": [
+      false
+    ]
+  },
+  "PlayerIncidents": {
+    "value": [
+      0
+    ]
+  },
+  "PitRepairLeft": {
+    "value": [
+      0
+    ]
+  },
+  "PitOptRepairLeft": {
+    "value": [
+      0
+    ]
+  },
+  "PitstopActive": {
+    "value": [
+      false
+    ]
+  },
+  "FastRepairUsed": {
+    "value": [
+      0
+    ]
+  },
+  "FastRepairAvailable": {
+    "value": [
+      0
+    ]
+  },
+  "LFTiresUsed": {
+    "value": [
+      1
+    ]
+  },
+  "RFTiresUsed": {
+    "value": [
+      1
+    ]
+  },
+  "LRTiresUsed": {
+    "value": [
+      1
+    ]
+  },
+  "RRTiresUsed": {
+    "value": [
+      1
+    ]
+  },
+  "LeftTireSetsUsed": {
+    "value": [
+      1
+    ]
+  },
+  "RightTireSetsUsed": {
+    "value": [
+      1
+    ]
+  },
+  "FrontTireSetsUsed": {
+    "value": [
+      1
+    ]
+  },
+  "RearTireSetsUsed": {
+    "value": [
+      1
+    ]
+  },
+  "TireSetsUsed": {
+    "value": [
+      1
+    ]
+  },
+  "LFTiresAvailable": {
+    "value": [
+      1
+    ]
+  },
+  "RFTiresAvailable": {
+    "value": [
+      1
+    ]
+  },
+  "LRTiresAvailable": {
+    "value": [
+      1
+    ]
+  },
+  "RRTiresAvailable": {
+    "value": [
+      1
+    ]
+  },
+  "LeftTireSetsAvailable": {
+    "value": [
+      1
+    ]
+  },
+  "RightTireSetsAvailable": {
+    "value": [
+      1
+    ]
+  },
+  "FrontTireSetsAvailable": {
+    "value": [
+      1
+    ]
+  },
+  "RearTireSetsAvailable": {
+    "value": [
+      1
+    ]
+  },
+  "TireSetsAvailable": {
+    "value": [
+      1
+    ]
+  },
+  "CamCarIdx": {
+    "value": [
+      14
+    ]
+  },
+  "CamCameraNumber": {
+    "value": [
+      1
+    ]
+  },
+  "CamGroupNumber": {
+    "value": [
+      9
+    ]
+  },
+  "CamCameraState": {
+    "value": [
+      80
+    ]
+  },
+  "IsOnTrackCar": {
+    "value": [
+      true
+    ]
+  },
+  "IsInGarage": {
+    "value": [
+      false
+    ]
+  },
+  "SteeringWheelAngleMax": {
+    "value": [
+      10.097594261169434
+    ]
+  },
+  "ShiftPowerPct": {
+    "value": [
+      0
+    ]
+  },
+  "ShiftGrindRPM": {
+    "value": [
+      0
+    ]
+  },
+  "ThrottleRaw": {
+    "value": [
+      0
+    ]
+  },
+  "BrakeRaw": {
+    "value": [
+      0
+    ]
+  },
+  "ClutchRaw": {
+    "value": [
+      1
+    ]
+  },
+  "HandbrakeRaw": {
+    "value": [
+      0
+    ]
+  },
+  "BrakeABSactive": {
+    "value": [
+      false
+    ]
+  },
+  "Shifter": {
+    "value": [
+      0
+    ]
+  },
+  "EngineWarnings": {
+    "value": [
+      0
+    ]
+  },
+  "FuelLevelPct": {
+    "value": [
+      0.5522140860557556
+    ]
+  },
+  "PitSvFlags": {
+    "value": [
+      31
+    ]
+  },
+  "PitSvLFP": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "PitSvRFP": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "PitSvLRP": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "PitSvRRP": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "PitSvFuel": {
+    "value": [
+      76
+    ]
+  },
+  "PitSvTireCompound": {
+    "value": [
+      0
+    ]
+  },
+  "CarIdxP2P_Status": {
+    "value": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "CarIdxP2P_Count": {
+    "value": [
+      65,
+      65,
+      65,
+      65,
+      65,
+      65,
+      65,
+      65,
+      65,
+      65,
+      -1,
+      65,
+      65,
+      65,
+      65,
+      65,
+      -1,
+      65,
+      -1,
+      65,
+      -1,
+      -1,
+      -1,
+      65,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1,
+      -1
+    ]
+  },
+  "P2P_Status": {
+    "value": [
+      false
+    ]
+  },
+  "P2P_Count": {
+    "value": [
+      65
+    ]
+  },
+  "SteeringWheelPctTorque": {
+    "value": [
+      0.005370124708861113
+    ]
+  },
+  "SteeringWheelPctTorqueSign": {
+    "value": [
+      -0.005370124708861113
+    ]
+  },
+  "SteeringWheelPctTorqueSignStops": {
+    "value": [
+      -0.0017721735639497638
+    ]
+  },
+  "SteeringWheelPctIntensity": {
+    "value": [
+      0.5
+    ]
+  },
+  "SteeringWheelPctSmoothing": {
+    "value": [
+      0
+    ]
+  },
+  "SteeringWheelPctDamper": {
+    "value": [
+      0
+    ]
+  },
+  "SteeringWheelLimiter": {
+    "value": [
+      0
+    ]
+  },
+  "SteeringWheelMaxForceNm": {
+    "value": [
+      67.98896789550781
+    ]
+  },
+  "SteeringWheelPeakForceNm": {
+    "value": [
+      -1
+    ]
+  },
+  "SteeringWheelUseLinear": {
+    "value": [
+      true
+    ]
+  },
+  "ShiftIndicatorPct": {
+    "value": [
+      0
+    ]
+  },
+  "IsGarageVisible": {
+    "value": [
+      false
+    ]
+  },
+  "ReplayPlaySpeed": {
+    "value": [
+      1
+    ]
+  },
+  "ReplayPlaySlowMotion": {
+    "value": [
+      false
+    ]
+  },
+  "ReplaySessionTime": {
+    "value": [
+      0
+    ]
+  },
+  "ReplaySessionNum": {
+    "value": [
+      -1
+    ]
+  },
+  "TireLF_RumblePitch": {
+    "value": [
+      0
+    ]
+  },
+  "TireRF_RumblePitch": {
+    "value": [
+      0
+    ]
+  },
+  "TireLR_RumblePitch": {
+    "value": [
+      0
+    ]
+  },
+  "TireRR_RumblePitch": {
+    "value": [
+      0
+    ]
+  },
+  "SteeringWheelTorque_ST": {
+    "value": [
+      -0.36466604471206665,
+      -0.36478087306022644,
+      -0.3649004399776459,
+      -0.36500346660614014,
+      -0.36506080627441406,
+      -0.36510923504829407
+    ]
+  },
+  "SteeringWheelTorque": {
+    "value": [
+      -0.36510923504829407
+    ]
+  },
+  "VelocityZ_ST": {
+    "value": [
+      0.0000017093847191063105,
+      0.0000016239639535342576,
+      0.00000186294289505895,
+      0.000002467684225848643,
+      0.0000034937661439471412,
+      0.000004850427558267256
+    ]
+  },
+  "VelocityY_ST": {
+    "value": [
+      0.00003878228017129004,
+      0.00001971930942090694,
+      0.000001947575810845592,
+      -0.000014609370737161953,
+      -0.00003005930921062827,
+      -0.0000444791694462765
+    ]
+  },
+  "VelocityX_ST": {
+    "value": [
+      0.00000834035745356232,
+      -0.000001883038066807785,
+      -0.000011364985766704194,
+      -0.000020163690351182595,
+      -0.00002834201222867705,
+      -0.000035941542591899633
+    ]
+  },
+  "VelocityZ": {
+    "value": [
+      0.000004850427558267256
+    ]
+  },
+  "VelocityY": {
+    "value": [
+      -0.0000444791694462765
+    ]
+  },
+  "VelocityX": {
+    "value": [
+      -0.000035941542591899633
+    ]
+  },
+  "YawRate_ST": {
+    "value": [
+      -0.000055076998251024634,
+      -0.00006214863969944417,
+      -0.00006846951873740181,
+      -0.00007398152229143307,
+      -0.000078891622251831,
+      -0.00008323130896314979
+    ]
+  },
+  "PitchRate_ST": {
+    "value": [
+      0.000014759451005375013,
+      0.000013406536709226202,
+      0.000011806933798652608,
+      0.000010187136467720848,
+      0.000008549022822990082,
+      0.000006799047696404159
+    ]
+  },
+  "RollRate_ST": {
+    "value": [
+      -0.000022787333364249207,
+      -0.000013279543054522946,
+      -6.093190449973918e-7,
+      0.00001545629493193701,
+      0.00003187422771588899,
+      0.00004617842205334455
+    ]
+  },
+  "YawRate": {
+    "value": [
+      -0.00008323130896314979
+    ]
+  },
+  "PitchRate": {
+    "value": [
+      0.000006799047696404159
+    ]
+  },
+  "RollRate": {
+    "value": [
+      0.00004617842205334455
+    ]
+  },
+  "VertAccel_ST": {
+    "value": [
+      9.79271411895752,
+      9.792733192443848,
+      9.79284954071045,
+      9.79298210144043,
+      9.793133735656738,
+      9.793252944946289
+    ]
+  },
+  "LatAccel_ST": {
+    "value": [
+      0.11954247206449509,
+      0.12006795406341553,
+      0.12053268402814865,
+      0.12097029387950897,
+      0.12136957049369812,
+      0.12174157053232193
+    ]
+  },
+  "LongAccel_ST": {
+    "value": [
+      0.5020379424095154,
+      0.5023264288902283,
+      0.5025929808616638,
+      0.5028386116027832,
+      0.5030615925788879,
+      0.5032697916030884
+    ]
+  },
+  "VertAccel": {
+    "value": [
+      9.793252944946289
+    ]
+  },
+  "LatAccel": {
+    "value": [
+      0.12174157053232193
+    ]
+  },
+  "LongAccel": {
+    "value": [
+      0.5032697916030884
+    ]
+  },
+  "dcStarter": {
+    "value": [
+      false
+    ]
+  },
+  "dcPitSpeedLimiterToggle": {
+    "value": [
+      false
+    ]
+  },
+  "dcPushToPass": {
+    "value": [
+      false
+    ]
+  },
+  "dcTearOffVisor": {
+    "value": [
+      false
+    ]
+  },
+  "dpTireChange": {
+    "value": [
+      1
+    ]
+  },
+  "dpFuelFill": {
+    "value": [
+      1
+    ]
+  },
+  "dpFuelAutoFillEnabled": {
+    "value": [
+      0
+    ]
+  },
+  "dpFuelAutoFillActive": {
+    "value": [
+      0
+    ]
+  },
+  "dpFuelAddKg": {
+    "value": [
+      76
+    ]
+  },
+  "dpFastRepair": {
+    "value": [
+      0
+    ]
+  },
+  "dcDashPage": {
+    "value": [
+      0
+    ]
+  },
+  "dcBrakeBias": {
+    "value": [
+      53.77294921875
+    ]
+  },
+  "dpLFTireColdPress": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "dpRFTireColdPress": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "dpLRTireColdPress": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "dpRRTireColdPress": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "dcAntiRollFront": {
+    "value": [
+      2
+    ]
+  },
+  "dcAntiRollRear": {
+    "value": [
+      1
+    ]
+  },
+  "dcThrottleShape": {
+    "value": [
+      3
+    ]
+  },
+  "RFbrakeLinePress": {
+    "value": [
+      0
+    ]
+  },
+  "RFcoldPressure": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "RFodometer": {
+    "value": [
+      0
+    ]
+  },
+  "RFtempCL": {
+    "value": [
+      77.45108032226562
+    ]
+  },
+  "RFtempCM": {
+    "value": [
+      74.39462280273438
+    ]
+  },
+  "RFtempCR": {
+    "value": [
+      67.80325317382812
+    ]
+  },
+  "RFwearL": {
+    "value": [
+      0.9899576306343079
+    ]
+  },
+  "RFwearM": {
+    "value": [
+      0.9904812574386597
+    ]
+  },
+  "RFwearR": {
+    "value": [
+      0.9940803050994873
+    ]
+  },
+  "LFbrakeLinePress": {
+    "value": [
+      0
+    ]
+  },
+  "LFcoldPressure": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "LFodometer": {
+    "value": [
+      0
+    ]
+  },
+  "LFtempCL": {
+    "value": [
+      68.99148559570312
+    ]
+  },
+  "LFtempCM": {
+    "value": [
+      75.6275634765625
+    ]
+  },
+  "LFtempCR": {
+    "value": [
+      78.4501953125
+    ]
+  },
+  "LFwearL": {
+    "value": [
+      0.9888178706169128
+    ]
+  },
+  "LFwearM": {
+    "value": [
+      0.9850785732269287
+    ]
+  },
+  "LFwearR": {
+    "value": [
+      0.9850285053253174
+    ]
+  },
+  "FuelUsePerHour": {
+    "value": [
+      64.35360717773438
+    ]
+  },
+  "Voltage": {
+    "value": [
+      13.40000057220459
+    ]
+  },
+  "WaterTemp": {
+    "value": [
+      73.16063690185547
+    ]
+  },
+  "WaterLevel": {
+    "value": [
+      7
+    ]
+  },
+  "FuelPress": {
+    "value": [
+      4.900000095367432
+    ]
+  },
+  "OilTemp": {
+    "value": [
+      76.83158874511719
+    ]
+  },
+  "OilPress": {
+    "value": [
+      4.499998569488525
+    ]
+  },
+  "OilLevel": {
+    "value": [
+      7
+    ]
+  },
+  "ManifoldPress": {
+    "value": [
+      0.4524190127849579
+    ]
+  },
+  "FuelLevel": {
+    "value": [
+      41.96826934814453
+    ]
+  },
+  "Engine0_RPM": {
+    "value": [
+      2499.760986328125
+    ]
+  },
+  "RRbrakeLinePress": {
+    "value": [
+      0
+    ]
+  },
+  "RRcoldPressure": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "RRodometer": {
+    "value": [
+      0
+    ]
+  },
+  "RRtempCL": {
+    "value": [
+      82.9039306640625
+    ]
+  },
+  "RRtempCM": {
+    "value": [
+      78.75897216796875
+    ]
+  },
+  "RRtempCR": {
+    "value": [
+      67.93246459960938
+    ]
+  },
+  "RRwearL": {
+    "value": [
+      0.9875990152359009
+    ]
+  },
+  "RRwearM": {
+    "value": [
+      0.9878625273704529
+    ]
+  },
+  "RRwearR": {
+    "value": [
+      0.9956969618797302
+    ]
+  },
+  "LRbrakeLinePress": {
+    "value": [
+      0
+    ]
+  },
+  "LRcoldPressure": {
+    "value": [
+      124.10600280761719
+    ]
+  },
+  "LRodometer": {
+    "value": [
+      0
+    ]
+  },
+  "LRtempCL": {
+    "value": [
+      68.58795166015625
+    ]
+  },
+  "LRtempCM": {
+    "value": [
+      78.61575317382812
+    ]
+  },
+  "LRtempCR": {
+    "value": [
+      82.85211181640625
+    ]
+  },
+  "LRwearL": {
+    "value": [
+      0.9932742714881897
+    ]
+  },
+  "LRwearM": {
+    "value": [
+      0.9869638085365295
+    ]
+  },
+  "LRwearR": {
+    "value": [
+      0.9868659377098083
+    ]
+  },
+  "LRshockDefl": {
+    "value": [
+      0.016452135518193245
+    ]
+  },
+  "LRshockDefl_ST": {
+    "value": [
+      0.01645251363515854,
+      0.01645236276090145,
+      0.016452262178063393,
+      0.016452185809612274,
+      0.016452161595225334,
+      0.016452135518193245
+    ]
+  },
+  "LRshockVel": {
+    "value": [
+      -0.000005487486760102911
+    ]
+  },
+  "LRshockVel_ST": {
+    "value": [
+      -0.00005601555676548742,
+      -0.00004564425034914166,
+      -0.000031863553886068985,
+      -0.000018413142242934555,
+      -0.000008661917490826454,
+      -0.000005487486760102911
+    ]
+  },
+  "RRshockDefl": {
+    "value": [
+      0.016855211928486824
+    ]
+  },
+  "RRshockDefl_ST": {
+    "value": [
+      0.016855590045452118,
+      0.01685543917119503,
+      0.016855338588356972,
+      0.016855262219905853,
+      0.016855211928486824,
+      0.016855211928486824
+    ]
+  },
+  "RRshockVel": {
+    "value": [
+      2.2338605276672752e-7
+    ]
+  },
+  "RRshockVel_ST": {
+    "value": [
+      -0.000057353761803824455,
+      -0.000045235021389089525,
+      -0.000033148193324450403,
+      -0.000020482160834944807,
+      -0.000010201966688327957,
+      2.2338605276672752e-7
+    ]
+  },
+  "LFshockDefl": {
+    "value": [
+      0.011612236499786377
+    ]
+  },
+  "LFshockDefl_ST": {
+    "value": [
+      0.01161244511604309,
+      0.011612385511398315,
+      0.01161232590675354,
+      0.011612296104431152,
+      0.011612266302108765,
+      0.011612236499786377
+    ]
+  },
+  "LFshockVel": {
+    "value": [
+      -0.0000060797829064540565
+    ]
+  },
+  "LFshockVel_ST": {
+    "value": [
+      -0.00001817864722397644,
+      -0.00001855614027590491,
+      -0.000013708792721445207,
+      -0.000011685259778460022,
+      -0.000008662675099913031,
+      -0.0000060797829064540565
+    ]
+  },
+  "RFshockDefl": {
+    "value": [
+      0.011579841375350952
+    ]
+  },
+  "RFshockDefl_ST": {
+    "value": [
+      0.011579722166061401,
+      0.011579692363739014,
+      0.011579662561416626,
+      0.011579692363739014,
+      0.011579751968383789,
+      0.011579841375350952
+    ]
+  },
+  "RFshockVel": {
+    "value": [
+      0.000028219870728207752
+    ]
+  },
+  "RFshockVel_ST": {
+    "value": [
+      -0.00002584822868811898,
+      -0.000011759728295146488,
+      -4.009626195511373e-7,
+      0.000012925325791002251,
+      0.000024347053113160655,
+      0.000028219870728207752
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Fixes opponent Push-to-Pass values being hidden or rendered as exhausted when the car reports `CarIdxP2P_Count` as a plain integer.

The implementation now records the count encoding per supported car:

- IR18 (CarID 99) uses integer counts and has no client-side cooldown.
- IL-15 (CarID 205) uses integer counts, confirmed by the recorded fixture.
- Super Formula 2023 (CarIDs 171/172) uses float32/tenths counts with a 100-second recharge interval, matching the Kapps implementation.
- F3 (CarID 106) was removed because it does not support P2P in the available IOA metadata, and Kapps has no F3 P2P implementation.

The fixture contains P2P count/status fields but no separate use-limit or uses-remaining field, so the reported 10-use restriction is left as future work.

Adds regression coverage for IL-15 integer counts, IR18 integer counts and cooldown behavior, and Super Formula float32/tenths decoding. Adds a Storybook story using the recorded IL-15 session at `test-data/1783998516193`.

## Screenshots

### Before

Opponent IL-15 P2P values were missing while the player value was visible.

### After

The recorded Storybook session displays `65 s` for the player and supported opponents.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)