### PR TITLE
perf: poll session data at 2Hz instead of every telemetry tick

### DIFF
--- a/src/app/bridge/iracingSdk/iracingSdkBridge.spec.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.spec.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '@irdashies/types';
+
+const mockGetSessionData = vi.hoisted(() => vi.fn());
+const mockWaitForData = vi.hoisted(() => vi.fn());
+const mockStopSDK = vi.hoisted(() => vi.fn());
+
+vi.mock('../../irsdk', () => ({
+  IRacingSDK: class {
+    autoEnableTelemetry = false;
+    currDataVersion = 1;
+    sessionStatusOK = true;
+
+    ready = vi.fn().mockResolvedValue(true);
+    waitForData = mockWaitForData;
+    getTelemetry = vi.fn().mockReturnValue(null);
+    getSessionData = mockGetSessionData;
+    stopSDK = mockStopSDK;
+  },
+}));
+
+vi.mock('../../perfMetrics', () => ({
+  TelemetryPerfMetrics: class {
+    startReporting = vi.fn();
+    stopReporting = vi.fn();
+    markStart = vi.fn();
+    markEnd = vi.fn();
+    tick = vi.fn();
+  },
+}));
+
+vi.mock('../../perfRunConfig', () => ({
+  getPerfRunConfig: () => ({ enabled: false }),
+  PERF_REPLAY_READY_LOG_MARKER: 'replay-ready',
+}));
+
+vi.mock('../../logger', () => ({
+  default: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { publishIRacingSDKEvents } from './iracingSdkBridge';
+
+describe('publishIRacingSDKEvents session polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: 0 });
+    mockGetSessionData.mockReset();
+    mockGetSessionData.mockReturnValue({} as Session);
+    mockWaitForData.mockReset();
+    mockWaitForData.mockReturnValue(true);
+    mockStopSDK.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  const createOverlayManager = () => ({
+    onOverlayReady: vi.fn(),
+    publishMessage: vi.fn(),
+    publishMessageToOverlay: vi.fn(),
+  });
+
+  it('polls immediately and every 500 ms using monotonic time', async () => {
+    const overlayManager = createOverlayManager();
+
+    const bridge = await publishIRacingSDKEvents(overlayManager as never);
+
+    expect(mockGetSessionData).toHaveBeenCalledTimes(1);
+
+    // A backward wall-clock adjustment must not stall elapsed-time polling.
+    vi.setSystemTime(new Date(-60_000));
+    await vi.advanceTimersByTimeAsync(480);
+    expect(mockGetSessionData).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(40);
+    expect(mockGetSessionData).toHaveBeenCalledTimes(2);
+
+    bridge.stop();
+  });
+
+  it('polls immediately after reconnecting', async () => {
+    const bridge = await publishIRacingSDKEvents(
+      createOverlayManager() as never
+    );
+    expect(mockGetSessionData).toHaveBeenCalledTimes(1);
+
+    mockWaitForData.mockReturnValueOnce(false);
+    await vi.advanceTimersByTimeAsync(40);
+    expect(mockGetSessionData).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(mockGetSessionData).toHaveBeenCalledTimes(2);
+
+    bridge.stop();
+  });
+});

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -124,6 +124,12 @@ function telemetryForRenderer(
 const WAIT_TIMEOUT = 16;
 // How long to sleep between connection retry attempts when iRacing isn't running.
 const RETRY_INTERVAL = 1000;
+// How often to ask the SDK for session data. The native getSessionData() copies
+// and transcodes the whole session YAML on every call even when nothing has
+// changed, and currDataVersion only refreshes as a side effect of that call, so
+// there is no cheap way to check first. Session data is published at 1 Hz at
+// most (see the publish gate below), so polling faster than this buys nothing.
+const SESSION_POLL_INTERVAL = 500;
 
 export async function publishIRacingSDKEvents(
   overlayManager: OverlayManager,
@@ -203,6 +209,8 @@ export async function publishIRacingSDKEvents(
     while (!shouldStop) {
       let lastSessionVersion = -1;
       let lastSessionPublishTime = 0;
+      // 0 so the first tick after connecting always fetches session data.
+      let lastSessionPollTime = 0;
       let wasRunning = false;
 
       while (!shouldStop && sdk.waitForData(WAIT_TIMEOUT)) {
@@ -215,9 +223,14 @@ export async function publishIRacingSDKEvents(
         perfMetrics.markStart('sdkTelemetryRead');
         const telemetry = sdk.getTelemetry();
         perfMetrics.markEnd('sdkTelemetryRead');
-        perfMetrics.markStart('sdkSessionRead');
-        const session = sdk.getSessionData();
-        perfMetrics.markEnd('sdkSessionRead');
+        const tickTime = Date.now();
+        let session: Session | null = null;
+        if (tickTime - lastSessionPollTime >= SESSION_POLL_INTERVAL) {
+          lastSessionPollTime = tickTime;
+          perfMetrics.markStart('sdkSessionRead');
+          session = sdk.getSessionData();
+          perfMetrics.markEnd('sdkSessionRead');
+        }
 
         if (telemetry) {
           latestTelemetry = telemetry;
@@ -239,15 +252,14 @@ export async function publishIRacingSDKEvents(
 
         if (session) {
           // Only publish the session data if it has changed or if 1 second has passed since the last publish
-          const now = Date.now();
-          const timeSinceLastPublish = now - lastSessionPublishTime;
+          const timeSinceLastPublish = tickTime - lastSessionPublishTime;
           if (
             sdk.currDataVersion !== lastSessionVersion ||
             timeSinceLastPublish >= 1000
           ) {
             perfMetrics.markStart('sessionPublish');
             lastSessionVersion = sdk.currDataVersion;
-            lastSessionPublishTime = now;
+            lastSessionPublishTime = tickTime;
             latestSession = session;
             lifecycle?._onSession(session);
             overlayManager.publishMessage('sessionData', session);

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -127,8 +127,8 @@ const RETRY_INTERVAL = 1000;
 // How often to ask the SDK for session data. The native getSessionData() copies
 // and transcodes the whole session YAML on every call even when nothing has
 // changed, and currDataVersion only refreshes as a side effect of that call, so
-// there is no cheap way to check first. Session data is published at 1 Hz at
-// most (see the publish gate below), so polling faster than this buys nothing.
+// there is no cheap way to check first. Polling at 2 Hz bounds session-change
+// detection latency to about 500 ms while avoiding work on every telemetry tick.
 const SESSION_POLL_INTERVAL = 500;
 
 export async function publishIRacingSDKEvents(
@@ -208,9 +208,9 @@ export async function publishIRacingSDKEvents(
   (async () => {
     while (!shouldStop) {
       let lastSessionVersion = -1;
-      let lastSessionPublishTime = 0;
-      // 0 so the first tick after connecting always fetches session data.
-      let lastSessionPollTime = 0;
+      // Negative infinity makes the first tick fetch and publish immediately.
+      let lastSessionPublishTime = Number.NEGATIVE_INFINITY;
+      let lastSessionPollTime = Number.NEGATIVE_INFINITY;
       let wasRunning = false;
 
       while (!shouldStop && sdk.waitForData(WAIT_TIMEOUT)) {
@@ -223,7 +223,7 @@ export async function publishIRacingSDKEvents(
         perfMetrics.markStart('sdkTelemetryRead');
         const telemetry = sdk.getTelemetry();
         perfMetrics.markEnd('sdkTelemetryRead');
-        const tickTime = Date.now();
+        const tickTime = performance.now();
         let session: Session | null = null;
         if (tickTime - lastSessionPollTime >= SESSION_POLL_INTERVAL) {
           lastSessionPollTime = tickTime;
@@ -251,7 +251,7 @@ export async function publishIRacingSDKEvents(
         }
 
         if (session) {
-          // Only publish the session data if it has changed or if 1 second has passed since the last publish
+          // Publish changes at the next poll and refresh unchanged data at 1 Hz.
           const timeSinceLastPublish = tickTime - lastSessionPublishTime;
           if (
             sdk.currDataVersion !== lastSessionVersion ||


### PR DESCRIPTION
## Description

Reduces main-process work by polling iRacing's session data at 2 Hz instead of on every telemetry tick.

`getSessionData()` copies and re-encodes the entire session YAML on every call, even when the data has not changed — and because `currDataVersion` only refreshes as a side effect of that call, there is no cheap way to check first. With a full grid the session string is 150 KB or more, so at ~21 Hz that was several MB/s of allocation and transcoding for data that is only ever *published* at 1 Hz.

The publish gate is unchanged, so **renderers see exactly the same data at the same rate**. The only behavioural difference is that a genuine session change is now detected up to ~450 ms later. That is well inside the tolerance of what the session YAML carries (driver roster, qualifying/results positions, session type and state). Live timing — positions, gaps, deltas, speed — comes from the telemetry feed and is untouched.

### Measured

Captured with the existing perf harness (`PERF_METRICS=1`) on a packaged build, three monitors, 40-car AI race at Watkins Glen. Two runs, 24 and 49 minutes.

| | before | after |
|---|---|---|
| `sdkSessionRead` calls/s | 21.1 | **1.9** |
| avg per call | 0.33 ms | 1.92 ms |
| total time per second | 6.96 ms | **3.65 ms** |
| cost | 0.71% of a core | **0.37% of a core** |
| `processTelemetry` avg | 2.23 ms | **2.08 ms** |

The per-call average rises because it no longer averages ~19 cheap no-op calls against ~2 real ones — total work is what dropped, by ~48%. The two figures cross-check: 3.31 ms/s saved over ~21 ticks is 0.157 ms/tick, and `processTelemetry` fell by 0.15 ms.

Worth noting for expectations: this reduces steady-state cost, not the occasional stall. Those spikes turned out to be genuine `yaml.load()` calls rather than the wasted re-encode, so the worst-case tick only moved from 59 ms to 46 ms.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced background session data polling frequency for smoother telemetry processing.
  * Improved session update timing and efficiency without changing the information displayed.
  * Improved polling behavior during connection interruptions and reconnections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->