### PR TITLE
chore: add performance benchmark harness and plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ PITLANE_DETECTION_FIXES.md
 
 # storybook
 storybook-static/
+perf-results/
 
 # landing site
 site/dist/

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -362,21 +362,124 @@ summary rather than carried as a manual caveat.
 widget paths show changing inputs in the coverage report. Two repetitions of
 the same A/B pair agree on direction.
 
-#### PB3 - Reduce measured renderer wake-ups and paint work
+#### PB3 - Actionable optimization sequence
 
-This is the measurement-driven entry into existing Architecture Phase 3, not a
-parallel channel design.
+PB1 and PB2 improve confidence, but they do **not** block the first optimization
+PRs. Existing live-session Phase 0 evidence already confirmed telemetry fanout
+and duplicated renderer work, while the July replay showed that full-dashboard
+cost appears when widgets are mounted rather than from empty windows alone.
 
-- [ ] Add perf-only per-widget render/update counters and per-window wake-up
-      rates.
-- [ ] Implement rate-aware channel subscriptions using the Phase 3 buckets
-      (`driverFocused`, `gapTiming`, `informational`, `static`), defaulting
-      unmigrated widgets to the legacy rate.
-- [ ] Publish only the channels required by the active widgets in each window.
-- [ ] Mount specialized providers/processors only in windows whose widgets
-      require them.
-- [ ] Migrate one measured hotspot at a time and preserve full-rate paths for
-      input controls and calculations whose precision rules prohibit throttling.
+Deliver these as separate PRs so each change remains reviewable and its effect
+can be attributed.
+
+##### OP1 - Gate renderer-global store updaters
+
+`OverlayContainer` currently mounts `SectorTimingUpdater`,
+`PushToPassUpdater`, and `PitLapUpdater` in every display renderer regardless of
+which widgets that renderer contains.
+
+- [ ] Add a typed widget-to-runtime-dependency registry outside widget folders.
+- [ ] Mount `SectorTimingUpdater` only for displays containing `map`, `flatmap`,
+      or `sectordelta`.
+- [ ] Mount `PushToPassUpdater` only for displays containing `standings` or
+      `relative`.
+- [ ] Mount `PitLapUpdater` only for displays containing `standings`,
+      `relative`, or `battle`.
+- [ ] Re-evaluate dependencies when a profile changes or a widget moves between
+      displays.
+- [ ] Add component tests proving each updater mounts once when required and
+      zero times when no local widget consumes it.
+
+**Expected result:** remove known per-tick calculations from unrelated display
+renderers without changing widget behavior or waiting for the channel bus.
+
+##### OP2 - Make specialized providers display-aware
+
+`App.tsx` currently mounts `PitLaneProvider` and `ReferenceStoreProvider` in
+every overlay renderer before the local display's active widgets are known.
+
+- [ ] Split overlay bootstrap into the always-required
+      Dashboard/Running/Session/Telemetry shell and a display-aware specialized
+      provider layer.
+- [ ] Mount `PitLaneProvider` only for displays containing `standings`,
+      `relative`, or `pitlanehelper`.
+- [ ] Mount `ReferenceStoreProvider` only for displays containing consumers of
+      reference-lap or sector data (`standings`, `relative`, `map`, `flatmap`,
+      or `sectordelta`).
+- [ ] Dispose subscriptions and release feature-store state when the last local
+      consumer disappears.
+- [ ] Keep settings-window provider behavior unchanged.
+
+**Expected result:** eliminate duplicate reference-lap and pit-lane processing
+from renderers that cannot display those results.
+
+##### OP3 - Build the Phase 3 per-window channel bus
+
+This is the existing Architecture Phase 3 design, now split into an executable
+foundation PR.
+
+- [ ] Define typed channel names and payloads in `src/types/`.
+- [ ] Add a main-process subscription registry keyed by `webContents.id`.
+- [ ] Expose `subscribe(channels)` / `unsubscribe(channels)` through preload;
+      frontend code must not import from `src/app`.
+- [ ] Remove subscriptions automatically when a renderer closes or reloads.
+- [ ] Recompute a window's manifest when its profile or display widget set
+      changes.
+- [ ] Keep the legacy telemetry bridge as an explicit compatibility channel
+      until all in-tree widgets migrate.
+- [ ] Pilot the bus with on-change session state plus low-risk Weather and Flag
+      snapshots.
+
+**Expected result:** a renderer receives only channels requested by widgets on
+its display; closed windows retain no subscription callbacks.
+
+##### OP4 - Add rate-aware publishing and migrate high-churn widgets
+
+- [ ] Add developer defaults with an optional per-widget override:
+  - `driverFocused`: native telemetry rate for Input and controls.
+  - `relative`: 20 Hz for Relative and proximity warnings.
+  - `gapTiming`: 10 Hz for Standings, Battle, and sector deltas.
+  - `informational`: 1-5 Hz for Weather and derived Fuel presentation.
+  - `static`: on-change for session metadata, track shape, and widget chrome.
+- [ ] Coalesce channel updates per window in main; do not run independent
+      renderer timers that wake only to discard data.
+- [ ] Migrate Standings, Relative, Battle, Track Map/Flat Map, Weather, and Flag
+      away from the legacy full-telemetry message.
+- [ ] Preserve exact/full-rate inputs required by the no-round rules, including
+      controls, `FuelLevel`, and `SessionTime`.
+- [ ] Emit per-window channel deliveries/second in perf mode.
+
+**Expected result:** non-input renderers stop waking at the SDK rate when their
+visible widgets only require 1-10 Hz data.
+
+##### OP5 - Move duplicated derived work to main-process processors
+
+Start only after OP3 establishes typed channel delivery, but implementation does
+not wait for every benchmark-fidelity item.
+
+- [ ] Implement `FuelProjectionProcessor` as the first end-to-end processor and
+      publish `fuel.projection`; compute history once, not once per renderer.
+- [ ] Move relative-gap and standings augmentation into processors after Fuel,
+      retaining pure-function unit tests for every derivation.
+- [ ] Key processor lifecycle to `sessionLifecycle` and release driver/session
+      state on leave, session change, and disconnect.
+- [ ] Keep raw telemetry acquisition and persistence out of frontend code.
+
+**Expected result:** expensive history and field-wide derivations run once per
+SDK tick and only subscribed windows receive immutable snapshots.
+
+##### OP6 - Remove the legacy firehose and redundant providers
+
+- [ ] Track migration status in the widget registry.
+- [ ] Stop publishing the legacy telemetry object to windows containing no
+      legacy widgets.
+- [ ] Delete renderer-side processors/providers after their final consumer
+      migrates.
+- [ ] Remove the legacy telemetry channel in one final cleanup PR once all
+      in-tree widgets use typed channels.
+
+**Expected result:** renderer work scales with its local widgets and declared
+rates rather than with every SDK tick and every feature in the application.
 
 **Exit gates:**
 
@@ -459,6 +562,7 @@ LLM agents: read this file at the start of any session that touches the architec
 
 Append-only. Newest entries at the top. Format: `YYYY-MM-DD — item — branch — outcome`.
 
+- **2026-07-26** — PB3 revised from generic profiling tasks into six executable optimization PRs. Immediate OP1/OP2 work gates unconditional per-display store updaters and providers; OP3-OP6 deliver the existing Phase 3 channel bus, rate-aware widget migrations, main-process processors, and removal of the telemetry firehose. PB1/PB2 remain parallel measurement support and are no longer described as blockers — `chore/performance-benchmark-harness` — plan revision
 - **2026-07-26** — PB0 packaged performance harness and PB1-PB4 follow-up plan: observer/empty/full/widget-filter modes, structured process/renderer/iRacing metrics, fixed-duration runner, analyzer, regression gates, and replay/live protocol. Controlled 59-car replay established a static/compositor lower bound but exposed incomplete replay telemetry, so telemetry coverage, private memory, deterministic live capture, and PresentMon are explicit gates before targeted or drastic architecture work — `chore/performance-benchmark-harness` — in review
 - **2026-05-19** — R1 reference-lap fetch dedup + R2 post-debounce write log landed on integration branch. R1: 5s-TTL invoke dedup in `referenceLapsBridge.ts` collapses 3× per-renderer `[Main] Fetching reference lap` log lines to 1 per class per transition; subsequent invokes log at DEBUG level. R2: `flushAsync` in `referenceLaps.ts` logs `[Main] Reference laps written to disk (N entries)` after each successful `fs.promises.writeFile`, giving ground-truth save-count evidence to discriminate against the misleading renderer-side log clusters. 9 new spec tests (6 new bridge spec file + 3 in referenceLaps spec). 809/809 tests pass — `feat/phase-2a-integration` — landed
 - **2026-05-19** — Working-tree identity-key implementation for mid-session leave detection reverted to HEAD on `feat/phase-2a-integration`. Decline decision from 2026-05-18 enacted before any commit landed; sessionLifecycle.ts and its spec match the post-2026-05-17 state again. The 2026-05-17 follow-up work (empty-Drivers guard, disconnect log line, Released summary, bridge stale-state nulling) was also still uncommitted and got re-applied cleanly in the same revert+restore operation, then committed separately

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -282,7 +282,127 @@ Today every renderer wakes 25 times/sec regardless of what's mounted. A weather 
 
 These do not belong to a single phase; tracked separately so they do not get lost.
 
-- [ ] **`tools/perfBench/`** — headless trace-replay harness with memory-slope assertion (per `PERFORMANCE_TEST_SUMMARY.md` §7.3). Use the existing per-session CSVs as the seed corpus.
+### Performance measurement and optimization plan (2026-07-26)
+
+This plan follows the decision rule in
+[`PERFORMANCE_BENCHMARKS.md`](./PERFORMANCE_BENCHMARKS.md): optimize the layer
+identified by measurement and do not begin the worker-thread or native phases
+without evidence that they address the measured bottleneck.
+
+#### Current evidence and limits
+
+The packaged benchmark harness was exercised against a 59-car, multi-class
+replay from a fixed cockpit camera at Race 04:24. Each observer, empty-window,
+and full-dashboard run used the same seven-minute replay segment.
+
+| Measurement                             |                  Result | Interpretation                                                        |
+| --------------------------------------- | ----------------------: | --------------------------------------------------------------------- |
+| Empty vs observer average FPS           |                  -0.06% | Window/provider substrate was FPS-neutral in this replay              |
+| Full vs empty average FPS               |                  -0.43% | Capped steady-state average hides demanding intervals                 |
+| Full vs empty, first 90s below cap      |                  -2.71% | Partial evidence of widget paint/compositor cost under GPU load       |
+| Full vs empty app CPU                   | +3.95 percentage points | Renderer work is measurable even with incomplete replay telemetry     |
+| Empty vs observer aggregate working set |               +1,160 MB | Three renderers are expensive, but shared pages may be double-counted |
+| Full vs empty aggregate working set     |                 +288 MB | Widget/configuration cost above the renderer substrate                |
+| Full `processTelemetry` p99 mean        |                 1.99 ms | Below the 3 ms gate                                                   |
+| Renderer frames over 50 ms              |                      0% | No renderer-main-thread hitch was reproduced                          |
+
+These numbers are a lower-bound static/rendering baseline, not a complete live
+workload. iRacing replays omit or freeze telemetry used by Fuel and other
+widgets, so their calculations, history, allocations, and update fanout were
+not exercised. The iRacing `FrameRate` variable is also smoothed and cannot
+replace present-to-present timing from PresentMon/ETW.
+
+#### PB0 - Land the repeatable packaged harness
+
+- [ ] Add fixed-duration `observer`, `empty`, `full`, and widget-filter run
+      modes without changing the persisted dashboard.
+- [ ] Capture structured iRacing, app/process, telemetry, event-loop, and
+      renderer-frame metrics.
+- [ ] Produce JSON and Markdown comparisons with warm-up filtering and
+      regression gates.
+- [ ] Document controlled replay and live-session protocols.
+
+**Branch:** `chore/performance-benchmark-harness`
+
+**Exit gate:** packaged observer/empty/full captures complete automatically;
+the analyzer reproduces the metrics above; lint and the full test suite pass.
+Tick these items only after the branch merges.
+
+#### PB1 - Make benchmark coverage and memory claims trustworthy
+
+- [ ] Report telemetry coverage per run: key present, valid sample count,
+      changed sample count, and effective update rate.
+- [ ] Map the changing keys to active widgets and flag widgets whose important
+      inputs were not exercised.
+- [ ] Record process private bytes and shared bytes where available; do not use
+      summed working set alone to justify a window/process rewrite.
+- [ ] Add an analysis-window option so the same high-load interval can be
+      compared without including the later FPS-capped section.
+- [ ] Record benchmark metadata: simulator mode, replay/live, field/class
+      count, display geometry, FPS cap, sync mode, and active widget types.
+
+**Exit gate:** every result states which widget inputs changed, and memory gates
+use private memory. Incomplete replay coverage must be visible in the generated
+summary rather than carried as a manual caveat.
+
+#### PB2 - Exercise real telemetry reproducibly
+
+- [ ] Add a bounded capture format for the allowlisted live telemetry frames
+      and matching session snapshots. Recording must be opt-in and batched so the
+      recorder does not become the bottleneck.
+- [ ] Feed a captured stream through the existing bridge boundary for
+      deterministic overlay playback while iRacing supplies a repeatable visual
+      replay workload.
+- [ ] Add a live A/B/A/B controller that alternates empty and full phases
+      without restarting Electron and writes phase markers into the structured log.
+- [ ] Add PresentMon/ETW present-time capture for live tests where internal
+      renderer timing is clean but visible stutter remains.
+
+**Exit gate:** Fuel, standings, relative, input, reference-lap, and other active
+widget paths show changing inputs in the coverage report. Two repetitions of
+the same A/B pair agree on direction.
+
+#### PB3 - Reduce measured renderer wake-ups and paint work
+
+This is the measurement-driven entry into existing Architecture Phase 3, not a
+parallel channel design.
+
+- [ ] Add perf-only per-widget render/update counters and per-window wake-up
+      rates.
+- [ ] Implement rate-aware channel subscriptions using the Phase 3 buckets
+      (`driverFocused`, `gapTiming`, `informational`, `static`), defaulting
+      unmigrated widgets to the legacy rate.
+- [ ] Publish only the channels required by the active widgets in each window.
+- [ ] Mount specialized providers/processors only in windows whose widgets
+      require them.
+- [ ] Migrate one measured hotspot at a time and preserve full-rate paths for
+      input controls and calculations whose precision rules prohibit throttling.
+
+**Exit gates:**
+
+- Full-vs-empty app CPU delta <= 2.5 percentage points in the controlled
+  workload.
+- Full-vs-empty average FPS regression >= -2% in the aligned below-cap window.
+- Renderer frames over 50 ms < 0.1%.
+- `processTelemetry` p99 mean < 3 ms and minimum telemetry cadence >= 20 Hz.
+- No active widget loses required precision or update smoothness.
+
+#### PB4 - Architecture gates
+
+- [ ] Consider fewer renderer processes only if private-memory measurement
+      proves duplicated renderer/provider state is material. Compare this against
+      the compositor cost of a larger transparent surface first.
+- [ ] Move derived calculations to Phase 4 processors only when render/update
+      counters identify duplicated per-renderer computation.
+- [ ] Start the Phase 5 SDK worker only if observer-mode or event-loop traces
+      correlate the blocking SDK loop with user-visible latency.
+- [ ] Keep Phase 6 native work deferred until a CPU profile identifies a
+      specific calculation that remains hot after Phase 4.
+
+**Explicitly not justified by the current replay:** a native rewrite, a single
+7680x1440 overlay window, a Fuel-specific optimization, or treating the
+31 ms SDK-loop event delay as the primary FPS cause.
+
 - [ ] **ESLint boundaries plugin** — enforce R1.x layering and R7.x widget isolation
 - [ ] **CI hash check on `_GENERATED_telemetry.ts`** — R10.4
 - [ ] **Pre-PR checklist enforcement** — either PR template additions or a CI step that scans for the checklist in the PR description
@@ -339,6 +459,7 @@ LLM agents: read this file at the start of any session that touches the architec
 
 Append-only. Newest entries at the top. Format: `YYYY-MM-DD — item — branch — outcome`.
 
+- **2026-07-26** — PB0 packaged performance harness and PB1-PB4 follow-up plan: observer/empty/full/widget-filter modes, structured process/renderer/iRacing metrics, fixed-duration runner, analyzer, regression gates, and replay/live protocol. Controlled 59-car replay established a static/compositor lower bound but exposed incomplete replay telemetry, so telemetry coverage, private memory, deterministic live capture, and PresentMon are explicit gates before targeted or drastic architecture work — `chore/performance-benchmark-harness` — in review
 - **2026-05-19** — R1 reference-lap fetch dedup + R2 post-debounce write log landed on integration branch. R1: 5s-TTL invoke dedup in `referenceLapsBridge.ts` collapses 3× per-renderer `[Main] Fetching reference lap` log lines to 1 per class per transition; subsequent invokes log at DEBUG level. R2: `flushAsync` in `referenceLaps.ts` logs `[Main] Reference laps written to disk (N entries)` after each successful `fs.promises.writeFile`, giving ground-truth save-count evidence to discriminate against the misleading renderer-side log clusters. 9 new spec tests (6 new bridge spec file + 3 in referenceLaps spec). 809/809 tests pass — `feat/phase-2a-integration` — landed
 - **2026-05-19** — Working-tree identity-key implementation for mid-session leave detection reverted to HEAD on `feat/phase-2a-integration`. Decline decision from 2026-05-18 enacted before any commit landed; sessionLifecycle.ts and its spec match the post-2026-05-17 state again. The 2026-05-17 follow-up work (empty-Drivers guard, disconnect log line, Released summary, bridge stale-state nulling) was also still uncommitted and got re-applied cleanly in the same revert+restore operation, then committed separately
 - **2026-05-18** — Spectated PCC race at GR86 Navarra (23.5 min, 4-class spectated race): zero `Driver left (session-update)` events in 20 min despite genuine driver departures. Mid-session per-driver leave detection **declined for fix** after cost/benefit review — see PERFORMANCE_TEST_LOG.md §4 "Declined for fix". Reference-lap fetch storm at session-load captured: 24 fetches in 30s where 4 would suffice — promoted to highest-priority remaining performance item (R1, landed 2026-05-19)

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -1,0 +1,174 @@
+# irDashies Performance Benchmarks
+
+This is the repeatable benchmark protocol for diagnosing iRacing FPS loss,
+overlay stutter, and long-session degradation. It complements
+[`PERFORMANCE_TEST_SUMMARY.md`](./PERFORMANCE_TEST_SUMMARY.md), whose earlier
+runs established the memory and telemetry-processing targets.
+
+## What the harness captures
+
+When launched through `npm run perf:run`, irDashies records structured samples
+without changing the saved dashboard:
+
+- iRacing-reported FPS, foreground/background CPU usage, and GPU usage
+- irDashies total and per-process CPU and working-set memory
+- telemetry tick cadence and `processTelemetry` / IPC broadcast percentiles
+- Electron main-process event-loop stalls
+- per-renderer animation-frame timing and frames over 25 ms / 50 ms
+
+The metrics are disabled during normal app launches.
+
+For quick development iteration, the default target is the Vite development
+build. Before accepting a result as a release baseline, package the app and add
+`--target packaged` to every run:
+
+```powershell
+npm run package
+npm run perf:run -- --target packaged --mode observer --scenario release-observer --duration-seconds 420
+```
+
+Do not compare a development run with a packaged run. Vite, source maps, React
+development checks, and hot-module tooling materially change renderer memory
+and startup work.
+
+The iRacing FPS values come from the simulator telemetry stream. They are good
+for controlled A/B regressions but are not a substitute for PresentMon
+present-to-present frame times. If these runs show an FPS-neutral hitch, use an
+ETW/PresentMon trace as the second-stage investigation.
+
+## Controlled replay benchmark
+
+Use a replay with a representative field size and the same fixed cockpit camera
+for every run. A replay is preferred because live-session traffic, weather, and
+physics load change between samples.
+
+Before starting:
+
+1. Keep iRacing resolution, graphics, mirrors, FPS cap, and camera identical.
+2. Do not resize or edit overlays during a run.
+3. Close browsers, launchers, recording software, and other variable GPU loads.
+4. Let the replay and camera settle for 60 seconds.
+5. Run each mode for at least 6 minutes. Stop it with Ctrl+C.
+
+### 1. SDK observer baseline
+
+This connects to iRacing and samples telemetry, but creates no Electron overlay
+or settings windows.
+
+```powershell
+npm run perf:run -- --mode observer --scenario replay-observer --duration-seconds 420
+```
+
+### 2. Empty transparent-window baseline
+
+This creates the normal transparent overlay windows with every widget disabled.
+It measures the window, renderer bootstrap, and global-provider substrate
+without widget rendering. It does not isolate Windows composition alone because
+each renderer still mounts the dashboard, telemetry, session, pit-lane, and
+reference-lap providers.
+
+```powershell
+npm run perf:run -- --mode empty --scenario replay-empty --duration-seconds 420
+```
+
+### 3. Full dashboard
+
+This loads the current dashboard, but omits the settings and gamepad-host
+windows so the measurement is focused on overlays.
+
+```powershell
+npm run perf:run -- --mode full --scenario replay-full --duration-seconds 420
+```
+
+### 4. Widget isolation
+
+Repeat only if the full dashboard materially regresses FPS or frame pacing.
+Comma-separated widget types can be tested together. The filter is applied in
+memory and is never persisted.
+
+```powershell
+npm run perf:run -- --mode full --widgets standings --scenario replay-standings --duration-seconds 420
+npm run perf:run -- --mode full --widgets relative --scenario replay-relative --duration-seconds 420
+npm run perf:run -- --mode full --widgets trackmap --scenario replay-trackmap --duration-seconds 420
+```
+
+Use the widget type from `WidgetIndex.tsx`, not a widget instance ID.
+
+## Analyse and compare
+
+Each run writes `perf-results/<run-id>.log`. Analyse a single run:
+
+```powershell
+npm run perf:analyze -- perf-results/<run-id>.log --warmup-seconds 60
+```
+
+Compare the empty or full dashboard against the observer:
+
+```powershell
+npm run perf:analyze -- perf-results/<candidate>.log --baseline perf-results/<observer>.log --warmup-seconds 60
+```
+
+The analyzer writes adjacent `.summary.json` and `.summary.md` files. Its
+initial regression gates are:
+
+| Metric                                  |              Gate |
+| --------------------------------------- | ----------------: |
+| iRacing average FPS vs observer         | no worse than -2% |
+| iRacing sampled FPS p1 mean vs observer | no worse than -5% |
+| `processTelemetry` p99 mean             |            < 3 ms |
+| Minimum interval telemetry rate         |          >= 20 Hz |
+| Steady-state app memory slope           |        < 5 MB/min |
+| Renderer frames over 50 ms              |            < 0.1% |
+
+Treat a failed gate as a signal to inspect, not proof of causality. Repeat any
+failed A/B pair once before making an architectural decision.
+
+## Live-session benchmark
+
+Use a real multiplayer practice after the replay A/B matrix. Run the full
+dashboard for at least 20 minutes, ideally covering a join burst and a session
+transition:
+
+```powershell
+npm run perf:run -- --mode full --scenario live-practice-churn --duration-seconds 1500
+```
+
+Record these notes alongside the result:
+
+- session and series
+- car/track and field/class count
+- monitor resolution and refresh rate
+- iRacing FPS cap and whether VSync/G-Sync is active
+- approximate times of joining, entering the car, session transition, and any
+  visible stutter
+
+The live run validates memory slope, join/transition spikes, and subjective
+stutter. Do not compare its FPS directly with the replay baseline.
+
+## Interpreting the mode deltas
+
+| Observation                                        | Likely next investigation                                           |
+| -------------------------------------------------- | ------------------------------------------------------------------- |
+| Observer already hurts iRacing                     | SDK polling/main loop or CPU scheduling                             |
+| Empty regresses vs observer                        | renderer/provider bootstrap, transparent composition, window bounds |
+| Full regresses vs empty                            | React work, canvas/SVG paint, telemetry fanout, widget allocation   |
+| One widget reproduces most of the full delta       | profile that widget's render/paint path                             |
+| FPS is stable but 50 ms renderer frames rise       | renderer main-thread stalls or GC                                   |
+| Renderer timing is clean but visible hitch remains | compositor/GPU present trace with PresentMon/ETW                    |
+
+## Architectural decision rule
+
+Do not begin the worker-thread SDK loop, channel bus, binary IPC, or native
+rewrite solely from subjective stutter. Use the smallest change matching the
+measured layer:
+
+- SDK observer regression: investigate the blocking SDK loop and worker thread.
+- Full-vs-empty CPU regression: reduce renderer wake-ups or move derived
+  telemetry to typed, rate-limited channels/processors.
+- Empty-window GPU regression: reduce transparent surface area/window count or
+  change the Chromium composition path.
+- A single widget's paint regression: optimize that renderer before moving
+  application-wide architecture.
+
+Follow-up work, evidence gates, and measurable exit criteria are tracked in
+[`IMPLEMENTATION_PLAN.md`](./IMPLEMENTATION_PLAN.md#performance-measurement-and-optimization-plan-2026-07-26).

--- a/docs/PERFORMANCE_TEST_SUMMARY.md
+++ b/docs/PERFORMANCE_TEST_SUMMARY.md
@@ -4,6 +4,10 @@
 > **Author:** Kev (with AI-assisted analysis)
 > **Companion file:** [`ARCHITECTURE_REVIEW.md`](./ARCHITECTURE_REVIEW.md)
 > **Purpose:** Empirical evidence to inform updates to the architecture review and prioritisation of remediation work.
+>
+> **Repeatable harness:** See
+> [`PERFORMANCE_BENCHMARKS.md`](./PERFORMANCE_BENCHMARKS.md) for the current
+> replay A/B and live-session protocol.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test": "vitest --coverage",
+    "perf:run": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON tools/perf/run.ts",
+    "perf:analyze": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON tools/perf/analyze.ts",
     "ensure-tracks": "npx tsx ./tools/ensure-tracks.ts",
     "fetch-lovely-data": "npx tsx ./tools/fetch-lovely-data.ts",
     "fetch-lovely-track-data": "npx tsx ./tools/fetch-lovely-track-data.ts",

--- a/src/app/bridge/dashboard/dashboardBridge.ts
+++ b/src/app/bridge/dashboard/dashboardBridge.ts
@@ -216,7 +216,10 @@ export const dashboardBridge: DashboardBridge = {
 
 export async function publishDashboardUpdates(
   overlayManager: OverlayManager,
-  analytics: Analytics
+  analytics: Analytics,
+  dashboardTransform: (dashboard: DashboardLayout) => DashboardLayout = (
+    dashboard
+  ) => dashboard
 ) {
   let lastProfileId = getCurrentProfileId();
   let hideTimer: ReturnType<typeof setTimeout> | undefined;
@@ -236,7 +239,9 @@ export async function publishDashboardUpdates(
   };
 
   onDashboardUpdated((dashboard) => {
-    const merged = mergeDriverTagsIntoLayout(dashboard, getDriverTagSettings());
+    const merged = dashboardTransform(
+      mergeDriverTagsIntoLayout(dashboard, getDriverTagSettings())
+    );
     const profileId = getCurrentProfileId();
 
     if (profileId === lastProfileId) {
@@ -293,7 +298,9 @@ export async function publishDashboardUpdates(
     const currentProfileId = getCurrentProfileId();
     const dashboard = getDashboard(currentProfileId);
     if (!dashboard) return;
-    const merged = mergeDriverTagsIntoLayout(dashboard, getDriverTagSettings());
+    const merged = dashboardTransform(
+      mergeDriverTagsIntoLayout(dashboard, getDriverTagSettings())
+    );
     overlayManager.closeOrCreateWindows(merged);
     overlayManager.publishMessage('dashboardUpdated', merged);
   });

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -216,7 +216,7 @@ export async function publishIRacingSDKEvents(
           }
         }
         perfMetrics.markEnd('processTelemetry');
-        perfMetrics.tick();
+        perfMetrics.tick(telemetry);
 
         // Throttling to ~25Hz to save system resources as requested.
         // We sleep AFTER publishing to ensure each frame is sent with minimal latency.

--- a/src/app/bridge/iracingSdk/mock-data/mockSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/mock-data/mockSdkBridge.ts
@@ -18,7 +18,7 @@ export async function publishIRacingSDKEvents(overlayManager: OverlayManager) {
     overlayManager.publishMessage('telemetry', telemetry);
     perfMetrics.markEnd('broadcast');
     perfMetrics.markEnd('processTelemetry');
-    perfMetrics.tick();
+    perfMetrics.tick(telemetry);
   });
 
   bridge.onRunningState((running) => {

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -12,6 +12,7 @@ import { getDashboard } from './storage/dashboards';
 import { getChromiumFlags, parseCustomSwitches } from './storage/chromiumFlags';
 import { trackSettingsWindowMovement } from './trackWindowMovement';
 import logger from './logger';
+import { createRendererPerfArguments } from './perfRendererArguments';
 
 // used for Hot Module Replacement
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;
@@ -77,7 +78,10 @@ export class OverlayManager {
   /**
    * Create one overlay window per display
    */
-  public createOverlays(dashboardLayout: DashboardLayout): void {
+  public createOverlays(
+    dashboardLayout: DashboardLayout,
+    options: { createSettingsWindow?: boolean } = {}
+  ): void {
     this.currentDashboard = dashboardLayout;
     const { generalSettings } = dashboardLayout;
     this.skipTaskbar = generalSettings?.skipTaskbar ?? true;
@@ -128,8 +132,10 @@ export class OverlayManager {
       this.createWindowForDisplay(display, isPrimary);
     }
 
-    const startMinimized = generalSettings?.startMinimized ?? false;
-    this.createSettingsWindow(undefined, { startHidden: startMinimized });
+    if (options.createSettingsWindow !== false) {
+      const startMinimized = generalSettings?.startMinimized ?? false;
+      this.createSettingsWindow(undefined, { startHidden: startMinimized });
+    }
   }
 
   /**
@@ -179,6 +185,7 @@ export class OverlayManager {
       webPreferences: {
         preload: path.join(__dirname, 'preload.js'),
         backgroundThrottling: false,
+        additionalArguments: createRendererPerfArguments(),
         // Enables the <webview> used by the Heart Rate widget to embed
         // HypeRate's overlay and inject transparent-background CSS (the same
         // technique OBS uses). Global-by-design: webPreferences are fixed at

--- a/src/app/perfMetrics.ts
+++ b/src/app/perfMetrics.ts
@@ -8,14 +8,18 @@
  * Enabled via PERF_METRICS=1 environment variable.
  */
 
-import { performance } from 'perf_hooks';
+import { monitorEventLoopDelay, performance } from 'node:perf_hooks';
 import { app, BrowserWindow } from 'electron';
+import type { NumericSampleStats, Telemetry } from '@irdashies/types';
+import { FixedSampleBuffer } from '../shared/performanceSamples';
 import logger from './logger';
 
 export interface SectionStats {
   count: number;
   avgMs: number;
+  minMs: number;
   maxMs: number;
+  p95Ms: number;
   p99Ms: number;
 }
 
@@ -28,22 +32,38 @@ export interface ProcessMetrics {
 }
 
 export interface PerfReport {
+  schemaVersion: 1;
+  timestamp: string;
+  runId: string;
+  scenario: string;
+  overlayMode: string;
   intervalMs: number;
   tickCount: number;
+  tickRateHz: number;
+  tickIntervalMs: NumericSampleStats;
   sections: Record<string, SectionStats>;
+  eventLoopDelayMs: {
+    mean: number;
+    max: number;
+    p99: number;
+  };
+  iracing: {
+    frameRate: NumericSampleStats;
+    cpuUsageForeground: NumericSampleStats;
+    cpuUsageBackground: NumericSampleStats;
+    gpuUsage: NumericSampleStats;
+  };
   cpuPercent: number;
   processes?: ProcessMetrics[];
   totalAppCpuPercent?: number;
   totalAppMemoryMB?: number;
 }
 
-const RING_BUFFER_SIZE = 1024;
 const DEFAULT_REPORT_INTERVAL_MS = 10_000;
+export const PERF_MAIN_LOG_PREFIX = '[PerfMetrics:JSON] ';
 
 class SectionBuffer {
-  private buffer: Float64Array = new Float64Array(RING_BUFFER_SIZE);
-  private writeIndex = 0;
-  private count = 0;
+  private samples = new FixedSampleBuffer();
   private startTime = 0;
 
   markStart(): void {
@@ -51,56 +71,37 @@ class SectionBuffer {
   }
 
   markEnd(): void {
-    const elapsed = performance.now() - this.startTime;
-    this.buffer[this.writeIndex] = elapsed;
-    this.writeIndex = (this.writeIndex + 1) % RING_BUFFER_SIZE;
-    if (this.count < RING_BUFFER_SIZE) this.count++;
+    this.samples.add(performance.now() - this.startTime);
   }
 
   getStats(): SectionStats {
-    if (this.count === 0) {
-      return { count: 0, avgMs: 0, maxMs: 0, p99Ms: 0 };
-    }
-
-    const samples = new Float64Array(this.count);
-    if (this.count < RING_BUFFER_SIZE) {
-      samples.set(this.buffer.subarray(0, this.count));
-    } else {
-      const tailLen = RING_BUFFER_SIZE - this.writeIndex;
-      samples.set(this.buffer.subarray(this.writeIndex, RING_BUFFER_SIZE), 0);
-      samples.set(this.buffer.subarray(0, this.writeIndex), tailLen);
-    }
-
-    samples.sort();
-
-    let sum = 0;
-    for (const sample of samples) {
-      sum += sample;
-    }
-
-    const p99Index = Math.min(
-      Math.floor(samples.length * 0.99),
-      samples.length - 1
-    );
-
+    const stats = this.samples.summarize();
     return {
-      count: this.count,
-      avgMs: sum / samples.length,
-      maxMs: samples[samples.length - 1],
-      p99Ms: samples[p99Index],
+      count: stats.count,
+      avgMs: stats.avg,
+      minMs: stats.min,
+      maxMs: stats.max,
+      p95Ms: stats.p95,
+      p99Ms: stats.p99,
     };
   }
 
   reset(): void {
-    this.writeIndex = 0;
-    this.count = 0;
+    this.samples.reset();
   }
 }
 
 export class TelemetryPerfMetrics {
   private sections = new Map<string, SectionBuffer>();
+  private tickIntervals = new FixedSampleBuffer();
+  private iracingFrameRate = new FixedSampleBuffer();
+  private iracingCpuForeground = new FixedSampleBuffer();
+  private iracingCpuBackground = new FixedSampleBuffer();
+  private iracingGpuUsage = new FixedSampleBuffer();
+  private eventLoopDelay = monitorEventLoopDelay({ resolution: 20 });
   private reportTimer: NodeJS.Timeout | null = null;
   private lastReportTime = 0;
+  private lastTickTime = 0;
   private lastCpuUsage: NodeJS.CpuUsage = { user: 0, system: 0 };
   private tickCount = 0;
   private _enabled: boolean;
@@ -116,12 +117,19 @@ export class TelemetryPerfMetrics {
   startReporting(intervalMs: number = DEFAULT_REPORT_INTERVAL_MS): void {
     if (!this._enabled) return;
     this.stopReporting();
+    const configuredInterval = Number(process.env.PERF_REPORT_INTERVAL_MS);
+    const effectiveInterval =
+      Number.isFinite(configuredInterval) && configuredInterval >= 1000
+        ? configuredInterval
+        : intervalMs;
     this.lastReportTime = performance.now();
+    this.lastTickTime = 0;
     this.lastCpuUsage = process.cpuUsage();
+    this.eventLoopDelay.enable();
     this.reportTimer = setInterval(() => {
       const report = this.report();
       this.logReport(report);
-    }, intervalMs);
+    }, effectiveInterval);
   }
 
   stopReporting(): void {
@@ -129,6 +137,7 @@ export class TelemetryPerfMetrics {
       clearInterval(this.reportTimer);
       this.reportTimer = null;
     }
+    this.eventLoopDelay.disable();
   }
 
   markStart(label: string): void {
@@ -141,9 +150,17 @@ export class TelemetryPerfMetrics {
     this.getOrCreateSection(label).markEnd();
   }
 
-  tick(): void {
+  tick(telemetry?: Telemetry | null): void {
     if (!this._enabled) return;
+    const now = performance.now();
+    if (this.lastTickTime > 0) {
+      this.tickIntervals.add(now - this.lastTickTime);
+    }
+    this.lastTickTime = now;
     this.tickCount++;
+    if (telemetry) {
+      this.observeIRacing(telemetry);
+    }
   }
 
   report(): PerfReport {
@@ -162,11 +179,32 @@ export class TelemetryPerfMetrics {
     }
 
     const { processes, totalCpu, totalMemory } = this.getProcessMetrics();
+    const elapsedMs = now - this.lastReportTime;
+    const nanosecondsToMilliseconds = (value: number): number =>
+      Number.isFinite(value) ? value / 1_000_000 : 0;
 
     const report: PerfReport = {
-      intervalMs: now - this.lastReportTime,
+      schemaVersion: 1,
+      timestamp: new Date().toISOString(),
+      runId: process.env.PERF_RUN_ID ?? 'manual',
+      scenario: process.env.PERF_SCENARIO ?? 'unspecified',
+      overlayMode: process.env.PERF_OVERLAY_MODE ?? 'full',
+      intervalMs: elapsedMs,
       tickCount: this.tickCount,
+      tickRateHz: this.tickCount / (elapsedMs / 1000),
+      tickIntervalMs: this.tickIntervals.summarize(),
       sections,
+      eventLoopDelayMs: {
+        mean: nanosecondsToMilliseconds(this.eventLoopDelay.mean),
+        max: nanosecondsToMilliseconds(this.eventLoopDelay.max),
+        p99: nanosecondsToMilliseconds(this.eventLoopDelay.percentile(99)),
+      },
+      iracing: {
+        frameRate: this.iracingFrameRate.summarize(),
+        cpuUsageForeground: this.iracingCpuForeground.summarize(),
+        cpuUsageBackground: this.iracingCpuBackground.summarize(),
+        gpuUsage: this.iracingGpuUsage.summarize(),
+      },
       cpuPercent,
       processes,
       totalAppCpuPercent: totalCpu,
@@ -176,6 +214,12 @@ export class TelemetryPerfMetrics {
     this.lastReportTime = now;
     this.lastCpuUsage = process.cpuUsage();
     this.tickCount = 0;
+    this.tickIntervals.reset();
+    this.iracingFrameRate.reset();
+    this.iracingCpuForeground.reset();
+    this.iracingCpuBackground.reset();
+    this.iracingGpuUsage.reset();
+    this.eventLoopDelay.reset();
     for (const buf of this.sections.values()) {
       buf.reset();
     }
@@ -190,6 +234,15 @@ export class TelemetryPerfMetrics {
       this.sections.set(label, buf);
     }
     return buf;
+  }
+
+  private observeIRacing(telemetry: Telemetry): void {
+    this.iracingFrameRate.add(telemetry.FrameRate?.value?.[0]);
+    const percentage = (value: number | undefined): number | undefined =>
+      value === undefined ? undefined : value * 100;
+    this.iracingCpuForeground.add(percentage(telemetry.CpuUsageFG?.value?.[0]));
+    this.iracingCpuBackground.add(percentage(telemetry.CpuUsageBG?.value?.[0]));
+    this.iracingGpuUsage.add(percentage(telemetry.GpuUsage?.value?.[0]));
   }
 
   private getProcessMetrics(): {
@@ -254,13 +307,21 @@ export class TelemetryPerfMetrics {
   }
 
   private logReport(report: PerfReport): void {
-    const hz = report.tickCount / (report.intervalMs / 1000);
-
     const totalCpu = report.totalAppCpuPercent ?? report.cpuPercent;
     const totalMem = report.totalAppMemoryMB ?? 0;
     const lines = [
-      `[PerfMetrics] ${report.tickCount} ticks in ${(report.intervalMs / 1000).toFixed(1)}s (${hz.toFixed(1)} Hz) | App CPU: ${totalCpu.toFixed(1)}% | App Memory: ${totalMem.toFixed(0)}MB`,
+      `[PerfMetrics] ${report.tickCount} ticks in ${(report.intervalMs / 1000).toFixed(1)}s (${report.tickRateHz.toFixed(1)} Hz) | App CPU: ${totalCpu.toFixed(1)}% | App Memory: ${totalMem.toFixed(0)}MB`,
     ];
+
+    if (report.iracing.frameRate.count > 0) {
+      lines.push(
+        `  iRacing: FPS avg=${report.iracing.frameRate.avg.toFixed(1)} p1=${report.iracing.frameRate.p1.toFixed(1)} min=${report.iracing.frameRate.min.toFixed(1)} | CPU FG=${report.iracing.cpuUsageForeground.avg.toFixed(1)}% | GPU=${report.iracing.gpuUsage.avg.toFixed(1)}%`
+      );
+    }
+
+    lines.push(
+      `  eventLoop: mean=${report.eventLoopDelayMs.mean.toFixed(3)}ms max=${report.eventLoopDelayMs.max.toFixed(3)}ms p99=${report.eventLoopDelayMs.p99.toFixed(3)}ms`
+    );
 
     for (const [label, stats] of Object.entries(report.sections)) {
       if (stats.count === 0) continue;
@@ -285,5 +346,6 @@ export class TelemetryPerfMetrics {
     }
 
     logger.info(lines.join('\n'));
+    logger.info(`${PERF_MAIN_LOG_PREFIX}${JSON.stringify(report)}`);
   }
 }

--- a/src/app/perfRendererArguments.spec.ts
+++ b/src/app/perfRendererArguments.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createRendererPerfArguments,
+  readRendererPerfArguments,
+} from './perfRendererArguments';
+
+describe('renderer performance arguments', () => {
+  it('creates no renderer arguments when profiling is disabled', () => {
+    expect(createRendererPerfArguments({})).toEqual([]);
+  });
+
+  it('round-trips a sanitized performance configuration', () => {
+    const args = createRendererPerfArguments({
+      PERF_METRICS: '1',
+      PERF_RUN_ID: 'run 1',
+      PERF_SCENARIO: 'full/dashboard',
+      PERF_REPORT_INTERVAL_MS: '5000',
+    });
+
+    expect(readRendererPerfArguments(args)).toEqual({
+      enabled: true,
+      runId: 'run-1',
+      scenario: 'full-dashboard',
+      reportIntervalMs: 5000,
+    });
+  });
+});

--- a/src/app/perfRendererArguments.ts
+++ b/src/app/perfRendererArguments.ts
@@ -1,0 +1,49 @@
+export interface RendererPerfConfig {
+  enabled: boolean;
+  runId: string;
+  scenario: string;
+  reportIntervalMs: number;
+}
+
+const PERF_ARGUMENT = '--irdashies-perf-metrics';
+const RUN_ID_ARGUMENT = '--irdashies-perf-run-id=';
+const SCENARIO_ARGUMENT = '--irdashies-perf-scenario=';
+const INTERVAL_ARGUMENT = '--irdashies-perf-interval-ms=';
+
+function safeValue(value: string | undefined, fallback: string): string {
+  if (!value) return fallback;
+  return value.replace(/[^a-z0-9_-]+/gi, '-').slice(0, 120) || fallback;
+}
+
+export function createRendererPerfArguments(
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  if (env.PERF_METRICS !== '1') return [];
+
+  const interval = Number(env.PERF_REPORT_INTERVAL_MS);
+  const reportIntervalMs =
+    Number.isFinite(interval) && interval >= 1000 ? interval : 10_000;
+
+  return [
+    PERF_ARGUMENT,
+    `${RUN_ID_ARGUMENT}${safeValue(env.PERF_RUN_ID, 'manual')}`,
+    `${SCENARIO_ARGUMENT}${safeValue(env.PERF_SCENARIO, 'unspecified')}`,
+    `${INTERVAL_ARGUMENT}${reportIntervalMs}`,
+  ];
+}
+
+export function readRendererPerfArguments(
+  args: string[] = process.argv
+): RendererPerfConfig {
+  const valueAfter = (prefix: string): string | undefined =>
+    args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+  const interval = Number(valueAfter(INTERVAL_ARGUMENT));
+
+  return {
+    enabled: args.includes(PERF_ARGUMENT),
+    runId: safeValue(valueAfter(RUN_ID_ARGUMENT), 'manual'),
+    scenario: safeValue(valueAfter(SCENARIO_ARGUMENT), 'unspecified'),
+    reportIntervalMs:
+      Number.isFinite(interval) && interval >= 1000 ? interval : 10_000,
+  };
+}

--- a/src/app/perfRunConfig.spec.ts
+++ b/src/app/perfRunConfig.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { DashboardLayout } from '@irdashies/types';
+import { createPerfDashboard, getPerfRunConfig } from './perfRunConfig';
+
+const dashboard: DashboardLayout = {
+  widgets: [
+    {
+      id: 'standings-1',
+      type: 'standings',
+      enabled: true,
+      layout: { x: 0, y: 0, width: 100, height: 100 },
+    },
+    {
+      id: 'relative',
+      enabled: true,
+      layout: { x: 100, y: 0, width: 100, height: 100 },
+    },
+  ],
+};
+
+describe('performance run configuration', () => {
+  it('allowlists overlay modes and widget names', () => {
+    expect(
+      getPerfRunConfig({
+        PERF_METRICS: '1',
+        PERF_OVERLAY_MODE: 'observer',
+        PERF_WIDGET_TYPES: 'standings, ../bad,relative',
+        PERF_DURATION_SECONDS: '60',
+      })
+    ).toMatchObject({
+      enabled: true,
+      overlayMode: 'observer',
+      widgetTypes: ['standings', 'relative'],
+      durationSeconds: 60,
+    });
+
+    expect(
+      getPerfRunConfig({
+        PERF_METRICS: '1',
+        PERF_OVERLAY_MODE: 'invalid',
+      }).overlayMode
+    ).toBe('full');
+  });
+
+  it('creates an empty dashboard without mutating the source', () => {
+    const result = createPerfDashboard(dashboard, {
+      enabled: true,
+      overlayMode: 'empty',
+      widgetTypes: [],
+      scenario: 'empty',
+      durationSeconds: 0,
+    });
+
+    expect(result.widgets.every((widget) => !widget.enabled)).toBe(true);
+    expect(dashboard.widgets.every((widget) => widget.enabled)).toBe(true);
+  });
+
+  it('isolates selected widget types', () => {
+    const result = createPerfDashboard(dashboard, {
+      enabled: true,
+      overlayMode: 'full',
+      widgetTypes: ['standings'],
+      scenario: 'standings',
+      durationSeconds: 0,
+    });
+
+    expect(result.widgets.map((widget) => widget.enabled)).toEqual([
+      true,
+      false,
+    ]);
+  });
+});

--- a/src/app/perfRunConfig.ts
+++ b/src/app/perfRunConfig.ts
@@ -1,0 +1,80 @@
+import type { DashboardLayout } from '@irdashies/types';
+
+export type PerfOverlayMode = 'full' | 'empty' | 'observer';
+
+export interface PerfRunConfig {
+  enabled: boolean;
+  overlayMode: PerfOverlayMode;
+  widgetTypes: string[];
+  scenario: string;
+  durationSeconds: number;
+}
+
+const PERF_OVERLAY_MODES = new Set<PerfOverlayMode>([
+  'full',
+  'empty',
+  'observer',
+]);
+
+export function getPerfRunConfig(
+  env: NodeJS.ProcessEnv = process.env
+): PerfRunConfig {
+  const requestedMode = env.PERF_OVERLAY_MODE as PerfOverlayMode | undefined;
+  const overlayMode =
+    requestedMode && PERF_OVERLAY_MODES.has(requestedMode)
+      ? requestedMode
+      : 'full';
+  const widgetTypes = (env.PERF_WIDGET_TYPES ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => /^[a-z0-9-]+$/i.test(value));
+  const requestedDuration = Number(env.PERF_DURATION_SECONDS);
+  const durationSeconds =
+    Number.isFinite(requestedDuration) &&
+    requestedDuration >= 10 &&
+    requestedDuration <= 86_400
+      ? requestedDuration
+      : 0;
+
+  return {
+    enabled: env.PERF_METRICS === '1',
+    overlayMode,
+    widgetTypes,
+    scenario:
+      env.PERF_SCENARIO ??
+      (widgetTypes.length > 0
+        ? `widgets-${widgetTypes.join('-')}`
+        : overlayMode),
+    durationSeconds,
+  };
+}
+
+export function createPerfDashboard(
+  dashboard: DashboardLayout,
+  config: PerfRunConfig
+): DashboardLayout {
+  if (!config.enabled || config.overlayMode === 'full') {
+    if (config.widgetTypes.length === 0) return dashboard;
+
+    const selectedTypes = new Set(config.widgetTypes);
+    return {
+      ...dashboard,
+      widgets: dashboard.widgets.map((widget) => ({
+        ...widget,
+        enabled: selectedTypes.has(widget.type ?? widget.id),
+      })),
+    };
+  }
+
+  if (config.overlayMode === 'empty') {
+    return {
+      ...dashboard,
+      widgets: dashboard.widgets.map((widget) => ({
+        ...widget,
+        enabled: false,
+      })),
+    };
+  }
+
+  return dashboard;
+}

--- a/src/app/rendererPerfMetrics.ts
+++ b/src/app/rendererPerfMetrics.ts
@@ -1,0 +1,69 @@
+import { ipcRenderer } from 'electron';
+import type { RendererPerfSample } from '@irdashies/types';
+import { FixedSampleBuffer } from '../shared/performanceSamples';
+import { readRendererPerfArguments } from './perfRendererArguments';
+
+export const PERF_RENDERER_LOG_PREFIX = '[PerfRenderer:JSON] ';
+
+export function startRendererPerfMetrics(): void {
+  const config = readRendererPerfArguments();
+  if (!config.enabled) return;
+
+  const configuredInterval = config.reportIntervalMs;
+  const reportIntervalMs =
+    Number.isFinite(configuredInterval) && configuredInterval >= 1000
+      ? configuredInterval
+      : 10_000;
+  const frameTimes = new FixedSampleBuffer(4096);
+  let intervalStart = performance.now();
+  let previousFrameTime = 0;
+  let framesOver25Ms = 0;
+  let framesOver50Ms = 0;
+
+  const onFrame = (now: number): void => {
+    if (previousFrameTime > 0) {
+      const frameTime = now - previousFrameTime;
+      frameTimes.add(frameTime);
+      if (frameTime > 25) framesOver25Ms++;
+      if (frameTime > 50) framesOver50Ms++;
+    }
+    previousFrameTime = now;
+    requestAnimationFrame(onFrame);
+  };
+
+  requestAnimationFrame(onFrame);
+
+  setInterval(() => {
+    const now = performance.now();
+    const stats = frameTimes.summarize();
+    if (stats.count === 0) {
+      intervalStart = now;
+      return;
+    }
+
+    const sample: RendererPerfSample = {
+      schemaVersion: 1,
+      timestamp: new Date().toISOString(),
+      runId: config.runId,
+      scenario: config.scenario,
+      pid: process.pid,
+      route: window.location.hash || window.location.pathname,
+      visibilityState: document.visibilityState,
+      intervalMs: now - intervalStart,
+      frameTimeMs: stats,
+      framesOver25Ms,
+      framesOver50Ms,
+    };
+
+    ipcRenderer.send(
+      'log',
+      'info',
+      `${PERF_RENDERER_LOG_PREFIX}${JSON.stringify(sample)}`
+    );
+
+    intervalStart = now;
+    frameTimes.reset();
+    framesOver25Ms = 0;
+    framesOver50Ms = 0;
+  }, reportIntervalMs);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import {
   flushReferenceLapsOnShutdown,
 } from './app/storage/referenceLaps';
 import { setupChromiumFlagsBridge } from './app/bridge/chromiumFlagsBridge';
+import { createPerfDashboard, getPerfRunConfig } from './app/perfRunConfig';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) app.quit();
@@ -38,6 +39,7 @@ updateElectronApp();
 
 const overlayManager = new OverlayManager();
 const analytics = new Analytics();
+const perfRun = getPerfRunConfig();
 analytics.setupLogTransport();
 
 overlayManager.setupChromiumFlags();
@@ -53,6 +55,18 @@ app.on('ready', async () => {
   // (this instance should be quitting)
   if (!overlayManager.hasLock()) {
     return;
+  }
+
+  if (perfRun.enabled) {
+    log.info('[PerfRun] Configuration', perfRun);
+    if (perfRun.durationSeconds > 0) {
+      setTimeout(() => {
+        log.info(
+          `[PerfRun] Completed fixed ${perfRun.durationSeconds}s capture`
+        );
+        app.quit();
+      }, perfRun.durationSeconds * 1000);
+    }
   }
 
   await iRacingSDKSetup(overlayManager);
@@ -76,21 +90,44 @@ app.on('ready', async () => {
 
   ipcMain.handle('getComponentServerPort', () => getComponentServerPort());
 
-  overlayManager.createOverlays(dashboard);
+  const runDashboard = createPerfDashboard(dashboard, perfRun);
+  if (!perfRun.enabled || perfRun.overlayMode !== 'observer') {
+    // Empty mode keeps the normal overlay window count/bounds while the
+    // renderer receives a dashboard with every widget disabled. This isolates
+    // transparent-window/global-provider cost from widget rendering.
+    const windowDashboard =
+      perfRun.enabled && perfRun.overlayMode === 'empty'
+        ? dashboard
+        : runDashboard;
+    overlayManager.createOverlays(windowDashboard, {
+      createSettingsWindow: !perfRun.enabled,
+    });
+  }
 
   keybindingManager = new KeybindingManager(overlayManager);
   keybindingManager.registerAll();
   // Start the WebHID host window that reads game controllers for gamepad bindings.
-  keybindingManager.startGamepad();
+  if (!perfRun.enabled) {
+    keybindingManager.startGamepad();
+  }
 
   setupTaskbar(overlayManager, keybindingManager);
-  publishDashboardUpdates(overlayManager, analytics);
+  await publishDashboardUpdates(
+    overlayManager,
+    analytics,
+    perfRun.enabled
+      ? (updatedDashboard) => createPerfDashboard(updatedDashboard, perfRun)
+      : undefined
+  );
   setupKeybindingsBridge(keybindingManager);
 
   await analytics.init(overlayManager.getVersion(), dashboard);
 });
 
 app.on('window-all-closed', () => {
+  if (perfRun.enabled && perfRun.overlayMode === 'observer') {
+    return;
+  }
   if (process.platform !== 'darwin') {
     app.quit();
   }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -2,6 +2,8 @@
 // https://www.electronjs.org/docs/latest/tutorial/process-model#preload-scripts
 import { exposeBridge } from './app/bridge/rendererExposeBridge';
 import { exposeInMainWorld } from './app/rendererExpose';
+import { startRendererPerfMetrics } from './app/rendererPerfMetrics';
 
 exposeBridge();
 exposeInMainWorld();
+startRendererPerfMetrics();

--- a/src/shared/performanceSamples.spec.ts
+++ b/src/shared/performanceSamples.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { FixedSampleBuffer } from './performanceSamples';
+
+describe('FixedSampleBuffer', () => {
+  it('summarizes samples and percentiles', () => {
+    const buffer = new FixedSampleBuffer(100);
+    for (let value = 1; value <= 100; value++) {
+      buffer.add(value);
+    }
+
+    expect(buffer.summarize()).toEqual({
+      count: 100,
+      avg: 50.5,
+      min: 1,
+      max: 100,
+      p1: 2,
+      p50: 51,
+      p95: 96,
+      p99: 100,
+    });
+  });
+
+  it('keeps only the newest samples when full', () => {
+    const buffer = new FixedSampleBuffer(3);
+    buffer.add(1);
+    buffer.add(2);
+    buffer.add(3);
+    buffer.add(4);
+
+    expect(buffer.summarize()).toMatchObject({
+      count: 3,
+      avg: 3,
+      min: 2,
+      max: 4,
+    });
+  });
+
+  it('resets and ignores non-finite values', () => {
+    const buffer = new FixedSampleBuffer();
+    buffer.add(Number.NaN);
+    buffer.add(Number.POSITIVE_INFINITY);
+    buffer.add(10);
+    buffer.reset();
+
+    expect(buffer.summarize().count).toBe(0);
+  });
+});

--- a/src/shared/performanceSamples.ts
+++ b/src/shared/performanceSamples.ts
@@ -1,0 +1,75 @@
+import type { NumericSampleStats } from '@irdashies/types';
+
+export class FixedSampleBuffer {
+  private readonly values: Float64Array;
+  private writeIndex = 0;
+  private sampleCount = 0;
+
+  constructor(size = 2048) {
+    this.values = new Float64Array(size);
+  }
+
+  add(value: number | undefined): void {
+    if (value === undefined || !Number.isFinite(value)) return;
+
+    this.values[this.writeIndex] = value;
+    this.writeIndex = (this.writeIndex + 1) % this.values.length;
+    if (this.sampleCount < this.values.length) {
+      this.sampleCount++;
+    }
+  }
+
+  summarize(): NumericSampleStats {
+    if (this.sampleCount === 0) {
+      return {
+        count: 0,
+        avg: 0,
+        min: 0,
+        max: 0,
+        p1: 0,
+        p50: 0,
+        p95: 0,
+        p99: 0,
+      };
+    }
+
+    const samples = new Float64Array(this.sampleCount);
+    if (this.sampleCount < this.values.length) {
+      samples.set(this.values.subarray(0, this.sampleCount));
+    } else {
+      const tailLength = this.values.length - this.writeIndex;
+      samples.set(this.values.subarray(this.writeIndex), 0);
+      samples.set(this.values.subarray(0, this.writeIndex), tailLength);
+    }
+    samples.sort();
+
+    let sum = 0;
+    for (const sample of samples) {
+      sum += sample;
+    }
+
+    const percentile = (fraction: number): number => {
+      const index = Math.min(
+        Math.floor(samples.length * fraction),
+        samples.length - 1
+      );
+      return samples[index];
+    };
+
+    return {
+      count: samples.length,
+      avg: sum / samples.length,
+      min: samples[0],
+      max: samples[samples.length - 1],
+      p1: percentile(0.01),
+      p50: percentile(0.5),
+      p95: percentile(0.95),
+      p99: percentile(0.99),
+    };
+  }
+
+  reset(): void {
+    this.writeIndex = 0;
+    this.sampleCount = 0;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,4 +15,5 @@ export * from './logBridge';
 export * from './keybindings';
 export * from './personalBestLapBridge';
 export * from './chromiumFlags';
+export * from './performance';
 export * from './gamepadToken';

--- a/src/types/performance.ts
+++ b/src/types/performance.ts
@@ -1,0 +1,24 @@
+export interface NumericSampleStats {
+  count: number;
+  avg: number;
+  min: number;
+  max: number;
+  p1: number;
+  p50: number;
+  p95: number;
+  p99: number;
+}
+
+export interface RendererPerfSample {
+  schemaVersion: 1;
+  timestamp: string;
+  runId: string;
+  scenario: string;
+  pid: number;
+  route: string;
+  visibilityState: DocumentVisibilityState;
+  intervalMs: number;
+  frameTimeMs: NumericSampleStats;
+  framesOver25Ms: number;
+  framesOver50Ms: number;
+}

--- a/tools/perf/analyze.spec.ts
+++ b/tools/perf/analyze.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import type { NumericSampleStats } from '../../src/types/performance';
+import { compareSummaries, parsePerfLog, summarizeCapture } from './analyze';
+
+const stats = (
+  avg: number,
+  overrides: Partial<NumericSampleStats> = {}
+): NumericSampleStats => ({
+  count: 100,
+  avg,
+  min: avg - 5,
+  max: avg + 5,
+  p1: avg - 4,
+  p50: avg,
+  p95: avg + 3,
+  p99: avg + 4,
+  ...overrides,
+});
+
+function mainSample(seconds: number, memoryMB: number, fps = 100) {
+  return {
+    timestamp: new Date(seconds * 1000).toISOString(),
+    runId: 'run',
+    scenario: 'full',
+    overlayMode: 'full',
+    tickRateHz: 24,
+    sections: {
+      processTelemetry: { count: 100, avgMs: 1, maxMs: 4, p99Ms: 2 },
+      broadcast: { count: 100, avgMs: 0.2, maxMs: 1, p99Ms: 0.5 },
+    },
+    eventLoopDelayMs: { mean: 20, max: 30, p99: 25 },
+    iracing: {
+      frameRate: stats(fps),
+      cpuUsageForeground: stats(40),
+      cpuUsageBackground: stats(5),
+      gpuUsage: stats(70),
+    },
+    totalAppCpuPercent: 12,
+    totalAppMemoryMB: memoryMB,
+  };
+}
+
+describe('performance analysis', () => {
+  it('parses structured records mixed with normal logs', () => {
+    const main = mainSample(0, 100);
+    const contents = [
+      'normal output',
+      `[PerfMetrics:JSON] ${JSON.stringify(main)}`,
+      '[PerfRenderer:JSON] {"timestamp":"1970-01-01T00:00:00.000Z","frameTimeMs":{"count":1,"avg":16,"min":16,"max":16,"p1":16,"p50":16,"p95":16,"p99":16},"framesOver25Ms":0,"framesOver50Ms":0}',
+    ].join('\n');
+
+    expect(parsePerfLog(contents)).toMatchObject({
+      main: [main],
+      renderer: [{ framesOver50Ms: 0 }],
+    });
+  });
+
+  it('summarizes memory slope and telemetry metrics', () => {
+    const summary = summarizeCapture(
+      {
+        main: [mainSample(0, 100), mainSample(60, 102), mainSample(120, 104)],
+        renderer: [],
+      },
+      0
+    );
+
+    expect(summary.app.memorySlopeMBPerMinute).toBeCloseTo(2);
+    expect(summary.iracing.averageFps).toBe(100);
+    expect(summary.telemetry.processTelemetryP99MeanMs).toBe(2);
+  });
+
+  it('flags a material iRacing FPS regression', () => {
+    const baseline = summarizeCapture(
+      { main: [mainSample(0, 100, 100)], renderer: [] },
+      0
+    );
+    const candidate = summarizeCapture(
+      { main: [mainSample(0, 100, 90)], renderer: [] },
+      0
+    );
+
+    const comparison = compareSummaries(baseline, candidate);
+    expect(comparison.delta.averageFpsPercent).toBe(-10);
+    expect(comparison.checks[0].passed).toBe(false);
+  });
+});

--- a/tools/perf/analyze.ts
+++ b/tools/perf/analyze.ts
@@ -1,0 +1,554 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type {
+  NumericSampleStats,
+  RendererPerfSample,
+} from '../../src/types/performance';
+
+const MAIN_PREFIX = '[PerfMetrics:JSON] ';
+const RENDERER_PREFIX = '[PerfRenderer:JSON] ';
+
+interface SectionStats {
+  count: number;
+  avgMs: number;
+  maxMs: number;
+  p99Ms: number;
+}
+
+interface MainPerfSample {
+  timestamp: string;
+  runId: string;
+  scenario: string;
+  overlayMode: string;
+  tickRateHz: number;
+  sections: Record<string, SectionStats>;
+  eventLoopDelayMs: { mean: number; max: number; p99: number };
+  iracing: {
+    frameRate: NumericSampleStats;
+    cpuUsageForeground: NumericSampleStats;
+    cpuUsageBackground: NumericSampleStats;
+    gpuUsage: NumericSampleStats;
+  };
+  totalAppCpuPercent?: number;
+  totalAppMemoryMB?: number;
+  processes?: {
+    pid: number;
+    type: string;
+    name?: string;
+    cpuPercent: number;
+    memoryMB: number;
+  }[];
+}
+
+export interface PerfCapture {
+  main: MainPerfSample[];
+  renderer: RendererPerfSample[];
+}
+
+export interface PerfSummary {
+  runId: string;
+  scenario: string;
+  overlayMode: string;
+  durationMinutes: number;
+  sampleCount: number;
+  iracing: {
+    averageFps: number;
+    meanOnePercentLowFps: number;
+    worstFps: number;
+    averageCpuForeground: number;
+    averageGpuUsage: number;
+  };
+  app: {
+    averageCpuPercent: number;
+    peakMemoryMB: number;
+    peakRendererMemoryMB: number;
+    peakMainMemoryMB: number;
+    peakGpuMemoryMB: number;
+    rendererProcessCount: number;
+    memorySlopeMBPerMinute: number;
+  };
+  telemetry: {
+    averageTickRateHz: number;
+    minimumTickRateHz: number;
+    processTelemetryP99MeanMs: number;
+    processTelemetryP99WorstMs: number;
+    broadcastP99MeanMs: number;
+  };
+  eventLoop: {
+    p99MeanMs: number;
+    p99WorstMs: number;
+    worstStallMs: number;
+  };
+  renderer: {
+    sampleCount: number;
+    frameTimeP99MeanMs: number;
+    worstFrameMs: number;
+    framesOver25MsPercent: number;
+    framesOver50MsPercent: number;
+  };
+}
+
+export interface PerfComparison {
+  baseline: PerfSummary;
+  candidate: PerfSummary;
+  delta: {
+    averageFpsPercent: number;
+    onePercentLowFpsPercent: number;
+    appCpuPercent: number;
+    peakMemoryMB: number;
+    processTelemetryP99Ms: number;
+    eventLoopP99Ms: number;
+  };
+  checks: {
+    name: string;
+    passed: boolean | null;
+    actual: number;
+    target: string;
+  }[];
+}
+
+function extractJson<T>(line: string, prefix: string): T | undefined {
+  const prefixIndex = line.indexOf(prefix);
+  if (prefixIndex < 0) return undefined;
+
+  try {
+    return JSON.parse(line.slice(prefixIndex + prefix.length)) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+export function parsePerfLog(contents: string): PerfCapture {
+  const capture: PerfCapture = { main: [], renderer: [] };
+  for (const line of contents.split(/\r?\n/)) {
+    const main = extractJson<MainPerfSample>(line, MAIN_PREFIX);
+    if (main) {
+      capture.main.push(main);
+      continue;
+    }
+
+    const renderer = extractJson<RendererPerfSample>(line, RENDERER_PREFIX);
+    if (renderer) capture.renderer.push(renderer);
+  }
+  return capture;
+}
+
+function average(values: number[]): number {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function weightedAverage(values: { value: number; weight: number }[]): number {
+  const totalWeight = values.reduce((sum, item) => sum + item.weight, 0);
+  if (totalWeight === 0) return 0;
+  return (
+    values.reduce((sum, item) => sum + item.value * item.weight, 0) /
+    totalWeight
+  );
+}
+
+function minimum(values: number[]): number {
+  return values.length > 0 ? Math.min(...values) : 0;
+}
+
+function maximum(values: number[]): number {
+  return values.length > 0 ? Math.max(...values) : 0;
+}
+
+function linearSlopePerMinute(
+  samples: { timestamp: string; value: number }[]
+): number {
+  if (samples.length < 2) return 0;
+  const start = Date.parse(samples[0].timestamp);
+  const points = samples.map((sample) => ({
+    x: (Date.parse(sample.timestamp) - start) / 60_000,
+    y: sample.value,
+  }));
+  const xMean = average(points.map((point) => point.x));
+  const yMean = average(points.map((point) => point.y));
+  let numerator = 0;
+  let denominator = 0;
+  for (const point of points) {
+    numerator += (point.x - xMean) * (point.y - yMean);
+    denominator += (point.x - xMean) ** 2;
+  }
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+export function summarizeCapture(
+  capture: PerfCapture,
+  warmupSeconds = 30
+): PerfSummary {
+  if (capture.main.length === 0) {
+    throw new Error('No structured PerfMetrics samples were found in the log.');
+  }
+
+  const firstTimestamp = Date.parse(capture.main[0].timestamp);
+  const warmupCutoff = firstTimestamp + warmupSeconds * 1000;
+  const main = capture.main.filter(
+    (sample) => Date.parse(sample.timestamp) >= warmupCutoff
+  );
+  const effectiveMain = main.length > 0 ? main : capture.main;
+  const earliest = Date.parse(effectiveMain[0].timestamp);
+  const latest = Date.parse(effectiveMain[effectiveMain.length - 1].timestamp);
+  const renderer = capture.renderer.filter((sample) => {
+    const timestamp = Date.parse(sample.timestamp);
+    return timestamp >= earliest && timestamp <= latest;
+  });
+
+  const iracingStats = effectiveMain.map((sample) => sample.iracing.frameRate);
+  const rendererFrameCount = renderer.reduce(
+    (sum, sample) => sum + sample.frameTimeMs.count,
+    0
+  );
+  const processTelemetry = effectiveMain
+    .map((sample) => sample.sections.processTelemetry)
+    .filter((value): value is SectionStats => value !== undefined);
+  const broadcast = effectiveMain
+    .map((sample) => sample.sections.broadcast)
+    .filter((value): value is SectionStats => value !== undefined);
+
+  return {
+    runId: effectiveMain[0].runId,
+    scenario: effectiveMain[0].scenario,
+    overlayMode: effectiveMain[0].overlayMode,
+    durationMinutes: (latest - earliest) / 60_000,
+    sampleCount: effectiveMain.length,
+    iracing: {
+      averageFps: weightedAverage(
+        iracingStats.map((stats) => ({
+          value: stats.avg,
+          weight: stats.count,
+        }))
+      ),
+      meanOnePercentLowFps: weightedAverage(
+        iracingStats.map((stats) => ({
+          value: stats.p1,
+          weight: stats.count,
+        }))
+      ),
+      worstFps: minimum(iracingStats.map((stats) => stats.min)),
+      averageCpuForeground: weightedAverage(
+        effectiveMain.map((sample) => ({
+          value: sample.iracing.cpuUsageForeground.avg,
+          weight: sample.iracing.cpuUsageForeground.count,
+        }))
+      ),
+      averageGpuUsage: weightedAverage(
+        effectiveMain.map((sample) => ({
+          value: sample.iracing.gpuUsage.avg,
+          weight: sample.iracing.gpuUsage.count,
+        }))
+      ),
+    },
+    app: {
+      averageCpuPercent: average(
+        effectiveMain.map((sample) => sample.totalAppCpuPercent ?? 0)
+      ),
+      peakMemoryMB: maximum(
+        effectiveMain.map((sample) => sample.totalAppMemoryMB ?? 0)
+      ),
+      peakRendererMemoryMB: maximum(
+        effectiveMain.map((sample) =>
+          (sample.processes ?? [])
+            .filter((process) => process.type === 'Tab')
+            .reduce((sum, process) => sum + process.memoryMB, 0)
+        )
+      ),
+      peakMainMemoryMB: maximum(
+        effectiveMain.flatMap((sample) =>
+          (sample.processes ?? [])
+            .filter((process) => process.type === 'Browser')
+            .map((process) => process.memoryMB)
+        )
+      ),
+      peakGpuMemoryMB: maximum(
+        effectiveMain.flatMap((sample) =>
+          (sample.processes ?? [])
+            .filter((process) => process.type === 'GPU')
+            .map((process) => process.memoryMB)
+        )
+      ),
+      rendererProcessCount: maximum(
+        effectiveMain.map(
+          (sample) =>
+            (sample.processes ?? []).filter((process) => process.type === 'Tab')
+              .length
+        )
+      ),
+      memorySlopeMBPerMinute: linearSlopePerMinute(
+        effectiveMain.map((sample) => ({
+          timestamp: sample.timestamp,
+          value: sample.totalAppMemoryMB ?? 0,
+        }))
+      ),
+    },
+    telemetry: {
+      averageTickRateHz: average(
+        effectiveMain.map((sample) => sample.tickRateHz)
+      ),
+      minimumTickRateHz: minimum(
+        effectiveMain.map((sample) => sample.tickRateHz)
+      ),
+      processTelemetryP99MeanMs: average(
+        processTelemetry.map((stats) => stats.p99Ms)
+      ),
+      processTelemetryP99WorstMs: maximum(
+        processTelemetry.map((stats) => stats.p99Ms)
+      ),
+      broadcastP99MeanMs: average(broadcast.map((stats) => stats.p99Ms)),
+    },
+    eventLoop: {
+      p99MeanMs: average(
+        effectiveMain.map((sample) => sample.eventLoopDelayMs.p99)
+      ),
+      p99WorstMs: maximum(
+        effectiveMain.map((sample) => sample.eventLoopDelayMs.p99)
+      ),
+      worstStallMs: maximum(
+        effectiveMain.map((sample) => sample.eventLoopDelayMs.max)
+      ),
+    },
+    renderer: {
+      sampleCount: renderer.length,
+      frameTimeP99MeanMs: weightedAverage(
+        renderer.map((sample) => ({
+          value: sample.frameTimeMs.p99,
+          weight: sample.frameTimeMs.count,
+        }))
+      ),
+      worstFrameMs: maximum(renderer.map((sample) => sample.frameTimeMs.max)),
+      framesOver25MsPercent:
+        rendererFrameCount === 0
+          ? 0
+          : (renderer.reduce((sum, sample) => sum + sample.framesOver25Ms, 0) /
+              rendererFrameCount) *
+            100,
+      framesOver50MsPercent:
+        rendererFrameCount === 0
+          ? 0
+          : (renderer.reduce((sum, sample) => sum + sample.framesOver50Ms, 0) /
+              rendererFrameCount) *
+            100,
+    },
+  };
+}
+
+function percentChange(baseline: number, candidate: number): number {
+  if (baseline === 0) return 0;
+  return ((candidate - baseline) / baseline) * 100;
+}
+
+export function compareSummaries(
+  baseline: PerfSummary,
+  candidate: PerfSummary
+): PerfComparison {
+  const averageFpsPercent = percentChange(
+    baseline.iracing.averageFps,
+    candidate.iracing.averageFps
+  );
+  const onePercentLowFpsPercent = percentChange(
+    baseline.iracing.meanOnePercentLowFps,
+    candidate.iracing.meanOnePercentLowFps
+  );
+
+  return {
+    baseline,
+    candidate,
+    delta: {
+      averageFpsPercent,
+      onePercentLowFpsPercent,
+      appCpuPercent:
+        candidate.app.averageCpuPercent - baseline.app.averageCpuPercent,
+      peakMemoryMB: candidate.app.peakMemoryMB - baseline.app.peakMemoryMB,
+      processTelemetryP99Ms:
+        candidate.telemetry.processTelemetryP99MeanMs -
+        baseline.telemetry.processTelemetryP99MeanMs,
+      eventLoopP99Ms:
+        candidate.eventLoop.p99MeanMs - baseline.eventLoop.p99MeanMs,
+    },
+    checks: [
+      {
+        name: 'iRacing average FPS regression',
+        passed: averageFpsPercent >= -2,
+        actual: averageFpsPercent,
+        target: '>= -2%',
+      },
+      {
+        name: 'iRacing sampled FPS p1 regression',
+        passed: onePercentLowFpsPercent >= -5,
+        actual: onePercentLowFpsPercent,
+        target: '>= -5%',
+      },
+      {
+        name: 'Telemetry processing p99',
+        passed: candidate.telemetry.processTelemetryP99MeanMs < 3,
+        actual: candidate.telemetry.processTelemetryP99MeanMs,
+        target: '< 3 ms',
+      },
+      {
+        name: 'Telemetry tick rate',
+        passed: candidate.telemetry.minimumTickRateHz >= 20,
+        actual: candidate.telemetry.minimumTickRateHz,
+        target: '>= 20 Hz',
+      },
+      {
+        name: 'Steady-state memory slope',
+        passed:
+          candidate.durationMinutes >= 5
+            ? candidate.app.memorySlopeMBPerMinute < 5
+            : null,
+        actual: candidate.app.memorySlopeMBPerMinute,
+        target:
+          candidate.durationMinutes >= 5 ? '< 5 MB/min' : 'requires >= 5 min',
+      },
+      {
+        name: 'Renderer frames over 50 ms',
+        passed: candidate.renderer.framesOver50MsPercent < 0.1,
+        actual: candidate.renderer.framesOver50MsPercent,
+        target: '< 0.1%',
+      },
+    ],
+  };
+}
+
+function format(value: number, digits = 2): string {
+  return Number.isFinite(value) ? value.toFixed(digits) : 'n/a';
+}
+
+export function summaryMarkdown(summary: PerfSummary): string {
+  return `# irDashies performance run
+
+- Run: \`${summary.runId}\`
+- Scenario: \`${summary.scenario}\`
+- Overlay mode: \`${summary.overlayMode}\`
+- Analysed duration: ${format(summary.durationMinutes)} min
+- Main samples: ${summary.sampleCount}
+
+| Metric | Result |
+| --- | ---: |
+| iRacing average FPS | ${format(summary.iracing.averageFps)} |
+| iRacing sampled FPS p1 mean | ${format(summary.iracing.meanOnePercentLowFps)} |
+| iRacing worst sampled FPS | ${format(summary.iracing.worstFps)} |
+| iRacing foreground CPU | ${format(summary.iracing.averageCpuForeground)}% |
+| iRacing GPU usage | ${format(summary.iracing.averageGpuUsage)}% |
+| irDashies app CPU | ${format(summary.app.averageCpuPercent)}% |
+| irDashies peak memory | ${format(summary.app.peakMemoryMB)} MB |
+| Peak renderer memory (${summary.app.rendererProcessCount} processes) | ${format(summary.app.peakRendererMemoryMB)} MB |
+| Peak main / GPU memory | ${format(summary.app.peakMainMemoryMB)} / ${format(summary.app.peakGpuMemoryMB)} MB |
+| irDashies memory slope | ${format(summary.app.memorySlopeMBPerMinute)} MB/min |
+| Telemetry tick rate, average / minimum | ${format(summary.telemetry.averageTickRateHz)} / ${format(summary.telemetry.minimumTickRateHz)} Hz |
+| processTelemetry p99, mean / worst interval | ${format(summary.telemetry.processTelemetryP99MeanMs)} / ${format(summary.telemetry.processTelemetryP99WorstMs)} ms |
+| broadcast p99 mean | ${format(summary.telemetry.broadcastP99MeanMs)} ms |
+| Main event-loop p99, mean / worst interval | ${format(summary.eventLoop.p99MeanMs)} / ${format(summary.eventLoop.p99WorstMs)} ms |
+| Worst main event-loop stall | ${format(summary.eventLoop.worstStallMs)} ms |
+| Renderer frame-time p99 mean | ${format(summary.renderer.frameTimeP99MeanMs)} ms |
+| Renderer frames over 25 / 50 ms | ${format(summary.renderer.framesOver25MsPercent, 3)}% / ${format(summary.renderer.framesOver50MsPercent, 3)}% |
+| Worst renderer frame | ${format(summary.renderer.worstFrameMs)} ms |
+`;
+}
+
+export function comparisonMarkdown(comparison: PerfComparison): string {
+  const { baseline, candidate, delta } = comparison;
+  const checks = comparison.checks
+    .map(
+      (check) =>
+        `| ${check.name} | ${check.passed === null ? 'SKIP' : check.passed ? 'PASS' : 'FAIL'} | ${format(check.actual, 3)} | ${check.target} |`
+    )
+    .join('\n');
+
+  return `# irDashies performance comparison
+
+- Baseline: \`${baseline.runId}\` (${baseline.scenario})
+- Candidate: \`${candidate.runId}\` (${candidate.scenario})
+
+| Delta | Result |
+| --- | ---: |
+| iRacing average FPS | ${format(delta.averageFpsPercent)}% |
+| iRacing sampled FPS p1 mean | ${format(delta.onePercentLowFpsPercent)}% |
+| irDashies app CPU | ${format(delta.appCpuPercent)} percentage points |
+| irDashies peak memory | ${format(delta.peakMemoryMB)} MB |
+| processTelemetry p99 mean | ${format(delta.processTelemetryP99Ms)} ms |
+| Main event-loop p99 mean | ${format(delta.eventLoopP99Ms)} ms |
+
+| Check | Status | Actual | Target |
+| --- | --- | ---: | ---: |
+${checks}
+`;
+}
+
+async function readSummary(
+  filePath: string,
+  warmupSeconds: number
+): Promise<PerfSummary> {
+  const contents = await fs.readFile(filePath, 'utf8');
+  return summarizeCapture(parsePerfLog(contents), warmupSeconds);
+}
+
+async function writeAnalysis(
+  candidatePath: string,
+  baselinePath: string | undefined,
+  warmupSeconds: number
+): Promise<void> {
+  const candidate = await readSummary(candidatePath, warmupSeconds);
+  const outputBase = candidatePath.replace(/\.[^.]+$/, '');
+  const summaryPath = `${outputBase}.summary.json`;
+  const markdownPath = `${outputBase}.summary.md`;
+
+  if (baselinePath) {
+    const baseline = await readSummary(baselinePath, warmupSeconds);
+    const comparison = compareSummaries(baseline, candidate);
+    await Promise.all([
+      fs.writeFile(summaryPath, JSON.stringify(comparison, null, 2), 'utf8'),
+      fs.writeFile(markdownPath, comparisonMarkdown(comparison), 'utf8'),
+    ]);
+  } else {
+    await Promise.all([
+      fs.writeFile(summaryPath, JSON.stringify(candidate, null, 2), 'utf8'),
+      fs.writeFile(markdownPath, summaryMarkdown(candidate), 'utf8'),
+    ]);
+  }
+
+  process.stdout.write(`${markdownPath}\n`);
+}
+
+function parseCliArgs(args: string[]): {
+  candidatePath: string;
+  baselinePath?: string;
+  warmupSeconds: number;
+} {
+  const positional = args.filter((arg) => !arg.startsWith('--'));
+  const baselineIndex = args.indexOf('--baseline');
+  const warmupIndex = args.indexOf('--warmup-seconds');
+  if (!positional[0]) {
+    throw new Error(
+      'Usage: npm run perf:analyze -- <candidate.log> [--baseline <baseline.log>] [--warmup-seconds 30]'
+    );
+  }
+
+  return {
+    candidatePath: path.resolve(positional[0]),
+    baselinePath:
+      baselineIndex >= 0 && args[baselineIndex + 1]
+        ? path.resolve(args[baselineIndex + 1])
+        : undefined,
+    warmupSeconds:
+      warmupIndex >= 0 && Number.isFinite(Number(args[warmupIndex + 1]))
+        ? Number(args[warmupIndex + 1])
+        : 30,
+  };
+}
+
+const isCli =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isCli) {
+  const options = parseCliArgs(process.argv.slice(2));
+  await writeAnalysis(
+    options.candidatePath,
+    options.baselinePath,
+    options.warmupSeconds
+  );
+}

--- a/tools/perf/run.ts
+++ b/tools/perf/run.ts
@@ -1,0 +1,171 @@
+import { spawn } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
+import { createWriteStream, promises as fs } from 'node:fs';
+import path from 'node:path';
+
+type OverlayMode = 'full' | 'empty' | 'observer';
+type RunTarget = 'dev' | 'packaged';
+
+interface RunOptions {
+  scenario: string;
+  mode: OverlayMode;
+  target: RunTarget;
+  widgets: string;
+  intervalMs: number;
+  durationSeconds: number;
+  runId: string;
+}
+
+function argumentValue(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+function safeName(value: string): string {
+  return value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '');
+}
+
+function parseArgs(args: string[]): RunOptions {
+  const requestedMode = argumentValue(args, '--mode');
+  const mode: OverlayMode =
+    requestedMode === 'observer' ||
+    requestedMode === 'empty' ||
+    requestedMode === 'full'
+      ? requestedMode
+      : 'full';
+  const target: RunTarget =
+    argumentValue(args, '--target') === 'packaged' ? 'packaged' : 'dev';
+  const widgets = argumentValue(args, '--widgets') ?? '';
+  const defaultScenario = widgets ? `widgets-${safeName(widgets)}` : mode;
+  const scenario = safeName(
+    argumentValue(args, '--scenario') ?? defaultScenario
+  );
+  const interval = Number(argumentValue(args, '--interval-ms') ?? 5000);
+  const duration = Number(argumentValue(args, '--duration-seconds') ?? 0);
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+
+  return {
+    scenario,
+    mode,
+    target,
+    widgets,
+    intervalMs: Number.isFinite(interval) && interval >= 1000 ? interval : 5000,
+    durationSeconds: Number.isFinite(duration) && duration >= 10 ? duration : 0,
+    runId: safeName(
+      argumentValue(args, '--run-id') ?? `${timestamp}-${scenario}`
+    ),
+  };
+}
+
+const options = parseArgs(process.argv.slice(2));
+const outputDirectory = path.resolve('perf-results');
+await fs.mkdir(outputDirectory, { recursive: true });
+const logPath = path.join(outputDirectory, `${options.runId}.log`);
+const output = createWriteStream(logPath, { encoding: 'utf8' });
+let childCommand: string;
+let childArguments: string[];
+if (options.target === 'packaged') {
+  if (process.platform !== 'win32') {
+    throw new Error('The packaged benchmark target is currently Windows-only.');
+  }
+  childCommand = path.resolve('out/irdashies-win32-x64/irdashies.exe');
+  try {
+    await fs.access(childCommand);
+  } catch {
+    throw new Error(
+      `Packaged app not found at ${childCommand}. Run "npm run package" first.`
+    );
+  }
+  childArguments = [];
+} else {
+  childCommand =
+    process.platform === 'win32'
+      ? (process.env.ComSpec ?? 'C:\\Windows\\System32\\cmd.exe')
+      : 'npm';
+  childArguments =
+    process.platform === 'win32'
+      ? ['/d', '/s', '/c', 'npm.cmd start']
+      : ['start'];
+}
+let build = 'unknown';
+try {
+  build = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+    encoding: 'utf8',
+  }).trim();
+} catch {
+  // A build identifier is useful but not required for a local run.
+}
+
+process.stdout.write(
+  [
+    `Performance run: ${options.runId}`,
+    `Scenario: ${options.scenario}`,
+    `Overlay mode: ${options.mode}`,
+    `Target: ${options.target}`,
+    options.widgets ? `Widgets: ${options.widgets}` : '',
+    options.durationSeconds > 0
+      ? `Duration: ${options.durationSeconds}s`
+      : 'Duration: until Ctrl+C',
+    `Raw log: ${logPath}`,
+    'Stop the run with Ctrl+C after the measured segment.',
+  ]
+    .filter(Boolean)
+    .join('\n') + '\n'
+);
+
+const child = spawn(childCommand, childArguments, {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    NODE_OPTIONS: '',
+    VSCODE_INSPECTOR_OPTIONS: '',
+    PERF_METRICS: '1',
+    PERF_RUN_ID: options.runId,
+    PERF_SCENARIO: options.scenario,
+    PERF_OVERLAY_MODE: options.mode,
+    PERF_WIDGET_TYPES: options.widgets,
+    PERF_REPORT_INTERVAL_MS: String(options.intervalMs),
+    PERF_DURATION_SECONDS: String(options.durationSeconds),
+    PERF_BUILD: build,
+    ELECTRON_ENABLE_LOGGING: '1',
+  },
+  stdio: ['inherit', 'pipe', 'pipe'],
+});
+
+let stdoutAvailable = true;
+process.stdout.on('error', (error: NodeJS.ErrnoException) => {
+  if (error.code === 'EPIPE') {
+    stdoutAvailable = false;
+    return;
+  }
+  throw error;
+});
+
+const copyOutput = (chunk: Buffer): void => {
+  if (stdoutAvailable) process.stdout.write(chunk);
+  output.write(chunk);
+};
+
+child.stdout.on('data', copyOutput);
+child.stderr.on('data', copyOutput);
+
+const stopChild = (): void => {
+  if (!child.killed) child.kill();
+};
+process.once('SIGINT', stopChild);
+process.once('SIGTERM', stopChild);
+
+const exitCode = await new Promise<number>((resolve) => {
+  child.once('exit', (code) => resolve(code ?? 0));
+});
+await new Promise<void>((resolve, reject) => {
+  output.end((error?: Error | null) => {
+    if (error) reject(error);
+    else resolve();
+  });
+});
+
+process.stdout.write(
+  `Captured ${logPath}\nAnalyse with: npm run perf:analyze -- "${logPath}"\n`
+);
+process.exitCode = exitCode;


### PR DESCRIPTION
## Description

Adds an opt-in, repeatable performance benchmark harness for diagnosing iRacing
FPS loss, overlay stutter, telemetry latency, renderer frame pacing, and memory
growth.

The harness supports packaged and development runs with fixed-duration
`observer`, `empty`, `full`, and widget-filter modes. It records structured
iRacing CPU/GPU/FPS samples, irDashies per-process CPU and working set,
telemetry cadence and processing percentiles, Electron main-event-loop delay,
and renderer animation-frame timing. A CLI analyzer produces JSON/Markdown
summaries and baseline comparisons with initial regression gates.

Normal app launches are unchanged; all benchmark behavior is gated behind
`PERF_METRICS=1`, and dashboard filtering is applied in memory without changing
persisted configuration.

Documentation adds the controlled replay/live protocol and extends
`IMPLEMENTATION_PLAN.md` with the benchmark support work plus an actionable
optimization sequence. PB1/PB2 improve telemetry coverage and frame/memory
measurement, but do not block the first optimization PRs:

1. Gate `SectorTimingUpdater`, `PushToPassUpdater`, and `PitLapUpdater` by the
   widgets present on each display.
2. Mount `PitLaneProvider` and `ReferenceStoreProvider` only in display
   renderers with local consumers.
3. Build the existing Architecture Phase 3 typed per-window channel bus.
4. Add rate-aware main-process publishing and migrate high-churn widgets.
5. Move duplicated fuel, relative, and standings derivation into
   session-scoped main-process processors.
6. Remove the legacy full-telemetry firehose and redundant renderer providers
   as their final consumers migrate.

The first two items remove unconditional per-tick work already visible in the
current component tree. Worker-thread, native, and window-topology rewrites
remain deferred until evidence shows that their added complexity is warranted.

Validation performed:

- `npm run lint`
- `npm run test -- --no-coverage` — 89 files, 1,070 tests
- `npm run package`
- Packaged seven-minute observer/empty/full captures against the same 59-car
  multiclass replay segment
- Analyzer comparisons with 60-second and 15-second warm-up windows

The replay runs validate the harness and establish a static/rendering lower
bound; they are not presented as a complete live-telemetry performance verdict.

## Screenshots

### Before

No UI change. Performance testing relied on manual launches and human
interpretation of periodic log output.

### After

No UI change. `perf:run` captures fixed, labeled scenarios and `perf:analyze`
writes structured JSON and Markdown comparisons.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
