### PR TITLE
feat: add fuel projection processor

### DIFF
--- a/src/app/bridge/channelBridge.ts
+++ b/src/app/bridge/channelBridge.ts
@@ -29,6 +29,8 @@ interface ChannelBusOptions {
   onDeliver?: (rendererId: number, channel: string) => void;
 }
 
+type SubscriberCountListener = (channel: string, count: number) => void;
+
 interface Subscription {
   target: RendererTarget;
   rateHz: number | 'event';
@@ -60,6 +62,8 @@ export class ChannelBus {
   private readonly latestSnapshots = new Map<string, unknown>();
   private readonly publicationCounts = new Map<string, number>();
   private readonly deliveryCounts = new Map<string, number>();
+  private readonly subscriberCountListeners =
+    new Set<SubscriberCountListener>();
 
   constructor(options: ChannelBusOptions = {}) {
     this.registry = options.registry ?? channelRegistry;
@@ -95,6 +99,7 @@ export class ChannelBus {
     }
     const subscription: Subscription = { target, rateHz };
     subscribers.set(target.id, subscription);
+    this.notifySubscriberCount(channel);
 
     if (definition.kind === 'snapshot' && this.latestSnapshots.has(channel)) {
       const latest = this.latestSnapshots.get(channel);
@@ -158,6 +163,11 @@ export class ChannelBus {
 
   subscriberCount(channel: string): number {
     return this.subscriptions.get(channel)?.size ?? 0;
+  }
+
+  onSubscriberCountChanged(listener: SubscriberCountListener): () => void {
+    this.subscriberCountListeners.add(listener);
+    return () => this.subscriberCountListeners.delete(listener);
   }
 
   metricsSnapshot(): ChannelBusMetricsSnapshot {
@@ -261,8 +271,16 @@ export class ChannelBus {
     const subscribers = this.subscriptions.get(channel);
     const subscription = subscribers?.get(rendererId);
     subscription?.timer?.cancel();
-    subscribers?.delete(rendererId);
+    const removed = subscribers?.delete(rendererId) ?? false;
     if (subscribers?.size === 0) this.subscriptions.delete(channel);
+    if (removed) this.notifySubscriberCount(channel);
+  }
+
+  private notifySubscriberCount(channel: string): void {
+    const count = this.subscriberCount(channel);
+    this.subscriberCountListeners.forEach((listener) =>
+      listener(channel, count)
+    );
   }
 }
 

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -8,6 +8,8 @@ import {
 import type { IrSdkBridge, Session, Telemetry } from '@irdashies/types';
 import logger from '../../logger';
 import type { SessionLifecycle } from '../../sessionLifecycle';
+import type { ChannelBus } from '../channelBridge';
+import { FuelProjectionRuntime } from '../../processors/fuelProjectionRuntime';
 
 // Keys consumed by the renderer. Anything outside this set is dropped before
 // the telemetry object crosses the IPC boundary — reducing structured-clone
@@ -133,7 +135,8 @@ const SESSION_POLL_INTERVAL = 500;
 
 export async function publishIRacingSDKEvents(
   overlayManager: OverlayManager,
-  lifecycle?: SessionLifecycle
+  lifecycle?: SessionLifecycle,
+  channelBus?: ChannelBus
 ): Promise<IrSdkBridge> {
   logger.info('[iracingSdkBridge] Loading iRacing SDK bridge...');
   const isTapeReplay = Boolean(process.env.IRDASHIES_TELEMETRY_REPLAY);
@@ -141,6 +144,10 @@ export async function publishIRacingSDKEvents(
 
   const perfMetrics = new TelemetryPerfMetrics();
   perfMetrics.startReporting();
+  const fuelProjectionRuntime =
+    lifecycle && channelBus
+      ? new FuelProjectionRuntime(channelBus, lifecycle, perfMetrics)
+      : undefined;
 
   let shouldStop = false;
   let lastRunningState: boolean | undefined = undefined;
@@ -237,6 +244,7 @@ export async function publishIRacingSDKEvents(
           perfMetrics.markStart('lifecycleTelemetry');
           lifecycle?._onTelemetry(telemetry);
           perfMetrics.markEnd('lifecycleTelemetry');
+          fuelProjectionRuntime?.onFrame(telemetry);
           if (perfTelemetryDeliveryEnabled) {
             perfMetrics.markStart('telemetryProjection');
             const rendererTelemetry = telemetryForRenderer(telemetry);
@@ -262,6 +270,7 @@ export async function publishIRacingSDKEvents(
             lastSessionPublishTime = tickTime;
             latestSession = session;
             lifecycle?._onSession(session);
+            fuelProjectionRuntime?.onSession(session);
             overlayManager.publishMessage('sessionData', session);
             sessionCallbacks.forEach((callback) => callback(session));
             perfMetrics.markEnd('sessionPublish');
@@ -318,6 +327,7 @@ export async function publishIRacingSDKEvents(
       telemetryCallbacks.clear();
       sessionCallbacks.clear();
       runningStateCallbacks.clear();
+      fuelProjectionRuntime?.dispose();
       perfMetrics.stopReporting();
     },
   };

--- a/src/app/bridge/iracingSdk/setup.ts
+++ b/src/app/bridge/iracingSdk/setup.ts
@@ -6,6 +6,7 @@ import {
   createSessionLifecycle,
   type SessionLifecycle,
 } from '../../sessionLifecycle';
+import type { ChannelBus } from '../channelBridge';
 
 let isDemoMode = false;
 let currentBridge: IrSdkBridge | undefined;
@@ -35,7 +36,10 @@ export function onBridgeChanged(callback: (bridge: IrSdkBridge) => void) {
   return () => onBridgeChangedCallbacks.delete(callback);
 }
 
-export async function iRacingSDKSetup(overlayManager: OverlayManager) {
+export async function iRacingSDKSetup(
+  overlayManager: OverlayManager,
+  channelBus?: ChannelBus
+) {
   ipcMain.on('toggleDemoMode', async (_, value: boolean) => {
     isDemoMode = value;
     if (currentBridge) {
@@ -51,13 +55,16 @@ export async function iRacingSDKSetup(overlayManager: OverlayManager) {
       await import('../dashboard/dashboardBridge');
     notifyDemoModeChanged(value);
 
-    await setupBridge(overlayManager);
+    await setupBridge(overlayManager, channelBus);
   });
 
-  await setupBridge(overlayManager);
+  await setupBridge(overlayManager, channelBus);
 }
 
-async function setupBridge(overlayManager: OverlayManager) {
+async function setupBridge(
+  overlayManager: OverlayManager,
+  channelBus?: ChannelBus
+) {
   try {
     if (currentBridge) {
       currentBridge.stop();
@@ -72,7 +79,11 @@ async function setupBridge(overlayManager: OverlayManager) {
 
     const { publishIRacingSDKEvents } = module;
     const lifecycle = isDemoMode ? undefined : getSessionLifecycle();
-    currentBridge = await publishIRacingSDKEvents(overlayManager, lifecycle);
+    currentBridge = await publishIRacingSDKEvents(
+      overlayManager,
+      lifecycle,
+      channelBus
+    );
 
     if (onBridgeChangedCallbacks.size > 0 && currentBridge) {
       const bridge = currentBridge;

--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Session, Telemetry } from '@irdashies/types';
+import { FuelProjectionProcessor } from './FuelProjectionProcessor';
+
+const frame = (values: Record<string, number>): Telemetry =>
+  Object.fromEntries(
+    Object.entries(values).map(([key, entry]) => [key, { value: [entry] }])
+  ) as unknown as Telemetry;
+
+describe('FuelProjectionProcessor', () => {
+  it('projects live usage and records a completed green lap', () => {
+    const lapCompleted = vi.fn();
+    const processor = new FuelProjectionProcessor({
+      persistence: { lapCompleted, saveLap: vi.fn() },
+    });
+    processor.init({} as Session);
+
+    processor.onFrame(
+      frame({
+        FuelLevel: 40,
+        Lap: 1,
+        LapDistPct: 0.01,
+        OnPitRoad: 0,
+        PlayerCarTowTime: 0,
+        SessionFlags: 4,
+        SessionNum: 0,
+        SessionTime: 10,
+      })
+    );
+    processor.onFrame(
+      frame({
+        FuelLevel: 38,
+        Lap: 1,
+        LapDistPct: 0.75,
+        OnPitRoad: 0,
+        PlayerCarTowTime: 0,
+        SessionFlags: 4,
+        SessionNum: 0,
+        SessionTime: 70,
+      })
+    );
+
+    expect(processor.snapshot().currentLapUsage).toBe(2);
+    expect(processor.snapshot().projectedLapUsage).toBeGreaterThan(0);
+
+    processor.onFrame(
+      frame({
+        FuelLevel: 37,
+        Lap: 2,
+        LapDistPct: 0.01,
+        OnPitRoad: 0,
+        PlayerCarTowTime: 0,
+        SessionFlags: 4,
+        SessionNum: 0,
+        SessionTime: 100,
+      })
+    );
+
+    expect(processor.snapshot().lastLapUsage).toBe(3);
+    expect(processor.snapshot().completedLaps).toHaveLength(1);
+    expect(lapCompleted).toHaveBeenCalledOnce();
+  });
+
+  it('resets volatile state on disconnect', () => {
+    const processor = new FuelProjectionProcessor();
+    processor.onFrame(
+      frame({ FuelLevel: 20, Lap: 3, LapDistPct: 0.5, SessionTime: 30 })
+    );
+
+    processor.onLifecycle({ type: 'disconnect' });
+
+    expect(processor.snapshot()).toMatchObject({
+      fuelLevel: 0,
+      currentLap: 0,
+      completedLaps: [],
+    });
+  });
+});

--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -75,4 +75,51 @@ describe('FuelProjectionProcessor', () => {
       completedLaps: [],
     });
   });
+
+  it('resets completed laps when the session number changes', () => {
+    const processor = new FuelProjectionProcessor();
+    processor.onFrame(
+      frame({
+        FuelLevel: 20,
+        Lap: 1,
+        LapDistPct: 0.01,
+        SessionFlags: 4,
+        SessionTime: 10,
+      })
+    );
+    processor.onFrame(
+      frame({
+        FuelLevel: 18,
+        Lap: 2,
+        LapDistPct: 0.01,
+        SessionFlags: 4,
+        SessionTime: 80,
+      })
+    );
+    expect(processor.snapshot().completedLaps).toHaveLength(1);
+
+    processor.onLifecycle({ type: 'sessionNumChange' });
+
+    expect(processor.snapshot().completedLaps).toEqual([]);
+    expect(processor.snapshot().engine.lastLap).toBe(0);
+  });
+
+  it('does not aggregate replay frames and resumes from clean state live', () => {
+    const processor = new FuelProjectionProcessor();
+    processor.onLifecycle({ type: 'enter', replay: true });
+
+    processor.onFrame(
+      frame({ FuelLevel: 20, Lap: 5, LapDistPct: 0.9, SessionTime: 100 })
+    );
+    expect(processor.snapshot()).toMatchObject({ fuelLevel: 0, currentLap: 0 });
+
+    processor.onLifecycle({ type: 'enter', replay: false });
+    processor.onFrame(
+      frame({ FuelLevel: 19, Lap: 1, LapDistPct: 0.1, SessionTime: 10 })
+    );
+    expect(processor.snapshot()).toMatchObject({
+      fuelLevel: 19,
+      currentLap: 1,
+    });
+  });
 });

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -1,0 +1,191 @@
+import type {
+  FuelLapData,
+  FuelProjectionSnapshot,
+  Session,
+  SessionLifecycleEvent,
+  Telemetry,
+} from '@irdashies/types';
+import {
+  FuelProjectionEngine,
+  type FuelEngineCommand,
+} from '@irdashies/shared';
+import type { TelemetryProcessor } from './TelemetryProcessor';
+
+const MAX_LAP_HISTORY = 50;
+
+export interface FuelProjectionPersistence {
+  lapCompleted(lap: FuelLapData): void;
+  saveLap(lap: FuelLapData): void;
+}
+
+export interface FuelProjectionProcessorOptions {
+  persistence?: FuelProjectionPersistence;
+  persistLaps?: boolean;
+  clock?: () => number;
+}
+
+const noPersistence: FuelProjectionPersistence = {
+  lapCompleted: () => undefined,
+  saveLap: () => undefined,
+};
+
+const value = (
+  frame: Telemetry,
+  key: keyof Telemetry,
+  fallback = 0
+): number => {
+  const candidate = frame[key]?.value?.[0];
+  return typeof candidate === 'number' ? candidate : fallback;
+};
+
+const isGreenFlag = (flags: number): boolean =>
+  (flags & (0x00004000 | 0x00008000 | 0x00010000)) === 0;
+
+const validateLap = (
+  fuelUsed: number,
+  lapTime: number,
+  recentLaps: FuelLapData[]
+): boolean => {
+  if (fuelUsed <= 0 || lapTime <= 0) return false;
+  const valid = recentLaps.filter((lap) => lap.isValidForCalc);
+  if (valid.length < 3) return true;
+  const fuels = valid.map((lap) => lap.fuelUsed).sort((a, b) => a - b);
+  const q1 = fuels[Math.floor(fuels.length * 0.25)];
+  const q3 = fuels[Math.floor(fuels.length * 0.75)];
+  const iqr = q3 - q1;
+  const mean = fuels.reduce((sum, fuel) => sum + fuel, 0) / fuels.length;
+  return (
+    (fuelUsed >= q1 - 2 * iqr && fuelUsed <= q3 + 2 * iqr) ||
+    Math.abs(fuelUsed - mean) <= mean * 0.15
+  );
+};
+
+export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectionSnapshot> {
+  readonly channel = 'fuel.projection';
+  readonly tickRateHz = 5;
+
+  private clockMilliseconds = 0;
+  private readonly engine: FuelProjectionEngine;
+  private readonly laps: FuelLapData[] = [];
+  private readonly persistence: FuelProjectionPersistence;
+  private readonly persistLaps: boolean;
+  private lastCommands: readonly FuelEngineCommand[] = [];
+  private latest: FuelProjectionSnapshot;
+
+  constructor(options: FuelProjectionProcessorOptions = {}) {
+    this.persistence = options.persistence ?? noPersistence;
+    this.persistLaps = options.persistLaps ?? false;
+    this.engine = new FuelProjectionEngine(
+      { now: options.clock ?? (() => this.clockMilliseconds) },
+      { debug: () => undefined }
+    );
+    this.latest = this.emptySnapshot();
+  }
+
+  init(session: Session): void {
+    // Session fields needed by the complete renderer projection are added when
+    // the Fuel widget migrates. The deterministic lap engine is frame-driven.
+    void session;
+  }
+
+  onFrame(frame: Telemetry): void {
+    const sessionTime = value(frame, 'SessionTime');
+    this.clockMilliseconds = Math.round(sessionTime * 1000);
+    const fuelLevel = value(frame, 'FuelLevel');
+    const lap = value(frame, 'Lap');
+    const lapDistPct = value(frame, 'LapDistPct');
+    const commands = this.engine.onFrame(
+      {
+        fuelLevel,
+        lap,
+        lapDistPct,
+        onPitRoad: Boolean(value(frame, 'OnPitRoad')),
+        playerCarTowTime: value(frame, 'PlayerCarTowTime'),
+        sessionFlags: value(frame, 'SessionFlags'),
+        sessionNum: value(frame, 'SessionNum'),
+        sessionTime,
+      },
+      { getRecentLaps: (count) => this.laps.slice(0, count) },
+      validateLap,
+      isGreenFlag,
+      { persistLaps: this.persistLaps }
+    );
+    this.lastCommands = commands;
+    this.execute(commands);
+
+    const engine = this.engine.snapshot();
+    const currentLapUsage =
+      engine.lapStartFuel > 0
+        ? Math.max(0, engine.lapStartFuel - fuelLevel)
+        : 0;
+    const validLaps = this.laps.filter((completed) => completed.isValidForCalc);
+    const average = validLaps.length
+      ? validLaps.reduce((sum, completed) => sum + completed.fuelUsed, 0) /
+        validLaps.length
+      : 0;
+    this.latest = {
+      fuelLevel,
+      currentLap: lap,
+      currentLapUsage,
+      projectedLapUsage: this.engine.project({
+        avgConsumption: average,
+        currentFuel: fuelLevel,
+        currentLapUsage,
+        lap,
+        lapDistPct,
+        lapStartFuel: engine.lapStartFuel,
+        lastLapUsage: this.laps[0]?.fuelUsed ?? 0,
+        qualifyConsumption: null,
+      }),
+      lastLapUsage: this.laps[0]?.fuelUsed ?? 0,
+      completedLaps: this.laps,
+      engine,
+    };
+  }
+
+  onLifecycle(event: SessionLifecycleEvent): void {
+    if (event.type === 'disconnect') this.reset();
+  }
+
+  snapshot(): FuelProjectionSnapshot {
+    return this.latest;
+  }
+
+  validationSnapshot(): {
+    commands: readonly FuelEngineCommand[];
+    state: ReturnType<FuelProjectionEngine['snapshot']>;
+  } {
+    return { commands: this.lastCommands, state: this.engine.snapshot() };
+  }
+
+  private execute(commands: readonly FuelEngineCommand[]): void {
+    for (const command of commands) {
+      if (command.type === 'lapCompleted') {
+        this.laps.unshift(command.lap);
+        if (this.laps.length > MAX_LAP_HISTORY) this.laps.pop();
+        this.persistence.lapCompleted(command.lap);
+      } else {
+        this.persistence.saveLap(command.lap);
+      }
+    }
+  }
+
+  private reset(): void {
+    this.engine.reset();
+    this.lastCommands = [];
+    this.laps.length = 0;
+    this.latest = this.emptySnapshot();
+  }
+
+  private emptySnapshot(): FuelProjectionSnapshot {
+    return {
+      fuelLevel: 0,
+      currentLap: 0,
+      currentLapUsage: 0,
+      projectedLapUsage: 0,
+      lastLapUsage: 0,
+      completedLaps: this.laps,
+      engine: this.engine.snapshot(),
+    };
+  }
+}

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -70,6 +70,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   private readonly persistence: FuelProjectionPersistence;
   private readonly persistLaps: boolean;
   private lastCommands: readonly FuelEngineCommand[] = [];
+  private aggregationEnabled = true;
   private latest: FuelProjectionSnapshot;
 
   constructor(options: FuelProjectionProcessorOptions = {}) {
@@ -89,6 +90,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   }
 
   onFrame(frame: Telemetry): void {
+    if (!this.aggregationEnabled) return;
     const sessionTime = value(frame, 'SessionTime');
     this.clockMilliseconds = Math.round(sessionTime * 1000);
     const fuelLevel = value(frame, 'FuelLevel');
@@ -144,7 +146,17 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   }
 
   onLifecycle(event: SessionLifecycleEvent): void {
-    if (event.type === 'disconnect') this.reset();
+    if (event.type === 'enter') {
+      this.reset();
+      this.aggregationEnabled = !event.replay;
+      return;
+    }
+    if (event.type === 'sessionNumChange') {
+      this.reset();
+      return;
+    }
+    this.reset();
+    this.aggregationEnabled = false;
   }
 
   snapshot(): FuelProjectionSnapshot {

--- a/src/app/processors/TelemetryProcessor.ts
+++ b/src/app/processors/TelemetryProcessor.ts
@@ -1,0 +1,14 @@
+import type {
+  Session,
+  SessionLifecycleEvent,
+  Telemetry,
+} from '@irdashies/types';
+
+export interface TelemetryProcessor<Snapshot> {
+  readonly channel: string;
+  readonly tickRateHz: number | 'event';
+  init(session: Session): void;
+  onFrame(frame: Telemetry): void;
+  onLifecycle(event: SessionLifecycleEvent): void;
+  snapshot(): Snapshot;
+}

--- a/src/app/processors/fuelProjectionRuntime.spec.ts
+++ b/src/app/processors/fuelProjectionRuntime.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Session, Telemetry } from '@irdashies/types';
+import { ChannelBus } from '../bridge/channelBridge';
+import { createSessionLifecycle } from '../sessionLifecycle';
+import { FuelProjectionRuntime } from './fuelProjectionRuntime';
+
+const telemetry = {
+  FuelLevel: { value: [40] },
+  Lap: { value: [1] },
+  LapDistPct: { value: [0.1] },
+  SessionTime: { value: [10] },
+} as unknown as Telemetry;
+
+describe('FuelProjectionRuntime', () => {
+  it('processes and publishes only while the channel has subscribers', () => {
+    const bus = new ChannelBus();
+    const publish = vi.spyOn(bus, 'publish');
+    const metrics = { markStart: vi.fn(), markEnd: vi.fn() };
+    const runtime = new FuelProjectionRuntime(
+      bus,
+      createSessionLifecycle(),
+      metrics
+    );
+    runtime.onSession({} as Session);
+
+    runtime.onFrame(telemetry);
+    expect(publish).not.toHaveBeenCalled();
+
+    const target = {
+      id: 1,
+      isDestroyed: () => false,
+      isVisible: () => true,
+      send: vi.fn(),
+    };
+    bus.subscribe(target, 'fuel.projection');
+    runtime.onFrame(telemetry);
+
+    expect(publish).toHaveBeenCalledWith(
+      'fuel.projection',
+      expect.objectContaining({ fuelLevel: 40 })
+    );
+    expect(metrics.markStart).toHaveBeenCalledWith('fuelProjectionProcessing');
+
+    bus.unsubscribe(1, 'fuel.projection');
+    publish.mockClear();
+    runtime.onFrame(telemetry);
+    expect(publish).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/processors/fuelProjectionRuntime.spec.ts
+++ b/src/app/processors/fuelProjectionRuntime.spec.ts
@@ -46,4 +46,31 @@ describe('FuelProjectionRuntime', () => {
     runtime.onFrame(telemetry);
     expect(publish).not.toHaveBeenCalled();
   });
+
+  it('remembers replay mode for subscribers that activate later', () => {
+    const bus = new ChannelBus();
+    const publish = vi.spyOn(bus, 'publish');
+    const lifecycle = createSessionLifecycle();
+    const runtime = new FuelProjectionRuntime(bus, lifecycle, {
+      markStart: vi.fn(),
+      markEnd: vi.fn(),
+    });
+    lifecycle._onEnter({ replay: true });
+
+    bus.subscribe(
+      {
+        id: 2,
+        isDestroyed: () => false,
+        isVisible: () => true,
+        send: vi.fn(),
+      },
+      'fuel.projection'
+    );
+    runtime.onFrame(telemetry);
+
+    expect(publish).toHaveBeenCalledWith(
+      'fuel.projection',
+      expect.objectContaining({ fuelLevel: 0, currentLap: 0 })
+    );
+  });
 });

--- a/src/app/processors/fuelProjectionRuntime.ts
+++ b/src/app/processors/fuelProjectionRuntime.ts
@@ -15,6 +15,7 @@ interface PerformanceSections {
 export class FuelProjectionRuntime {
   private processor?: FuelProjectionProcessor;
   private latestSession?: Session;
+  private replaySource?: boolean;
   private readonly disconnects: (() => void)[];
 
   constructor(
@@ -61,11 +62,21 @@ export class FuelProjectionRuntime {
   private activate(): void {
     if (this.processor) return;
     this.processor = new FuelProjectionProcessor();
+    if (this.replaySource !== undefined) {
+      this.processor.onLifecycle({
+        type: 'enter',
+        replay: this.replaySource,
+      });
+    }
     if (this.latestSession) this.processor.init(this.latestSession);
   }
 
   private onLifecycle(event: SessionLifecycleEvent): void {
+    if (event.type === 'enter') this.replaySource = event.replay;
     this.processor?.onLifecycle(event);
-    if (event.type === 'disconnect') this.latestSession = undefined;
+    if (event.type === 'disconnect') {
+      this.latestSession = undefined;
+      this.replaySource = undefined;
+    }
   }
 }

--- a/src/app/processors/fuelProjectionRuntime.ts
+++ b/src/app/processors/fuelProjectionRuntime.ts
@@ -1,0 +1,71 @@
+import type {
+  Session,
+  SessionLifecycleEvent,
+  Telemetry,
+} from '@irdashies/types';
+import type { ChannelBus } from '../bridge/channelBridge';
+import type { SessionLifecycle } from '../sessionLifecycle';
+import { FuelProjectionProcessor } from './FuelProjectionProcessor';
+
+interface PerformanceSections {
+  markStart(label: string): void;
+  markEnd(label: string): void;
+}
+
+export class FuelProjectionRuntime {
+  private processor?: FuelProjectionProcessor;
+  private latestSession?: Session;
+  private readonly disconnects: (() => void)[];
+
+  constructor(
+    private readonly bus: ChannelBus,
+    lifecycle: SessionLifecycle,
+    private readonly metrics: PerformanceSections
+  ) {
+    this.disconnects = [
+      bus.onSubscriberCountChanged((channel, count) => {
+        if (channel !== 'fuel.projection') return;
+        if (count > 0) this.activate();
+        else this.processor = undefined;
+      }),
+      lifecycle.onEnter(({ replay }) =>
+        this.onLifecycle({ type: 'enter', replay })
+      ),
+      lifecycle.onSessionNumChange(() =>
+        this.onLifecycle({ type: 'sessionNumChange' })
+      ),
+      lifecycle.onDisconnect(() => this.onLifecycle({ type: 'disconnect' })),
+    ];
+  }
+
+  onSession(session: Session): void {
+    this.latestSession = session;
+    this.processor?.init(session);
+  }
+
+  onFrame(frame: Telemetry): void {
+    if (!this.processor) return;
+    this.metrics.markStart('fuelProjectionProcessing');
+    this.processor.onFrame(frame);
+    this.metrics.markEnd('fuelProjectionProcessing');
+    this.metrics.markStart('fuelProjectionPublication');
+    this.bus.publish('fuel.projection', this.processor.snapshot());
+    this.metrics.markEnd('fuelProjectionPublication');
+  }
+
+  dispose(): void {
+    this.disconnects.forEach((disconnect) => disconnect());
+    this.processor = undefined;
+  }
+
+  private activate(): void {
+    if (this.processor) return;
+    this.processor = new FuelProjectionProcessor();
+    if (this.latestSession) this.processor.init(this.latestSession);
+  }
+
+  private onLifecycle(event: SessionLifecycleEvent): void {
+    this.processor?.onLifecycle(event);
+    if (event.type === 'disconnect') this.latestSession = undefined;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,7 +79,7 @@ app.on('ready', async () => {
     getSessionLifecycle(),
     channelBus
   );
-  await iRacingSDKSetup(overlayManager);
+  await iRacingSDKSetup(overlayManager, channelBus);
 
   // Perform one-time cleanup of old reference laps
   validateReferenceLapFile();

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -1,10 +1,34 @@
+import type { FuelLapData } from '../fuelCalculatorBridge';
+
 export type SessionLifecycleEvent =
   | { type: 'enter'; replay: boolean }
   | { type: 'sessionNumChange' }
   | { type: 'disconnect' };
 
 export interface ChannelPayloads {
+  'fuel.projection': FuelProjectionSnapshot;
   'session.lifecycle': SessionLifecycleEvent;
+}
+
+export interface FuelProjectionEngineSnapshot {
+  accumulatedRefuel: number;
+  isLapDistPctReset: boolean;
+  lapCrossingTime: number;
+  lapStartFuel: number;
+  lastLap: number;
+  lastLapDistPct: number;
+  lastSessionFlags: number;
+  wasOnPitRoad: boolean;
+}
+
+export interface FuelProjectionSnapshot {
+  fuelLevel: number;
+  currentLap: number;
+  currentLapUsage: number;
+  projectedLapUsage: number;
+  lastLapUsage: number;
+  completedLaps: readonly FuelLapData[];
+  engine: FuelProjectionEngineSnapshot;
 }
 
 export type ChannelName = keyof ChannelPayloads;
@@ -22,6 +46,11 @@ export type ChannelDefinition =
 export type ChannelRegistry = Readonly<Record<ChannelName, ChannelDefinition>>;
 
 export const channelRegistry = {
+  'fuel.projection': {
+    kind: 'snapshot',
+    defaultRateHz: 5,
+    maxRateHz: 25,
+  },
   'session.lifecycle': { kind: 'event' },
 } as const satisfies ChannelRegistry;
 

--- a/tools/telemetry-replay/fuel-probe.ts
+++ b/tools/telemetry-replay/fuel-probe.ts
@@ -1,16 +1,12 @@
-import {
-  FuelProjectionEngine,
-  type FuelEngineCommand,
-} from '../../src/shared/fuel';
-import {
-  isGreenFlag,
-  validateLapData,
-} from '../../src/frontend/components/FuelCalculator/fuelCalculations';
+import type { Telemetry } from '../../src/types';
+import { FuelProjectionProcessor } from '../../src/app/processors/FuelProjectionProcessor';
 import type { ReplayProbe, TelemetryFrame } from './validator';
 
 interface FuelProbeState {
-  commands: readonly FuelEngineCommand[];
-  state: ReturnType<FuelProjectionEngine['snapshot']>;
+  commands: ReturnType<
+    FuelProjectionProcessor['validationSnapshot']
+  >['commands'];
+  state: ReturnType<FuelProjectionProcessor['validationSnapshot']>['state'];
 }
 
 const numberValue = (frame: TelemetryFrame, name: string): number => {
@@ -23,11 +19,9 @@ const numberValue = (frame: TelemetryFrame, name: string): number => {
 
 export const createFuelStateProbe = (): ReplayProbe<FuelProbeState> => {
   let elapsedMilliseconds = 0;
-  const engine = new FuelProjectionEngine(
-    { now: () => elapsedMilliseconds },
-    { debug: () => undefined }
-  );
-  const laps: FuelEngineCommand[] = [];
+  const processor = new FuelProjectionProcessor({
+    clock: () => elapsedMilliseconds,
+  });
   let previousOnTrack = false;
   let previousOnPitRoad = false;
   let previousFlags: number | undefined;
@@ -53,37 +47,12 @@ export const createFuelStateProbe = (): ReplayProbe<FuelProbeState> => {
       const onPitRoad = Boolean(frame.OnPitRoad);
       const flags = numberValue(frame, 'SessionFlags');
       const lap = numberValue(frame, 'Lap');
-      const commands = engine.onFrame(
-        {
-          fuelLevel: numberValue(frame, 'FuelLevel'),
-          lap,
-          lapDistPct: numberValue(frame, 'LapDistPct'),
-          onPitRoad,
-          playerCarTowTime: numberValue(frame, 'PlayerCarTowTime'),
-          sessionFlags: flags,
-          sessionNum: numberValue(frame, 'SessionNum'),
-          sessionTime: numberValue(frame, 'SessionTime'),
-        },
-        {
-          getRecentLaps: (count) =>
-            laps
-              .filter(
-                (
-                  command
-                ): command is Extract<
-                  FuelEngineCommand,
-                  { type: 'lapCompleted' }
-                > => command.type === 'lapCompleted'
-              )
-              .map(({ lap: completedLap }) => completedLap)
-              .slice(-count)
-              .reverse(),
-        },
-        validateLapData,
-        isGreenFlag,
-        { persistLaps: false }
-      );
-      laps.push(...commands);
+      const telemetry = Object.fromEntries(
+        Object.entries(frame).map(([name, entry]) => [name, { value: [entry] }])
+      ) as unknown as Telemetry;
+      processor.onFrame(telemetry);
+      const validation = processor.validationSnapshot();
+      const commands = validation.commands;
 
       checkpoint = undefined;
       if (onTrack && !previousOnTrack) checkpoint = 'onTrack:enter';
@@ -99,14 +68,14 @@ export const createFuelStateProbe = (): ReplayProbe<FuelProbeState> => {
 
       return {
         commands,
-        state: engine.snapshot(),
+        state: validation.state,
       };
     },
     checkpoint() {
       return checkpoint;
     },
     onDisconnect() {
-      engine.reset();
+      processor.onLifecycle({ type: 'disconnect' });
     },
   };
 };


### PR DESCRIPTION
## Description

Implements Phase 3, PR 4 from `docs/PHASE_3_CHANNEL_BRIDGE_PLAN.md`: Fuel projection processing in main-process shadow mode.

- Adds the typed `fuel.projection` snapshot contract and rate definition.
- Adds a deterministic, I/O-free `FuelProjectionProcessor` over the engine extracted in PR #649.
- Adds a subscriber-driven runtime connected to raw telemetry, session snapshots, and centralized lifecycle events.
- Creates and runs the processor only while `fuel.projection` has at least one renderer subscriber.
- Publishes snapshots through the channel bus with dedicated processing/publication performance sections.
- Keeps persistence outside the processor behind an injected interface; shadow mode performs no persistence.
- Makes the curated Fuel probe execute the production processor, preserving the reviewed golden across every tape frame.
- Leaves the Fuel renderer on its existing telemetry path; renderer migration remains PR 5.

Validation:

- `npm run lint`
- `npm run test -- --no-coverage` — 1,145 passed, 1 skipped
- `npm run test:replay:curated` — 36,000 frames, 70 session revisions, 2 probes in 2.76s

No live iRacing session was used.

## Screenshots

### Before

No visual change. Fuel projection ran only in the renderer.

### After

No visual change. The main-process processor runs in shadow mode when subscribed; the renderer still displays the legacy result.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
