### PR TITLE
feat: add typed rate-aware channel bus

### DIFF
--- a/src/app/bridge/channelBridge.spec.ts
+++ b/src/app/bridge/channelBridge.spec.ts
@@ -167,4 +167,27 @@ describe('ChannelBus', () => {
       2
     );
   });
+
+  it('retains the latest pending snapshot until a hidden renderer is shown', () => {
+    const { bus, clock } = createBus();
+    const target = createTarget();
+    bus.subscribe(target, 'snapshot', 10);
+    bus.publish('snapshot', 1);
+    clock.advance(20);
+    bus.publish('snapshot', 2);
+
+    target.visible = false;
+    clock.advance(80);
+    bus.publish('snapshot', 3);
+    expect(target.send).toHaveBeenCalledTimes(1);
+
+    target.visible = true;
+    bus.rendererBecameVisible(target.id);
+    expect(target.send).toHaveBeenCalledTimes(2);
+    expect(target.send).toHaveBeenLastCalledWith(
+      CHANNEL_DELIVERY,
+      'snapshot',
+      3
+    );
+  });
 });

--- a/src/app/bridge/channelBridge.spec.ts
+++ b/src/app/bridge/channelBridge.spec.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ChannelDefinition } from '@irdashies/types';
+import { CHANNEL_DELIVERY, ChannelBus } from './channelBridge';
+
+class FakeClock {
+  now = 0;
+  private tasks: {
+    at: number;
+    callback: () => void;
+    cancelled: boolean;
+  }[] = [];
+
+  schedule = (callback: () => void, delayMs: number) => {
+    const task = { at: this.now + delayMs, callback, cancelled: false };
+    this.tasks.push(task);
+    return { cancel: () => (task.cancelled = true) };
+  };
+
+  advance(ms: number): void {
+    this.now += ms;
+    const due = this.tasks
+      .filter((task) => !task.cancelled && task.at <= this.now)
+      .sort((a, b) => a.at - b.at);
+    this.tasks = this.tasks.filter((task) => !due.includes(task));
+    for (const task of due) task.callback();
+  }
+}
+
+const registry: Readonly<Record<string, ChannelDefinition>> = {
+  snapshot: { kind: 'snapshot', defaultRateHz: 10, maxRateHz: 60 },
+  event: { kind: 'event' },
+};
+
+const createTarget = (id = 1) => ({
+  id,
+  destroyed: false,
+  visible: true,
+  send: vi.fn(),
+  isDestroyed() {
+    return this.destroyed;
+  },
+  isVisible() {
+    return this.visible;
+  },
+});
+
+const createBus = (clock = new FakeClock()) => ({
+  clock,
+  bus: new ChannelBus({
+    registry,
+    now: () => clock.now,
+    schedule: clock.schedule,
+  }),
+});
+
+describe('ChannelBus', () => {
+  it('rejects unknown channels and invalid rates', () => {
+    const { bus } = createBus();
+    const target = createTarget();
+
+    expect(() => bus.subscribe(target, 'missing')).toThrow('Unknown channel');
+    expect(() => bus.subscribe(target, 'snapshot', 0)).toThrow(
+      'Invalid channel rate'
+    );
+    expect(() => bus.subscribe(target, 'snapshot', 61)).toThrow(
+      'Invalid channel rate'
+    );
+    expect(() => bus.subscribe(target, 'event', 10)).toThrow(
+      'Event channels do not accept'
+    );
+  });
+
+  it('coalesces snapshot updates and trails with the latest value', () => {
+    const { bus, clock } = createBus();
+    const target = createTarget();
+    bus.subscribe(target, 'snapshot', 10);
+
+    bus.publish('snapshot', { value: 1 });
+    clock.advance(20);
+    bus.publish('snapshot', { value: 2 });
+    clock.advance(20);
+    bus.publish('snapshot', { value: 3 });
+
+    expect(target.send).toHaveBeenCalledTimes(1);
+    clock.advance(60);
+    expect(target.send).toHaveBeenLastCalledWith(CHANNEL_DELIVERY, 'snapshot', {
+      value: 3,
+    });
+    expect(target.send).toHaveBeenCalledTimes(2);
+  });
+
+  it('seeds snapshot subscribers but does not replay events', () => {
+    const { bus } = createBus();
+    bus.publish('snapshot', { value: 7 });
+    bus.publish('event', { type: 'old' });
+    const target = createTarget();
+
+    bus.subscribe(target, 'snapshot');
+    bus.subscribe(target, 'event');
+
+    expect(target.send).toHaveBeenCalledOnce();
+    expect(target.send).toHaveBeenCalledWith(CHANNEL_DELIVERY, 'snapshot', {
+      value: 7,
+    });
+  });
+
+  it('suppresses hidden renderers and removes destroyed renderers', () => {
+    const { bus } = createBus();
+    const target = createTarget();
+    bus.subscribe(target, 'event');
+
+    target.visible = false;
+    bus.publish('event', { type: 'hidden' });
+    expect(target.send).not.toHaveBeenCalled();
+
+    target.visible = true;
+    target.destroyed = true;
+    bus.publish('event', { type: 'destroyed' });
+    expect(bus.subscriberCount('event')).toBe(0);
+  });
+
+  it('cancels pending delivery on unsubscribe and renderer removal', () => {
+    const { bus, clock } = createBus();
+    const first = createTarget(1);
+    const second = createTarget(2);
+    bus.subscribe(first, 'snapshot', 10);
+    bus.subscribe(second, 'snapshot', 10);
+    bus.publish('snapshot', 1);
+    bus.publish('snapshot', 2);
+
+    bus.unsubscribe(first.id, 'snapshot');
+    bus.removeRenderer(second.id);
+    clock.advance(100);
+
+    expect(first.send).toHaveBeenCalledTimes(1);
+    expect(second.send).toHaveBeenCalledTimes(1);
+    expect(bus.subscriberCount('snapshot')).toBe(0);
+  });
+
+  it('tracks publication and delivery counts per renderer and channel', () => {
+    const { bus } = createBus();
+    const target = createTarget(9);
+    bus.subscribe(target, 'event');
+    bus.publish('event', { type: 'first' });
+    bus.publish('event', { type: 'second' });
+
+    expect(bus.metricsSnapshot()).toEqual({
+      publications: { '9:event': 2 },
+      deliveries: { '9:event': 2 },
+    });
+  });
+
+  it('reschedules a pending snapshot when the requested rate changes', () => {
+    const { bus, clock } = createBus();
+    const target = createTarget();
+    bus.subscribe(target, 'snapshot', 5);
+    bus.publish('snapshot', 1);
+    clock.advance(10);
+    bus.publish('snapshot', 2);
+
+    bus.subscribe(target, 'snapshot', 20);
+    clock.advance(40);
+    expect(target.send).toHaveBeenCalledTimes(2);
+    expect(target.send).toHaveBeenLastCalledWith(
+      CHANNEL_DELIVERY,
+      'snapshot',
+      2
+    );
+  });
+});

--- a/src/app/bridge/channelBridge.ts
+++ b/src/app/bridge/channelBridge.ts
@@ -96,12 +96,13 @@ export class ChannelBus {
     const subscription: Subscription = { target, rateHz };
     subscribers.set(target.id, subscription);
 
-    if (
-      definition.kind === 'snapshot' &&
-      this.latestSnapshots.has(channel) &&
-      target.isVisible()
-    ) {
-      this.deliver(channel, subscription, this.latestSnapshots.get(channel));
+    if (definition.kind === 'snapshot' && this.latestSnapshots.has(channel)) {
+      const latest = this.latestSnapshots.get(channel);
+      if (target.isVisible()) {
+        this.deliver(channel, subscription, latest);
+      } else {
+        subscription.pending = latest;
+      }
     }
   }
 
@@ -133,8 +134,25 @@ export class ChannelBus {
         this.remove(channel, rendererId);
         continue;
       }
-      if (!subscription.target.isVisible()) continue;
+      if (!subscription.target.isVisible()) {
+        if (definition.kind === 'snapshot') subscription.pending = payload;
+        continue;
+      }
       this.queueDelivery(channel, subscription, payload);
+    }
+  }
+
+  rendererBecameVisible(rendererId: number): void {
+    for (const [channel, subscribers] of this.subscriptions) {
+      const subscription = subscribers.get(rendererId);
+      if (
+        subscription?.pending === undefined ||
+        subscription.target.isDestroyed() ||
+        !subscription.target.isVisible()
+      ) {
+        continue;
+      }
+      this.queueDelivery(channel, subscription, subscription.pending);
     }
   }
 
@@ -208,14 +226,14 @@ export class ChannelBus {
     subscription.timer = this.schedule(() => {
       subscription.timer = undefined;
       const pending = subscription.pending;
-      subscription.pending = undefined;
-      if (
-        pending !== undefined &&
-        !subscription.target.isDestroyed() &&
-        subscription.target.isVisible()
-      ) {
-        this.deliver(channel, subscription, pending);
+      if (pending === undefined) return;
+      if (subscription.target.isDestroyed()) {
+        subscription.pending = undefined;
+        return;
       }
+      if (!subscription.target.isVisible()) return;
+      subscription.pending = undefined;
+      this.deliver(channel, subscription, pending);
     }, intervalMs - elapsed);
   }
 
@@ -256,7 +274,7 @@ const targetFor = (sender: Electron.WebContents): RendererTarget => ({
 });
 
 export const setupChannelBridge = (bus: ChannelBus): (() => void) => {
-  const trackedSenders = new Set<number>();
+  const rendererCleanup = new Map<number, () => void>();
   ipcMain.handle(
     CHANNEL_SUBSCRIBE,
     (event, channel: unknown, rate: unknown) => {
@@ -264,11 +282,18 @@ export const setupChannelBridge = (bus: ChannelBus): (() => void) => {
       if (rate !== undefined && typeof rate !== 'number') {
         throw new Error('Invalid channel rate');
       }
-      if (!trackedSenders.has(event.sender.id)) {
-        trackedSenders.add(event.sender.id);
-        event.sender.once('destroyed', () => {
-          trackedSenders.delete(event.sender.id);
+      if (!rendererCleanup.has(event.sender.id)) {
+        const window = BrowserWindow.fromWebContents(event.sender);
+        const onShow = () => bus.rendererBecameVisible(event.sender.id);
+        window?.on('show', onShow);
+        const cleanup = () => {
+          window?.removeListener('show', onShow);
+          rendererCleanup.delete(event.sender.id);
           bus.removeRenderer(event.sender.id);
+        };
+        rendererCleanup.set(event.sender.id, cleanup);
+        event.sender.once('destroyed', () => {
+          cleanup();
         });
       }
       bus.subscribe(targetFor(event.sender), channel, rate);
@@ -281,6 +306,8 @@ export const setupChannelBridge = (bus: ChannelBus): (() => void) => {
   return () => {
     ipcMain.removeHandler(CHANNEL_SUBSCRIBE);
     ipcMain.removeHandler(CHANNEL_UNSUBSCRIBE);
+    for (const cleanup of rendererCleanup.values()) cleanup();
+    rendererCleanup.clear();
     bus.dispose();
   };
 };

--- a/src/app/bridge/channelBridge.ts
+++ b/src/app/bridge/channelBridge.ts
@@ -1,0 +1,286 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import type {
+  ChannelDefinition,
+  ChannelName,
+  ChannelPayloads,
+} from '@irdashies/types';
+import { channelRegistry } from '@irdashies/types';
+
+export const CHANNEL_SUBSCRIBE = 'channels:subscribe';
+export const CHANNEL_UNSUBSCRIBE = 'channels:unsubscribe';
+export const CHANNEL_DELIVERY = 'channels:delivery';
+
+interface RendererTarget {
+  readonly id: number;
+  isDestroyed(): boolean;
+  isVisible(): boolean;
+  send(channel: string, name: string, payload: unknown): void;
+}
+
+interface TimerHandle {
+  cancel(): void;
+}
+
+interface ChannelBusOptions {
+  registry?: Readonly<Record<string, ChannelDefinition>>;
+  now?: () => number;
+  schedule?: (callback: () => void, delayMs: number) => TimerHandle;
+  onPublish?: (rendererId: number, channel: string) => void;
+  onDeliver?: (rendererId: number, channel: string) => void;
+}
+
+interface Subscription {
+  target: RendererTarget;
+  rateHz: number | 'event';
+  lastDeliveredAt?: number;
+  pending?: unknown;
+  timer?: TimerHandle;
+}
+
+export interface ChannelBusMetricsSnapshot {
+  publications: Readonly<Record<string, number>>;
+  deliveries: Readonly<Record<string, number>>;
+}
+
+const systemSchedule = (callback: () => void, delayMs: number): TimerHandle => {
+  const timeout = setTimeout(callback, delayMs);
+  return { cancel: () => clearTimeout(timeout) };
+};
+
+export class ChannelBus {
+  private readonly registry: Readonly<Record<string, ChannelDefinition>>;
+  private readonly now: () => number;
+  private readonly schedule: (
+    callback: () => void,
+    delayMs: number
+  ) => TimerHandle;
+  private readonly onPublish?: (rendererId: number, channel: string) => void;
+  private readonly onDeliver?: (rendererId: number, channel: string) => void;
+  private readonly subscriptions = new Map<string, Map<number, Subscription>>();
+  private readonly latestSnapshots = new Map<string, unknown>();
+  private readonly publicationCounts = new Map<string, number>();
+  private readonly deliveryCounts = new Map<string, number>();
+
+  constructor(options: ChannelBusOptions = {}) {
+    this.registry = options.registry ?? channelRegistry;
+    this.now = options.now ?? (() => performance.now());
+    this.schedule = options.schedule ?? systemSchedule;
+    this.onPublish = options.onPublish;
+    this.onDeliver = options.onDeliver;
+  }
+
+  subscribe(target: RendererTarget, channel: string, rate?: number): void {
+    const definition = this.definition(channel);
+    const rateHz = this.validateRate(definition, rate);
+    if (target.isDestroyed()) {
+      this.remove(channel, target.id);
+      return;
+    }
+    const existing = this.subscriptions.get(channel)?.get(target.id);
+    if (existing) {
+      existing.target = target;
+      existing.rateHz = rateHz;
+      existing.timer?.cancel();
+      existing.timer = undefined;
+      if (existing.pending !== undefined && target.isVisible()) {
+        this.queueDelivery(channel, existing, existing.pending);
+      }
+      return;
+    }
+    this.remove(channel, target.id);
+    let subscribers = this.subscriptions.get(channel);
+    if (!subscribers) {
+      subscribers = new Map();
+      this.subscriptions.set(channel, subscribers);
+    }
+    const subscription: Subscription = { target, rateHz };
+    subscribers.set(target.id, subscription);
+
+    if (
+      definition.kind === 'snapshot' &&
+      this.latestSnapshots.has(channel) &&
+      target.isVisible()
+    ) {
+      this.deliver(channel, subscription, this.latestSnapshots.get(channel));
+    }
+  }
+
+  unsubscribe(rendererId: number, channel: string): void {
+    this.definition(channel);
+    this.remove(channel, rendererId);
+  }
+
+  removeRenderer(rendererId: number): void {
+    for (const channel of this.subscriptions.keys()) {
+      this.remove(channel, rendererId);
+    }
+  }
+
+  publish<K extends ChannelName>(channel: K, payload: ChannelPayloads[K]): void;
+  publish(channel: string, payload: unknown): void;
+  publish(channel: string, payload: unknown): void {
+    const definition = this.definition(channel);
+    if (definition.kind === 'snapshot') {
+      this.latestSnapshots.set(channel, payload);
+    }
+
+    const subscribers = this.subscriptions.get(channel);
+    if (!subscribers) return;
+    for (const [rendererId, subscription] of subscribers) {
+      this.onPublish?.(rendererId, channel);
+      this.increment(this.publicationCounts, rendererId, channel);
+      if (subscription.target.isDestroyed()) {
+        this.remove(channel, rendererId);
+        continue;
+      }
+      if (!subscription.target.isVisible()) continue;
+      this.queueDelivery(channel, subscription, payload);
+    }
+  }
+
+  subscriberCount(channel: string): number {
+    return this.subscriptions.get(channel)?.size ?? 0;
+  }
+
+  metricsSnapshot(): ChannelBusMetricsSnapshot {
+    return {
+      publications: Object.fromEntries(this.publicationCounts),
+      deliveries: Object.fromEntries(this.deliveryCounts),
+    };
+  }
+
+  dispose(): void {
+    for (const subscribers of this.subscriptions.values()) {
+      for (const subscription of subscribers.values()) {
+        subscription.timer?.cancel();
+      }
+    }
+    this.subscriptions.clear();
+  }
+
+  private definition(channel: string): ChannelDefinition {
+    const definition = this.registry[channel];
+    if (!definition) throw new Error(`Unknown channel: ${channel}`);
+    return definition;
+  }
+
+  private validateRate(
+    definition: ChannelDefinition,
+    requested?: number
+  ): number | 'event' {
+    if (definition.kind === 'event') {
+      if (requested !== undefined) {
+        throw new Error('Event channels do not accept a requested rate');
+      }
+      return 'event';
+    }
+    const rate = requested ?? definition.defaultRateHz;
+    if (!Number.isFinite(rate) || rate <= 0 || rate > definition.maxRateHz) {
+      throw new Error(`Invalid channel rate: ${String(rate)}`);
+    }
+    return rate;
+  }
+
+  private queueDelivery(
+    channel: string,
+    subscription: Subscription,
+    payload: unknown
+  ): void {
+    if (subscription.rateHz === 'event') {
+      this.deliver(channel, subscription, payload);
+      return;
+    }
+    const intervalMs = 1000 / subscription.rateHz;
+    const now = this.now();
+    const elapsed =
+      subscription.lastDeliveredAt === undefined
+        ? intervalMs
+        : now - subscription.lastDeliveredAt;
+    if (elapsed >= intervalMs) {
+      subscription.timer?.cancel();
+      subscription.timer = undefined;
+      subscription.pending = undefined;
+      this.deliver(channel, subscription, payload);
+      return;
+    }
+    subscription.pending = payload;
+    if (subscription.timer) return;
+    subscription.timer = this.schedule(() => {
+      subscription.timer = undefined;
+      const pending = subscription.pending;
+      subscription.pending = undefined;
+      if (
+        pending !== undefined &&
+        !subscription.target.isDestroyed() &&
+        subscription.target.isVisible()
+      ) {
+        this.deliver(channel, subscription, pending);
+      }
+    }, intervalMs - elapsed);
+  }
+
+  private deliver(
+    channel: string,
+    subscription: Subscription,
+    payload: unknown
+  ): void {
+    subscription.target.send(CHANNEL_DELIVERY, channel, payload);
+    subscription.lastDeliveredAt = this.now();
+    this.onDeliver?.(subscription.target.id, channel);
+    this.increment(this.deliveryCounts, subscription.target.id, channel);
+  }
+
+  private increment(
+    counters: Map<string, number>,
+    rendererId: number,
+    channel: string
+  ): void {
+    const key = `${rendererId}:${channel}`;
+    counters.set(key, (counters.get(key) ?? 0) + 1);
+  }
+
+  private remove(channel: string, rendererId: number): void {
+    const subscribers = this.subscriptions.get(channel);
+    const subscription = subscribers?.get(rendererId);
+    subscription?.timer?.cancel();
+    subscribers?.delete(rendererId);
+    if (subscribers?.size === 0) this.subscriptions.delete(channel);
+  }
+}
+
+const targetFor = (sender: Electron.WebContents): RendererTarget => ({
+  id: sender.id,
+  isDestroyed: () => sender.isDestroyed(),
+  isVisible: () => BrowserWindow.fromWebContents(sender)?.isVisible() ?? false,
+  send: (channel, name, payload) => sender.send(channel, name, payload),
+});
+
+export const setupChannelBridge = (bus: ChannelBus): (() => void) => {
+  const trackedSenders = new Set<number>();
+  ipcMain.handle(
+    CHANNEL_SUBSCRIBE,
+    (event, channel: unknown, rate: unknown) => {
+      if (typeof channel !== 'string') throw new Error('Invalid channel name');
+      if (rate !== undefined && typeof rate !== 'number') {
+        throw new Error('Invalid channel rate');
+      }
+      if (!trackedSenders.has(event.sender.id)) {
+        trackedSenders.add(event.sender.id);
+        event.sender.once('destroyed', () => {
+          trackedSenders.delete(event.sender.id);
+          bus.removeRenderer(event.sender.id);
+        });
+      }
+      bus.subscribe(targetFor(event.sender), channel, rate);
+    }
+  );
+  ipcMain.handle(CHANNEL_UNSUBSCRIBE, (event, channel: unknown) => {
+    if (typeof channel !== 'string') throw new Error('Invalid channel name');
+    bus.unsubscribe(event.sender.id, channel);
+  });
+  return () => {
+    ipcMain.removeHandler(CHANNEL_SUBSCRIBE);
+    ipcMain.removeHandler(CHANNEL_UNSUBSCRIBE);
+    bus.dispose();
+  };
+};

--- a/src/app/bridge/channelBridgeIpc.spec.ts
+++ b/src/app/bridge/channelBridgeIpc.spec.ts
@@ -7,6 +7,7 @@ type Handler = (
 ) => void;
 
 const handlers = vi.hoisted(() => new Map<string, Handler>());
+const windowListeners = vi.hoisted(() => new Map<string, () => void>());
 
 class FakeSender {
   readonly id = 42;
@@ -28,7 +29,12 @@ vi.mock('electron', () => ({
     removeHandler: (channel: string) => handlers.delete(channel),
   },
   BrowserWindow: {
-    fromWebContents: () => ({ isVisible: () => true }),
+    fromWebContents: () => ({
+      isVisible: () => true,
+      on: (event: string, listener: () => void) =>
+        windowListeners.set(event, listener),
+      removeListener: (event: string) => windowListeners.delete(event),
+    }),
   },
 }));
 
@@ -39,7 +45,10 @@ import {
 } from './channelBridge';
 
 describe('channel bridge IPC boundary', () => {
-  beforeEach(() => handlers.clear());
+  beforeEach(() => {
+    handlers.clear();
+    windowListeners.clear();
+  });
 
   it('validates requests and removes subscriptions when a renderer dies', () => {
     const bus = new ChannelBus();

--- a/src/app/bridge/channelBridgeIpc.spec.ts
+++ b/src/app/bridge/channelBridgeIpc.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Handler = (
+  event: { sender: FakeSender },
+  channel: unknown,
+  rate?: unknown
+) => void;
+
+const handlers = vi.hoisted(() => new Map<string, Handler>());
+
+class FakeSender {
+  readonly id = 42;
+  private destroyedListener?: () => void;
+  send = vi.fn();
+  isDestroyed = () => false;
+  once = (_event: string, listener: () => void) => {
+    this.destroyedListener = listener;
+  };
+  destroy(): void {
+    this.destroyedListener?.();
+  }
+}
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: Handler) =>
+      handlers.set(channel, handler),
+    removeHandler: (channel: string) => handlers.delete(channel),
+  },
+  BrowserWindow: {
+    fromWebContents: () => ({ isVisible: () => true }),
+  },
+}));
+
+import {
+  CHANNEL_SUBSCRIBE,
+  ChannelBus,
+  setupChannelBridge,
+} from './channelBridge';
+
+describe('channel bridge IPC boundary', () => {
+  beforeEach(() => handlers.clear());
+
+  it('validates requests and removes subscriptions when a renderer dies', () => {
+    const bus = new ChannelBus();
+    setupChannelBridge(bus);
+    const subscribe = handlers.get(CHANNEL_SUBSCRIBE);
+    const sender = new FakeSender();
+    if (!subscribe) throw new Error('subscribe handler not installed');
+
+    expect(() => subscribe({ sender }, 'unknown')).toThrow('Unknown channel');
+    expect(() =>
+      subscribe({ sender }, 'session.lifecycle', Number.NaN)
+    ).toThrow('Event channels do not accept');
+    expect(() => subscribe({ sender }, 123)).toThrow('Invalid channel name');
+
+    subscribe({ sender }, 'session.lifecycle');
+    expect(bus.subscriberCount('session.lifecycle')).toBe(1);
+    sender.destroy();
+    expect(bus.subscriberCount('session.lifecycle')).toBe(0);
+  });
+});

--- a/src/app/bridge/channelRendererBridge.spec.ts
+++ b/src/app/bridge/channelRendererBridge.spec.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const listeners = vi.hoisted(
+  () => new Map<string, (...args: unknown[]) => void>()
+);
+const invoke = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    on: (channel: string, listener: (...args: unknown[]) => void) =>
+      listeners.set(channel, listener),
+    invoke,
+  },
+  contextBridge: { exposeInMainWorld: vi.fn() },
+  BrowserWindow: {},
+  ipcMain: {},
+}));
+
+import {
+  CHANNEL_DELIVERY,
+  CHANNEL_SUBSCRIBE,
+  CHANNEL_UNSUBSCRIBE,
+} from './channelBridge';
+import { createChannelRendererBridge } from './channelRendererBridge';
+
+interface TestSnapshotBridge {
+  subscribe(
+    channel: 'test.snapshot',
+    callback: (payload: number) => void,
+    requestedRateHz?: number
+  ): () => void;
+}
+
+describe('channel renderer bridge', () => {
+  beforeEach(() => {
+    listeners.clear();
+    invoke.mockClear();
+  });
+
+  it('reference counts consumers and subscribes at their highest rate', () => {
+    const bridge =
+      createChannelRendererBridge() as unknown as TestSnapshotBridge;
+    const callbackA = vi.fn();
+    const callbackB = vi.fn();
+
+    const unsubscribeA = bridge.subscribe('test.snapshot', callbackA, 5);
+    const unsubscribeB = bridge.subscribe('test.snapshot', callbackB, 20);
+
+    expect(invoke).toHaveBeenNthCalledWith(
+      1,
+      CHANNEL_SUBSCRIBE,
+      'test.snapshot',
+      5
+    );
+    expect(invoke).toHaveBeenNthCalledWith(
+      2,
+      CHANNEL_SUBSCRIBE,
+      'test.snapshot',
+      20
+    );
+
+    listeners.get(CHANNEL_DELIVERY)?.({}, 'test.snapshot', 12);
+    expect(callbackA).toHaveBeenCalledOnce();
+    expect(callbackB).toHaveBeenCalledOnce();
+
+    unsubscribeB();
+    expect(invoke).toHaveBeenLastCalledWith(
+      CHANNEL_SUBSCRIBE,
+      'test.snapshot',
+      5
+    );
+    unsubscribeA();
+    expect(invoke).toHaveBeenLastCalledWith(
+      CHANNEL_UNSUBSCRIBE,
+      'test.snapshot'
+    );
+  });
+});

--- a/src/app/bridge/channelRendererBridge.ts
+++ b/src/app/bridge/channelRendererBridge.ts
@@ -1,0 +1,90 @@
+import { ipcRenderer } from 'electron';
+import type {
+  ChannelBridge,
+  ChannelName,
+  ChannelPayloads,
+} from '@irdashies/types';
+import { defineBridge } from './defineBridge';
+import {
+  CHANNEL_DELIVERY,
+  CHANNEL_SUBSCRIBE,
+  CHANNEL_UNSUBSCRIBE,
+} from './channelBridge';
+
+interface LocalConsumer {
+  callback: (payload: never) => void;
+  rate?: number;
+}
+
+interface LocalSubscription {
+  consumers: Set<LocalConsumer>;
+  isSubscribed: boolean;
+  subscribedRate?: number;
+}
+
+export const createChannelRendererBridge = (): ChannelBridge => {
+  const subscriptions = new Map<ChannelName, LocalSubscription>();
+
+  ipcRenderer.on(
+    CHANNEL_DELIVERY,
+    (_event, channel: ChannelName, payload: unknown) => {
+      const subscription = subscriptions.get(channel);
+      if (!subscription) return;
+      for (const consumer of subscription.consumers) {
+        consumer.callback(payload as never);
+      }
+    }
+  );
+
+  const sync = (channel: ChannelName, subscription: LocalSubscription) => {
+    const rates = [...subscription.consumers]
+      .map((consumer) => consumer.rate)
+      .filter((rate): rate is number => rate !== undefined);
+    const requestedRate = rates.length > 0 ? Math.max(...rates) : undefined;
+    if (
+      subscription.isSubscribed &&
+      subscription.subscribedRate === requestedRate
+    ) {
+      return;
+    }
+    subscription.isSubscribed = true;
+    subscription.subscribedRate = requestedRate;
+    void ipcRenderer.invoke(CHANNEL_SUBSCRIBE, channel, requestedRate);
+  };
+
+  return {
+    subscribe: <K extends ChannelName>(
+      channel: K,
+      callback: (payload: ChannelPayloads[K]) => void,
+      requestedRateHz?: number
+    ) => {
+      let subscription = subscriptions.get(channel);
+      if (!subscription) {
+        subscription = { consumers: new Set(), isSubscribed: false };
+        subscriptions.set(channel, subscription);
+      }
+      const consumer: LocalConsumer = {
+        callback: callback as (payload: never) => void,
+        rate: requestedRateHz,
+      };
+      subscription.consumers.add(consumer);
+      sync(channel, subscription);
+
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        subscription?.consumers.delete(consumer);
+        if (!subscription || subscription.consumers.size === 0) {
+          subscriptions.delete(channel);
+          void ipcRenderer.invoke(CHANNEL_UNSUBSCRIBE, channel);
+          return;
+        }
+        sync(channel, subscription);
+      };
+    },
+  };
+};
+
+export const exposeChannelBridge = (): ChannelBridge =>
+  defineBridge<ChannelBridge>('channelBridge', createChannelRendererBridge());

--- a/src/app/bridge/defineBridge.ts
+++ b/src/app/bridge/defineBridge.ts
@@ -1,0 +1,7 @@
+import { contextBridge } from 'electron';
+
+/** Exposes a typed preload API through Electron's isolated world boundary. */
+export const defineBridge = <I>(name: string, implementation: I): I => {
+  contextBridge.exposeInMainWorld(name, implementation);
+  return implementation;
+};

--- a/src/app/bridge/sessionLifecycleChannel.spec.ts
+++ b/src/app/bridge/sessionLifecycleChannel.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionLifecycle } from '../sessionLifecycle';
+import { connectSessionLifecycleChannel } from './sessionLifecycleChannel';
+
+describe('session lifecycle channel', () => {
+  it('publishes source events and disconnects every listener', () => {
+    const callbacks: Record<string, (...args: never[]) => void> = {};
+    const removers = [vi.fn(), vi.fn(), vi.fn()];
+    const lifecycle = {
+      onEnter: (callback: () => void) => {
+        callbacks.enter = callback;
+        return removers[0];
+      },
+      onSessionNumChange: (callback: () => void) => {
+        callbacks.sessionNumChange = callback;
+        return removers[1];
+      },
+      onDisconnect: (callback: () => void) => {
+        callbacks.disconnect = callback;
+        return removers[2];
+      },
+    } as unknown as SessionLifecycle;
+    const publish = vi.fn();
+    const disconnect = connectSessionLifecycleChannel(lifecycle, {
+      publish,
+    } as never);
+
+    callbacks.enter({ replay: true } as never);
+    callbacks.sessionNumChange();
+    callbacks.disconnect();
+
+    expect(publish).toHaveBeenNthCalledWith(1, 'session.lifecycle', {
+      type: 'enter',
+      replay: true,
+    });
+    expect(publish).toHaveBeenNthCalledWith(2, 'session.lifecycle', {
+      type: 'sessionNumChange',
+    });
+    expect(publish).toHaveBeenNthCalledWith(3, 'session.lifecycle', {
+      type: 'disconnect',
+    });
+
+    disconnect();
+    for (const remove of removers) expect(remove).toHaveBeenCalledOnce();
+  });
+});

--- a/src/app/bridge/sessionLifecycleChannel.ts
+++ b/src/app/bridge/sessionLifecycleChannel.ts
@@ -1,0 +1,20 @@
+import type { SessionLifecycle } from '../sessionLifecycle';
+import type { ChannelBus } from './channelBridge';
+
+export const connectSessionLifecycleChannel = (
+  lifecycle: SessionLifecycle,
+  bus: ChannelBus
+): (() => void) => {
+  const unsubscribe = [
+    lifecycle.onEnter(({ replay }) =>
+      bus.publish('session.lifecycle', { type: 'enter', replay })
+    ),
+    lifecycle.onSessionNumChange(() =>
+      bus.publish('session.lifecycle', { type: 'sessionNumChange' })
+    ),
+    lifecycle.onDisconnect(() =>
+      bus.publish('session.lifecycle', { type: 'disconnect' })
+    ),
+  ];
+  return () => unsubscribe.forEach((remove) => remove());
+};

--- a/src/frontend/context/ChannelStore/ChannelSnapshotStore.spec.ts
+++ b/src/frontend/context/ChannelStore/ChannelSnapshotStore.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ChannelBridge, SessionLifecycleEvent } from '@irdashies/types';
+import { ChannelSnapshotStore } from './ChannelSnapshotStore';
+
+describe('ChannelSnapshotStore', () => {
+  it('shares one bridge subscription and disconnects the final listener', () => {
+    let publish: ((payload: SessionLifecycleEvent) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const subscribe = vi.fn(
+      (
+        _channel: string,
+        callback: (payload: SessionLifecycleEvent) => void
+      ) => {
+        publish = callback;
+        return unsubscribe;
+      }
+    );
+    const bridge = { subscribe } as unknown as ChannelBridge;
+    const store = new ChannelSnapshotStore(
+      'session.lifecycle',
+      undefined,
+      bridge
+    );
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const removeFirst = store.subscribe(first);
+    const removeSecond = store.subscribe(second);
+    publish?.({ type: 'enter', replay: true });
+
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+    expect(store.getSnapshot()).toEqual({ type: 'enter', replay: true });
+    removeFirst();
+    expect(unsubscribe).not.toHaveBeenCalled();
+    removeSecond();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+});

--- a/src/frontend/context/ChannelStore/ChannelSnapshotStore.ts
+++ b/src/frontend/context/ChannelStore/ChannelSnapshotStore.ts
@@ -1,0 +1,42 @@
+import type {
+  ChannelBridge,
+  ChannelName,
+  ChannelPayloads,
+} from '@irdashies/types';
+
+type ChangeListener = () => void;
+
+export class ChannelSnapshotStore<K extends ChannelName> {
+  private snapshot: ChannelPayloads[K] | undefined;
+  private readonly listeners = new Set<ChangeListener>();
+  private unsubscribeBridge?: () => void;
+
+  constructor(
+    private readonly channel: K,
+    private readonly rateHz?: number,
+    private readonly bridge: ChannelBridge = window.channelBridge
+  ) {}
+
+  getSnapshot = (): ChannelPayloads[K] | undefined => this.snapshot;
+
+  subscribe = (listener: ChangeListener): (() => void) => {
+    this.listeners.add(listener);
+    if (this.listeners.size === 1) {
+      this.unsubscribeBridge = this.bridge.subscribe(
+        this.channel,
+        (snapshot) => {
+          this.snapshot = snapshot;
+          for (const currentListener of this.listeners) currentListener();
+        },
+        this.rateHz
+      );
+    }
+    return () => {
+      this.listeners.delete(listener);
+      if (this.listeners.size === 0) {
+        this.unsubscribeBridge?.();
+        this.unsubscribeBridge = undefined;
+      }
+    };
+  };
+}

--- a/src/frontend/context/ChannelStore/index.ts
+++ b/src/frontend/context/ChannelStore/index.ts
@@ -1,0 +1,2 @@
+export * from './ChannelSnapshotStore';
+export * from './useChannelSnapshot';

--- a/src/frontend/context/ChannelStore/useChannelSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useChannelSnapshot.ts
@@ -1,0 +1,19 @@
+import { useMemo, useSyncExternalStore } from 'react';
+import type {
+  ChannelBridge,
+  ChannelName,
+  ChannelPayloads,
+} from '@irdashies/types';
+import { ChannelSnapshotStore } from './ChannelSnapshotStore';
+
+export const useChannelSnapshot = <K extends ChannelName>(
+  channel: K,
+  rateHz?: number,
+  bridge?: ChannelBridge
+): ChannelPayloads[K] | undefined => {
+  const store = useMemo(
+    () => new ChannelSnapshotStore(channel, rateHz, bridge),
+    [bridge, channel, rateHz]
+  );
+  return useSyncExternalStore(store.subscribe, store.getSnapshot);
+};

--- a/src/frontend/context/index.ts
+++ b/src/frontend/context/index.ts
@@ -3,6 +3,7 @@ export * from './RunningStateContext/RunningStateContext';
 export * from './SessionStore/SessionProvider';
 export * from './SessionStore/SessionStore';
 export * from './TelemetryStore/TelemetryProvider';
+export * from './ChannelStore';
 export * from './TelemetryStore/TelemetryStore';
 export * from './PitLapStore/PitLapStore';
 export * from './PitLapStore/PitLapStoreUpdater';

--- a/src/interface.d.ts
+++ b/src/interface.d.ts
@@ -9,9 +9,11 @@ import type {
   GamepadHostBridge,
   ChromiumFlagsBridge,
 } from '@irdashies/types';
+import type { ChannelBridge } from '@irdashies/types';
 
 declare global {
   interface Window {
+    channelBridge: ChannelBridge;
     irsdkBridge: IrSdkBridge;
     dashboardBridge: DashboardBridge;
     pitLaneBridge: PitLaneBridge;

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import log from './app/logger';
 import {
   iRacingSDKSetup,
   getCurrentBridge,
+  getSessionLifecycle,
 } from './app/bridge/iracingSdk/setup';
 import { getOrCreateDefaultDashboard } from './app/storage/dashboards';
 import { setupTaskbar, KeybindingManager } from './app';
@@ -31,6 +32,8 @@ import {
 } from './app/storage/referenceLaps';
 import { setupChromiumFlagsBridge } from './app/bridge/chromiumFlagsBridge';
 import { createPerfDashboard, getPerfRunConfig } from './app/perfRunConfig';
+import { ChannelBus, setupChannelBridge } from './app/bridge/channelBridge';
+import { connectSessionLifecycleChannel } from './app/bridge/sessionLifecycleChannel';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) app.quit();
@@ -49,6 +52,8 @@ overlayManager.setupAutoStart();
 
 // Hoisted so the quit handler can tear down the WebHID host window cleanly.
 let keybindingManager: KeybindingManager | undefined;
+const channelBus = new ChannelBus();
+let disconnectLifecycleChannel: (() => void) | undefined;
 
 app.on('ready', async () => {
   // Don't start services if we don't have the single instance lock
@@ -69,6 +74,11 @@ app.on('ready', async () => {
     }
   }
 
+  setupChannelBridge(channelBus);
+  disconnectLifecycleChannel = connectSessionLifecycleChannel(
+    getSessionLifecycle(),
+    channelBus
+  );
   await iRacingSDKSetup(overlayManager);
 
   // Perform one-time cleanup of old reference laps
@@ -140,6 +150,8 @@ app.on('quit', () => {
 app.on('before-quit', () => {
   overlayManager.markQuitting();
   keybindingManager?.stopGamepad();
+  disconnectLifecycleChannel?.();
+  channelBus.dispose();
   // Synchronous flush so any pending debounced reference-lap write completes
   // before the process exits.
   flushReferenceLapsOnShutdown();

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,7 +3,9 @@
 import { exposeBridge } from './app/bridge/rendererExposeBridge';
 import { exposeInMainWorld } from './app/rendererExpose';
 import { startRendererPerfMetrics } from './app/rendererPerfMetrics';
+import { exposeChannelBridge } from './app/bridge/channelRendererBridge';
 
 exposeBridge();
 exposeInMainWorld();
+exposeChannelBridge();
 startRendererPerfMetrics();

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -1,0 +1,34 @@
+export type SessionLifecycleEvent =
+  | { type: 'enter'; replay: boolean }
+  | { type: 'sessionNumChange' }
+  | { type: 'disconnect' };
+
+export interface ChannelPayloads {
+  'session.lifecycle': SessionLifecycleEvent;
+}
+
+export type ChannelName = keyof ChannelPayloads;
+
+export type ChannelDefinition =
+  | {
+      kind: 'snapshot';
+      defaultRateHz: number;
+      maxRateHz: number;
+    }
+  | {
+      kind: 'event';
+    };
+
+export type ChannelRegistry = Readonly<Record<ChannelName, ChannelDefinition>>;
+
+export const channelRegistry = {
+  'session.lifecycle': { kind: 'event' },
+} as const satisfies ChannelRegistry;
+
+export interface ChannelBridge {
+  subscribe<K extends ChannelName>(
+    channel: K,
+    callback: (payload: ChannelPayloads[K]) => void,
+    requestedRateHz?: number
+  ): () => void;
+}

--- a/src/types/channels/index.ts
+++ b/src/types/channels/index.ts
@@ -1,0 +1,1 @@
+export * from './channel';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,3 +17,4 @@ export * from './personalBestLapBridge';
 export * from './chromiumFlags';
 export * from './performance';
 export * from './gamepadToken';
+export * from './channels';


### PR DESCRIPTION
## Description

Implements Phase 3, PR 3 from `docs/PHASE_3_CHANNEL_BRIDGE_PLAN.md`: the typed, rate-aware channel transport foundation.

- Adds typed channel contracts and a registry with snapshot/event semantics.
- Adds a main-process channel bus keyed by `webContents.id`, with channel/rate validation, latest-snapshot seeding, deterministic trailing coalescing, hidden/destroyed renderer suppression, teardown cleanup, and per-renderer/channel counters.
- Adds a typed preload bridge with local listener reference counting and highest-requested-rate aggregation.
- Adds renderer snapshot-store primitives and a generic hook for future channel consumers.
- Publishes the existing session lifecycle source through `session.lifecycle` without replaying old lifecycle events to new subscribers.
- Keeps the legacy telemetry bridge unchanged; Fuel migration remains in later Phase 3 PRs.

Validation:

- `npm run lint`
- `npm run test -- --no-coverage` (1,141 passed, 1 skipped)
- `npm run test:replay:curated` (36,000 frames, 70 session revisions, 2 probes in 2.66s)

## Screenshots

### Before

No visual change. Channel transport did not exist.

### After

No visual change. This PR adds infrastructure only.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
