### PR TITLE
fix: handle YAML indicator-prefixed values

### DIFF
--- a/src/app/irsdk/node/irsdk-node.spec.ts
+++ b/src/app/irsdk/node/irsdk-node.spec.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import * as yaml from 'js-yaml';
 import { IRacingSDK } from './irsdk-node';
 import { getSdkOrMock } from './get-sdk';
 import type { INativeSDK } from '../native';
@@ -19,6 +22,51 @@ vi.mock('./get-sdk', () => ({
   } as INativeSDK),
 }));
 
+const sessionFixtureDirectories = [
+  '1731390354633',
+  '1731390745335',
+  '1731391056221',
+  '1731392546947',
+  '1731637331038',
+  '1731639076383',
+  '1731639563794',
+  '1731641231325',
+  '1731649593423',
+  '1731663455602',
+  '1731663749009',
+  '1731667156475',
+  '1731732047131',
+  '1731750041464',
+  '1732260478001',
+  '1732274253573',
+  '1732355190142',
+  '1732359661942',
+  '1733030013074',
+  '1735296198162',
+  '1747384033336',
+  '1752616787255',
+  '1752616787256',
+  '1762367281467',
+  '1762563786057',
+  '1762565848348',
+  '1762847139582',
+  '1763227688917',
+  '1763228431951',
+  '1763241199586',
+  '1763752236492',
+  '1767346240219',
+  '1769296540072',
+  '1769296545517',
+  '1770713899767',
+  '1770713906135',
+  '1770713920383',
+  '1772216560572',
+  '1772788167371',
+  '1781323503005',
+  '1783998516193',
+  'GT3 Sprint Arrays',
+] as const;
+
 describe('irsdk-node', () => {
   let sdk: IRacingSDK;
   let mockSdk: INativeSDK;
@@ -29,6 +77,25 @@ describe('irsdk-node', () => {
     await sdk.ready();
     // Get the mock SDK instance
     mockSdk = await getSdkOrMock();
+  });
+
+  it('should round-trip all tracked session data fixtures', async () => {
+    for (const [index, directory] of sessionFixtureDirectories.entries()) {
+      const fixturePath = resolve('test-data', directory, 'session.json');
+      const fixture = JSON.parse(
+        await readFile(fixturePath, 'utf8')
+      ) as unknown;
+
+      vi.mocked(mockSdk.getSessionData).mockReturnValue(
+        yaml.dump(fixture, { lineWidth: -1 })
+      );
+      Object.defineProperty(mockSdk, 'currDataVersion', {
+        configurable: true,
+        value: index + 1,
+      });
+
+      expect(sdk.getSessionData(), directory).toEqual(fixture);
+    }
   });
 
   it('should handle malformed YAML with trailing commas', () => {

--- a/src/app/irsdk/node/irsdk-node.spec.ts
+++ b/src/app/irsdk/node/irsdk-node.spec.ts
@@ -170,6 +170,48 @@ DriverInfo:
     expect(result?.DriverInfo?.Drivers[0]?.AbbrevName).toBe(null);
   });
 
+  it('should handle the anonymous driver name from irdashies.log', () => {
+    const malformedYaml = `
+DriverInfo:
+  Drivers:
+    - CarIdx: 18
+      UserName: ? ?
+      AbbrevName: ?? ?
+      Initials: ?
+`;
+
+    vi.mocked(mockSdk.getSessionData).mockReturnValue(malformedYaml);
+
+    const result = sdk.getSessionData();
+
+    expect(result).toBeDefined();
+    expect(result?.DriverInfo?.Drivers[0]?.UserName).toBe('? ?');
+    expect(result?.DriverInfo?.Drivers[0]?.AbbrevName).toBe('?? ?');
+    expect(result?.DriverInfo?.Drivers[0]?.Initials).toBe('?');
+  });
+
+  it('should handle a team name beginning with a YAML sequence indicator', () => {
+    const malformedYaml = `
+DriverInfo:
+  Drivers:
+    - CarIdx: 1
+      UserName: L M
+      TeamID: 469539
+      TeamName: - BLACKSUIT - Catteam Agency
+      CarNumber: "1"
+`;
+
+    vi.mocked(mockSdk.getSessionData).mockReturnValue(malformedYaml);
+
+    const result = sdk.getSessionData();
+
+    expect(result).toBeDefined();
+    expect(result?.DriverInfo?.Drivers[0]?.TeamName).toBe(
+      '- BLACKSUIT - Catteam Agency'
+    );
+    expect(result?.DriverInfo?.Drivers[0]?.CarNumber).toBe('1');
+  });
+
   it('should not consume the next key after a bare mapping indicator', () => {
     const malformedYaml = `
 DriverInfo:

--- a/src/app/irsdk/node/irsdk-node.spec.ts
+++ b/src/app/irsdk/node/irsdk-node.spec.ts
@@ -79,8 +79,9 @@ describe('irsdk-node', () => {
     mockSdk = await getSdkOrMock();
   });
 
-  it('should round-trip all tracked session data fixtures', async () => {
-    for (const [index, directory] of sessionFixtureDirectories.entries()) {
+  it.each(sessionFixtureDirectories)(
+    'should round-trip tracked session data fixture %s',
+    async (directory) => {
       const fixturePath = resolve('test-data', directory, 'session.json');
       const fixture = JSON.parse(
         await readFile(fixturePath, 'utf8')
@@ -89,14 +90,10 @@ describe('irsdk-node', () => {
       vi.mocked(mockSdk.getSessionData).mockReturnValue(
         yaml.dump(fixture, { lineWidth: -1 })
       );
-      Object.defineProperty(mockSdk, 'currDataVersion', {
-        configurable: true,
-        value: index + 1,
-      });
 
-      expect(sdk.getSessionData(), directory).toEqual(fixture);
+      expect(sdk.getSessionData()).toEqual(fixture);
     }
-  });
+  );
 
   it('should handle malformed YAML with trailing commas', () => {
     const malformedYaml = `

--- a/src/app/irsdk/node/irsdk-node.ts
+++ b/src/app/irsdk/node/irsdk-node.ts
@@ -215,13 +215,13 @@ export class IRacingSDK {
   }
 
   /**
-   * Quotes scalar values that iRacing emits with a leading YAML mapping
-   * indicator. For example, an anonymous driver's `UserName: ? ?` is not
-   * valid as an unquoted scalar because `? ` starts an explicit mapping key.
+   * Quotes scalar values that iRacing emits with a leading YAML mapping or
+   * sequence indicator. For example, `UserName: ? ?` and
+   * `TeamName: - BLACKSUIT` are not valid as unquoted scalars.
    */
-  private static fixMappingIndicatorValues(yamlText: string): string {
+  private static fixIndicatorValues(yamlText: string): string {
     return yamlText.replace(
-      /^(\s*(?:-\s+)?\w+:\s*)(\?(?:[^\S\r\n]+[^\r\n]*)?)\r?$/gm,
+      /^([^\S\r\n]*(?:-[^\S\r\n]+)?\w+:[^\S\r\n]*)([?-](?:[^\S\r\n]+[^\r\n]*)?)\r?$/gm,
       (_line, keyPart: string, value: string) =>
         `${keyPart}'${value.replace(/'/g, "''")}'`
     );
@@ -282,7 +282,7 @@ export class IRacingSDK {
       // The multiline-value pass handles iRacing setup names that contain a literal
       // newline (e.g. corrupted DriverSetupName paths), which YAML would otherwise reject.
       const fixedYaml = seshString
-        ? IRacingSDK.fixMappingIndicatorValues(
+        ? IRacingSDK.fixIndicatorValues(
             IRacingSDK.fixMultilineValues(seshString)
           )
             .replace(/(\w+: ) *, *\n/g, '$1 \n')


### PR DESCRIPTION
## Description

Fixes session YAML parsing when iRacing emits an unquoted scalar beginning with a YAML sequence indicator, such as `TeamName: - BLACKSUIT - Catteam Agency`.

The existing sanitizer handled anonymous driver names beginning with the mapping indicator `?`, but not values beginning with `-`. The sanitizer now quotes both forms and limits structural whitespace matching to the current line so list entries cannot be consumed accidentally.

Added regression fixtures derived from `irdashies.log` and `main.old.log` for both malformed value shapes. A corpus regression also serializes all 42 tracked `test-data` session captures in iRacing-style one-line YAML and verifies that the production parser preserves each complete session object exactly. This is a correctness follow-up in the Phase 0.5 YAML parsing area described in `docs/ARCHITECTURE_REVIEW.md`; it does not change the parse memoization architecture.

## Screenshots

### Before

No visual change. Session parsing returned `null` and logged `YAMLException: bad indentation of a mapping entry` for indicator-prefixed values.

### After

No visual change. Indicator-prefixed driver and team names parse as their original string values.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of session data when driver or team fields include YAML special-character prefixes.
  * Ensured anonymous driver details are read correctly and that team names/car numbers are preserved.
* **Tests**
  * Expanded regression coverage using multiple session-data fixtures, including edge-case scenarios for YAML parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->