### PR TITLE
feat: add native macOS telemetry replay

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -48,6 +48,21 @@
             ],
         },
         {
+            "target_name": "irsdk_tape_node",
+            "sources": [
+                "src/app/irsdk/native/irsdk_node.cc",
+                "src/app/irsdk/native/replay/irsdk_tape.cpp",
+                "src/app/irsdk/native/replay/irsdk_tape_utils.cpp",
+                "src/app/irsdk/native/lib/irsdk_defines.h",
+            ],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+            ],
+            "include_dirs": [
+                "<!(node -p \"require('node-addon-api').include_dir\")",
+            ],
+        },
+        {
             "target_name": "irsdk_replay",
             "type": "none",
             "sources": [],

--- a/docs/TELEMETRY_RECORD_REPLAY.md
+++ b/docs/TELEMETRY_RECORD_REPLAY.md
@@ -1,7 +1,8 @@
 # Raw iRacing Telemetry Record/Replay
 
 The `irsdk_replay` Windows tool records the complete live IRSDK shared-memory
-surface. Playback uses isolated irDashies test objects by default:
+surface. Its shared-memory playback uses isolated irDashies test objects by
+default:
 
 - `Local\IRDashiesReplayMemMapFileName`
 - `Local\IRDashiesReplayDataValidEvent`
@@ -18,6 +19,12 @@ indistinguishable from live iRacing data. Any future in-app replay controls must
 identify replay mode through an out-of-band test launch flag so session
 lifecycle events can still comply with rule R3.6.
 
+For macOS and other non-Windows development, the application can instead load
+the same tape through `irsdk_tape_node`. This native addon implements the
+existing `INativeSDK` boundary directly, so telemetry and embedded session YAML
+continue through the normal `IRacingSDK` and bridge pipeline without emulating
+Windows shared memory.
+
 ## Build
 
 The tool is built alongside the existing native addon:
@@ -26,7 +33,9 @@ The tool is built alongside the existing native addon:
 npm run irsdk:build
 ```
 
-The executable is written to `build\Release\irsdk_replay.exe`.
+On Windows, the executable is written to
+`build\Release\irsdk_replay.exe`. On every platform, the in-process tape addon
+is written to `build/Release/irsdk_tape_node.node`.
 
 ## Record a live session
 
@@ -63,6 +72,41 @@ npm run irsdk:inspect -- --input telemetry-captures\race.irdt
 ```
 
 ## Replay
+
+### In-process application replay (macOS, Windows, and Linux)
+
+Run any tape directly through irDashies:
+
+```bash
+npm run irsdk:replay:app -- --input test-data/telemetry/ai-race-10min.irdt
+```
+
+Playback supports speed factors from `0.25` through `100`, plus looping:
+
+```bash
+npm run irsdk:replay:app -- --input telemetry-captures/race.irdt --speed 2
+npm run irsdk:replay:app -- --input telemetry-captures/race.irdt --loop
+```
+
+The curated fixture has a convenience command:
+
+```bash
+npm run irsdk:replay:app:curated
+```
+
+The launcher sets these out-of-band development variables:
+
+- `IRDASHIES_TELEMETRY_REPLAY` — resolved tape path
+- `IRDASHIES_TELEMETRY_REPLAY_SPEED` — playback speed
+- `IRDASHIES_TELEMETRY_REPLAY_LOOP` — `1` to restart after disconnect
+
+Replay validates the same format, layout, schema, and payload checksums as the
+Windows tool. Recorded disconnects and loop boundaries pass through the normal
+session lifecycle, and `enter` identifies the source with `replay: true`.
+SDK broadcast commands are intentionally ignored because they cannot alter a
+recorded stream.
+
+### Windows shared-memory replay
 
 ```powershell
 npm run irsdk:replay -- --input telemetry-captures\race.irdt
@@ -138,8 +182,11 @@ npm run irsdk:inspect -- --input test-data\telemetry\ai-race-10min.irdt
 npm run irsdk:replay:curated -- --loop
 ```
 
-To run irDashies against it, set `IRDASHIES_IRSDK_REPLAY=1` before starting the
-application as described above.
+On any supported development platform, the simpler full-application path is:
+
+```bash
+npm run irsdk:replay:app:curated
+```
 
 ## Capture format
 

--- a/docs/TELEMETRY_RECORD_REPLAY.md
+++ b/docs/TELEMETRY_RECORD_REPLAY.md
@@ -29,7 +29,7 @@ Windows shared memory.
 
 The tool is built alongside the existing native addon:
 
-```powershell
+```bash
 npm run irsdk:build
 ```
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "irsdk:record": "build\\Release\\irsdk_replay.exe record",
     "irsdk:replay": "build\\Release\\irsdk_replay.exe play",
     "irsdk:replay:curated": "build\\Release\\irsdk_replay.exe play --input test-data\\telemetry\\ai-race-10min.irdt",
+    "irsdk:replay:app": "node tools/run-telemetry-replay.mjs",
+    "irsdk:replay:app:curated": "node tools/run-telemetry-replay.mjs --input test-data/telemetry/ai-race-10min.irdt --loop",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish:ci": "electron-forge publish",

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -130,6 +130,8 @@ export async function publishIRacingSDKEvents(
   lifecycle?: SessionLifecycle
 ): Promise<IrSdkBridge> {
   logger.info('[iracingSdkBridge] Loading iRacing SDK bridge...');
+  const isTapeReplay = Boolean(process.env.IRDASHIES_TELEMETRY_REPLAY);
+  const sourceName = isTapeReplay ? 'telemetry replay' : 'iRacing';
 
   const perfMetrics = new TelemetryPerfMetrics();
   perfMetrics.startReporting();
@@ -167,7 +169,10 @@ export async function publishIRacingSDKEvents(
   const sdk = new IRacingSDK();
   sdk.autoEnableTelemetry = true;
   await sdk.ready();
-  if (perfRunConfig.enabled && process.env.IRDASHIES_IRSDK_REPLAY === '1') {
+  if (
+    perfRunConfig.enabled &&
+    (process.env.IRDASHIES_IRSDK_REPLAY === '1' || isTapeReplay)
+  ) {
     logger.info(PERF_REPLAY_READY_LOG_MARKER);
   }
 
@@ -202,8 +207,9 @@ export async function publishIRacingSDKEvents(
 
       while (!shouldStop && sdk.waitForData(WAIT_TIMEOUT)) {
         if (!wasRunning) {
-          logger.info('[iracingSdkBridge] iRacing is running');
+          logger.info(`[iracingSdkBridge] ${sourceName} is running`);
           wasRunning = true;
+          lifecycle?._onEnter({ replay: isTapeReplay });
         }
         perfMetrics.markStart('processTelemetry');
         perfMetrics.markStart('sdkTelemetryRead');
@@ -259,7 +265,7 @@ export async function publishIRacingSDKEvents(
 
       if (wasRunning) {
         logger.info(
-          '[iracingSdkBridge] iRacing is no longer publishing telemetry'
+          `[iracingSdkBridge] ${sourceName} is no longer publishing telemetry`
         );
         // Release the last telemetry/session snapshots so new overlay windows
         // opened during a disconnect don't get re-seeded with stale data, and
@@ -295,6 +301,7 @@ export async function publishIRacingSDKEvents(
     },
     stop: () => {
       shouldStop = true;
+      sdk.stopSDK();
       clearInterval(runningStateInterval);
       telemetryCallbacks.clear();
       sessionCallbacks.clear();

--- a/src/app/bridge/iracingSdk/setup.ts
+++ b/src/app/bridge/iracingSdk/setup.ts
@@ -64,8 +64,9 @@ async function setupBridge(overlayManager: OverlayManager) {
       currentBridge = undefined;
     }
 
+    const isTapeReplay = Boolean(process.env.IRDASHIES_TELEMETRY_REPLAY);
     const module =
-      isDemoMode || process.platform !== 'win32'
+      isDemoMode || (process.platform !== 'win32' && !isTapeReplay)
         ? await import('./mock-data/mockSdkBridge')
         : await import('./iracingSdkBridge');
 

--- a/src/app/irsdk/native/binding.gyp
+++ b/src/app/irsdk/native/binding.gyp
@@ -32,21 +32,6 @@
       ]
     },
     {
-      "target_name": "irsdk_tape_node",
-      "sources": [
-        "irsdk_node.cc",
-        "replay/irsdk_tape.cpp",
-        "replay/irsdk_tape_utils.cpp",
-        "lib/irsdk_defines.h"
-      ],
-      "defines": [
-        "NAPI_DISABLE_CPP_EXCEPTIONS"
-      ],
-      "include_dirs": [
-        "<!(node -p \"require('node-addon-api').include_dir\")"
-      ]
-    },
-    {
       "target_name": "irsdk_replay",
       "type": "none",
       "sources": [],

--- a/src/app/irsdk/native/binding.gyp
+++ b/src/app/irsdk/native/binding.gyp
@@ -32,6 +32,21 @@
       ]
     },
     {
+      "target_name": "irsdk_tape_node",
+      "sources": [
+        "irsdk_node.cc",
+        "replay/irsdk_tape.cpp",
+        "replay/irsdk_tape_utils.cpp",
+        "lib/irsdk_defines.h"
+      ],
+      "defines": [
+        "NAPI_DISABLE_CPP_EXCEPTIONS"
+      ],
+      "include_dirs": [
+        "<!(node -p \"require('node-addon-api').include_dir\")"
+      ]
+    },
+    {
       "target_name": "irsdk_replay",
       "type": "none",
       "sources": [],

--- a/src/app/irsdk/native/index.js
+++ b/src/app/irsdk/native/index.js
@@ -1,8 +1,10 @@
 // Import from JS so that we can type the API in a nicer way (without aliases)
 // The alternative would be to somehow get types generated, or use aliases to
 // fake a module and then define that module... but those are gross, so no thanks
-const nativeModule =
-  process.env.IRDASHIES_IRSDK_REPLAY === '1'
+const nativeModule = process.env.IRDASHIES_TELEMETRY_REPLAY
+  ? // eslint-disable-next-line @typescript-eslint/no-require-imports
+    require('../build/Release/irsdk_tape_node.node')
+  : process.env.IRDASHIES_IRSDK_REPLAY === '1'
     ? // eslint-disable-next-line @typescript-eslint/no-require-imports
       require('../build/Release/irsdk_node_replay.node')
     : // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/src/app/irsdk/native/irsdk-tape-node.spec.ts
+++ b/src/app/irsdk/native/irsdk-tape-node.spec.ts
@@ -1,9 +1,10 @@
 import { createRequire } from 'node:module';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { INativeSDK } from './index';
 
@@ -83,7 +84,15 @@ function createFrame(index: number): Buffer {
   return frame;
 }
 
-function createTapeFixture(): Buffer {
+interface TapeFixtureOptions {
+  includeEndRecord?: boolean;
+  qpcFrequency?: bigint;
+}
+
+function createTapeFixture({
+  includeEndRecord = true,
+  qpcFrequency = 60n,
+}: TapeFixtureOptions = {}): Buffer {
   const variables = [
     createVariableHeader({
       type: 5,
@@ -169,8 +178,10 @@ function createTapeFixture(): Buffer {
     createRecord(1, 0n, 100, 0, createFrame(0)),
     createRecord(1, 1n, 101, 0, createFrame(1)),
     createRecord(1, 2n, 102, 0, createFrame(2)),
-    createRecord(5, 3n, 102, 0),
   ];
+  if (includeEndRecord) {
+    records.push(createRecord(5, 3n, 102, 0));
+  }
 
   const fileHeader = Buffer.alloc(FILE_HEADER_SIZE);
   fileHeader.write('IRDTRCE\0', 0, 'ascii');
@@ -181,7 +192,7 @@ function createTapeFixture(): Buffer {
   fileHeader.writeUInt32LE(VARIABLE_HEADER_SIZE, 24);
   fileHeader.writeUInt32LE(variables.length, 28);
   fileHeader.writeBigUInt64LE(BigInt(mappingSize), 32);
-  fileHeader.writeBigUInt64LE(60n, 40);
+  fileHeader.writeBigUInt64LE(qpcFrequency, 40);
   fileHeader.writeBigUInt64LE(BigInt(records.length), 48);
   fileHeader.writeUInt32LE(checksum(variableBytes), 56);
 
@@ -194,15 +205,36 @@ const floatValue = (value: unknown): number =>
   new Float32Array(value as ArrayBuffer)[0];
 const intValue = (value: unknown): number =>
   new Int32Array(value as ArrayBuffer)[0];
+const addonPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  '..',
+  'build',
+  'Release',
+  'irsdk_tape_node.node'
+);
+
+function loadAddon(): { iRacingSdkNode: new () => INativeSDK } {
+  const require = createRequire(import.meta.url);
+  return require(addonPath) as { iRacingSdkNode: new () => INativeSDK };
+}
 
 describe('tape-backed native SDK', () => {
   let temporaryDirectory: string | undefined;
 
+  beforeEach(() => {
+    delete process.env.IRDASHIES_TELEMETRY_REPLAY_SPEED;
+  });
+
   afterEach(async () => {
     delete process.env.IRDASHIES_TELEMETRY_REPLAY;
     delete process.env.IRDASHIES_TELEMETRY_REPLAY_LOOP;
+    delete process.env.IRDASHIES_TELEMETRY_REPLAY_SPEED;
     if (temporaryDirectory) {
       await rm(temporaryDirectory, { recursive: true, force: true });
+      temporaryDirectory = undefined;
     }
   });
 
@@ -216,10 +248,7 @@ describe('tape-backed native SDK', () => {
     process.env.IRDASHIES_TELEMETRY_REPLAY = tapePath;
     process.env.IRDASHIES_TELEMETRY_REPLAY_LOOP = '1';
 
-    const require = createRequire(import.meta.url);
-    const addon = require(
-      path.resolve('build', 'Release', 'irsdk_tape_node.node')
-    ) as { iRacingSdkNode: new () => INativeSDK };
+    const addon = loadAddon();
     const sdk = new addon.iRacingSdkNode();
 
     try {
@@ -249,6 +278,61 @@ describe('tape-backed native SDK', () => {
       expect(sdk.isRunning()).toBe(false);
       expect(sdk.waitForData(20)).toBe(true);
       expect(floatValue(sdk.getTelemetryData().Speed.value)).toBeCloseTo(50, 5);
+    } finally {
+      sdk.stopSDK();
+    }
+  });
+
+  it('reports a disconnect before looping at physical end-of-file', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'irdashies-tape-node-eof-')
+    );
+    const tapePath = path.join(temporaryDirectory, 'synthetic-eof.irdt');
+    await writeFile(tapePath, createTapeFixture({ includeEndRecord: false }));
+
+    process.env.IRDASHIES_TELEMETRY_REPLAY = tapePath;
+    process.env.IRDASHIES_TELEMETRY_REPLAY_LOOP = '1';
+
+    const addon = loadAddon();
+    const sdk = new addon.iRacingSdkNode();
+
+    try {
+      expect(sdk.startSDK()).toBe(true);
+
+      let speed = 0;
+      while (speed < 52) {
+        expect(sdk.waitForData(20)).toBe(true);
+        speed = floatValue(sdk.getTelemetryData().Speed.value);
+      }
+
+      expect(speed).toBeCloseTo(52, 5);
+      expect(sdk.waitForData(20)).toBe(false);
+      expect(sdk.isRunning()).toBe(false);
+      expect(sdk.waitForData(20)).toBe(true);
+      expect(floatValue(sdk.getTelemetryData().Speed.value)).toBeCloseTo(50, 5);
+    } finally {
+      sdk.stopSDK();
+    }
+  });
+
+  it('returns when the requested wait timeout expires', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'irdashies-tape-node-timeout-')
+    );
+    const tapePath = path.join(temporaryDirectory, 'synthetic-timeout.irdt');
+    await writeFile(tapePath, createTapeFixture({ qpcFrequency: 1n }));
+
+    process.env.IRDASHIES_TELEMETRY_REPLAY = tapePath;
+
+    const addon = loadAddon();
+    const sdk = new addon.iRacingSdkNode();
+
+    try {
+      expect(sdk.startSDK()).toBe(true);
+      expect(sdk.waitForData(20)).toBe(true);
+      expect(floatValue(sdk.getTelemetryData().Speed.value)).toBeCloseTo(50, 5);
+      expect(sdk.waitForData(5)).toBe(false);
+      expect(sdk.isRunning()).toBe(true);
     } finally {
       sdk.stopSDK();
     }

--- a/src/app/irsdk/native/irsdk-tape-node.spec.ts
+++ b/src/app/irsdk/native/irsdk-tape-node.spec.ts
@@ -4,7 +4,15 @@ import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
 
 import type { INativeSDK } from './index';
 
@@ -222,27 +230,31 @@ function loadAddon(): { iRacingSdkNode: new () => INativeSDK } {
 }
 
 describe('tape-backed native SDK', () => {
-  let temporaryDirectory: string | undefined;
+  let temporaryDirectory: string;
+  let tapePath: string;
+
+  beforeAll(async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'irdashies-tape-node-')
+    );
+    tapePath = path.join(temporaryDirectory, 'synthetic.irdt');
+  });
 
   beforeEach(() => {
     delete process.env.IRDASHIES_TELEMETRY_REPLAY_SPEED;
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     delete process.env.IRDASHIES_TELEMETRY_REPLAY;
     delete process.env.IRDASHIES_TELEMETRY_REPLAY_LOOP;
     delete process.env.IRDASHIES_TELEMETRY_REPLAY_SPEED;
-    if (temporaryDirectory) {
-      await rm(temporaryDirectory, { recursive: true, force: true });
-      temporaryDirectory = undefined;
-    }
+  });
+
+  afterAll(async () => {
+    await rm(temporaryDirectory, { recursive: true, force: true });
   });
 
   it('replays raw frames and embedded session YAML through INativeSDK', async () => {
-    temporaryDirectory = await mkdtemp(
-      path.join(tmpdir(), 'irdashies-tape-node-')
-    );
-    const tapePath = path.join(temporaryDirectory, 'synthetic.irdt');
     await writeFile(tapePath, createTapeFixture());
 
     process.env.IRDASHIES_TELEMETRY_REPLAY = tapePath;
@@ -284,10 +296,6 @@ describe('tape-backed native SDK', () => {
   });
 
   it('reports a disconnect before looping at physical end-of-file', async () => {
-    temporaryDirectory = await mkdtemp(
-      path.join(tmpdir(), 'irdashies-tape-node-eof-')
-    );
-    const tapePath = path.join(temporaryDirectory, 'synthetic-eof.irdt');
     await writeFile(tapePath, createTapeFixture({ includeEndRecord: false }));
 
     process.env.IRDASHIES_TELEMETRY_REPLAY = tapePath;
@@ -316,10 +324,6 @@ describe('tape-backed native SDK', () => {
   });
 
   it('returns when the requested wait timeout expires', async () => {
-    temporaryDirectory = await mkdtemp(
-      path.join(tmpdir(), 'irdashies-tape-node-timeout-')
-    );
-    const tapePath = path.join(temporaryDirectory, 'synthetic-timeout.irdt');
     await writeFile(tapePath, createTapeFixture({ qpcFrequency: 1n }));
 
     process.env.IRDASHIES_TELEMETRY_REPLAY = tapePath;

--- a/src/app/irsdk/native/irsdk-tape-node.spec.ts
+++ b/src/app/irsdk/native/irsdk-tape-node.spec.ts
@@ -1,0 +1,250 @@
+import { createRequire } from 'node:module';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { INativeSDK } from './index';
+
+const FILE_HEADER_SIZE = 96;
+const SDK_HEADER_SIZE = 112;
+const VARIABLE_HEADER_SIZE = 144;
+const RECORD_HEADER_SIZE = 40;
+const FNV_OFFSET = 2166136261;
+const FNV_PRIME = 16777619;
+
+function checksum(data: Uint8Array): number {
+  let value = FNV_OFFSET;
+  for (const byte of data) {
+    value ^= byte;
+    value = Math.imul(value, FNV_PRIME) >>> 0;
+  }
+  return value;
+}
+
+function writeCString(
+  target: Buffer,
+  offset: number,
+  length: number,
+  value: string
+): void {
+  target.write(value, offset, length - 1, 'ascii');
+}
+
+interface VariableFixture {
+  type: number;
+  offset: number;
+  count: number;
+  name: string;
+  description: string;
+  unit: string;
+}
+
+function createVariableHeader(variable: VariableFixture): Buffer {
+  const header = Buffer.alloc(VARIABLE_HEADER_SIZE);
+  header.writeInt32LE(variable.type, 0);
+  header.writeInt32LE(variable.offset, 4);
+  header.writeInt32LE(variable.count, 8);
+  writeCString(header, 16, 32, variable.name);
+  writeCString(header, 48, 64, variable.description);
+  writeCString(header, 112, 32, variable.unit);
+  return header;
+}
+
+function createRecord(
+  kind: number,
+  elapsedTicks: bigint,
+  sourceTick: number,
+  value: number,
+  payload: Uint8Array = Buffer.alloc(0)
+): Buffer {
+  const header = Buffer.alloc(RECORD_HEADER_SIZE);
+  header.writeUInt32LE(kind, 0);
+  header.writeUInt32LE(RECORD_HEADER_SIZE, 4);
+  header.writeUInt32LE(payload.length, 8);
+  header.writeBigUInt64LE(elapsedTicks, 16);
+  header.writeInt32LE(sourceTick, 24);
+  header.writeInt32LE(value, 28);
+  header.writeUInt32LE(checksum(payload), 32);
+  return Buffer.concat([header, payload]);
+}
+
+function createFrame(index: number): Buffer {
+  const frame = Buffer.alloc(36);
+  frame.writeDoubleLE(10 + index / 60, 0);
+  frame.writeInt32LE(100 + index, 8);
+  frame.writeInt8(index === 0 ? 0 : 1, 12);
+  frame.writeUInt32LE(0x80000000, 16);
+  frame.writeFloatLE(50 + index, 20);
+  frame.writeFloatLE(0.1 + index / 100, 24);
+  frame.writeFloatLE(0.2 + index / 100, 28);
+  frame.writeFloatLE(0.3 + index / 100, 32);
+  return frame;
+}
+
+function createTapeFixture(): Buffer {
+  const variables = [
+    createVariableHeader({
+      type: 5,
+      offset: 0,
+      count: 1,
+      name: 'SessionTime',
+      description: 'Seconds since session start',
+      unit: 's',
+    }),
+    createVariableHeader({
+      type: 2,
+      offset: 8,
+      count: 1,
+      name: 'SessionTick',
+      description: 'Current update number',
+      unit: '',
+    }),
+    createVariableHeader({
+      type: 1,
+      offset: 12,
+      count: 1,
+      name: 'IsOnTrack',
+      description: 'Player is on track',
+      unit: '',
+    }),
+    createVariableHeader({
+      type: 3,
+      offset: 16,
+      count: 1,
+      name: 'SessionFlags',
+      description: 'Session flags',
+      unit: 'irsdk_Flags',
+    }),
+    createVariableHeader({
+      type: 4,
+      offset: 20,
+      count: 1,
+      name: 'Speed',
+      description: 'Player speed',
+      unit: 'm/s',
+    }),
+    createVariableHeader({
+      type: 4,
+      offset: 24,
+      count: 3,
+      name: 'CarIdxLapDistPct',
+      description: 'Car positions',
+      unit: '%',
+    }),
+  ];
+  const variableBytes = Buffer.concat(variables);
+  const sessionOffset = SDK_HEADER_SIZE + variableBytes.length;
+  const sessionCapacity = 1024;
+  const firstBufferOffset = sessionOffset + sessionCapacity;
+  const mappingSize = firstBufferOffset + 3 * 36;
+
+  const sdkHeader = Buffer.alloc(SDK_HEADER_SIZE);
+  sdkHeader.writeInt32LE(2, 0);
+  sdkHeader.writeInt32LE(1, 4);
+  sdkHeader.writeInt32LE(60, 8);
+  sdkHeader.writeInt32LE(1, 12);
+  sdkHeader.writeInt32LE(sessionCapacity, 16);
+  sdkHeader.writeInt32LE(sessionOffset, 20);
+  sdkHeader.writeInt32LE(variables.length, 24);
+  sdkHeader.writeInt32LE(SDK_HEADER_SIZE, 28);
+  sdkHeader.writeInt32LE(3, 32);
+  sdkHeader.writeInt32LE(36, 36);
+  for (let index = 0; index < 3; index++) {
+    const bufferHeaderOffset = 48 + index * 16;
+    sdkHeader.writeInt32LE(-1, bufferHeaderOffset);
+    sdkHeader.writeInt32LE(
+      firstBufferOffset + index * 36,
+      bufferHeaderOffset + 4
+    );
+  }
+
+  const session = Buffer.from(
+    '---\nWeekendInfo:\n TrackName: Replay Test Track\n...\n',
+    'ascii'
+  );
+  const records = [
+    createRecord(2, 0n, -1, 1, session),
+    createRecord(1, 0n, 100, 0, createFrame(0)),
+    createRecord(1, 1n, 101, 0, createFrame(1)),
+    createRecord(1, 2n, 102, 0, createFrame(2)),
+    createRecord(5, 3n, 102, 0),
+  ];
+
+  const fileHeader = Buffer.alloc(FILE_HEADER_SIZE);
+  fileHeader.write('IRDTRCE\0', 0, 'ascii');
+  fileHeader.writeUInt32LE(1, 8);
+  fileHeader.writeUInt32LE(0x01020304, 12);
+  fileHeader.writeUInt32LE(FILE_HEADER_SIZE, 16);
+  fileHeader.writeUInt32LE(SDK_HEADER_SIZE, 20);
+  fileHeader.writeUInt32LE(VARIABLE_HEADER_SIZE, 24);
+  fileHeader.writeUInt32LE(variables.length, 28);
+  fileHeader.writeBigUInt64LE(BigInt(mappingSize), 32);
+  fileHeader.writeBigUInt64LE(60n, 40);
+  fileHeader.writeBigUInt64LE(BigInt(records.length), 48);
+  fileHeader.writeUInt32LE(checksum(variableBytes), 56);
+
+  return Buffer.concat([fileHeader, sdkHeader, variableBytes, ...records]);
+}
+
+const doubleValue = (value: unknown): number =>
+  new Float64Array(value as ArrayBuffer)[0];
+const floatValue = (value: unknown): number =>
+  new Float32Array(value as ArrayBuffer)[0];
+const intValue = (value: unknown): number =>
+  new Int32Array(value as ArrayBuffer)[0];
+
+describe('tape-backed native SDK', () => {
+  let temporaryDirectory: string | undefined;
+
+  afterEach(async () => {
+    delete process.env.IRDASHIES_TELEMETRY_REPLAY;
+    delete process.env.IRDASHIES_TELEMETRY_REPLAY_LOOP;
+    if (temporaryDirectory) {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('replays raw frames and embedded session YAML through INativeSDK', async () => {
+    temporaryDirectory = await mkdtemp(
+      path.join(tmpdir(), 'irdashies-tape-node-')
+    );
+    const tapePath = path.join(temporaryDirectory, 'synthetic.irdt');
+    await writeFile(tapePath, createTapeFixture());
+
+    process.env.IRDASHIES_TELEMETRY_REPLAY = tapePath;
+    process.env.IRDASHIES_TELEMETRY_REPLAY_LOOP = '1';
+
+    const require = createRequire(import.meta.url);
+    const addon = require(
+      path.resolve('build', 'Release', 'irsdk_tape_node.node')
+    ) as { iRacingSdkNode: new () => INativeSDK };
+    const sdk = new addon.iRacingSdkNode();
+
+    try {
+      expect(sdk.startSDK()).toBe(true);
+
+      expect(sdk.waitForData(20)).toBe(true);
+      let telemetry = sdk.getTelemetryData();
+      expect(doubleValue(telemetry.SessionTime.value)).toBeCloseTo(10, 8);
+      expect(intValue(telemetry.SessionTick.value)).toBe(100);
+      expect(sdk.getSessionData()).toContain('TrackName: Replay Test Track');
+
+      expect(sdk.waitForData(20)).toBe(true);
+      telemetry = sdk.getTelemetryData();
+      expect(floatValue(telemetry.Speed.value)).toBeCloseTo(51, 5);
+
+      expect(sdk.waitForData(20)).toBe(true);
+      telemetry = sdk.getTelemetryData();
+      expect(floatValue(telemetry.Speed.value)).toBeCloseTo(52, 5);
+
+      expect(sdk.waitForData(20)).toBe(false);
+      expect(sdk.isRunning()).toBe(false);
+      expect(sdk.waitForData(20)).toBe(true);
+      expect(floatValue(sdk.getTelemetryData().Speed.value)).toBeCloseTo(50, 5);
+    } finally {
+      sdk.stopSDK();
+    }
+  });
+});

--- a/src/app/irsdk/native/irsdk-tape-node.spec.ts
+++ b/src/app/irsdk/native/irsdk-tape-node.spec.ts
@@ -233,11 +233,17 @@ describe('tape-backed native SDK', () => {
 
       expect(sdk.waitForData(20)).toBe(true);
       telemetry = sdk.getTelemetryData();
-      expect(floatValue(telemetry.Speed.value)).toBeCloseTo(51, 5);
+      const nextSpeed = floatValue(telemetry.Speed.value);
+      expect(nextSpeed).toBeGreaterThanOrEqual(51);
+      expect(nextSpeed).toBeLessThanOrEqual(52);
 
-      expect(sdk.waitForData(20)).toBe(true);
-      telemetry = sdk.getTelemetryData();
-      expect(floatValue(telemetry.Speed.value)).toBeCloseTo(52, 5);
+      // A busy runner can make both remaining frames due before waitForData
+      // returns. The replay source correctly catches up to the newest frame.
+      if (nextSpeed < 52) {
+        expect(sdk.waitForData(20)).toBe(true);
+        telemetry = sdk.getTelemetryData();
+        expect(floatValue(telemetry.Speed.value)).toBeCloseTo(52, 5);
+      }
 
       expect(sdk.waitForData(20)).toBe(false);
       expect(sdk.isRunning()).toBe(false);

--- a/src/app/irsdk/native/irsdk_node.cc
+++ b/src/app/irsdk/native/irsdk_node.cc
@@ -45,12 +45,12 @@ Napi::Object iRacingSdkNode::Init(Napi::Env env, Napi::Object exports)
 
 iRacingSdkNode::iRacingSdkNode(const Napi::CallbackInfo &info)
   : Napi::ObjectWrap<iRacingSdkNode>(info)
+  , _loggingEnabled(false)
   , _data(NULL)
   , _bufLineLen(0)
   , _sessionStatusID(0)
   , _lastSessionCt(-1)
   , _sessionData(NULL)
-  , _loggingEnabled(false)
 {
   printf("Initializing cpp class instance...\n");
 }

--- a/src/app/irsdk/native/lib/irsdk_defines.h
+++ b/src/app/irsdk/native/lib/irsdk_defines.h
@@ -81,6 +81,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Constant Definitions
 
+#include <cstring>
+#include <ctime>
+
+#if defined(_WIN32)
 #include <tchar.h>
 
 #include "./irsdk_shared_objects.h"
@@ -97,6 +101,7 @@ static const _TCHAR IRSDK_MEMMAPFILENAME[] =
 	IRDASHIES_IRSDK_PRODUCTION_MAPPING_NAME;
 #endif
 static const _TCHAR IRSDK_BROADCASTMSGNAME[]   = _T("IRSDK_BROADCASTMSG");
+#endif
 
 static const int IRSDK_MAX_BUFS = 4;
 static const int IRSDK_MAX_STRING = 32;

--- a/src/app/irsdk/native/replay/irsdk_tape_utils.cpp
+++ b/src/app/irsdk/native/replay/irsdk_tape_utils.cpp
@@ -1,0 +1,345 @@
+#include "./irsdk_tape.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace replay = irdashies::irsdk_replay;
+
+namespace {
+
+enum class PlaybackState {
+  Stopped,
+  Playing,
+  NeedsDisconnectSignal,
+  ReadyToLoop,
+  Finished,
+  Failed,
+};
+
+std::unique_ptr<replay::TapeReader> tape;
+irsdk_header header{};
+std::vector<char> frame;
+std::vector<char> session;
+replay::TapeRecordHeader pendingRecord{};
+std::vector<char> pendingPayload;
+bool hasPendingRecord = false;
+PlaybackState state = PlaybackState::Stopped;
+std::chrono::steady_clock::time_point playbackStart;
+double playbackSpeed = 1.0;
+bool loopPlayback = false;
+
+bool parsePlaybackOptions(std::string& error) {
+  const char* speedText = std::getenv("IRDASHIES_TELEMETRY_REPLAY_SPEED");
+  if (speedText != nullptr && speedText[0] != '\0') {
+    char* end = nullptr;
+    const double parsed = std::strtod(speedText, &end);
+    if (end == speedText || end == nullptr || *end != '\0' ||
+        !std::isfinite(parsed) || parsed < 0.25 || parsed > 100.0) {
+      error = "IRDASHIES_TELEMETRY_REPLAY_SPEED must be between 0.25 and 100";
+      return false;
+    }
+    playbackSpeed = parsed;
+  } else {
+    playbackSpeed = 1.0;
+  }
+
+  const char* loopText = std::getenv("IRDASHIES_TELEMETRY_REPLAY_LOOP");
+  loopPlayback = loopText != nullptr && std::strcmp(loopText, "1") == 0;
+  return true;
+}
+
+void resetPublishedData() {
+  header = tape->sdkHeader();
+  header.status = irsdk_stConnected;
+  header.sessionInfoLen = 0;
+  header.sessionInfoUpdate = -1;
+  for (int i = 0; i < header.numBuf; ++i) {
+    header.varBuf[i].tickCount = -1;
+  }
+  frame.assign(static_cast<std::size_t>(header.bufLen), 0);
+  session.assign(1, '\0');
+  hasPendingRecord = false;
+  pendingPayload.clear();
+  playbackStart = std::chrono::steady_clock::now();
+  state = PlaybackState::Playing;
+}
+
+bool openTape(std::string& error) {
+  const char* input = std::getenv("IRDASHIES_TELEMETRY_REPLAY");
+  if (input == nullptr || input[0] == '\0') {
+    error = "IRDASHIES_TELEMETRY_REPLAY is not set";
+    return false;
+  }
+  if (!parsePlaybackOptions(error)) {
+    return false;
+  }
+
+  auto candidate = std::make_unique<replay::TapeReader>();
+  if (!candidate->open(std::filesystem::path(input), error)) {
+    return false;
+  }
+  tape = std::move(candidate);
+  resetPublishedData();
+  return true;
+}
+
+bool restartTape(std::string& error) {
+  if (tape == nullptr || !tape->rewindRecords(error)) {
+    return false;
+  }
+  resetPublishedData();
+  return true;
+}
+
+void finishPlayback(bool frameWillBePublished) {
+  header.status = 0;
+  if (!loopPlayback) {
+    state = PlaybackState::Finished;
+  } else {
+    state = frameWillBePublished
+        ? PlaybackState::NeedsDisconnectSignal
+        : PlaybackState::ReadyToLoop;
+  }
+}
+
+bool loadPendingRecord(std::string& error) {
+  if (hasPendingRecord) {
+    return true;
+  }
+  const auto result = tape->readNext(pendingRecord, pendingPayload, error);
+  if (result == replay::TapeReadResult::Record) {
+    hasPendingRecord = true;
+    return true;
+  }
+  if (result == replay::TapeReadResult::EndOfFile) {
+    finishPlayback(false);
+    return false;
+  }
+  state = PlaybackState::Failed;
+  header.status = 0;
+  return false;
+}
+
+std::chrono::steady_clock::time_point pendingTargetTime() {
+  const double seconds =
+      static_cast<double>(pendingRecord.elapsedTicks) /
+      static_cast<double>(tape->fileHeader().qpcFrequency) /
+      playbackSpeed;
+  return playbackStart +
+      std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+          std::chrono::duration<double>(seconds));
+}
+
+void applySessionRecord() {
+  session.resize(pendingPayload.size() + 1);
+  if (!pendingPayload.empty()) {
+    std::memcpy(session.data(), pendingPayload.data(), pendingPayload.size());
+  }
+  session.back() = '\0';
+  header.sessionInfoLen = static_cast<int>(pendingPayload.size());
+  header.sessionInfoUpdate = pendingRecord.value;
+}
+
+bool publishFrameRecord(char* destination, std::string& error) {
+  if (pendingPayload.size() != frame.size()) {
+    error = "Frame record length does not match the SDK buffer length";
+    state = PlaybackState::Failed;
+    header.status = 0;
+    return false;
+  }
+  std::memcpy(frame.data(), pendingPayload.data(), frame.size());
+  if (destination != nullptr) {
+    std::memcpy(destination, frame.data(), frame.size());
+  }
+  return true;
+}
+
+bool readTimedFrame(int timeoutMs, char* destination) {
+  bool foundFrame = false;
+  std::string error;
+
+  while (state == PlaybackState::Playing) {
+    if (!loadPendingRecord(error)) {
+      if (!error.empty()) {
+        std::cerr << "Telemetry tape playback failed: " << error << '\n';
+      }
+      return foundFrame;
+    }
+
+    const auto target = pendingTargetTime();
+    const auto now = std::chrono::steady_clock::now();
+    if (target > now) {
+      if (foundFrame) {
+        return true;
+      }
+      const auto remaining = target - now;
+      const auto waitLimit = std::chrono::milliseconds(
+          std::max(timeoutMs, 1));
+      const auto typedWaitLimit =
+          std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+              waitLimit);
+      std::this_thread::sleep_for(std::min(remaining, typedWaitLimit));
+      continue;
+    }
+
+    const auto kind = static_cast<replay::RecordKind>(pendingRecord.kind);
+    switch (kind) {
+      case replay::RecordKind::Frame:
+        if (!publishFrameRecord(destination, error)) {
+          std::cerr << "Telemetry tape playback failed: " << error << '\n';
+          return false;
+        }
+        foundFrame = true;
+        break;
+
+      case replay::RecordKind::SessionInfo:
+        applySessionRecord();
+        break;
+
+      case replay::RecordKind::Gap:
+        std::cerr << "Telemetry tape capture gap: " << pendingRecord.value
+                  << " source ticks\n";
+        break;
+
+      case replay::RecordKind::Disconnect:
+      case replay::RecordKind::End:
+        finishPlayback(foundFrame);
+        break;
+    }
+    hasPendingRecord = false;
+  }
+
+  return foundFrame;
+}
+
+}  // namespace
+
+bool irsdk_startup() {
+  if (state == PlaybackState::Playing) {
+    return true;
+  }
+  if (state == PlaybackState::NeedsDisconnectSignal) {
+    state = loopPlayback
+        ? PlaybackState::ReadyToLoop
+        : PlaybackState::Finished;
+    return false;
+  }
+
+  std::string error;
+  if (state == PlaybackState::ReadyToLoop) {
+    if (restartTape(error)) {
+      return true;
+    }
+  } else if (state == PlaybackState::Stopped) {
+    if (openTape(error)) {
+      return true;
+    }
+  } else {
+    return false;
+  }
+
+  std::cerr << "Could not start telemetry tape playback: " << error << '\n';
+  state = PlaybackState::Failed;
+  return false;
+}
+
+void irsdk_shutdown() {
+  tape.reset();
+  frame.clear();
+  session.clear();
+  pendingPayload.clear();
+  hasPendingRecord = false;
+  header = {};
+  state = PlaybackState::Stopped;
+}
+
+bool irsdk_getNewData(char* data) {
+  return readTimedFrame(1, data);
+}
+
+bool irsdk_waitForDataReady(int timeoutMs, char* data) {
+  if (state != PlaybackState::Playing && !irsdk_startup()) {
+    return false;
+  }
+  return readTimedFrame(timeoutMs, data);
+}
+
+bool irsdk_isConnected() {
+  return state == PlaybackState::Playing &&
+      (header.status & irsdk_stConnected) != 0;
+}
+
+const irsdk_header* irsdk_getHeader() {
+  return tape == nullptr ? nullptr : &header;
+}
+
+const char* irsdk_getData(int index) {
+  if (index < 0 || index >= header.numBuf || frame.empty()) {
+    return nullptr;
+  }
+  return frame.data();
+}
+
+const char* irsdk_getSessionInfoStr() {
+  return session.empty() ? nullptr : session.data();
+}
+
+int irsdk_getSessionInfoStrUpdate() {
+  return session.size() <= 1 ? -1 : header.sessionInfoUpdate;
+}
+
+const irsdk_varHeader* irsdk_getVarHeaderPtr() {
+  if (tape == nullptr || tape->variables().empty()) {
+    return nullptr;
+  }
+  return tape->variables().data();
+}
+
+const irsdk_varHeader* irsdk_getVarHeaderEntry(int index) {
+  if (tape == nullptr || index < 0 ||
+      index >= static_cast<int>(tape->variables().size())) {
+    return nullptr;
+  }
+  return &tape->variables()[static_cast<std::size_t>(index)];
+}
+
+int irsdk_varNameToIndex(const char* name) {
+  if (name == nullptr || tape == nullptr) {
+    return -1;
+  }
+  const auto& variables = tape->variables();
+  for (std::size_t index = 0; index < variables.size(); ++index) {
+    if (std::strncmp(name, variables[index].name, IRSDK_MAX_STRING) == 0) {
+      return static_cast<int>(index);
+    }
+  }
+  return -1;
+}
+
+int irsdk_varNameToOffset(const char* name) {
+  const int index = irsdk_varNameToIndex(name);
+  const auto* variable = irsdk_getVarHeaderEntry(index);
+  return variable == nullptr ? -1 : variable->offset;
+}
+
+void irsdk_broadcastMsg(irsdk_BroadcastMsg, int, int, int) {}
+void irsdk_broadcastMsg(irsdk_BroadcastMsg, int, int) {}
+void irsdk_broadcastMsg(irsdk_BroadcastMsg, int, float) {}
+
+int irsdk_padCarNum(int num, int zero) {
+  int places = num > 99 ? 3 : (num > 9 ? 2 : 1);
+  if (zero == 0) {
+    return num;
+  }
+  places += zero;
+  return num + 1000 * places;
+}

--- a/src/app/irsdk/native/replay/irsdk_tape_utils.cpp
+++ b/src/app/irsdk/native/replay/irsdk_tape_utils.cpp
@@ -111,7 +111,7 @@ void finishPlayback(bool frameWillBePublished) {
   }
 }
 
-bool loadPendingRecord(std::string& error) {
+bool loadPendingRecord(bool frameWillBePublished, std::string& error) {
   if (hasPendingRecord) {
     return true;
   }
@@ -121,7 +121,7 @@ bool loadPendingRecord(std::string& error) {
     return true;
   }
   if (result == replay::TapeReadResult::EndOfFile) {
-    finishPlayback(false);
+    finishPlayback(frameWillBePublished);
     return false;
   }
   state = PlaybackState::Failed;
@@ -166,9 +166,11 @@ bool publishFrameRecord(char* destination, std::string& error) {
 bool readTimedFrame(int timeoutMs, char* destination) {
   bool foundFrame = false;
   std::string error;
+  const auto deadline = std::chrono::steady_clock::now() +
+      std::chrono::milliseconds(std::max(timeoutMs, 0));
 
   while (state == PlaybackState::Playing) {
-    if (!loadPendingRecord(error)) {
+    if (!loadPendingRecord(foundFrame, error)) {
       if (!error.empty()) {
         std::cerr << "Telemetry tape playback failed: " << error << '\n';
       }
@@ -178,16 +180,10 @@ bool readTimedFrame(int timeoutMs, char* destination) {
     const auto target = pendingTargetTime();
     const auto now = std::chrono::steady_clock::now();
     if (target > now) {
-      if (foundFrame) {
-        return true;
+      if (foundFrame || now >= deadline) {
+        return foundFrame;
       }
-      const auto remaining = target - now;
-      const auto waitLimit = std::chrono::milliseconds(
-          std::max(timeoutMs, 1));
-      const auto typedWaitLimit =
-          std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-              waitLimit);
-      std::this_thread::sleep_for(std::min(remaining, typedWaitLimit));
+      std::this_thread::sleep_for(std::min(target - now, deadline - now));
       continue;
     }
 

--- a/src/app/irsdk/node/get-sdk.ts
+++ b/src/app/irsdk/node/get-sdk.ts
@@ -5,7 +5,7 @@ import type { INativeSDK } from '../native';
 import { MockSDK } from './utils/mock-sdk';
 
 export async function getSdkOrMock(): Promise<INativeSDK> {
-  if (platform() === 'win32') {
+  if (process.env.IRDASHIES_TELEMETRY_REPLAY || platform() === 'win32') {
     const Sdk = (await import('../native')).NativeSDK;
     return new Sdk();
   }

--- a/src/app/sessionLifecycle/index.ts
+++ b/src/app/sessionLifecycle/index.ts
@@ -1,2 +1,3 @@
 export { createSessionLifecycle } from './sessionLifecycle';
 export type { SessionLifecycle } from './sessionLifecycle';
+export type { SessionEnterEvent } from './sessionLifecycle';

--- a/src/app/sessionLifecycle/sessionLifecycle.spec.ts
+++ b/src/app/sessionLifecycle/sessionLifecycle.spec.ts
@@ -48,6 +48,19 @@ describe('sessionLifecycle', () => {
     lifecycle = createSessionLifecycle();
   });
 
+  describe('session entry', () => {
+    it('identifies recorded telemetry independently from live telemetry', () => {
+      const enterSpy = vi.fn();
+      lifecycle.onEnter(enterSpy);
+
+      lifecycle._onEnter({ replay: true });
+      lifecycle._onEnter({ replay: false });
+
+      expect(enterSpy).toHaveBeenNthCalledWith(1, { replay: true });
+      expect(enterSpy).toHaveBeenNthCalledWith(2, { replay: false });
+    });
+  });
+
   describe('driver joins', () => {
     it('fires onDriverJoined for each new carIdx', () => {
       const joinSpy = vi.fn();

--- a/src/app/sessionLifecycle/sessionLifecycle.ts
+++ b/src/app/sessionLifecycle/sessionLifecycle.ts
@@ -3,8 +3,14 @@ import logger from '../logger';
 
 type Callback = () => void;
 type CarIdxCallback = (carIdx: number) => void;
+export interface SessionEnterEvent {
+  replay: boolean;
+}
+type EnterCallback = (event: SessionEnterEvent) => void;
 
 export interface SessionLifecycle {
+  /** Called when a live or recorded telemetry source begins publishing. */
+  onEnter: (cb: EnterCallback) => () => void;
   /** Called when a new driver joins (carIdx newly populated in DriverInfo). */
   onDriverJoined: (cb: CarIdxCallback) => () => void;
   /** Called when a driver leaves (carIdx removed from DriverInfo). */
@@ -15,12 +21,14 @@ export interface SessionLifecycle {
   onDisconnect: (cb: Callback) => () => void;
 
   // Internal — called by iracingSdkBridge on each SDK tick.
+  _onEnter: (event: SessionEnterEvent) => void;
   _onTelemetry: (telemetry: Telemetry) => void;
   _onSession: (session: Session) => void;
   _onDisconnect: () => void;
 }
 
 export function createSessionLifecycle(): SessionLifecycle {
+  const enterCallbacks = new Set<EnterCallback>();
   const driverJoinedCallbacks = new Set<CarIdxCallback>();
   const driverLeftCallbacks = new Set<CarIdxCallback>();
   const sessionNumChangeCallbacks = new Set<Callback>();
@@ -51,6 +59,10 @@ export function createSessionLifecycle(): SessionLifecycle {
   }
 
   return {
+    onEnter(cb) {
+      enterCallbacks.add(cb);
+      return () => enterCallbacks.delete(cb);
+    },
     onDriverJoined(cb) {
       driverJoinedCallbacks.add(cb);
       return () => driverJoinedCallbacks.delete(cb);
@@ -66,6 +78,10 @@ export function createSessionLifecycle(): SessionLifecycle {
     onDisconnect(cb) {
       disconnectCallbacks.add(cb);
       return () => disconnectCallbacks.delete(cb);
+    },
+
+    _onEnter(event) {
+      fire(enterCallbacks, event);
     },
 
     _onTelemetry(telemetry) {

--- a/tools/run-telemetry-replay.mjs
+++ b/tools/run-telemetry-replay.mjs
@@ -15,9 +15,16 @@ if (!input) {
   );
   process.exitCode = 2;
 } else {
-  const speedText = optionValue(arguments_, '--speed') ?? '1';
+  const speedIndex = arguments_.indexOf('--speed');
+  const speedText =
+    speedIndex === -1 ? '1' : optionValue(arguments_, '--speed');
   const speed = Number(speedText);
-  if (!Number.isFinite(speed) || speed < 0.25 || speed > 100) {
+  if (
+    speedText === undefined ||
+    !Number.isFinite(speed) ||
+    speed < 0.25 ||
+    speed > 100
+  ) {
     process.stderr.write('--speed must be between 0.25 and 100\n');
     process.exitCode = 2;
   } else if (path.extname(input).toLowerCase() !== '.irdt') {

--- a/tools/run-telemetry-replay.mjs
+++ b/tools/run-telemetry-replay.mjs
@@ -1,0 +1,47 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+function optionValue(arguments_, name) {
+  const index = arguments_.indexOf(name);
+  return index >= 0 ? arguments_[index + 1] : undefined;
+}
+
+const arguments_ = process.argv.slice(2);
+const input = optionValue(arguments_, '--input');
+if (!input) {
+  process.stderr.write(
+    'Usage: npm run irsdk:replay:app -- --input <capture.irdt> ' +
+      '[--speed <0.25-100>] [--loop]\n'
+  );
+  process.exitCode = 2;
+} else {
+  const speedText = optionValue(arguments_, '--speed') ?? '1';
+  const speed = Number(speedText);
+  if (!Number.isFinite(speed) || speed < 0.25 || speed > 100) {
+    process.stderr.write('--speed must be between 0.25 and 100\n');
+    process.exitCode = 2;
+  } else if (path.extname(input).toLowerCase() !== '.irdt') {
+    process.stderr.write('--input must be an .irdt telemetry tape\n');
+    process.exitCode = 2;
+  } else {
+    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    const child = spawn(npmCommand, ['start'], {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        IRDASHIES_TELEMETRY_REPLAY: path.resolve(input),
+        IRDASHIES_TELEMETRY_REPLAY_SPEED: speedText,
+        IRDASHIES_TELEMETRY_REPLAY_LOOP: arguments_.includes('--loop')
+          ? '1'
+          : '0',
+      },
+    });
+    child.on('error', (error) => {
+      process.stderr.write(`Could not start irDashies: ${error.message}\n`);
+      process.exitCode = 1;
+    });
+    child.on('exit', (code, signal) => {
+      process.exitCode = code ?? (signal ? 1 : 0);
+    });
+  }
+}

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       [
         'build/Release/irsdk_node.node',
         'build/Release/irsdk_node_replay.node',
+        'build/Release/irsdk_tape_node.node',
       ],
       '.vite/build/Release/'
     ),
@@ -53,10 +54,6 @@ function irsdkNativeModule(nodeFiles: string[], outDir: string) {
       return nodeFileMap.has(path.basename(source)) ? source : null;
     },
     transform(code: string, id: string) {
-      // check platform
-      if (process.platform !== 'win32') {
-        return code;
-      }
       const file = nodeFileMap.get(path.basename(id));
       if (file) {
         return {
@@ -74,10 +71,6 @@ function irsdkNativeModule(nodeFiles: string[], outDir: string) {
       return nodeFileMap.has(path.basename(id)) ? '' : null;
     },
     generateBundle() {
-      // check platform
-      if (process.platform !== 'win32') {
-        return;
-      }
       nodeFileMap.forEach((fileAbs, file) => {
         const out = `${outDir}/${file}`;
         if (!fs.existsSync(fileAbs)) {


### PR DESCRIPTION
## Description

Adds native in-process playback for `.irdt` telemetry tapes on macOS, Windows, and Linux.

The new `irsdk_tape_node` addon implements the existing `INativeSDK` boundary directly using `TapeReader`. Telemetry frames and embedded session YAML therefore continue through the normal `IRacingSDK`, bridge, and session lifecycle pipeline without emulating Windows shared memory.

This also:

- selects the tape addon when `IRDASHIES_TELEMETRY_REPLAY` is set
- adds cross-platform replay launcher commands with speed and loop controls
- marks session `enter` events with `replay: true` per architecture rule R3.6
- preserves disconnect behavior at tape and loop boundaries
- validates tape format, layout, schema, and payload checksums
- documents the new workflow and adds native integration coverage

Architecture review alignment: Phase 2 lifecycle completion (`onEnter` with live/replay distinction) and the trace-replay tooling foundation described by the performance harness plan.

Validation:

- `npm run irsdk:build`
- `npm run lint`
- `npm run test -- --no-coverage` — 1,073 passed, 1 skipped
- focused native replay and lifecycle tests after rebasing — 18 passed
- launched Electron on macOS ARM64 with the 332 MiB curated AI-race tape; verified 40 drivers, embedded Road America session YAML, session revisions, disconnect, and loop re-entry

## Screenshots

### Before

No visual UI change. On macOS the application always fell back to mock telemetry, and tape playback depended on the Windows shared-memory replay executable.

### After

No visual UI change. macOS can run the recorded session through the normal application pipeline with `npm run irsdk:replay:app:curated`.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-platform telemetry tape replay for running the application with recorded data.
  * Added configurable playback speed, looping, validation, and replay lifecycle handling.
  * Added commands for standard and curated application replay.
* **Documentation**
  * Documented replay setup, controls, environment variables, validation, lifecycle behavior, and supported platforms.
* **Bug Fixes**
  * Improved replay status reporting and clean SDK shutdown behavior.
* **Tests**
  * Added coverage for telemetry playback, session data, looping, end-of-tape handling, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->