### PR TITLE
feat: add compact SoF and per-manufacturer car counts to standings class header

### DIFF
--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -1063,6 +1063,21 @@ export const StandingsSettings = () => {
                         })
                       }
                     />
+                    <SettingToggleRow
+                      title="Compact SoF Formatting"
+                      description='Display SoF as a compact value (e.g. "2.4k" instead of "2432")'
+                      enabled={
+                        settings.config.classHeaderStyle?.compactSof ?? false
+                      }
+                      onToggle={(newValue) =>
+                        handleConfigChange({
+                          classHeaderStyle: {
+                            ...settings.config.classHeaderStyle,
+                            compactSof: newValue,
+                          },
+                        })
+                      }
+                    />
                   </SettingsSection>
 
                   <SettingDivider />

--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -1078,6 +1078,86 @@ export const StandingsSettings = () => {
                         })
                       }
                     />
+                    <SettingToggleRow
+                      title="Show Manufacturer Counts"
+                      description="Show manufacturer icons with driver counts in the class header (multi-make classes only)"
+                      enabled={
+                        settings.config.classHeaderStyle?.manufacturerStats
+                          ?.enabled ?? false
+                      }
+                      onToggle={(newValue) =>
+                        handleConfigChange({
+                          classHeaderStyle: {
+                            ...settings.config.classHeaderStyle,
+                            manufacturerStats: {
+                              enabled: newValue,
+                              cap:
+                                settings.config.classHeaderStyle?.manufacturerStats
+                                  ?.cap ?? 5,
+                              showPlayerManufacturer:
+                                settings.config.classHeaderStyle?.manufacturerStats
+                                  ?.showPlayerManufacturer ?? false,
+                            },
+                          },
+                        })
+                      }
+                    />
+                    {(settings.config.classHeaderStyle?.manufacturerStats
+                      ?.enabled ?? false) && (
+                      <>
+                        <SettingSelectRow
+                          title="Max manufacturers to show"
+                          value={
+                            settings.config.classHeaderStyle?.manufacturerStats
+                              ?.cap?.toString() ?? 'all'
+                          }
+                          options={[
+                            ...Array.from({ length: 10 }, (_, i) => ({
+                              label: (i + 1).toString(),
+                              value: (i + 1).toString(),
+                            })),
+                            { label: 'All', value: 'all' },
+                          ]}
+                          onChange={(v) =>
+                            handleConfigChange({
+                              classHeaderStyle: {
+                                ...settings.config.classHeaderStyle,
+                                manufacturerStats: {
+                                  enabled: true,
+                                  cap: v === 'all' ? null : parseInt(v),
+                                  showPlayerManufacturer:
+                                    settings.config.classHeaderStyle
+                                      ?.manufacturerStats
+                                      ?.showPlayerManufacturer ?? false,
+                                },
+                              },
+                            })
+                          }
+                        />
+                        <SettingToggleRow
+                          title="Always show your manufacturer"
+                          description="If your manufacturer is outside the cap, it replaces the last shown entry"
+                          enabled={
+                            settings.config.classHeaderStyle?.manufacturerStats
+                              ?.showPlayerManufacturer ?? false
+                          }
+                          onToggle={(newValue) =>
+                            handleConfigChange({
+                              classHeaderStyle: {
+                                ...settings.config.classHeaderStyle,
+                                manufacturerStats: {
+                                  enabled: true,
+                                  cap:
+                                    settings.config.classHeaderStyle
+                                      ?.manufacturerStats?.cap ?? 5,
+                                  showPlayerManufacturer: newValue,
+                                },
+                              },
+                            })
+                          }
+                        />
+                      </>
+                    )}
                   </SettingsSection>
 
                   <SettingDivider />

--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -51,7 +51,6 @@ export const Relative = () => {
 
   const p2pDisplayStates = useP2PDisplayStates();
 
-
   const lapTimeDeltasEnabled = settings?.lapTimeDeltas?.enabled ?? false;
   useLapTimesStoreUpdater(lapTimeDeltasEnabled);
   const numLapDeltas = settings?.lapTimeDeltas?.numLaps ?? 3;
@@ -66,7 +65,9 @@ export const Relative = () => {
   const pitExitPct = usePitLaneStore((s) => s.pitExitPct);
   const pitExitAfterSF = pitExitPct !== null && pitExitPct > 0.85;
 
-  const isSingleMake = useIsSingleMake();
+  const isSingleMake = useIsSingleMake(
+    !!settings?.carManufacturer?.hideIfSingleMake
+  );
   const hideCarManufacturer = !!(
     settings?.carManufacturer?.hideIfSingleMake && isSingleMake
   );

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -26,6 +26,7 @@ import {
 } from '@irdashies/context';
 import { useIsSingleMake } from './hooks/useIsSingleMake';
 import { computeStintLap } from './components/DriverInfoRow/cells/lapCountUtils';
+import { CAR_ID_TO_CAR_MANUFACTURER } from './components/CarManufacturer/carManufacturerMapping';
 
 export const Standings = () => {
   const settings = useStandingsSettings();
@@ -120,6 +121,18 @@ export const Standings = () => {
                   ? (classColorHex ?? highlightHex)
                   : highlightHex;
 
+            const mfrMap = new Map<string, { carId: number; count: number }>();
+            for (const s of classStandings) {
+              if (s.carId === undefined) continue;
+              const mfr =
+                CAR_ID_TO_CAR_MANUFACTURER[s.carId]?.manufacturer ?? 'unknown';
+              if (!mfrMap.has(mfr)) mfrMap.set(mfr, { carId: s.carId, count: 0 });
+              mfrMap.get(mfr)!.count += 1;
+            }
+            const manufacturerCounts = Array.from(mfrMap.values()).sort(
+              (a, b) => b.count - a.count
+            );
+
             return classStandings.length > 0 ? (
               <Fragment key={classId}>
                 <DriverClassHeader
@@ -135,6 +148,7 @@ export const Standings = () => {
                   colSpan={100}
                   classHeaderStyle={settings?.classHeaderStyle}
                   compactMode={generalSettings?.compactMode}
+                  manufacturerCounts={manufacturerCounts}
                 />
                 {classStandings.map((result, driverIndex) => {
                   const prev = classStandings[driverIndex - 1];

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -132,6 +132,18 @@ export const Standings = () => {
             const manufacturerCounts = Array.from(mfrMap.values()).sort(
               (a, b) => b.count - a.count
             );
+            const playerCarId = classStandings.find((s) => s.isPlayer)?.carId;
+            const playerMfr =
+              playerCarId !== undefined
+                ? (CAR_ID_TO_CAR_MANUFACTURER[playerCarId]?.manufacturer ?? 'unknown')
+                : undefined;
+            const playerManufacturerEntry = playerMfr
+              ? manufacturerCounts.find(
+                  (m) =>
+                    (CAR_ID_TO_CAR_MANUFACTURER[m.carId]?.manufacturer ?? 'unknown') ===
+                    playerMfr
+                )
+              : undefined;
 
             return classStandings.length > 0 ? (
               <Fragment key={classId}>
@@ -149,6 +161,7 @@ export const Standings = () => {
                   classHeaderStyle={settings?.classHeaderStyle}
                   compactMode={generalSettings?.compactMode}
                   manufacturerCounts={manufacturerCounts}
+                  playerManufacturerEntry={playerManufacturerEntry}
                 />
                 {classStandings.map((result, driverIndex) => {
                   const prev = classStandings[driverIndex - 1];

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -57,7 +57,9 @@ export const Standings = () => {
   const pitExitAfterSF = pitExitPct !== null && pitExitPct > 0.85;
 
   // Determine whether we should hide the car manufacturer column
-  const isSingleMake = useIsSingleMake();
+  const isSingleMake = useIsSingleMake(
+    !!settings?.carManufacturer?.hideIfSingleMake
+  );
   const hideCarManufacturer = !!(
     settings?.carManufacturer?.hideIfSingleMake && isSingleMake
   );
@@ -126,8 +128,12 @@ export const Standings = () => {
               if (s.carId === undefined) continue;
               const mfr =
                 CAR_ID_TO_CAR_MANUFACTURER[s.carId]?.manufacturer ?? 'unknown';
-              if (!mfrMap.has(mfr)) mfrMap.set(mfr, { carId: s.carId, count: 0 });
-              mfrMap.get(mfr)!.count += 1;
+              const existing = mfrMap.get(mfr);
+              if (existing) {
+                existing.count += 1;
+              } else {
+                mfrMap.set(mfr, { carId: s.carId, count: 1 });
+              }
             }
             const manufacturerCounts = Array.from(mfrMap.values()).sort(
               (a, b) => b.count - a.count
@@ -135,13 +141,14 @@ export const Standings = () => {
             const playerCarId = classStandings.find((s) => s.isPlayer)?.carId;
             const playerMfr =
               playerCarId !== undefined
-                ? (CAR_ID_TO_CAR_MANUFACTURER[playerCarId]?.manufacturer ?? 'unknown')
+                ? (CAR_ID_TO_CAR_MANUFACTURER[playerCarId]?.manufacturer ??
+                  'unknown')
                 : undefined;
             const playerManufacturerEntry = playerMfr
               ? manufacturerCounts.find(
                   (m) =>
-                    (CAR_ID_TO_CAR_MANUFACTURER[m.carId]?.manufacturer ?? 'unknown') ===
-                    playerMfr
+                    (CAR_ID_TO_CAR_MANUFACTURER[m.carId]?.manufacturer ??
+                      'unknown') === playerMfr
                 )
               : undefined;
 

--- a/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.stories.tsx
@@ -1,0 +1,94 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { DriverClassHeader } from './DriverClassHeader';
+
+const TableWrapper = ({ children }: { children: React.ReactNode }) => (
+  <table className="text-white text-sm">
+    <tbody>{children}</tbody>
+  </table>
+);
+
+export default {
+  component: DriverClassHeader,
+  title: 'widgets/Standings/components/DriverClassHeader',
+  decorators: [
+    (Story) => (
+      <TableWrapper>
+        <Story />
+      </TableWrapper>
+    ),
+  ],
+} as Meta;
+
+type Story = StoryObj<typeof DriverClassHeader>;
+
+export const Default: Story = {
+  args: {
+    className: 'GTE',
+    classColor: 0x00d4ff,
+    totalDrivers: 12,
+    sof: 2432,
+    isMultiClass: true,
+    classHeaderStyle: { compactSof: false },
+  },
+};
+
+export const CompactSoF: Story = {
+  args: {
+    className: 'GTE',
+    classColor: 0x00d4ff,
+    totalDrivers: 12,
+    sof: 2432,
+    isMultiClass: true,
+    classHeaderStyle: { compactSof: true },
+  },
+};
+
+export const LowSoF: Story = {
+  args: {
+    className: 'LMP2',
+    classColor: 0xff6600,
+    totalDrivers: 8,
+    sof: 850,
+    isMultiClass: true,
+    classHeaderStyle: { compactSof: true },
+  },
+};
+
+export const AllClasses: Story = {
+  render: () => (
+    <TableWrapper>
+      <DriverClassHeader
+        className="GTE"
+        classColor={0x00d4ff}
+        totalDrivers={12}
+        sof={2432}
+        isMultiClass={true}
+        classHeaderStyle={{ compactSof: false }}
+      />
+      <DriverClassHeader
+        className="GTE"
+        classColor={0x00d4ff}
+        totalDrivers={12}
+        sof={2432}
+        isMultiClass={true}
+        classHeaderStyle={{ compactSof: true }}
+      />
+      <DriverClassHeader
+        className="LMP2"
+        classColor={0xff6600}
+        totalDrivers={8}
+        sof={850}
+        isMultiClass={true}
+        classHeaderStyle={{ compactSof: true }}
+      />
+      <DriverClassHeader
+        className="LMP1"
+        classColor={0xffd700}
+        totalDrivers={5}
+        sof={12540}
+        isMultiClass={true}
+        classHeaderStyle={{ compactSof: true }}
+      />
+    </TableWrapper>
+  ),
+};

--- a/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.stories.tsx
@@ -7,6 +7,10 @@ const TableWrapper = ({ children }: { children: React.ReactNode }) => (
   </table>
 );
 
+const mfrStatsEnabled = {
+  manufacturerStats: { enabled: true, cap: 5, showPlayerManufacturer: false },
+};
+
 export default {
   component: DriverClassHeader,
   title: 'widgets/Standings/components/DriverClassHeader',
@@ -28,7 +32,7 @@ export const Default: Story = {
     totalDrivers: 12,
     sof: 2432,
     isMultiClass: true,
-    classHeaderStyle: { compactSof: false },
+    classHeaderStyle: { compactSof: false, ...mfrStatsEnabled },
     manufacturerCounts: [
       { carId: 56, count: 7 },
       { carId: 122, count: 5 },
@@ -43,7 +47,7 @@ export const CompactSoF: Story = {
     totalDrivers: 12,
     sof: 2432,
     isMultiClass: true,
-    classHeaderStyle: { compactSof: true },
+    classHeaderStyle: { compactSof: true, ...mfrStatsEnabled },
     manufacturerCounts: [
       { carId: 56, count: 7 },
       { carId: 122, count: 5 },
@@ -58,7 +62,8 @@ export const SingleMake: Story = {
     totalDrivers: 10,
     sof: 1850,
     isMultiClass: true,
-    classHeaderStyle: { compactSof: false },
+    classHeaderStyle: { compactSof: false, ...mfrStatsEnabled },
+    // length === 1 → no manufacturer breakdown shown
     manufacturerCounts: [{ carId: 160, count: 10 }],
   },
 };
@@ -70,15 +75,42 @@ export const ManyManufacturers: Story = {
     totalDrivers: 18,
     sof: 3100,
     isMultiClass: true,
-    classHeaderStyle: { compactSof: true },
+    classHeaderStyle: {
+      compactSof: true,
+      manufacturerStats: { enabled: true, cap: 5, showPlayerManufacturer: false },
+    },
     manufacturerCounts: [
       { carId: 56, count: 5 },
       { carId: 122, count: 4 },
       { carId: 145, count: 3 },
       { carId: 160, count: 3 },
       { carId: 1, count: 2 },
-      { carId: 3, count: 1 },
+      { carId: 3, count: 1 }, // hidden as +1
     ],
+  },
+};
+
+export const PlayerManufacturerOverride: Story = {
+  args: {
+    className: 'GT3',
+    classColor: 0x00aa44,
+    totalDrivers: 18,
+    sof: 3100,
+    isMultiClass: true,
+    classHeaderStyle: {
+      compactSof: true,
+      manufacturerStats: { enabled: true, cap: 5, showPlayerManufacturer: true },
+    },
+    manufacturerCounts: [
+      { carId: 56, count: 5 },
+      { carId: 122, count: 4 },
+      { carId: 145, count: 3 },
+      { carId: 160, count: 3 },
+      { carId: 1, count: 2 },
+      { carId: 3, count: 1 }, // player's manufacturer — replaces carId:1 in slot 5
+    ],
+    // carId 3 is the player's manufacturer, not in top 5 → replaces last entry
+    playerManufacturerEntry: { carId: 3, count: 1 },
   },
 };
 
@@ -91,7 +123,7 @@ export const AllClasses: Story = {
         totalDrivers={12}
         sof={2432}
         isMultiClass={true}
-        classHeaderStyle={{ compactSof: false }}
+        classHeaderStyle={{ compactSof: false, ...mfrStatsEnabled }}
         manufacturerCounts={[
           { carId: 56, count: 7 },
           { carId: 122, count: 5 },
@@ -103,7 +135,7 @@ export const AllClasses: Story = {
         totalDrivers={12}
         sof={2432}
         isMultiClass={true}
-        classHeaderStyle={{ compactSof: true }}
+        classHeaderStyle={{ compactSof: true, ...mfrStatsEnabled }}
         manufacturerCounts={[
           { carId: 56, count: 7 },
           { carId: 122, count: 5 },
@@ -115,7 +147,7 @@ export const AllClasses: Story = {
         totalDrivers={8}
         sof={850}
         isMultiClass={true}
-        classHeaderStyle={{ compactSof: true }}
+        classHeaderStyle={{ compactSof: true, ...mfrStatsEnabled }}
         manufacturerCounts={[{ carId: 56, count: 8 }]}
       />
       <DriverClassHeader
@@ -124,7 +156,7 @@ export const AllClasses: Story = {
         totalDrivers={5}
         sof={12540}
         isMultiClass={true}
-        classHeaderStyle={{ compactSof: true }}
+        classHeaderStyle={{ compactSof: true, ...mfrStatsEnabled }}
         manufacturerCounts={[
           { carId: 56, count: 3 },
           { carId: 145, count: 2 },

--- a/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.stories.tsx
@@ -114,6 +114,34 @@ export const PlayerManufacturerOverride: Story = {
   },
 };
 
+export const TwelveManufacturersCapAll: Story = {
+  args: {
+    className: 'GT3',
+    classColor: 0x00aa44,
+    totalDrivers: 36,
+    sof: 4200,
+    isMultiClass: true,
+    classHeaderStyle: {
+      compactSof: true,
+      manufacturerStats: { enabled: true, cap: null, showPlayerManufacturer: false },
+    },
+    manufacturerCounts: [
+      { carId: 56, count: 6 },
+      { carId: 122, count: 5 },
+      { carId: 145, count: 4 },
+      { carId: 160, count: 4 },
+      { carId: 1, count: 3 },
+      { carId: 3, count: 3 },
+      { carId: 10, count: 3 },
+      { carId: 20, count: 2 },
+      { carId: 30, count: 2 },
+      { carId: 40, count: 2 },
+      { carId: 50, count: 1 },
+      { carId: 60, count: 1 },
+    ],
+  },
+};
+
 export const AllClasses: Story = {
   render: () => (
     <TableWrapper>

--- a/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.stories.tsx
@@ -29,6 +29,10 @@ export const Default: Story = {
     sof: 2432,
     isMultiClass: true,
     classHeaderStyle: { compactSof: false },
+    manufacturerCounts: [
+      { carId: 56, count: 7 },
+      { carId: 122, count: 5 },
+    ],
   },
 };
 
@@ -40,17 +44,41 @@ export const CompactSoF: Story = {
     sof: 2432,
     isMultiClass: true,
     classHeaderStyle: { compactSof: true },
+    manufacturerCounts: [
+      { carId: 56, count: 7 },
+      { carId: 122, count: 5 },
+    ],
   },
 };
 
-export const LowSoF: Story = {
+export const SingleMake: Story = {
   args: {
-    className: 'LMP2',
-    classColor: 0xff6600,
-    totalDrivers: 8,
-    sof: 850,
+    className: 'Porsche Cup',
+    classColor: 0xff0000,
+    totalDrivers: 10,
+    sof: 1850,
+    isMultiClass: true,
+    classHeaderStyle: { compactSof: false },
+    manufacturerCounts: [{ carId: 160, count: 10 }],
+  },
+};
+
+export const ManyManufacturers: Story = {
+  args: {
+    className: 'GT3',
+    classColor: 0x00aa44,
+    totalDrivers: 18,
+    sof: 3100,
     isMultiClass: true,
     classHeaderStyle: { compactSof: true },
+    manufacturerCounts: [
+      { carId: 56, count: 5 },
+      { carId: 122, count: 4 },
+      { carId: 145, count: 3 },
+      { carId: 160, count: 3 },
+      { carId: 1, count: 2 },
+      { carId: 3, count: 1 },
+    ],
   },
 };
 
@@ -64,22 +92,31 @@ export const AllClasses: Story = {
         sof={2432}
         isMultiClass={true}
         classHeaderStyle={{ compactSof: false }}
+        manufacturerCounts={[
+          { carId: 56, count: 7 },
+          { carId: 122, count: 5 },
+        ]}
       />
       <DriverClassHeader
-        className="GTE"
+        className="GTE (compact SoF)"
         classColor={0x00d4ff}
         totalDrivers={12}
         sof={2432}
         isMultiClass={true}
         classHeaderStyle={{ compactSof: true }}
+        manufacturerCounts={[
+          { carId: 56, count: 7 },
+          { carId: 122, count: 5 },
+        ]}
       />
       <DriverClassHeader
-        className="LMP2"
+        className="LMP2 (single make)"
         classColor={0xff6600}
         totalDrivers={8}
         sof={850}
         isMultiClass={true}
         classHeaderStyle={{ compactSof: true }}
+        manufacturerCounts={[{ carId: 56, count: 8 }]}
       />
       <DriverClassHeader
         className="LMP1"
@@ -88,6 +125,10 @@ export const AllClasses: Story = {
         sof={12540}
         isMultiClass={true}
         classHeaderStyle={{ compactSof: true }}
+        manufacturerCounts={[
+          { carId: 56, count: 3 },
+          { carId: 145, count: 2 },
+        ]}
       />
     </TableWrapper>
   ),

--- a/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.tsx
+++ b/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.tsx
@@ -67,7 +67,12 @@ export const DriverClassHeader = ({
           >
             {sof ? (
               <>
-                <BarbellIcon /> <span>{sof?.toFixed(0)}</span>
+                <BarbellIcon />{' '}
+                <span>
+                  {classHeaderStyle?.compactSof && sof >= 1000
+                    ? `${(sof / 1000).toFixed(1)}k`
+                    : sof.toFixed(0)}
+                </span>
               </>
             ) : (
               ''

--- a/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.tsx
+++ b/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.tsx
@@ -1,6 +1,9 @@
 import { BarbellIcon, UsersIcon } from '@phosphor-icons/react';
 import { getTailwindStyle } from '@irdashies/utils/colors';
 import type { ClassHeaderStyle } from '@irdashies/types';
+import { CarManufacturer } from '../CarManufacturer/CarManufacturer';
+
+const MAX_MANUFACTURERS_SHOWN = 5;
 
 interface DriverClassHeaderProps {
   className: string | undefined;
@@ -12,6 +15,7 @@ interface DriverClassHeaderProps {
   colSpan?: number;
   classHeaderStyle?: ClassHeaderStyle;
   compactMode?: string;
+  manufacturerCounts?: { carId: number; count: number }[];
 }
 
 export const DriverClassHeader = ({
@@ -24,6 +28,7 @@ export const DriverClassHeader = ({
   colSpan,
   classHeaderStyle,
   compactMode,
+  manufacturerCounts,
 }: DriverClassHeaderProps) => {
   if (!className) {
     return (
@@ -79,6 +84,23 @@ export const DriverClassHeader = ({
             )}{' '}
             <UsersIcon className={sof ? 'ml-3' : ''} />
             <span>{totalDrivers}</span>
+            {manufacturerCounts && manufacturerCounts.length > 1 && (() => {
+              const visible = manufacturerCounts.slice(0, MAX_MANUFACTURERS_SHOWN);
+              const hidden = manufacturerCounts.length - visible.length;
+              return (
+                <>
+                  {visible.map(({ carId, count }) => (
+                    <span key={carId} className="flex items-center gap-0.5 ml-2">
+                      <CarManufacturer carId={carId} />
+                      <span>{count}</span>
+                    </span>
+                  ))}
+                  {hidden > 0 && (
+                    <span className="ml-1 text-white/50">+{hidden}</span>
+                  )}
+                </>
+              );
+            })()}
           </span>
         </div>
       </td>

--- a/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.tsx
+++ b/src/frontend/components/Standings/components/DriverClassHeader/DriverClassHeader.tsx
@@ -3,8 +3,6 @@ import { getTailwindStyle } from '@irdashies/utils/colors';
 import type { ClassHeaderStyle } from '@irdashies/types';
 import { CarManufacturer } from '../CarManufacturer/CarManufacturer';
 
-const MAX_MANUFACTURERS_SHOWN = 5;
-
 interface DriverClassHeaderProps {
   className: string | undefined;
   classColor: number | undefined;
@@ -16,6 +14,7 @@ interface DriverClassHeaderProps {
   classHeaderStyle?: ClassHeaderStyle;
   compactMode?: string;
   manufacturerCounts?: { carId: number; count: number }[];
+  playerManufacturerEntry?: { carId: number; count: number };
 }
 
 export const DriverClassHeader = ({
@@ -29,6 +28,7 @@ export const DriverClassHeader = ({
   classHeaderStyle,
   compactMode,
   manufacturerCounts,
+  playerManufacturerEntry,
 }: DriverClassHeaderProps) => {
   if (!className) {
     return (
@@ -84,8 +84,33 @@ export const DriverClassHeader = ({
             )}{' '}
             <UsersIcon className={sof ? 'ml-3' : ''} />
             <span>{totalDrivers}</span>
-            {manufacturerCounts && manufacturerCounts.length > 1 && (() => {
-              const visible = manufacturerCounts.slice(0, MAX_MANUFACTURERS_SHOWN);
+            {(() => {
+              const stats = classHeaderStyle?.manufacturerStats;
+              if (!stats?.enabled) return null;
+              if (!manufacturerCounts || manufacturerCounts.length <= 1) return null;
+
+              // undefined → default cap 5; null → All; number → specific cap
+              const rawCap = stats.cap;
+              const capValue = rawCap !== undefined ? rawCap : 5;
+
+              let visible =
+                capValue === null
+                  ? [...manufacturerCounts]
+                  : manufacturerCounts.slice(0, capValue);
+              const totalHidden = manufacturerCounts.length - visible.length;
+
+              if (
+                stats.showPlayerManufacturer &&
+                playerManufacturerEntry &&
+                totalHidden > 0 &&
+                !visible.some((v) => v.carId === playerManufacturerEntry.carId)
+              ) {
+                visible = [
+                  ...visible.slice(0, visible.length - 1),
+                  playerManufacturerEntry,
+                ];
+              }
+
               const hidden = manufacturerCounts.length - visible.length;
               return (
                 <>

--- a/src/frontend/components/Standings/hooks/useIsSingleMake.spec.ts
+++ b/src/frontend/components/Standings/hooks/useIsSingleMake.spec.ts
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  useSessionDrivers,
+  useWeekendInfoNumCarClasses,
+} from '@irdashies/context';
+import { useIsSingleMake } from './useIsSingleMake';
+import type { Driver } from '@irdashies/types';
+
+vi.mock('@irdashies/context');
+
+const SINGLE_MAKE_DRIVERS = [
+  { CarID: 1, CarIsPaceCar: false, IsSpectator: false },
+  { CarID: 1, CarIsPaceCar: false, IsSpectator: false },
+] as unknown as Driver[];
+
+describe('useIsSingleMake', () => {
+  it('returns false without scanning drivers when disabled', () => {
+    vi.mocked(useSessionDrivers).mockReturnValue(SINGLE_MAKE_DRIVERS);
+    vi.mocked(useWeekendInfoNumCarClasses).mockReturnValue(1);
+
+    const { result } = renderHook(() => useIsSingleMake(false));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('recomputes correctly from live data when toggled on mid-session', () => {
+    vi.mocked(useSessionDrivers).mockReturnValue(SINGLE_MAKE_DRIVERS);
+    vi.mocked(useWeekendInfoNumCarClasses).mockReturnValue(1);
+
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useIsSingleMake(enabled),
+      { initialProps: { enabled: false } }
+    );
+    expect(result.current).toBe(false);
+
+    rerender({ enabled: true });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when multi-class even while enabled', () => {
+    vi.mocked(useSessionDrivers).mockReturnValue(SINGLE_MAKE_DRIVERS);
+    vi.mocked(useWeekendInfoNumCarClasses).mockReturnValue(2);
+
+    const { result } = renderHook(() => useIsSingleMake(true));
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/frontend/components/Standings/hooks/useIsSingleMake.ts
+++ b/src/frontend/components/Standings/hooks/useIsSingleMake.ts
@@ -1,17 +1,27 @@
 import { useMemo } from 'react';
-import { useSessionDrivers, useWeekendInfoNumCarClasses } from '@irdashies/context';
+import {
+  useSessionDrivers,
+  useWeekendInfoNumCarClasses,
+} from '@irdashies/context';
 import { CAR_ID_TO_CAR_MANUFACTURER } from '../components/CarManufacturer/carManufacturerMapping';
 
 /**
  * Returns true when the session contains only a single car manufacturer.
  * If the session is multi-class (NumCarClasses > 1) this will always return false
  * so manufacturers remain visible in multi-class sessions.
+ *
+ * `enabled` skips the per-driver manufacturer scan entirely when the caller
+ * doesn't need the result (e.g. hideIfSingleMake is off) — the underlying
+ * telemetry/session subscriptions stay live either way, so flipping `enabled`
+ * back on recomputes correctly from current data on the next render.
  */
-export const useIsSingleMake = () => {
+export const useIsSingleMake = (enabled: boolean) => {
   const sessionDrivers = useSessionDrivers();
   const numCarClasses = useWeekendInfoNumCarClasses();
 
   return useMemo(() => {
+    if (!enabled) return false;
+
     if (!sessionDrivers?.length) return false;
 
     // Multi-class = never single make
@@ -21,11 +31,7 @@ export const useIsSingleMake = () => {
 
     for (const driver of sessionDrivers) {
       // Skip non-competitors
-      if (
-        driver.CarIsPaceCar ||
-        driver.IsSpectator ||
-        driver.CarID == null
-      ) {
+      if (driver.CarIsPaceCar || driver.IsSpectator || driver.CarID == null) {
         continue;
       }
 
@@ -42,5 +48,5 @@ export const useIsSingleMake = () => {
     }
 
     return manufacturers.size === 1;
-  }, [sessionDrivers, numCarClasses]);
+  }, [enabled, sessionDrivers, numCarClasses]);
 };

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -94,6 +94,11 @@ export interface ClassHeaderStyle {
   classInfo?: { colorBackground?: boolean };
   classDivider?: { bottomBorder?: boolean };
   compactSof?: boolean;
+  manufacturerStats?: {
+    enabled: boolean;
+    cap: number | null; // null = All
+    showPlayerManufacturer: boolean;
+  };
 }
 
 // ===========================

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -93,6 +93,7 @@ export interface ClassHeaderStyle {
   className?: { colorBackground?: boolean };
   classInfo?: { colorBackground?: boolean };
   classDivider?: { bottomBorder?: boolean };
+  compactSof?: boolean;
 }
 
 // ===========================


### PR DESCRIPTION
## Description

Enhances the standings widget class header row with two new display options:

**Compact SoF formatting** (optional toggle)
- Displays Strength of Field in a compact format for values >= 1000 (e.g. `2.4k` instead of `2400`)
- Controlled per class header via a settings toggle

**Per-manufacturer car counts** (optional, configurable)
- Shows manufacturer icon + driver count for each make within the class (e.g. Toyota icon + `7`)
- Manufacturers sorted by count descending (most represented first)
- Configurable cap from 1 to 10 or All — a `+N` overflow badge appears when manufacturers are hidden
- Optional "always show player manufacturer" override: if the player make falls outside the cap, it replaces the last visible slot so the driver always sees their own count
- Hidden automatically when all cars in the class share the same manufacturer

## Screenshots
<img width="502" height="247" alt="standings compact SoF and per-manufacturer car counts -config" src="https://github.com/user-attachments/assets/e02a69da-11d5-4b13-b8b3-d323adb600f8" />
<img width="555" height="437" alt="standings compact SoF and per-manufacturer car counts" src="https://github.com/user-attachments/assets/d3b4b645-1d66-415c-9285-a3f024407ec2" />

### Before
Class header shows class name, SoF and total driver count only.

### After

<!-- Drag and drop screenshots here -->

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Added optional compact Strength of Field formatting in standings headers.
* Added manufacturer count displays for each class, with configurable limits.
* Added an option to always show the player’s manufacturer.
* Added settings controls to enable and customize manufacturer statistics.
* Improved single-make detection based on standings display preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->