### PR TITLE
fix: sign packaged Windows application

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch: # Manually run the signed-release flow from any branch (creates a draft release)
 
 permissions:
@@ -15,103 +15,221 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 2  # Fetch the last 2 commits to compare changes
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2 # Fetch the last 2 commits to compare changes
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: '24'
-        cache: 'npm'
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
 
-    - name: Cache node_modules and native builds
-      uses: actions/cache@v5
-      id: cache-deps
-      with:
-        path: |
-          node_modules
-          .vite
-          **/node_modules
-          **/*.node
-          **/build/Release
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/binding.gyp', '**/node_modules/**/*.node') }}
-        restore-keys: |
-          ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-
-          ${{ runner.os }}-node-
+      - name: Cache node_modules and native builds
+        uses: actions/cache@v5
+        id: cache-deps
+        with:
+          path: |
+            node_modules
+            .vite
+            **/node_modules
+            **/*.node
+            **/build/Release
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/binding.gyp', '**/node_modules/**/*.node') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-
+            ${{ runner.os }}-node-
 
-    - name: Install dependencies
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      run: npm ci
+      - name: Install dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: npm ci
 
-    - name: Run linting
-      run: npm run lint
+      - name: Run linting
+        run: npm run lint
 
-    - name: Build Storybook
-      run: npm run build-storybook
+      - name: Build Storybook
+        run: npm run build-storybook
 
-    - name: Run tests with coverage
-      run: npm test
+      - name: Run tests with coverage
+        run: npm test
 
-    - name: Upload coverage report
-      uses: actions/upload-artifact@v7
-      with:
-        name: coverage-report
-        path: coverage 
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage
 
-    - name: Check if version changed
-      id: check_version
-      shell: pwsh
-      run: |
-        $currentVersion = (Get-Content package.json | ConvertFrom-Json).version
-        $previousVersion = (git show HEAD^:package.json | ConvertFrom-Json).version
-        if ($currentVersion -ne $previousVersion) {
-          echo "version_changed=true" >> $env:GITHUB_OUTPUT
-          echo "Version changed from $previousVersion to $currentVersion"
-        }
+      - name: Check if version changed
+        id: check_version
+        shell: pwsh
+        run: |
+          $currentVersion = (Get-Content package.json | ConvertFrom-Json).version
+          $previousVersion = (git show HEAD^:package.json | ConvertFrom-Json).version
+          if ($currentVersion -ne $previousVersion) {
+            echo "version_changed=true" >> $env:GITHUB_OUTPUT
+            echo "Version changed from $previousVersion to $currentVersion"
+          }
 
-    # --- Signed release (only when the version bumps) ---------------------
-    # Flow: build unsigned (dry-run) -> sign Setup.exe via SignPath -> swap the
-    # signed installer back in place -> publish from the saved dry-run.
-    # The dry-run manifest stores paths to out/make/... (no content hashing), so
-    # replacing the Setup.exe file is picked up by --from-dry-run. RELEASES and
-    # the .nupkg are never touched, keeping auto-updates valid.
+      # --- Signed release (only when the version bumps) ---------------------
+      # Flow: build unsigned (dry-run) -> sign the packaged application via
+      # SignPath -> rebuild Squirrel artifacts from the signed package -> sign
+      # Setup.exe via SignPath -> publish from the saved dry-run.
+      # The dry-run manifest stores paths to out/make/... (no content hashing), so
+      # rebuilding the artifacts and replacing Setup.exe are picked up by
+      # --from-dry-run. Rebuilding all Squirrel artifacts together keeps RELEASES
+      # and the .nupkg checksums consistent for auto-updates.
 
-    - name: Build unsigned artifacts (publish dry-run)
-      if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
-      run: npx electron-forge publish --dry-run
-      env:
-        POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+      - name: Build unsigned artifacts (publish dry-run)
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        run: npx electron-forge publish --dry-run
+        env:
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
 
-    - name: Upload unsigned installer for signing
-      id: upload-unsigned
-      if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
-      uses: actions/upload-artifact@v7
-      with:
-        name: unsigned-installer
-        if-no-files-found: error
-        path: out/make/squirrel.windows/x64/*Setup.exe
+      - name: Archive packaged Windows application
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        shell: pwsh
+        run: |
+          $packageDirectory = 'out/irdashies-win32-x64'
+          if (-not (Test-Path -LiteralPath $packageDirectory -PathType Container)) {
+            throw "Packaged application not found: $packageDirectory"
+          }
+          Compress-Archive `
+            -Path "$packageDirectory/*" `
+            -DestinationPath packaged-windows-app.zip `
+            -CompressionLevel Optimal
 
-    - name: Sign installer with SignPath
-      if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
-      uses: signpath/github-action-submit-signing-request@v2
-      with:
-        api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-        organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-        project-slug: irdashies
-        signing-policy-slug: release-signing
-        artifact-configuration-slug: initial
-        github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
-        wait-for-completion: true
-        output-artifact-directory: signed-installer
+      - name: Upload packaged application for signing
+        id: upload-packaged-app
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: unsigned-packaged-windows-app
+          if-no-files-found: error
+          path: packaged-windows-app.zip
 
-    - name: Swap in the signed installer
-      if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
-      shell: pwsh
-      run: Copy-Item signed-installer/*Setup.exe out/make/squirrel.windows/x64/ -Force
+      - name: Sign packaged application
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: irdashies
+          signing-policy-slug: release-signing
+          artifact-configuration-slug: packaged-app
+          github-artifact-id: ${{ steps.upload-packaged-app.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed-packaged-app
 
-    - name: Publish signed release
-      if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
-      run: npx electron-forge publish --from-dry-run
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Restore and verify signed packaged application
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        shell: pwsh
+        run: |
+          $signedArchive = Get-ChildItem `
+            -LiteralPath signed-packaged-app `
+            -Filter '*.zip' `
+            -File `
+            -Recurse |
+            Select-Object -First 1
+          if (-not $signedArchive) {
+            throw 'SignPath did not return the signed packaged application ZIP.'
+          }
+
+          Expand-Archive `
+            -LiteralPath $signedArchive.FullName `
+            -DestinationPath out/irdashies-win32-x64 `
+            -Force
+
+          $appExecutable = 'out/irdashies-win32-x64/irdashies.exe'
+          $signature = Get-AuthenticodeSignature -LiteralPath $appExecutable
+          if ($signature.Status -ne 'Valid') {
+            throw "Packaged application signature is $($signature.Status): $($signature.StatusMessage)"
+          }
+          Write-Output "Verified signed packaged application: $($signature.SignerCertificate.Subject)"
+
+      - name: Rebuild Squirrel artifacts from signed application
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        run: npx electron-forge make --skip-package
+
+      - name: Verify signed application in Squirrel package
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        shell: pwsh
+        run: |
+          $package = Get-ChildItem `
+            -Path out/make/squirrel.windows/x64 `
+            -Filter '*.nupkg' `
+            -File |
+            Where-Object { $_.Name -notlike '*-delta.nupkg' } |
+            Select-Object -First 1
+          if (-not $package) {
+            throw 'Squirrel full package was not generated.'
+          }
+
+          $extractDirectory = Join-Path $env:RUNNER_TEMP 'irdashies-nupkg'
+          New-Item -ItemType Directory -Path $extractDirectory -Force | Out-Null
+          $packageArchive = Join-Path $env:RUNNER_TEMP 'irdashies-nupkg.zip'
+          Copy-Item -LiteralPath $package.FullName -Destination $packageArchive -Force
+          Expand-Archive `
+            -LiteralPath $packageArchive `
+            -DestinationPath $extractDirectory `
+            -Force
+
+          $packagedExecutable = Get-ChildItem `
+            -LiteralPath $extractDirectory `
+            -Recurse `
+            -Filter 'irdashies.exe' `
+            -File |
+            Select-Object -First 1
+          if (-not $packagedExecutable) {
+            throw 'irdashies.exe was not found in the Squirrel package.'
+          }
+
+          $signature = Get-AuthenticodeSignature `
+            -LiteralPath $packagedExecutable.FullName
+          if ($signature.Status -ne 'Valid') {
+            throw "Squirrel package contains an application with signature status $($signature.Status)."
+          }
+          Write-Output "Verified signed application in $($package.Name)."
+
+      - name: Upload unsigned installer for signing
+        id: upload-unsigned
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: unsigned-installer
+          if-no-files-found: error
+          path: out/make/squirrel.windows/x64/*Setup.exe
+
+      - name: Sign installer with SignPath
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: irdashies
+          signing-policy-slug: release-signing
+          artifact-configuration-slug: initial
+          github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed-installer
+
+      - name: Swap in the signed installer
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        shell: pwsh
+        run: |
+          Copy-Item signed-installer/*Setup.exe out/make/squirrel.windows/x64/ -Force
+          $installer = Get-ChildItem `
+            -Path out/make/squirrel.windows/x64 `
+            -Filter '*Setup.exe' `
+            -File |
+            Select-Object -First 1
+          $signature = Get-AuthenticodeSignature -LiteralPath $installer.FullName
+          if ($signature.Status -ne 'Valid') {
+            throw "Installer signature is $($signature.Status): $($signature.StatusMessage)"
+          }
+          Write-Output "Verified signed installer: $($signature.SignerCertificate.Subject)"
+
+      - name: Publish signed release
+        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        run: npx electron-forge publish --from-dry-run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  workflow_dispatch: # Manually run the signed-release flow from any branch (creates a draft release)
+  workflow_dispatch:
+    inputs:
+      should_release:
+        description: Build, sign, and publish a draft release
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -18,6 +24,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 2 # Fetch the last 2 commits to compare changes
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -59,18 +66,32 @@ jobs:
           name: coverage-report
           path: coverage
 
-      - name: Check if version changed
+      - name: Determine release eligibility
         id: check_version
         shell: pwsh
+        env:
+          DISPATCH_SHOULD_RELEASE: ${{ inputs.should_release }}
         run: |
           $currentVersion = (Get-Content package.json | ConvertFrom-Json).version
           $previousVersion = (git show HEAD^:package.json | ConvertFrom-Json).version
-          if ($currentVersion -ne $previousVersion) {
-            echo "version_changed=true" >> $env:GITHUB_OUTPUT
+          $versionChanged = $currentVersion -ne $previousVersion
+          $shouldRelease = (
+            ($env:GITHUB_EVENT_NAME -eq 'push' -and $versionChanged) -or
+            ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch' -and
+              $env:DISPATCH_SHOULD_RELEASE -eq 'true')
+          )
+
+          echo "version_changed=$($versionChanged.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          echo "should_release=$($shouldRelease.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+
+          if ($versionChanged) {
             echo "Version changed from $previousVersion to $currentVersion"
           }
 
-      # --- Signed release (only when the version bumps) ---------------------
+      # --- Signed release ----------------------------------------------------
+      # Pushes release only when the version changes. Manual runs release only
+      # when the should_release workflow-dispatch input is enabled. Pull
+      # requests never enter this flow.
       # Flow: build unsigned (dry-run) -> sign the packaged application via
       # SignPath -> rebuild Squirrel artifacts from the signed package -> sign
       # Setup.exe via SignPath -> publish from the saved dry-run.
@@ -80,13 +101,13 @@ jobs:
       # and the .nupkg checksums consistent for auto-updates.
 
       - name: Build unsigned artifacts (publish dry-run)
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         run: npx electron-forge publish --dry-run
         env:
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
 
       - name: Archive packaged Windows application
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         shell: pwsh
         run: |
           $packageDirectory = 'out/irdashies-win32-x64'
@@ -100,7 +121,7 @@ jobs:
 
       - name: Upload packaged application for signing
         id: upload-packaged-app
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: unsigned-packaged-windows-app
@@ -108,7 +129,7 @@ jobs:
           path: packaged-windows-app.zip
 
       - name: Sign packaged application
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -121,7 +142,7 @@ jobs:
           output-artifact-directory: signed-packaged-app
 
       - name: Restore and verify signed packaged application
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         shell: pwsh
         run: |
           $signedArchive = Get-ChildItem `
@@ -147,11 +168,11 @@ jobs:
           Write-Output "Verified signed packaged application: $($signature.SignerCertificate.Subject)"
 
       - name: Rebuild Squirrel artifacts from signed application
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         run: npx electron-forge make --skip-package
 
       - name: Verify signed application in Squirrel package
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         shell: pwsh
         run: |
           $package = Get-ChildItem `
@@ -192,7 +213,7 @@ jobs:
 
       - name: Upload unsigned installer for signing
         id: upload-unsigned
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: unsigned-installer
@@ -200,7 +221,7 @@ jobs:
           path: out/make/squirrel.windows/x64/*Setup.exe
 
       - name: Sign installer with SignPath
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -213,7 +234,7 @@ jobs:
           output-artifact-directory: signed-installer
 
       - name: Swap in the signed installer
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         shell: pwsh
         run: |
           Copy-Item signed-installer/*Setup.exe out/make/squirrel.windows/x64/ -Force
@@ -229,7 +250,7 @@ jobs:
           Write-Output "Verified signed installer: $($signature.SignerCertificate.Subject)"
 
       - name: Publish signed release
-        if: steps.check_version.outputs.version_changed == 'true' || github.event_name == 'workflow_dispatch'
+        if: steps.check_version.outputs.should_release == 'true'
         run: npx electron-forge publish --from-dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.signpath/artifact-configurations/packaged-app.xml
+++ b/.signpath/artifact-configurations/packaged-app.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  SignPath artifact configuration for the packaged Windows application.
+
+  The CI workflow archives the contents of out/irdashies-win32-x64, so the
+  application executable is at the root of the uploaded ZIP. This
+  configuration signs that executable before the Squirrel artifacts are
+  rebuilt.
+
+  This file is the repo copy for review/versioning. The authoritative copy must
+  also be uploaded in the SignPath portal with the slug "packaged-app". Keep
+  them in sync. Schema: https://docs.signpath.io/artifact-configuration/
+-->
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <pe-file path="irdashies.exe" min-matches="1" max-matches="1">
+      <authenticode-sign />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>


### PR DESCRIPTION
## Description

Signs the nested .exe in the installer so both the installer and the runtime executable are signed.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

### After
<!-- Screenshot or description of the new behaviour -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run lint` and fixed any issues
- [ ] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Windows release signing now covers the full packaged application and includes Authenticode verification before publishing.
  * Installer signing was expanded to ensure the installer is signed and verified as part of the release flow.
* **Chores**
  * Updated CI to run release-related logic only for events targeting the main branch.
  * Added a manual release toggle to control whether a release is eligible to be published.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->