### PR TITLE
perf: parallelize CI validation and avoid duplicate packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,30 @@ on:
         default: false
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
+  validation:
+    name: Validate (${{ matrix.check.name }})
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - name: Lint
+            command: npm run lint
+          - name: Storybook
+            command: npm run build-storybook
+          - name: Tests
+            command: npm test
 
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 2 # Fetch the last 2 commits to compare changes
           persist-credentials: false
 
       - name: Setup Node.js
@@ -51,42 +65,88 @@ jobs:
         if: steps.cache-deps.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Run linting
-        run: npm run lint
-
-      - name: Build Storybook
-        run: npm run build-storybook
-
-      - name: Run tests with coverage
-        run: npm test
+      - name: Run ${{ matrix.check.name }}
+        run: ${{ matrix.check.command }}
 
       - name: Upload coverage report
+        if: matrix.check.name == 'Tests'
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage
 
-      - name: Determine release eligibility
-        id: check_version
-        shell: pwsh
+  release-gate:
+    name: Determine release eligibility
+    if: github.event_name == 'push' || inputs.should_release
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.gate.outputs.should_release }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2 # Fetch the last 2 commits to compare versions
+          persist-credentials: false
+
+      - name: Check release conditions
+        id: gate
+        shell: bash
         env:
           DISPATCH_SHOULD_RELEASE: ${{ inputs.should_release }}
         run: |
-          $currentVersion = (Get-Content package.json | ConvertFrom-Json).version
-          $previousVersion = (git show HEAD^:package.json | ConvertFrom-Json).version
-          $versionChanged = $currentVersion -ne $previousVersion
-          $shouldRelease = (
-            ($env:GITHUB_EVENT_NAME -eq 'push' -and $versionChanged) -or
-            ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch' -and
-              $env:DISPATCH_SHOULD_RELEASE -eq 'true')
-          )
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "should_release=$DISPATCH_SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
-          echo "version_changed=$($versionChanged.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
-          echo "should_release=$($shouldRelease.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
-
-          if ($versionChanged) {
+          currentVersion=$(node -p "require('./package.json').version")
+          previousVersion=$(git show HEAD^:package.json | node -e \
+            "let input = ''; process.stdin.on('data', chunk => input += chunk); process.stdin.on('end', () => console.log(JSON.parse(input).version));")
+          if [[ "$currentVersion" != "$previousVersion" ]]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "Version changed from $previousVersion to $currentVersion"
-          }
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Build and publish signed release
+    needs: [validation, release-gate]
+    if: needs.release-gate.outputs.should_release == 'true'
+    runs-on: windows-latest
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Cache node_modules and native builds
+        uses: actions/cache@v5
+        id: cache-deps
+        with:
+          path: |
+            node_modules
+            .vite
+            **/node_modules
+            **/*.node
+            **/build/Release
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/binding.gyp', '**/node_modules/**/*.node') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: npm ci
 
       # --- Signed release ----------------------------------------------------
       # Pushes release only when the version changes. Manual runs release only
@@ -101,13 +161,11 @@ jobs:
       # and the .nupkg checksums consistent for auto-updates.
 
       - name: Build unsigned artifacts (publish dry-run)
-        if: steps.check_version.outputs.should_release == 'true'
         run: npx electron-forge publish --dry-run
         env:
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
 
       - name: Archive packaged Windows application
-        if: steps.check_version.outputs.should_release == 'true'
         shell: pwsh
         run: |
           $packageDirectory = 'out/irdashies-win32-x64'
@@ -121,7 +179,6 @@ jobs:
 
       - name: Upload packaged application for signing
         id: upload-packaged-app
-        if: steps.check_version.outputs.should_release == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: unsigned-packaged-windows-app
@@ -129,7 +186,6 @@ jobs:
           path: packaged-windows-app.zip
 
       - name: Sign packaged application
-        if: steps.check_version.outputs.should_release == 'true'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -142,7 +198,6 @@ jobs:
           output-artifact-directory: signed-packaged-app
 
       - name: Restore and verify signed packaged application
-        if: steps.check_version.outputs.should_release == 'true'
         shell: pwsh
         run: |
           $signedArchive = Get-ChildItem `
@@ -168,11 +223,9 @@ jobs:
           Write-Output "Verified signed packaged application: $($signature.SignerCertificate.Subject)"
 
       - name: Rebuild Squirrel artifacts from signed application
-        if: steps.check_version.outputs.should_release == 'true'
         run: npx electron-forge make --skip-package
 
       - name: Verify signed application in Squirrel package
-        if: steps.check_version.outputs.should_release == 'true'
         shell: pwsh
         run: |
           $package = Get-ChildItem `
@@ -213,7 +266,6 @@ jobs:
 
       - name: Upload unsigned installer for signing
         id: upload-unsigned
-        if: steps.check_version.outputs.should_release == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: unsigned-installer
@@ -221,7 +273,6 @@ jobs:
           path: out/make/squirrel.windows/x64/*Setup.exe
 
       - name: Sign installer with SignPath
-        if: steps.check_version.outputs.should_release == 'true'
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -234,7 +285,6 @@ jobs:
           output-artifact-directory: signed-installer
 
       - name: Swap in the signed installer
-        if: steps.check_version.outputs.should_release == 'true'
         shell: pwsh
         run: |
           Copy-Item signed-installer/*Setup.exe out/make/squirrel.windows/x64/ -Force
@@ -250,7 +300,6 @@ jobs:
           Write-Output "Verified signed installer: $($signature.SignerCertificate.Subject)"
 
       - name: Publish signed release
-        if: steps.check_version.outputs.should_release == 'true'
         run: npx electron-forge publish --from-dry-run
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,22 @@ jobs:
           name: coverage-report
           path: coverage
 
+  build:
+    name: build
+    needs: validation
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Confirm validation passed
+        env:
+          VALIDATION_RESULT: ${{ needs.validation.result }}
+        run: |
+          if [[ "$VALIDATION_RESULT" != "success" ]]; then
+            echo "Validation result: $VALIDATION_RESULT" >&2
+            exit 1
+          fi
+
   release-gate:
     name: Determine release eligibility
     if: github.event_name == 'push' || inputs.should_release
@@ -122,7 +138,7 @@ jobs:
 
   release:
     name: Build and publish signed release
-    needs: [validation, release-gate]
+    needs: [build, release-gate]
     if: needs.release-gate.outputs.should_release == 'true'
     runs-on: windows-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,16 +152,16 @@ jobs:
       # Pushes release only when the version changes. Manual runs release only
       # when the should_release workflow-dispatch input is enabled. Pull
       # requests never enter this flow.
-      # Flow: build unsigned (dry-run) -> sign the packaged application via
-      # SignPath -> rebuild Squirrel artifacts from the signed package -> sign
-      # Setup.exe via SignPath -> publish from the saved dry-run.
+      # Flow: package once -> sign the packaged application via SignPath -> make
+      # Squirrel artifacts once while saving a publish dry-run -> sign Setup.exe
+      # via SignPath -> publish from the saved dry-run.
       # The dry-run manifest stores paths to out/make/... (no content hashing), so
-      # rebuilding the artifacts and replacing Setup.exe are picked up by
-      # --from-dry-run. Rebuilding all Squirrel artifacts together keeps RELEASES
-      # and the .nupkg checksums consistent for auto-updates.
+      # replacing Setup.exe is picked up by --from-dry-run. Making all Squirrel
+      # artifacts together keeps RELEASES and the .nupkg checksums consistent for
+      # auto-updates.
 
-      - name: Build unsigned artifacts (publish dry-run)
-        run: npx electron-forge publish --dry-run
+      - name: Package unsigned Windows application
+        run: npx electron-forge package
         env:
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
 
@@ -222,12 +222,16 @@ jobs:
           }
           Write-Output "Verified signed packaged application: $($signature.SignerCertificate.Subject)"
 
-      - name: Rebuild Squirrel artifacts from signed application
-        run: npx electron-forge make --skip-package
+      - name: Build Squirrel artifacts from signed application
+        run: node tools/publish-signed-dry-run.mjs
 
       - name: Verify signed application in Squirrel package
         shell: pwsh
         run: |
+          if (-not (Test-Path -LiteralPath out/publish-dry-run -PathType Container)) {
+            throw 'Electron Forge publish dry-run state was not generated.'
+          }
+
           $package = Get-ChildItem `
             -Path out/make/squirrel.windows/x64 `
             -Filter '*.nupkg' `

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,17 +23,20 @@ concurrency:
 jobs:
   validation:
     name: Validate (${{ matrix.check.name }})
-    runs-on: windows-latest
+    runs-on: ${{ matrix.check.runner }}
     strategy:
       fail-fast: false
       matrix:
         check:
           - name: Lint
             command: npm run lint
+            runner: ubuntu-latest
           - name: Storybook
             command: npm run build-storybook
+            runner: ubuntu-latest
           - name: Tests
             command: npm test
+            runner: windows-latest
 
     steps:
       - uses: actions/checkout@v6
@@ -94,6 +97,8 @@ jobs:
         env:
           DISPATCH_SHOULD_RELEASE: ${{ inputs.should_release }}
         run: |
+          set -euo pipefail
+
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "should_release=$DISPATCH_SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
             exit 0
@@ -102,6 +107,12 @@ jobs:
           currentVersion=$(node -p "require('./package.json').version")
           previousVersion=$(git show HEAD^:package.json | node -e \
             "let input = ''; process.stdin.on('data', chunk => input += chunk); process.stdin.on('end', () => console.log(JSON.parse(input).version));")
+
+          if [[ -z "$currentVersion" || -z "$previousVersion" ]]; then
+            echo "Could not determine current and previous package versions." >&2
+            exit 1
+          fi
+
           if [[ "$currentVersion" != "$previousVersion" ]]; then
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "Version changed from $previousVersion to $currentVersion"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irdashies",
   "productName": "irdashies",
-  "version": "0.9.1",
+  "version": "0.9.0",
   "description": "iRacing Dashboards & Overlays",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irdashies",
   "productName": "irdashies",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "iRacing Dashboards & Overlays",
   "repository": {
     "type": "git",

--- a/tools/publish-signed-dry-run.mjs
+++ b/tools/publish-signed-dry-run.mjs
@@ -1,0 +1,8 @@
+import { api } from '@electron-forge/core';
+
+await api.publish({
+  dryRun: true,
+  makeOptions: {
+    skipPackage: true,
+  },
+});


### PR DESCRIPTION
## Description

Parallelizes the independent lint, Storybook, and test validation tasks, while preserving the requirement that every validation task passes before release signing or publishing begins.

Adds pull-request concurrency cancellation so superseded commits stop consuming runner time. Global workflow permissions are now read-only; write access is scoped to the signed-release job.

Optimizes the Windows release pipeline to package the application once. After SignPath returns the signed packaged application, Electron Forge performs one Squirrel Make with `skipPackage` and saves the publish dry-run. This removes the previous duplicate Squirrel build while retaining signature and dry-run verification.

Architecture phase: N/A — CI/release infrastructure only; no application architecture changes.

Validation performed locally:

- `npm run lint`
- Prettier checks for the workflow and helper script
- `actionlint .github/workflows/ci.yml`
- Node syntax validation for `tools/publish-signed-dry-run.mjs`
- `git diff --check`

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before

No visual changes. CI validation ran sequentially, and the Windows release flow built Squirrel artifacts twice.

### After

No visual changes. Validation jobs run in parallel, and the signed release flow packages once and builds Squirrel artifacts once.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved CI validation by using a matrix for linting, Storybook build, and tests.
  - Reduced redundant PR activity by canceling in-progress runs when newer changes arrive.
  - Refined release publishing with centralized eligibility gating before any publish actions.
  - Strengthened the signed Windows release flow with additional checks around signed installer packaging.
  - Added a safe dry-run publish step to verify signed publishing behavior before performing the real release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->