### PR TITLE
fix: prevent inflated timed-race fuel estimates

### DIFF
--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -81,8 +81,11 @@ export function useFuelCalculation(
   const isOnTrack = useTelemetryValue('IsOnTrack');
 
   // Use centralized total race laps calculation
-  const { isFixedLapRace, totalRaceLaps: calculatedTotalRaceLaps } =
-    useTotalRaceValue();
+  const {
+    totalRaceLaps: calculatedTotalRaceLaps,
+    estimatedLapsRemaining,
+    hasValidRaceEstimate,
+  } = useTotalRaceValue();
 
   // Check if current session is a Race
   const sessions = useStore(
@@ -1063,10 +1066,14 @@ export function useFuelCalculation(
       }
     } else if (sessionLapsRemain === TIMED_RACE_LAPS_REMAINING) {
       // Use centralized useTotalRaceLaps hook for timed race calculations
-      if (calculatedTotalRaceLaps > 0) {
+      if (
+        hasValidRaceEstimate &&
+        calculatedTotalRaceLaps > 0 &&
+        estimatedLapsRemaining > 0
+      ) {
         // Use the hook's result directly
         totalLaps = Math.ceil(calculatedTotalRaceLaps);
-        lapsRemaining = Math.max(0, totalLaps - (lap - 1) - (lapDistPct || 0));
+        lapsRemaining = estimatedLapsRemaining;
 
         // Add safety buffer for refuel calculations
         const TIME_PADDING_REFUEL = 45.0;
@@ -1545,6 +1552,8 @@ export function useFuelCalculation(
     lapDistPct,
     storeLastLapUsage,
     calculatedTotalRaceLaps,
+    estimatedLapsRemaining,
+    hasValidRaceEstimate,
     lapHistorySize,
   ]);
 

--- a/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
+++ b/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
@@ -1,11 +1,7 @@
 import React from 'react';
-import {
-  useTelemetryValue,
-  useSessionStore,
-  useTotalRaceLaps,
-} from '@irdashies/context';
+import { useTelemetryValue, useSessionStore } from '@irdashies/context';
 import { useStore } from 'zustand';
-import { fuelDisplayValue } from '../fuelCalculations';
+import { fuelDisplayValue, isFinalLap } from '../fuelCalculations';
 import type { FuelCalculation, FuelCalculatorSettings } from '../types';
 
 interface FuelCalculatorWidgetProps {
@@ -54,9 +50,6 @@ export const FuelCalculatorConsumptionGrid: React.FC<
       )?.SessionType
   );
 
-  // Use shared hook for total race laps (handles timed races and leader lapping)
-  const { totalRaceLaps } = useTotalRaceLaps();
-
   // Custom style handling for separate label/value sizes
   const widgetStyle =
     customStyles || (widgetId && settings?.widgetStyles?.[widgetId]) || {};
@@ -90,12 +83,11 @@ export const FuelCalculatorConsumptionGrid: React.FC<
   const lapsRemainingToUse = displayData?.lapsRemaining || 0;
   const currentLap = displayData?.currentLap || 0;
   const fuelLevelToUse = displayData?.fuelLevel ?? 0;
-  // Check for White (0x0002) or Checkered (0x0004) flag
   const isFinalLapOrFinished =
-    sessionFlags && (sessionFlags & 0x0002 || sessionFlags & 0x0004);
+    sessionFlags !== undefined && isFinalLap(sessionFlags);
 
   // If final lap/finished, we clamp the total race laps to the current lap (so it shows X / X)
-  let effectiveTotalLaps = Math.max(totalRaceLaps, currentLap);
+  let effectiveTotalLaps = Math.max(displayData?.totalLaps ?? 0, currentLap);
   if (isFinalLapOrFinished) {
     effectiveTotalLaps = currentLap;
   }

--- a/src/frontend/context/shared/raceDistanceCalculations.spec.ts
+++ b/src/frontend/context/shared/raceDistanceCalculations.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateTimedRaceDistance,
+  isValidRaceLapTime,
+  selectRaceLapTime,
+} from './raceDistanceCalculations';
+
+describe('race distance calculations', () => {
+  it('rejects transient and invalid lap times', () => {
+    expect(isValidRaceLapTime(1)).toBe(false);
+    expect(isValidRaceLapTime(Number.NaN)).toBe(false);
+    expect(isValidRaceLapTime(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it('uses the first plausible lap-time source', () => {
+    expect(selectRaceLapTime(1, -1, 98.5, 100, undefined, undefined)).toBe(
+      98.5
+    );
+    expect(
+      selectRaceLapTime(1, -1, undefined, undefined, undefined, undefined)
+    ).toBeNull();
+  });
+
+  it('estimates a 25-minute race without inflating the remaining distance', () => {
+    const estimate = calculateTimedRaceDistance(25 * 60, 100, 1, 0, 1, 0);
+
+    expect(estimate).toEqual({
+      totalRaceLaps: 15,
+      lapsRemaining: 15,
+    });
+  });
+
+  it('returns no estimate for a one-second leader lap', () => {
+    expect(calculateTimedRaceDistance(25 * 60, 1, 1, 0, 1, 0)).toBeNull();
+  });
+
+  it('accounts for player progress when returning remaining laps', () => {
+    const estimate = calculateTimedRaceDistance(500, 100, 3, 0.5, 3, 0.75);
+
+    expect(estimate?.totalRaceLaps).toBe(7.75);
+    expect(estimate?.lapsRemaining).toBe(5.5);
+  });
+});

--- a/src/frontend/context/shared/raceDistanceCalculations.ts
+++ b/src/frontend/context/shared/raceDistanceCalculations.ts
@@ -1,0 +1,63 @@
+/** Minimum plausible race lap time, including short oval configurations. */
+export const MIN_VALID_RACE_LAP_TIME = 10;
+
+export const isValidRaceLapTime = (
+  lapTime: number | null | undefined
+): lapTime is number =>
+  lapTime !== null &&
+  lapTime !== undefined &&
+  Number.isFinite(lapTime) &&
+  lapTime >= MIN_VALID_RACE_LAP_TIME;
+
+export const selectRaceLapTime = (
+  primaryAverage: number | null | undefined,
+  primaryClassEstimate: number | null | undefined,
+  primaryBest: number | null | undefined,
+  fallbackAverage: number | null | undefined,
+  fallbackClassEstimate: number | null | undefined,
+  fallbackBest: number | null | undefined
+): number | null => {
+  if (isValidRaceLapTime(primaryAverage)) return primaryAverage;
+  if (isValidRaceLapTime(primaryClassEstimate)) return primaryClassEstimate;
+  if (isValidRaceLapTime(primaryBest)) return primaryBest;
+  if (isValidRaceLapTime(fallbackAverage)) return fallbackAverage;
+  if (isValidRaceLapTime(fallbackClassEstimate)) return fallbackClassEstimate;
+  if (isValidRaceLapTime(fallbackBest)) return fallbackBest;
+
+  return null;
+};
+
+export interface TimedRaceDistanceEstimate {
+  totalRaceLaps: number;
+  lapsRemaining: number;
+}
+
+export const calculateTimedRaceDistance = (
+  timeRemaining: number,
+  lapTime: number,
+  playerLap: number,
+  playerLapDistPct: number,
+  leaderLap: number,
+  leaderLapDistPct: number
+): TimedRaceDistanceEstimate | null => {
+  if (
+    !isValidRaceLapTime(lapTime) ||
+    !Number.isFinite(timeRemaining) ||
+    timeRemaining < 0
+  ) {
+    return null;
+  }
+
+  const playerProgress = Math.max(0, playerLap - 1) + playerLapDistPct;
+  const leaderProgress =
+    Math.max(0, leaderLap - 1) + Math.max(0, leaderLapDistPct);
+  const lapsBehind =
+    leaderLap > playerLap + 1 ? Math.floor(leaderLap - playerLap) : 0;
+  const totalRaceLaps = timeRemaining / lapTime + leaderProgress - lapsBehind;
+  const finishLap = Math.ceil(totalRaceLaps);
+
+  return {
+    totalRaceLaps,
+    lapsRemaining: Math.max(0, finishLap - playerProgress),
+  };
+};

--- a/src/frontend/context/shared/useTotalRaceValue.tsx
+++ b/src/frontend/context/shared/useTotalRaceValue.tsx
@@ -1,135 +1,155 @@
 import { useSessionLapCount } from '../../components/Standings/hooks/useSessionLapCount';
 import {
-    useCurrentSessionType,
-    useCarIdxClassEstLapTime,
-    useFocusCarIdx,
-    useTelemetryValue,
-    useTelemetryValues,
-    useTelemetryValuesRounded,
+  useCurrentSessionType,
+  useCarIdxClassEstLapTime,
+  useFocusCarIdx,
+  useTelemetryValue,
+  useTelemetryValues,
+  useTelemetryValuesRounded,
 } from '@irdashies/context';
 import { useCarIdxAverageLapTime } from './useCarIdxAverageLapTime';
 import { SessionState } from '@irdashies/types';
+import {
+  calculateTimedRaceDistance,
+  selectRaceLapTime,
+} from './raceDistanceCalculations';
 
 // Estimate the total number of laps that will be completed by the drivers car in a timed session.
 export const useTotalRaceValue = () => {
-    const carIdx = useFocusCarIdx() as number;
-    const { timeRemaining, timeTotal, totalLaps, state } = useSessionLapCount();
-    const lap = useTelemetryValues('CarIdxLap')?.[carIdx] as number;
-    const sessionType = useCurrentSessionType();
-    const lapDistPct = useTelemetryValue('LapDistPct');
-    const carIdxLap = useTelemetryValues('CarIdxLap');
-    const carIdxPosition = useTelemetryValues('CarIdxPosition');
-    const carIdxLapDistPct = useTelemetryValuesRounded('CarIdxLapDistPct', 3);
-    const avgLapTimes = useCarIdxAverageLapTime();
-    const bestLapTime = useTelemetryValues('CarIdxBestLapTime')?.[carIdx] as number | undefined;
-    const classEstLapTimes = useCarIdxClassEstLapTime();
-    const isFixedLapRace = !((timeRemaining > 0) && (timeRemaining !== 604800));
-    const result = {
-        isFixedLapRace: isFixedLapRace,
-        totalRaceLaps: 0,
-        totalRaceTime: 0,
-        adjustedRaceTime: 0,
+  const carIdx = useFocusCarIdx() as number;
+  const { timeRemaining, timeTotal, totalLaps, state } = useSessionLapCount();
+  const lap = useTelemetryValues('CarIdxLap')?.[carIdx] as number;
+  const sessionType = useCurrentSessionType();
+  const lapDistPct = useTelemetryValue('LapDistPct');
+  const carIdxLap = useTelemetryValues('CarIdxLap');
+  const carIdxPosition = useTelemetryValues('CarIdxPosition');
+  const carIdxLapDistPct = useTelemetryValuesRounded('CarIdxLapDistPct', 3);
+  const avgLapTimes = useCarIdxAverageLapTime();
+  const bestLapTimes = useTelemetryValues('CarIdxBestLapTime');
+  const classEstLapTimes = useCarIdxClassEstLapTime();
+  const isFixedLapRace = !(timeRemaining > 0 && timeRemaining !== 604800);
+  const result = {
+    isFixedLapRace: isFixedLapRace,
+    totalRaceLaps: 0,
+    totalRaceTime: 0,
+    adjustedRaceTime: 0,
+    estimatedLapsRemaining: 0,
+    hasValidRaceEstimate: false,
+  };
+
+  // No race, no business
+  if (sessionType !== 'Race') return result;
+
+  let leaderCarIdx = -1;
+  let leaderLap = 0;
+  let leaderLapDistPct = 0;
+  for (let i = 0; i < carIdxPosition.length; i++) {
+    if (
+      carIdxPosition[i] === 1 &&
+      carIdxLap[i] !== undefined &&
+      carIdxLapDistPct[i] !== undefined
+    ) {
+      leaderCarIdx = i;
+      leaderLap = carIdxLap[i] ?? 0;
+      leaderLapDistPct = carIdxLapDistPct[i] ?? 0;
+      break;
+    }
+  }
+  // When no leader found yet (pre-race), fall back to player's carIdx for lap time lookup
+  const lapTimeCarIdx = leaderCarIdx >= 0 ? leaderCarIdx : carIdx;
+  // Use P1's average lap time, falling back to class estimated lap time if no laps recorded yet
+  // Use best lap time as last resort
+  const avgLapTime = selectRaceLapTime(
+    avgLapTimes[lapTimeCarIdx],
+    classEstLapTimes?.[lapTimeCarIdx],
+    bestLapTimes?.[lapTimeCarIdx],
+    avgLapTimes[carIdx],
+    classEstLapTimes?.[carIdx],
+    bestLapTimes?.[carIdx]
+  );
+
+  if (isFixedLapRace) {
+    // Easy case, fixed lap count. We just have to account for the race leader that might have lapped us
+    result.totalRaceLaps = totalLaps;
+
+    const lapsValid =
+      lap !== undefined &&
+      leaderLap !== undefined &&
+      lapDistPct !== undefined &&
+      leaderLapDistPct !== undefined &&
+      lap > 0 &&
+      leaderLap > 0;
+    if (lapsValid) {
+      const totalDist = lap + lapDistPct;
+      const totalLeaderDist = leaderLap + leaderLapDistPct;
+
+      if (totalLeaderDist > totalDist) {
+        result.totalRaceLaps -= Math.floor(totalLeaderDist - totalDist);
+      }
+    }
+
+    if (avgLapTime !== null) {
+      result.totalRaceTime = totalLaps * avgLapTime;
+      result.adjustedRaceTime = result.totalRaceTime;
+
+      if (lapsValid) {
+        const totalDist = lap + lapDistPct;
+        const totalLeaderDist = leaderLap + leaderLapDistPct;
+        if (totalLeaderDist > totalDist) {
+          result.adjustedRaceTime =
+            (totalLaps - Math.floor(totalLeaderDist - totalDist)) * avgLapTime;
+        }
+      }
+    }
+  } else {
+    // Time-limited race, so we have to estimate based on remaining time and expected laptimes
+    // In replays, the average lap time is reported as 1s, which is obviously invalid, so we skip
+    // the estimation in this case
+    result.totalRaceTime = timeTotal;
+
+    if (avgLapTime !== null) {
+      if (lap === 0) {
+        // Race has not yet started
+        result.totalRaceLaps = timeTotal / avgLapTime;
+        result.estimatedLapsRemaining = Math.ceil(result.totalRaceLaps);
+        result.hasValidRaceEstimate = true;
+      } else {
+        const estimateLeaderLap = leaderCarIdx >= 0 ? leaderLap : lap;
+        const estimateLeaderLapDistPct =
+          leaderCarIdx >= 0 ? leaderLapDistPct : (lapDistPct ?? 0);
+        const estimate = calculateTimedRaceDistance(
+          timeRemaining,
+          avgLapTime,
+          lap,
+          lapDistPct ?? 0,
+          estimateLeaderLap,
+          estimateLeaderLapDistPct
+        );
+
+        if (estimate) {
+          result.totalRaceLaps = estimate.totalRaceLaps;
+          result.estimatedLapsRemaining = estimate.lapsRemaining;
+          result.hasValidRaceEstimate = true;
+        }
+      }
+    }
+
+    if ((totalLaps ?? 0) > 0 && result.totalRaceLaps > totalLaps) {
+      result.totalRaceLaps = totalLaps;
+    }
+  }
+
+  if (state >= SessionState.Checkered) {
+    // After checkered: freeze at the lap count captured when the flag was shown
+    return {
+      isFixedLapRace: isFixedLapRace,
+      totalRaceLaps: lap,
+      totalRaceTime: result.totalRaceTime,
+      adjustedRaceTime: result.adjustedRaceTime,
+      estimatedLapsRemaining: 0,
+      hasValidRaceEstimate: true,
     };
+  }
 
-    // No race, no business
-    if (sessionType !== 'Race') return result;
-
-    let leaderCarIdx = -1;
-    let leaderLap = 0;
-    let leaderLapDistPct = 0;
-    for (let i = 0; i < carIdxPosition.length; i++) {
-        if (carIdxPosition[i] === 1 && carIdxLap[i] !== undefined && carIdxLapDistPct[i] !== undefined) {
-            leaderCarIdx = i;
-            leaderLap = carIdxLap[i] ?? 0;
-            leaderLapDistPct = carIdxLapDistPct[i] ?? 0;
-            break;
-        }
-    }
-    // When no leader found yet (pre-race), fall back to player's carIdx for lap time lookup
-    const lapTimeCarIdx = leaderCarIdx >= 0 ? leaderCarIdx : carIdx;
-    // Use P1's average lap time, falling back to class estimated lap time if no laps recorded yet
-    // Use best lap time as last resort
-    const avgLapTime =
-        (avgLapTimes[lapTimeCarIdx] > 0)
-            ? avgLapTimes[lapTimeCarIdx]
-            : (classEstLapTimes?.[lapTimeCarIdx] ?? 0) > 0 && classEstLapTimes?.[lapTimeCarIdx] !== undefined
-                ? classEstLapTimes?.[lapTimeCarIdx]
-                : (bestLapTime ?? 0);
-
-
-    if (isFixedLapRace) {
-        // Easy case, fixed lap count. We just have to account for the race leader that might have lapped us
-        result.totalRaceLaps = totalLaps;
-
-        const lapsValid = lap !== undefined &&
-            leaderLap !== undefined &&
-            lapDistPct !== undefined &&
-            leaderLapDistPct !== undefined &&
-            lap > 0 &&
-            leaderLap > 0;
-        if (lapsValid) {
-            const totalDist = lap + lapDistPct;
-            const totalLeaderDist = leaderLap + leaderLapDistPct;
-
-            if (totalLeaderDist > totalDist) {
-                result.totalRaceLaps -= Math.floor(totalLeaderDist - totalDist);
-            }
-        }
-
-        if (avgLapTime > 0) {
-            result.totalRaceTime = totalLaps * avgLapTime;
-            result.adjustedRaceTime = result.totalRaceTime;
-
-            if (lapsValid) {
-                const totalDist = lap + lapDistPct;
-                const totalLeaderDist = leaderLap + leaderLapDistPct;
-                if (totalLeaderDist > totalDist) {
-                    result.adjustedRaceTime =
-                        (totalLaps - Math.floor(totalLeaderDist - totalDist)) * avgLapTime;
-                }
-            }
-        }
-    } else {
-        // Time-limited race, so we have to estimate based on remaining time and expected laptimes
-        // In replays, the average lap time is reported as 1s, which is obviously invalid, so we skip
-        // the estimation in this case
-        result.totalRaceTime = timeTotal;
-
-        if (avgLapTime !== undefined) {
-            if (lap === 0) {
-                // Race has not yet started
-                result.totalRaceLaps = timeTotal / avgLapTime;
-            } else {
-                // Race has started, so we have to add the number of completed laps and the percentage of the current lap
-                result.totalRaceLaps =
-                    timeRemaining / avgLapTime +
-                    (leaderLap - 1) +
-                    (leaderLapDistPct ?? 0);
-
-                // Remove laps if not on the same lap as the leader
-                const totalDist = lap;
-                const totalLeaderDist = leaderLap;
-
-                if (leaderLap > lap + 1) {
-                    result.totalRaceLaps -= Math.floor(totalLeaderDist - totalDist);
-                }
-            }
-        }
-
-        if ((totalLaps ?? 0) > 0 && result.totalRaceLaps > totalLaps) {
-            result.totalRaceLaps = totalLaps;
-        }
-    }
-
-    if (state >= SessionState.Checkered) {
-        // After checkered: freeze at the lap count captured when the flag was shown
-        return {
-            isFixedLapRace: isFixedLapRace,
-            totalRaceLaps: lap,
-            totalRaceTime: result.totalRaceTime,
-            adjustedRaceTime: result.adjustedRaceTime
-        };
-    }
-
-    return result;
+  return result;
 };


### PR DESCRIPTION
## Description

Fixes inflated fuel recommendations in timed races when transient or invalid lap-time telemetry produced an unrealistic race-distance estimate. The race-distance calculation now rejects implausible lap times, falls back through validated leader and player timing sources, and returns remaining distance directly so the fuel calculator does not reconstruct it from a rounded total.

Also fixes the fuel grid's checkered-flag mask and removes its duplicate race-distance telemetry subscription. This reduces unnecessary renderer work and aligns with the cheap subscription/performance improvements described in Architecture Review Phase 1.

Root cause: the shared timed-race estimator accepted any positive leader lap time, including the approximately one-second values that can appear transiently or in replay data. That could project hundreds of remaining laps, trigger multi-stop logic, and turn a small fuel deficit into a full-tank recommendation.

Validated with `npm run lint` and `npm run test -- --no-coverage` (86 test files, 1,064 tests). Added regression coverage for a 25-minute timed race, invalid one-second lap times, timing-source fallback, and partial-lap progress.

## Screenshots

No visual changes.

### Before

A transient invalid lap time could produce an excessive timed-race distance and recommend adding more than 50 L when only a small amount was required.

### After

Invalid lap times are rejected, validated fallbacks are used, and the grid displays the corrected fuel recommendation without adding a duplicate race-distance subscription.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
