### PR TITLE
feat: migrate fuel renderer to channel snapshots

### DIFF
--- a/.storybook/channelSnapshotDecorator.tsx
+++ b/.storybook/channelSnapshotDecorator.tsx
@@ -1,0 +1,29 @@
+import type { Decorator } from '@storybook/react-vite';
+import type {
+  ChannelBridge,
+  ChannelName,
+  ChannelPayloads,
+} from '@irdashies/types';
+
+type ChannelSnapshots = Partial<ChannelPayloads>;
+
+export const ChannelSnapshotDecorator = (
+  snapshots: ChannelSnapshots
+): Decorator => {
+  const bridge: ChannelBridge = {
+    subscribe: <K extends ChannelName>(
+      channel: K,
+      callback: (payload: ChannelPayloads[K]) => void
+    ) => {
+      const snapshot = snapshots[channel];
+      if (snapshot !== undefined) callback(snapshot as ChannelPayloads[K]);
+      return () => undefined;
+    },
+  };
+
+  const DecoratorComponent: Decorator = (Story) => {
+    window.channelBridge = bridge;
+    return <Story />;
+  };
+  return DecoratorComponent;
+};

--- a/.storybook/channelSnapshotDecorator.tsx
+++ b/.storybook/channelSnapshotDecorator.tsx
@@ -1,4 +1,5 @@
 import type { Decorator } from '@storybook/react-vite';
+import { useEffect, useRef } from 'react';
 import type {
   ChannelBridge,
   ChannelName,
@@ -22,7 +23,18 @@ export const ChannelSnapshotDecorator = (
   };
 
   const DecoratorComponent: Decorator = (Story) => {
+    const previousBridge = useRef(window.channelBridge);
     window.channelBridge = bridge;
+    useEffect(
+      () => () => {
+        if (previousBridge.current === undefined) {
+          Reflect.deleteProperty(window, 'channelBridge');
+        } else {
+          window.channelBridge = previousBridge.current;
+        }
+      },
+      []
+    );
     return <Story />;
   };
   return DecoratorComponent;

--- a/.storybook/index.ts
+++ b/.storybook/index.ts
@@ -1,3 +1,4 @@
 export * from './telemetryDecorator';
+export * from './channelSnapshotDecorator';
 export * from './DynamicTelemetrySelector';
 export * from './mockDashboardBridge';

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -146,7 +146,9 @@ export async function publishIRacingSDKEvents(
   perfMetrics.startReporting();
   const fuelProjectionRuntime =
     lifecycle && channelBus
-      ? new FuelProjectionRuntime(channelBus, lifecycle, perfMetrics)
+      ? new FuelProjectionRuntime(channelBus, lifecycle, perfMetrics, {
+          aggregateReplay: isTapeReplay,
+        })
       : undefined;
 
   let shouldStop = false;

--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -87,6 +87,43 @@ describe('FuelProjectionProcessor', () => {
     expect(processor.snapshot().engine.wasOnPitRoad).toBe(true);
   });
 
+  it('projects timed-race distance using class pace', () => {
+    const processor = new FuelProjectionProcessor();
+    processor.init({
+      DriverInfo: {
+        DriverCarIdx: 0,
+        Drivers: [{ CarIdx: 0, CarClassEstLapTime: 90 }],
+      },
+      SessionInfo: {
+        Sessions: [
+          { SessionNum: 0, SessionType: 'Race', SessionLaps: 'unlimited' },
+        ],
+      },
+    } as unknown as Session);
+
+    processor.onFrame({
+      FuelLevel: { value: [45.39] },
+      Lap: { value: [2] },
+      LapDistPct: { value: [0.1] },
+      SessionNum: { value: [0] },
+      SessionState: { value: [4] },
+      SessionLapsRemain: { value: [32767] },
+      SessionTimeRemain: { value: [1620] },
+      SessionTimeTotal: { value: [1800] },
+      CamCarIdx: { value: [0] },
+      CarIdxLap: { value: [2] },
+      CarIdxLapDistPct: { value: [0.1] },
+      CarIdxPosition: { value: [1] },
+      CarIdxLastLapTime: { value: [1] },
+      CarIdxBestLapTime: { value: [1] },
+    } as unknown as Telemetry);
+
+    expect(processor.snapshot()).toMatchObject({
+      calculatedTotalRaceLaps: 19.1,
+      isFixedLapRace: false,
+    });
+  });
+
   it('resets completed laps when the session number changes', () => {
     const processor = new FuelProjectionProcessor();
     processor.onFrame(

--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -101,7 +101,7 @@ describe('FuelProjectionProcessor', () => {
       },
     } as unknown as Session);
 
-    processor.onFrame({
+    const timedRaceFrame = {
       FuelLevel: { value: [45.39] },
       Lap: { value: [2] },
       LapDistPct: { value: [0.1] },
@@ -116,12 +116,27 @@ describe('FuelProjectionProcessor', () => {
       CarIdxPosition: { value: [1] },
       CarIdxLastLapTime: { value: [1] },
       CarIdxBestLapTime: { value: [1] },
-    } as unknown as Telemetry);
+    } as unknown as Telemetry;
+    processor.onFrame(timedRaceFrame);
 
     expect(processor.snapshot()).toMatchObject({
       calculatedTotalRaceLaps: 19.1,
       isFixedLapRace: false,
     });
+
+    processor.onFrame({
+      ...timedRaceFrame,
+      CarIdxLastLapTime: { value: [100] },
+    } as unknown as Telemetry);
+    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(17.3);
+
+    processor.onFrame({
+      ...timedRaceFrame,
+      CarIdxLastLapTime: { value: [110] },
+    } as unknown as Telemetry);
+    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(
+      1620 / 105 + 1.1
+    );
   });
 
   it('resets completed laps when the session number changes', () => {

--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Session, Telemetry } from '@irdashies/types';
 import { FuelProjectionProcessor } from './FuelProjectionProcessor';
 
-const frame = (values: Record<string, number>): Telemetry =>
+const frame = (values: Record<string, number | boolean>): Telemetry =>
   Object.fromEntries(
     Object.entries(values).map(([key, entry]) => [key, { value: [entry] }])
   ) as unknown as Telemetry;
@@ -74,6 +74,17 @@ describe('FuelProjectionProcessor', () => {
       currentLap: 0,
       completedLaps: [],
     });
+  });
+
+  it('preserves boolean track and pit state in the snapshot', () => {
+    const processor = new FuelProjectionProcessor();
+
+    processor.onFrame(
+      frame({ FuelLevel: 20, IsOnTrack: true, OnPitRoad: true })
+    );
+
+    expect(processor.snapshot().isOnTrack).toBe(true);
+    expect(processor.snapshot().engine.wasOnPitRoad).toBe(true);
   });
 
   it('resets completed laps when the session number changes', () => {

--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -137,6 +137,37 @@ describe('FuelProjectionProcessor', () => {
     expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(19.1);
   });
 
+  it('uses fractional distance when correcting a timed race for lapping', () => {
+    const processor = new FuelProjectionProcessor();
+    processor.init({
+      DriverInfo: {
+        DriverCarIdx: 1,
+        Drivers: [
+          { CarIdx: 0, CarClassEstLapTime: 100 },
+          { CarIdx: 1, CarClassEstLapTime: 100 },
+        ],
+      },
+      SessionInfo: {
+        Sessions: [
+          { SessionNum: 0, SessionType: 'Race', SessionLaps: 'unlimited' },
+        ],
+      },
+    } as unknown as Session);
+
+    processor.onFrame({
+      SessionNum: { value: [0] },
+      SessionState: { value: [4] },
+      SessionTimeRemain: { value: [900] },
+      CamCarIdx: { value: [1] },
+      CarIdxLap: { value: [10, 8] },
+      CarIdxLapDistPct: { value: [0.1, 0.8] },
+      CarIdxPosition: { value: [1, 10] },
+      CarIdxBestLapTime: { value: [100, 100] },
+    } as unknown as Telemetry);
+
+    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(17.1);
+  });
+
   it('resets completed laps when the session number changes', () => {
     const processor = new FuelProjectionProcessor();
     processor.onFrame(

--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -128,15 +128,13 @@ describe('FuelProjectionProcessor', () => {
       ...timedRaceFrame,
       CarIdxLastLapTime: { value: [100] },
     } as unknown as Telemetry);
-    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(17.3);
+    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(19.1);
 
     processor.onFrame({
       ...timedRaceFrame,
       CarIdxLastLapTime: { value: [110] },
     } as unknown as Telemetry);
-    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(
-      1620 / 105 + 1.1
-    );
+    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(19.1);
   });
 
   it('resets completed laps when the session number changes', () => {

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -71,6 +71,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   private readonly persistLaps: boolean;
   private lastCommands: readonly FuelEngineCommand[] = [];
   private aggregationEnabled = true;
+  private session?: Session;
   private latest: FuelProjectionSnapshot;
 
   constructor(options: FuelProjectionProcessorOptions = {}) {
@@ -84,9 +85,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   }
 
   init(session: Session): void {
-    // Session fields needed by the complete renderer projection are added when
-    // the Fuel widget migrates. The deterministic lap engine is frame-driven.
-    void session;
+    this.session = session;
   }
 
   onFrame(frame: Telemetry): void {
@@ -96,6 +95,13 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     const fuelLevel = value(frame, 'FuelLevel');
     const lap = value(frame, 'Lap');
     const lapDistPct = value(frame, 'LapDistPct');
+    const sessionNum = value(frame, 'SessionNum');
+    const sessionInfo = this.session?.SessionInfo?.Sessions?.find(
+      (candidate) => candidate.SessionNum === sessionNum
+    );
+    const driverInfo = this.session?.DriverInfo;
+    const maxFuel = driverInfo?.DriverCarFuelMaxLtr;
+    const maxFuelPct = driverInfo?.DriverCarMaxFuelPct;
     const commands = this.engine.onFrame(
       {
         fuelLevel,
@@ -104,7 +110,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
         onPitRoad: Boolean(value(frame, 'OnPitRoad')),
         playerCarTowTime: value(frame, 'PlayerCarTowTime'),
         sessionFlags: value(frame, 'SessionFlags'),
-        sessionNum: value(frame, 'SessionNum'),
+        sessionNum,
         sessionTime,
       },
       { getRecentLaps: (count) => this.laps.slice(0, count) },
@@ -127,7 +133,9 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       : 0;
     this.latest = {
       fuelLevel,
+      fuelLevelPct: value(frame, 'FuelLevelPct'),
       currentLap: lap,
+      lapDistPct,
       currentLapUsage,
       projectedLapUsage: this.engine.project({
         avgConsumption: average,
@@ -140,6 +148,25 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
         qualifyConsumption: null,
       }),
       lastLapUsage: this.laps[0]?.fuelUsed ?? 0,
+      sessionLapsRemain: value(frame, 'SessionLapsRemain'),
+      sessionTimeRemain: value(frame, 'SessionTimeRemain'),
+      sessionTimeTotal: value(frame, 'SessionTimeTotal'),
+      sessionFlags: value(frame, 'SessionFlags'),
+      sessionState: value(frame, 'SessionState'),
+      sessionNum,
+      sessionLaps: sessionInfo?.SessionLaps ?? 0,
+      sessionType: sessionInfo?.SessionType,
+      isOnTrack: Boolean(value(frame, 'IsOnTrack')),
+      trackId:
+        this.session?.WeekendInfo?.TrackName ??
+        this.session?.WeekendInfo?.TrackID,
+      carName: driverInfo?.Drivers?.find(
+        (driver) => driver.CarIdx === driverInfo.DriverCarIdx
+      )?.CarPath,
+      fuelTankCapacity:
+        maxFuel !== undefined && maxFuelPct !== undefined
+          ? maxFuel * maxFuelPct
+          : maxFuel,
       completedLaps: this.laps,
       engine,
     };
@@ -156,6 +183,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       return;
     }
     this.reset();
+    this.session = undefined;
     this.aggregationEnabled = false;
   }
 
@@ -192,10 +220,20 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   private emptySnapshot(): FuelProjectionSnapshot {
     return {
       fuelLevel: 0,
+      fuelLevelPct: 0,
       currentLap: 0,
+      lapDistPct: 0,
       currentLapUsage: 0,
       projectedLapUsage: 0,
       lastLapUsage: 0,
+      sessionLapsRemain: 0,
+      sessionTimeRemain: 0,
+      sessionTimeTotal: 0,
+      sessionFlags: 0,
+      sessionState: 0,
+      sessionNum: 0,
+      sessionLaps: 0,
+      isOnTrack: false,
       completedLaps: this.laps,
       engine: this.engine.snapshot(),
     };

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -44,6 +44,17 @@ const booleanValue = (frame: Telemetry, key: keyof Telemetry): boolean => {
   return candidate === true || candidate === 1;
 };
 
+const values = (frame: Telemetry, key: keyof Telemetry): readonly number[] => {
+  const candidates = frame[key]?.value;
+  return Array.isArray(candidates)
+    ? candidates.map((candidate) =>
+        typeof candidate === 'number' && Number.isFinite(candidate)
+          ? candidate
+          : 0
+      )
+    : [];
+};
+
 const isGreenFlag = (flags: number): boolean =>
   (flags & (0x00004000 | 0x00008000 | 0x00010000)) === 0;
 
@@ -79,6 +90,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   private aggregationEnabled = true;
   private session?: Session;
   private sourceReplay: boolean;
+  private readonly carLapTimes: number[] = [];
   private latest: FuelProjectionSnapshot;
 
   constructor(options: FuelProjectionProcessorOptions = {}) {
@@ -115,6 +127,16 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     const driverInfo = this.session?.DriverInfo;
     const maxFuel = driverInfo?.DriverCarFuelMaxLtr;
     const maxFuelPct = driverInfo?.DriverCarMaxFuelPct;
+    const lastLapTimes = values(frame, 'CarIdxLastLapTime');
+    for (let index = 0; index < lastLapTimes.length; index++) {
+      const lastLapTime = lastLapTimes[index];
+      if (lastLapTime > 1) this.carLapTimes[index] = lastLapTime;
+    }
+    const raceProjection = this.calculateRaceProjection(
+      frame,
+      sessionInfo?.SessionType,
+      sessionInfo?.SessionLaps
+    );
     const commands = this.engine.onFrame(
       {
         fuelLevel,
@@ -169,6 +191,8 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       sessionState: value(frame, 'SessionState'),
       sessionNum,
       sessionLaps: sessionInfo?.SessionLaps ?? 0,
+      calculatedTotalRaceLaps: raceProjection.totalRaceLaps,
+      isFixedLapRace: raceProjection.isFixedLapRace,
       sessionType: sessionInfo?.SessionType,
       isOnTrack: booleanValue(frame, 'IsOnTrack'),
       trackId:
@@ -228,6 +252,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     this.engine.reset();
     this.lastCommands = [];
     this.laps.length = 0;
+    this.carLapTimes.length = 0;
     this.latest = this.emptySnapshot();
   }
 
@@ -248,9 +273,80 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       sessionState: 0,
       sessionNum: 0,
       sessionLaps: 0,
+      calculatedTotalRaceLaps: 0,
+      isFixedLapRace: false,
       isOnTrack: false,
       completedLaps: this.laps,
       engine: this.engine.snapshot(),
     };
+  }
+
+  private calculateRaceProjection(
+    frame: Telemetry,
+    sessionType?: string,
+    sessionLaps?: string
+  ): { totalRaceLaps: number; isFixedLapRace: boolean } {
+    const timeRemaining = value(frame, 'SessionTimeRemain');
+    const isFixedLapRace = !(timeRemaining > 0 && timeRemaining !== 604800);
+    if (sessionType !== 'Race') return { totalRaceLaps: 0, isFixedLapRace };
+
+    const driverCarIdx = this.session?.DriverInfo?.DriverCarIdx ?? 0;
+    const cameraCarIdx = value(frame, 'CamCarIdx', -1);
+    const playerCarIdx = cameraCarIdx >= 0 ? cameraCarIdx : driverCarIdx;
+    const carLaps = values(frame, 'CarIdxLap');
+    const positions = values(frame, 'CarIdxPosition');
+    const lapDistances = values(frame, 'CarIdxLapDistPct');
+    const playerLap = carLaps[playerCarIdx] ?? value(frame, 'Lap');
+    let leaderCarIdx = -1;
+    for (let index = 0; index < positions.length; index++) {
+      if (positions[index] === 1) {
+        leaderCarIdx = index;
+        break;
+      }
+    }
+    const projectionCarIdx = leaderCarIdx >= 0 ? leaderCarIdx : playerCarIdx;
+    const classEstimate = this.session?.DriverInfo?.Drivers?.find(
+      (driver) => driver.CarIdx === projectionCarIdx
+    )?.CarClassEstLapTime;
+    const bestLapTimes = values(frame, 'CarIdxBestLapTime');
+    const averageLapTime =
+      this.carLapTimes[projectionCarIdx] > 0
+        ? this.carLapTimes[projectionCarIdx]
+        : classEstimate && classEstimate > 0
+          ? classEstimate
+          : (bestLapTimes[playerCarIdx] ?? 0);
+    const configuredLaps = Number.parseInt(sessionLaps ?? '0', 10) || 0;
+
+    if (value(frame, 'SessionState') >= 5) {
+      return { totalRaceLaps: playerLap, isFixedLapRace };
+    }
+    if (isFixedLapRace) {
+      let totalRaceLaps = configuredLaps;
+      const leaderLap = carLaps[leaderCarIdx] ?? 0;
+      const leaderDistance = lapDistances[leaderCarIdx] ?? 0;
+      const playerDistance = value(frame, 'LapDistPct');
+      if (playerLap > 0 && leaderLap > 0) {
+        const distanceBehind =
+          leaderLap + leaderDistance - (playerLap + playerDistance);
+        if (distanceBehind > 0) totalRaceLaps -= Math.floor(distanceBehind);
+      }
+      return { totalRaceLaps, isFixedLapRace };
+    }
+    if (averageLapTime <= 0) {
+      return { totalRaceLaps: 0, isFixedLapRace };
+    }
+
+    const leaderLap = carLaps[leaderCarIdx] ?? playerLap;
+    const leaderDistance = lapDistances[leaderCarIdx] ?? 0;
+    let totalRaceLaps =
+      playerLap === 0
+        ? value(frame, 'SessionTimeTotal') / averageLapTime
+        : timeRemaining / averageLapTime + (leaderLap - 1) + leaderDistance;
+    const distanceBehind = leaderLap - playerLap;
+    if (distanceBehind > 1) totalRaceLaps -= Math.floor(distanceBehind);
+    if (configuredLaps > 0 && totalRaceLaps > configuredLaps) {
+      totalRaceLaps = configuredLaps;
+    }
+    return { totalRaceLaps, isFixedLapRace };
   }
 }

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -22,6 +22,7 @@ export interface FuelProjectionProcessorOptions {
   persistence?: FuelProjectionPersistence;
   persistLaps?: boolean;
   clock?: () => number;
+  sourceReplay?: boolean;
 }
 
 const noPersistence: FuelProjectionPersistence = {
@@ -77,11 +78,13 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   private lastCommands: readonly FuelEngineCommand[] = [];
   private aggregationEnabled = true;
   private session?: Session;
+  private sourceReplay: boolean;
   private latest: FuelProjectionSnapshot;
 
   constructor(options: FuelProjectionProcessorOptions = {}) {
     this.persistence = options.persistence ?? noPersistence;
     this.persistLaps = options.persistLaps ?? false;
+    this.sourceReplay = options.sourceReplay ?? false;
     this.engine = new FuelProjectionEngine(
       { now: options.clock ?? (() => this.clockMilliseconds) },
       { debug: () => undefined }
@@ -91,6 +94,11 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
 
   init(session: Session): void {
     this.session = session;
+  }
+
+  setSourceReplay(replay: boolean): void {
+    this.sourceReplay = replay;
+    this.latest = { ...this.latest, isReplay: replay };
   }
 
   onFrame(frame: Telemetry): void {
@@ -137,6 +145,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
         validLaps.length
       : 0;
     this.latest = {
+      isReplay: this.sourceReplay,
       fuelLevel,
       fuelLevelPct: value(frame, 'FuelLevelPct'),
       currentLap: lap,
@@ -224,6 +233,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
 
   private emptySnapshot(): FuelProjectionSnapshot {
     return {
+      isReplay: this.sourceReplay,
       fuelLevel: 0,
       fuelLevelPct: 0,
       currentLap: 0,

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -329,12 +329,15 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
 
     const leaderLap = carLaps[leaderCarIdx] ?? playerLap;
     const leaderDistance = lapDistances[leaderCarIdx] ?? 0;
+    const playerDistance =
+      lapDistances[playerCarIdx] ?? value(frame, 'LapDistPct');
     let totalRaceLaps =
       playerLap === 0
         ? value(frame, 'SessionTimeTotal') / averageLapTime
         : timeRemaining / averageLapTime + (leaderLap - 1) + leaderDistance;
-    const distanceBehind = leaderLap - playerLap;
-    if (distanceBehind > 1) totalRaceLaps -= Math.floor(distanceBehind);
+    const distanceBehind =
+      leaderLap + leaderDistance - (playerLap + playerDistance);
+    totalRaceLaps -= Math.max(0, Math.floor(distanceBehind));
     if (configuredLaps > 0 && totalRaceLaps > configuredLaps) {
       totalRaceLaps = configuredLaps;
     }

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -58,6 +58,27 @@ const values = (frame: Telemetry, key: keyof Telemetry): readonly number[] => {
 const isGreenFlag = (flags: number): boolean =>
   (flags & (0x00004000 | 0x00008000 | 0x00010000)) === 0;
 
+const median = (numbers: readonly number[]): number => {
+  const sorted = [...numbers].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[middle];
+};
+
+const filteredMedian = (numbers: readonly number[]): number => {
+  if (numbers.length < 3) return median(numbers);
+  const mean =
+    numbers.reduce((sum, number) => sum + number, 0) / numbers.length;
+  const variance =
+    numbers.reduce((sum, number) => sum + (number - mean) ** 2, 0) /
+    numbers.length;
+  const threshold = Math.sqrt(variance);
+  return median(
+    numbers.filter((number) => Math.abs(number - mean) <= threshold)
+  );
+};
+
 const validateLap = (
   fuelUsed: number,
   lapTime: number,
@@ -90,7 +111,9 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   private aggregationEnabled = true;
   private session?: Session;
   private sourceReplay: boolean;
-  private readonly carLapTimes: number[] = [];
+  private previousCarLapTimes?: readonly number[];
+  private readonly carLapTimeHistory: number[][] = [];
+  private readonly averageCarLapTimes: number[] = [];
   private latest: FuelProjectionSnapshot;
 
   constructor(options: FuelProjectionProcessorOptions = {}) {
@@ -127,11 +150,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     const driverInfo = this.session?.DriverInfo;
     const maxFuel = driverInfo?.DriverCarFuelMaxLtr;
     const maxFuelPct = driverInfo?.DriverCarMaxFuelPct;
-    const lastLapTimes = values(frame, 'CarIdxLastLapTime');
-    for (let index = 0; index < lastLapTimes.length; index++) {
-      const lastLapTime = lastLapTimes[index];
-      if (lastLapTime > 1) this.carLapTimes[index] = lastLapTime;
-    }
+    this.updateAverageLapTimes(values(frame, 'CarIdxLastLapTime'));
     const raceProjection = this.calculateRaceProjection(
       frame,
       sessionInfo?.SessionType,
@@ -252,7 +271,9 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     this.engine.reset();
     this.lastCommands = [];
     this.laps.length = 0;
-    this.carLapTimes.length = 0;
+    this.previousCarLapTimes = undefined;
+    this.carLapTimeHistory.length = 0;
+    this.averageCarLapTimes.length = 0;
     this.latest = this.emptySnapshot();
   }
 
@@ -310,8 +331,8 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     )?.CarClassEstLapTime;
     const bestLapTimes = values(frame, 'CarIdxBestLapTime');
     const averageLapTime =
-      this.carLapTimes[projectionCarIdx] > 0
-        ? this.carLapTimes[projectionCarIdx]
+      this.averageCarLapTimes[projectionCarIdx] > 0
+        ? this.averageCarLapTimes[projectionCarIdx]
         : classEstimate && classEstimate > 0
           ? classEstimate
           : (bestLapTimes[playerCarIdx] ?? 0);
@@ -348,5 +369,21 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       totalRaceLaps = configuredLaps;
     }
     return { totalRaceLaps, isFixedLapRace };
+  }
+
+  private updateAverageLapTimes(lastLapTimes: readonly number[]): void {
+    const previous = this.previousCarLapTimes;
+    this.previousCarLapTimes = lastLapTimes;
+    if (!previous || previous.length !== lastLapTimes.length) return;
+
+    for (let index = 0; index < lastLapTimes.length; index++) {
+      const lapTime = lastLapTimes[index];
+      if (lapTime <= 0 || lapTime === previous[index]) continue;
+      const history = [...(this.carLapTimeHistory[index] ?? []), lapTime].slice(
+        -10
+      );
+      this.carLapTimeHistory[index] = history;
+      this.averageCarLapTimes[index] = filteredMedian(history);
+    }
   }
 }

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -58,27 +58,6 @@ const values = (frame: Telemetry, key: keyof Telemetry): readonly number[] => {
 const isGreenFlag = (flags: number): boolean =>
   (flags & (0x00004000 | 0x00008000 | 0x00010000)) === 0;
 
-const median = (numbers: readonly number[]): number => {
-  const sorted = [...numbers].sort((a, b) => a - b);
-  const middle = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0
-    ? (sorted[middle - 1] + sorted[middle]) / 2
-    : sorted[middle];
-};
-
-const filteredMedian = (numbers: readonly number[]): number => {
-  if (numbers.length < 3) return median(numbers);
-  const mean =
-    numbers.reduce((sum, number) => sum + number, 0) / numbers.length;
-  const variance =
-    numbers.reduce((sum, number) => sum + (number - mean) ** 2, 0) /
-    numbers.length;
-  const threshold = Math.sqrt(variance);
-  return median(
-    numbers.filter((number) => Math.abs(number - mean) <= threshold)
-  );
-};
-
 const validateLap = (
   fuelUsed: number,
   lapTime: number,
@@ -111,9 +90,6 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   private aggregationEnabled = true;
   private session?: Session;
   private sourceReplay: boolean;
-  private previousCarLapTimes?: readonly number[];
-  private readonly carLapTimeHistory: number[][] = [];
-  private readonly averageCarLapTimes: number[] = [];
   private latest: FuelProjectionSnapshot;
 
   constructor(options: FuelProjectionProcessorOptions = {}) {
@@ -150,7 +126,6 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     const driverInfo = this.session?.DriverInfo;
     const maxFuel = driverInfo?.DriverCarFuelMaxLtr;
     const maxFuelPct = driverInfo?.DriverCarMaxFuelPct;
-    this.updateAverageLapTimes(values(frame, 'CarIdxLastLapTime'));
     const raceProjection = this.calculateRaceProjection(
       frame,
       sessionInfo?.SessionType,
@@ -271,9 +246,6 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     this.engine.reset();
     this.lastCommands = [];
     this.laps.length = 0;
-    this.previousCarLapTimes = undefined;
-    this.carLapTimeHistory.length = 0;
-    this.averageCarLapTimes.length = 0;
     this.latest = this.emptySnapshot();
   }
 
@@ -331,11 +303,9 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     )?.CarClassEstLapTime;
     const bestLapTimes = values(frame, 'CarIdxBestLapTime');
     const averageLapTime =
-      this.averageCarLapTimes[projectionCarIdx] > 0
-        ? this.averageCarLapTimes[projectionCarIdx]
-        : classEstimate && classEstimate > 0
-          ? classEstimate
-          : (bestLapTimes[playerCarIdx] ?? 0);
+      classEstimate && classEstimate > 0
+        ? classEstimate
+        : (bestLapTimes[playerCarIdx] ?? 0);
     const configuredLaps = Number.parseInt(sessionLaps ?? '0', 10) || 0;
 
     if (value(frame, 'SessionState') >= 5) {
@@ -369,21 +339,5 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       totalRaceLaps = configuredLaps;
     }
     return { totalRaceLaps, isFixedLapRace };
-  }
-
-  private updateAverageLapTimes(lastLapTimes: readonly number[]): void {
-    const previous = this.previousCarLapTimes;
-    this.previousCarLapTimes = lastLapTimes;
-    if (!previous || previous.length !== lastLapTimes.length) return;
-
-    for (let index = 0; index < lastLapTimes.length; index++) {
-      const lapTime = lastLapTimes[index];
-      if (lapTime <= 0 || lapTime === previous[index]) continue;
-      const history = [...(this.carLapTimeHistory[index] ?? []), lapTime].slice(
-        -10
-      );
-      this.carLapTimeHistory[index] = history;
-      this.averageCarLapTimes[index] = filteredMedian(history);
-    }
   }
 }

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -38,6 +38,11 @@ const value = (
   return typeof candidate === 'number' ? candidate : fallback;
 };
 
+const booleanValue = (frame: Telemetry, key: keyof Telemetry): boolean => {
+  const candidate = frame[key]?.value?.[0];
+  return candidate === true || candidate === 1;
+};
+
 const isGreenFlag = (flags: number): boolean =>
   (flags & (0x00004000 | 0x00008000 | 0x00010000)) === 0;
 
@@ -107,7 +112,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
         fuelLevel,
         lap,
         lapDistPct,
-        onPitRoad: Boolean(value(frame, 'OnPitRoad')),
+        onPitRoad: booleanValue(frame, 'OnPitRoad'),
         playerCarTowTime: value(frame, 'PlayerCarTowTime'),
         sessionFlags: value(frame, 'SessionFlags'),
         sessionNum,
@@ -156,7 +161,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       sessionNum,
       sessionLaps: sessionInfo?.SessionLaps ?? 0,
       sessionType: sessionInfo?.SessionType,
-      isOnTrack: Boolean(value(frame, 'IsOnTrack')),
+      isOnTrack: booleanValue(frame, 'IsOnTrack'),
       trackId:
         this.session?.WeekendInfo?.TrackName ??
         this.session?.WeekendInfo?.TrackID,

--- a/src/app/processors/fuelProjectionRuntime.spec.ts
+++ b/src/app/processors/fuelProjectionRuntime.spec.ts
@@ -99,7 +99,11 @@ describe('FuelProjectionRuntime', () => {
 
     expect(publish).toHaveBeenCalledWith(
       'fuel.projection',
-      expect.objectContaining({ fuelLevel: 40, currentLap: 1 })
+      expect.objectContaining({
+        fuelLevel: 40,
+        currentLap: 1,
+        isReplay: true,
+      })
     );
   });
 });

--- a/src/app/processors/fuelProjectionRuntime.spec.ts
+++ b/src/app/processors/fuelProjectionRuntime.spec.ts
@@ -73,4 +73,33 @@ describe('FuelProjectionRuntime', () => {
       expect.objectContaining({ fuelLevel: 0, currentLap: 0 })
     );
   });
+
+  it('aggregates chronological tape replay when explicitly enabled', () => {
+    const bus = new ChannelBus();
+    const publish = vi.spyOn(bus, 'publish');
+    const lifecycle = createSessionLifecycle();
+    const runtime = new FuelProjectionRuntime(
+      bus,
+      lifecycle,
+      { markStart: vi.fn(), markEnd: vi.fn() },
+      { aggregateReplay: true }
+    );
+    lifecycle._onEnter({ replay: true });
+    bus.subscribe(
+      {
+        id: 3,
+        isDestroyed: () => false,
+        isVisible: () => true,
+        send: vi.fn(),
+      },
+      'fuel.projection'
+    );
+
+    runtime.onFrame(telemetry);
+
+    expect(publish).toHaveBeenCalledWith(
+      'fuel.projection',
+      expect.objectContaining({ fuelLevel: 40, currentLap: 1 })
+    );
+  });
 });

--- a/src/app/processors/fuelProjectionRuntime.ts
+++ b/src/app/processors/fuelProjectionRuntime.ts
@@ -12,6 +12,11 @@ interface PerformanceSections {
   markEnd(label: string): void;
 }
 
+interface FuelProjectionRuntimeOptions {
+  /** Recorded tapes are chronological and safe to aggregate. */
+  aggregateReplay?: boolean;
+}
+
 export class FuelProjectionRuntime {
   private processor?: FuelProjectionProcessor;
   private latestSession?: Session;
@@ -21,7 +26,8 @@ export class FuelProjectionRuntime {
   constructor(
     private readonly bus: ChannelBus,
     lifecycle: SessionLifecycle,
-    private readonly metrics: PerformanceSections
+    private readonly metrics: PerformanceSections,
+    private readonly options: FuelProjectionRuntimeOptions = {}
   ) {
     this.disconnects = [
       bus.onSubscriberCountChanged((channel, count) => {
@@ -30,7 +36,10 @@ export class FuelProjectionRuntime {
         else this.processor = undefined;
       }),
       lifecycle.onEnter(({ replay }) =>
-        this.onLifecycle({ type: 'enter', replay })
+        this.onLifecycle({
+          type: 'enter',
+          replay: replay && !this.options.aggregateReplay,
+        })
       ),
       lifecycle.onSessionNumChange(() =>
         this.onLifecycle({ type: 'sessionNumChange' })

--- a/src/app/processors/fuelProjectionRuntime.ts
+++ b/src/app/processors/fuelProjectionRuntime.ts
@@ -35,12 +35,14 @@ export class FuelProjectionRuntime {
         if (count > 0) this.activate();
         else this.processor = undefined;
       }),
-      lifecycle.onEnter(({ replay }) =>
+      lifecycle.onEnter(({ replay }) => {
+        this.replaySource = replay;
+        this.processor?.setSourceReplay(replay);
         this.onLifecycle({
           type: 'enter',
           replay: replay && !this.options.aggregateReplay,
-        })
-      ),
+        });
+      }),
       lifecycle.onSessionNumChange(() =>
         this.onLifecycle({ type: 'sessionNumChange' })
       ),
@@ -70,18 +72,19 @@ export class FuelProjectionRuntime {
 
   private activate(): void {
     if (this.processor) return;
-    this.processor = new FuelProjectionProcessor();
+    this.processor = new FuelProjectionProcessor({
+      sourceReplay: this.replaySource ?? false,
+    });
     if (this.replaySource !== undefined) {
       this.processor.onLifecycle({
         type: 'enter',
-        replay: this.replaySource,
+        replay: this.replaySource && !this.options.aggregateReplay,
       });
     }
     if (this.latestSession) this.processor.init(this.latestSession);
   }
 
   private onLifecycle(event: SessionLifecycleEvent): void {
-    if (event.type === 'enter') this.replaySource = event.replay;
     this.processor?.onLifecycle(event);
     if (event.type === 'disconnect') {
       this.latestSession = undefined;

--- a/src/app/webserver/bridgeProxy.ts
+++ b/src/app/webserver/bridgeProxy.ts
@@ -4,6 +4,7 @@ import type { Telemetry, Session, DashboardLayout } from '@irdashies/types';
 import type { IrSdkBridge, DashboardBridge } from '@irdashies/types';
 import { getIsDemoMode } from '../bridge/iracingSdk/setup';
 import logger from '../logger';
+import type { ChannelBus } from '../bridge/channelBridge';
 
 // Export current state so it can be accessed by other parts of the app
 export let currentDashboard: DashboardLayout | null = null;
@@ -15,11 +16,13 @@ export let currentDashboard: DashboardLayout | null = null;
 export function createBridgeProxy(
   httpServer: HTTPServer,
   irsdkBridge: IrSdkBridge,
-  dashboardBridge?: DashboardBridge
+  dashboardBridge?: DashboardBridge,
+  channelBus?: ChannelBus
 ) {
   const wss = new WebSocketServer({ server: httpServer });
 
   const clients = new Set<WebSocket>();
+  let nextChannelTargetId = -1;
   let currentTelemetry: Telemetry | null = null;
   let currentSession: Session | null = null;
   let isRunning = false;
@@ -103,6 +106,18 @@ export function createBridgeProxy(
 
   wss.on('connection', (ws: WebSocket) => {
     clients.add(ws);
+    const channelTarget = {
+      id: nextChannelTargetId--,
+      isDestroyed: () => ws.readyState === WebSocket.CLOSED,
+      isVisible: () => ws.readyState === WebSocket.OPEN,
+      send: (_delivery: string, channel: string, payload: unknown) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(
+            JSON.stringify({ type: 'channel', data: { channel, payload } })
+          );
+        }
+      },
+    };
 
     if (unsubscribeFunctions.length === 0) {
       logger.info('No active subscriptions, subscribing to bridge...');
@@ -127,6 +142,26 @@ export function createBridgeProxy(
         const parsed = JSON.parse(message.toString());
 
         switch (parsed.type) {
+          case 'channelSubscribe': {
+            const channel = parsed.data?.channel;
+            const rate = parsed.data?.requestedRateHz;
+            if (
+              typeof channel !== 'string' ||
+              (rate !== undefined && typeof rate !== 'number')
+            ) {
+              throw new Error('Invalid channel subscription');
+            }
+            channelBus?.subscribe(channelTarget, channel, rate);
+            break;
+          }
+          case 'channelUnsubscribe': {
+            const channel = parsed.data?.channel;
+            if (typeof channel !== 'string') {
+              throw new Error('Invalid channel unsubscribe');
+            }
+            channelBus?.unsubscribe(channelTarget.id, channel);
+            break;
+          }
           case 'getDashboard':
             ws.send(
               JSON.stringify({
@@ -296,6 +331,7 @@ export function createBridgeProxy(
 
     ws.on('close', () => {
       clients.delete(ws);
+      channelBus?.removeRenderer(channelTarget.id);
 
       if (clients.size === 0) {
         logger.info('No clients connected, unsubscribing from bridge...');

--- a/src/app/webserver/componentRenderer.spec.ts
+++ b/src/app/webserver/componentRenderer.spec.ts
@@ -31,6 +31,7 @@ class FakeWebSocket {
 }
 
 const projection: FuelProjectionSnapshot = {
+  isReplay: false,
   fuelLevel: 40,
   fuelLevelPct: 0.5,
   currentLap: 2,

--- a/src/app/webserver/componentRenderer.spec.ts
+++ b/src/app/webserver/componentRenderer.spec.ts
@@ -116,8 +116,10 @@ describe('WebSocketBridge channels', () => {
     const socket = FakeWebSocket.latest;
     socket?.onopen?.();
     await connecting;
+    const messagesBeforeSecondConsumer = socket?.sent.length ?? 0;
     bridge.subscribe('fuel.projection', vi.fn(), 2);
 
+    expect(socket?.sent).toHaveLength(messagesBeforeSecondConsumer + 1);
     expect(JSON.parse(socket?.sent.at(-1) ?? '{}')).toEqual({
       type: 'channelSubscribe',
       data: { channel: 'fuel.projection', requestedRateHz: 5 },

--- a/src/app/webserver/componentRenderer.spec.ts
+++ b/src/app/webserver/componentRenderer.spec.ts
@@ -46,6 +46,8 @@ const projection: FuelProjectionSnapshot = {
   sessionState: 4,
   sessionNum: 0,
   sessionLaps: 12,
+  calculatedTotalRaceLaps: 12,
+  isFixedLapRace: true,
   sessionType: 'Race',
   isOnTrack: true,
   completedLaps: [],

--- a/src/app/webserver/componentRenderer.spec.ts
+++ b/src/app/webserver/componentRenderer.spec.ts
@@ -106,4 +106,43 @@ describe('WebSocketBridge channels', () => {
       data: { channel: 'fuel.projection' },
     });
   });
+
+  it('preserves the channel default when another consumer requests less', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+
+    const bridge = new WebSocketBridge();
+    bridge.subscribe('fuel.projection', vi.fn());
+    const connecting = bridge.connect('http://localhost:3000');
+    const socket = FakeWebSocket.latest;
+    socket?.onopen?.();
+    await connecting;
+    bridge.subscribe('fuel.projection', vi.fn(), 2);
+
+    expect(JSON.parse(socket?.sent.at(-1) ?? '{}')).toEqual({
+      type: 'channelSubscribe',
+      data: { channel: 'fuel.projection', requestedRateHz: 5 },
+    });
+  });
+
+  it('drops channel callbacks when stopped', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+
+    const bridge = new WebSocketBridge();
+    const callback = vi.fn();
+    bridge.subscribe('fuel.projection', callback);
+    const connecting = bridge.connect('http://localhost:3000');
+    const socket = FakeWebSocket.latest;
+    socket?.onopen?.();
+    await connecting;
+    bridge.stop();
+
+    socket?.onmessage?.({
+      data: JSON.stringify({
+        type: 'channel',
+        data: { channel: 'fuel.projection', payload: projection },
+      }),
+    } as MessageEvent);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/webserver/componentRenderer.spec.ts
+++ b/src/app/webserver/componentRenderer.spec.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { FuelProjectionSnapshot } from '@irdashies/types';
+import { WebSocketBridge } from './componentRenderer';
+
+class FakeWebSocket {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  static latest?: FakeWebSocket;
+
+  readonly sent: string[] = [];
+  readyState = FakeWebSocket.OPEN;
+  onopen?: () => void;
+  onmessage?: (event: MessageEvent) => void;
+  onerror?: (event: Event) => void;
+  onclose?: () => void;
+
+  constructor(readonly url: string) {
+    FakeWebSocket.latest = this;
+  }
+
+  send(message: string): void {
+    this.sent.push(message);
+  }
+
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+}
+
+const projection: FuelProjectionSnapshot = {
+  fuelLevel: 40,
+  fuelLevelPct: 0.5,
+  currentLap: 2,
+  lapDistPct: 0.25,
+  currentLapUsage: 0.5,
+  projectedLapUsage: 2,
+  lastLapUsage: 2.1,
+  sessionLapsRemain: 10,
+  sessionTimeRemain: 900,
+  sessionTimeTotal: 1800,
+  sessionFlags: 0,
+  sessionState: 4,
+  sessionNum: 0,
+  sessionLaps: 12,
+  sessionType: 'Race',
+  isOnTrack: true,
+  completedLaps: [],
+  engine: {
+    accumulatedRefuel: 0,
+    isLapDistPctReset: false,
+    lapCrossingTime: 90,
+    lapStartFuel: 40.5,
+    lastLap: 1,
+    lastLapDistPct: 0.25,
+    lastSessionFlags: 0,
+    wasOnPitRoad: false,
+  },
+};
+
+describe('WebSocketBridge channels', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('subscribes at the highest local rate and dispatches channel snapshots', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+
+    const bridge = new WebSocketBridge();
+    const first = vi.fn();
+    const second = vi.fn();
+    const unsubscribeFirst = bridge.subscribe('fuel.projection', first, 5);
+    const connecting = bridge.connect('http://localhost:3000');
+    const socket = FakeWebSocket.latest;
+    socket?.onopen?.();
+    await connecting;
+
+    const unsubscribeSecond = bridge.subscribe('fuel.projection', second, 10);
+    socket?.onmessage?.({
+      data: JSON.stringify({
+        type: 'channel',
+        data: { channel: 'fuel.projection', payload: projection },
+      }),
+    } as MessageEvent);
+
+    expect(first).toHaveBeenCalledWith(projection);
+    expect(second).toHaveBeenCalledWith(projection);
+    expect(socket?.sent.map((message) => JSON.parse(message))).toEqual([
+      {
+        type: 'channelSubscribe',
+        data: { channel: 'fuel.projection', requestedRateHz: 5 },
+      },
+      {
+        type: 'channelSubscribe',
+        data: { channel: 'fuel.projection', requestedRateHz: 10 },
+      },
+    ]);
+
+    unsubscribeSecond();
+    unsubscribeFirst();
+    expect(JSON.parse(socket?.sent.at(-1) ?? '{}')).toEqual({
+      type: 'channelUnsubscribe',
+      data: { channel: 'fuel.projection' },
+    });
+  });
+});

--- a/src/app/webserver/componentRenderer.tsx
+++ b/src/app/webserver/componentRenderer.tsx
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type { IrSdkBridge } from '../../types';
+import type {
+  ChannelBridge,
+  ChannelName,
+  ChannelPayloads,
+  IrSdkBridge,
+} from '../../types';
 import logger from '../../frontend/utils/logger';
 
 const isDebugMode = () =>
@@ -14,11 +19,18 @@ const debugLog = (...args: any[]) => {
 /**
  * Web-based bridge that connects to the WebSocket server
  */
-export class WebSocketBridge implements IrSdkBridge {
+export class WebSocketBridge implements IrSdkBridge, ChannelBridge {
   private socket: WebSocket | null;
   private telemetryCallbacks: Set<(data: any) => void>;
   private sessionCallbacks: Set<(data: any) => void>;
   private runningCallbacks: Set<(running: boolean) => void>;
+  private channelCallbacks = new Map<
+    ChannelName,
+    Set<{
+      callback: (data: ChannelPayloads[ChannelName]) => void;
+      rate?: number;
+    }>
+  >();
   private isConnecting: boolean;
   private connectionPromise: Promise<void> | null;
   private isConnected: boolean;
@@ -122,6 +134,17 @@ export class WebSocketBridge implements IrSdkBridge {
             }
           });
           break;
+        case 'channel': {
+          const channel = data?.channel as ChannelName;
+          this.channelCallbacks.get(channel)?.forEach((consumer) => {
+            try {
+              consumer.callback(data.payload);
+            } catch (e) {
+              logger.error('Error in channel callback:', e);
+            }
+          });
+          break;
+        }
         case 'sessionData':
           this.sessionCallbacks.forEach((cb) => {
             try {
@@ -237,6 +260,9 @@ export class WebSocketBridge implements IrSdkBridge {
           this.isConnecting = false;
           this.isConnected = true;
           this.reconnectAttempts = 0;
+          for (const channel of this.channelCallbacks.keys()) {
+            this.sendChannelSubscription(channel);
+          }
           resolve();
         };
 
@@ -278,6 +304,54 @@ export class WebSocketBridge implements IrSdkBridge {
     });
 
     return this.connectionPromise;
+  }
+
+  subscribe<K extends ChannelName>(
+    channel: K,
+    callback: (payload: ChannelPayloads[K]) => void,
+    requestedRateHz?: number
+  ): () => void {
+    let callbacks = this.channelCallbacks.get(channel);
+    if (!callbacks) {
+      callbacks = new Set();
+      this.channelCallbacks.set(channel, callbacks);
+    }
+    const consumer = {
+      callback: callback as (data: ChannelPayloads[ChannelName]) => void,
+      rate: requestedRateHz,
+    };
+    callbacks.add(consumer);
+    this.sendChannelSubscription(channel);
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      callbacks?.delete(consumer);
+      if (callbacks?.size === 0) {
+        this.channelCallbacks.delete(channel);
+        if (this.socket?.readyState === WebSocket.OPEN) {
+          this.socket.send(
+            JSON.stringify({ type: 'channelUnsubscribe', data: { channel } })
+          );
+        }
+      } else {
+        this.sendChannelSubscription(channel);
+      }
+    };
+  }
+
+  private sendChannelSubscription(channel: ChannelName): void {
+    if (this.socket?.readyState !== WebSocket.OPEN) return;
+    const rates = [...(this.channelCallbacks.get(channel) ?? [])]
+      .map((consumer) => consumer.rate)
+      .filter((rate): rate is number => rate !== undefined);
+    const requestedRateHz = rates.length > 0 ? Math.max(...rates) : undefined;
+    this.socket.send(
+      JSON.stringify({
+        type: 'channelSubscribe',
+        data: { channel, requestedRateHz },
+      })
+    );
   }
 
   onTelemetry(callback: (data: any) => void): (() => void) | undefined {
@@ -858,9 +932,7 @@ export class WebSocketBridge implements IrSdkBridge {
     });
   }
 
-  async getPlayerIconImageAsDataUrl(
-    imagePath: string
-  ): Promise<string | null> {
+  async getPlayerIconImageAsDataUrl(imagePath: string): Promise<string | null> {
     return new Promise((resolve) => {
       if (this.socket && this.socket.readyState === WebSocket.OPEN) {
         const requestId = Math.random().toString(36).substring(7);

--- a/src/app/webserver/componentRenderer.tsx
+++ b/src/app/webserver/componentRenderer.tsx
@@ -1,9 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import type {
-  ChannelBridge,
-  ChannelName,
-  ChannelPayloads,
-  IrSdkBridge,
+import {
+  channelRegistry,
+  type ChannelBridge,
+  type ChannelName,
+  type ChannelPayloads,
+  type IrSdkBridge,
+  type Session,
+  type Telemetry,
 } from '../../types';
 import logger from '../../frontend/utils/logger';
 
@@ -21,8 +24,8 @@ const debugLog = (...args: any[]) => {
  */
 export class WebSocketBridge implements IrSdkBridge, ChannelBridge {
   private socket: WebSocket | null;
-  private telemetryCallbacks: Set<(data: any) => void>;
-  private sessionCallbacks: Set<(data: any) => void>;
+  private telemetryCallbacks: Set<(data: Telemetry) => void>;
+  private sessionCallbacks: Set<(data: Session) => void>;
   private runningCallbacks: Set<(running: boolean) => void>;
   private channelCallbacks = new Map<
     ChannelName,
@@ -342,8 +345,11 @@ export class WebSocketBridge implements IrSdkBridge, ChannelBridge {
 
   private sendChannelSubscription(channel: ChannelName): void {
     if (this.socket?.readyState !== WebSocket.OPEN) return;
+    const definition = channelRegistry[channel];
+    const defaultRate =
+      definition.kind === 'snapshot' ? definition.defaultRateHz : undefined;
     const rates = [...(this.channelCallbacks.get(channel) ?? [])]
-      .map((consumer) => consumer.rate)
+      .map((consumer) => consumer.rate ?? defaultRate)
       .filter((rate): rate is number => rate !== undefined);
     const requestedRateHz = rates.length > 0 ? Math.max(...rates) : undefined;
     this.socket.send(
@@ -354,13 +360,13 @@ export class WebSocketBridge implements IrSdkBridge, ChannelBridge {
     );
   }
 
-  onTelemetry(callback: (data: any) => void): (() => void) | undefined {
+  onTelemetry(callback: (data: Telemetry) => void): (() => void) | undefined {
     if (!callback) return undefined;
     this.telemetryCallbacks.add(callback);
     return () => this.telemetryCallbacks.delete(callback);
   }
 
-  onSessionData(callback: (data: any) => void): (() => void) | undefined {
+  onSessionData(callback: (data: Session) => void): (() => void) | undefined {
     if (!callback) return undefined;
     this.sessionCallbacks.add(callback);
     return () => this.sessionCallbacks.delete(callback);
@@ -387,6 +393,7 @@ export class WebSocketBridge implements IrSdkBridge, ChannelBridge {
     this.telemetryCallbacks.clear();
     this.sessionCallbacks.clear();
     this.runningCallbacks.clear();
+    this.channelCallbacks.clear();
     this.dashboardUpdateCallbacks.clear();
     this.demoModeCallbacks.clear();
   }

--- a/src/app/webserver/componentServer.ts
+++ b/src/app/webserver/componentServer.ts
@@ -186,7 +186,8 @@ async function serveStaticFile(filePath: string, res: http.ServerResponse) {
  */
 export async function startComponentServer(
   irsdkBridge?: IrSdkBridge,
-  dashboardBridge?: DashboardBridge
+  dashboardBridge?: DashboardBridge,
+  channelBus?: import('../bridge/channelBridge').ChannelBus
 ) {
   const { getDashboard, getCurrentProfileId } =
     await import('../storage/dashboards');
@@ -458,7 +459,8 @@ export async function startComponentServer(
       const { resubscribeToBridge } = createBridgeProxy(
         httpServer,
         irsdkBridge,
-        dashboardBridge
+        dashboardBridge,
+        channelBus
       );
 
       const { onBridgeChanged } = await import('../bridge/iracingSdk/setup');

--- a/src/dashboard-view-entry.tsx
+++ b/src/dashboard-view-entry.tsx
@@ -11,7 +11,7 @@ import {
   SessionProvider,
   TelemetryProvider,
 } from '@irdashies/context';
-import type { DashboardBridge } from '@irdashies/types';
+import type { DashboardBridge, FuelCalculatorBridge } from '@irdashies/types';
 
 // Get profileId from URL params
 const urlParams = new URLSearchParams(window.location.search);
@@ -29,6 +29,17 @@ async function initializeDashboardView() {
   const bridge = new WebSocketBridge();
 
   await bridge.connect(wsUrl);
+  window.channelBridge = bridge;
+  window.fuelCalculatorBridge = {
+    getHistoricalLaps: async () => [],
+    saveLap: async () => undefined,
+    clearHistory: async () => undefined,
+    clearAllHistory: async () => undefined,
+    getQualifyMax: async () => null,
+    saveQualifyMax: async () => undefined,
+    startNewLog: async () => undefined,
+    logData: async () => undefined,
+  } satisfies FuelCalculatorBridge;
 
   const rootElement = document.getElementById('root');
   if (!rootElement) {

--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -119,6 +119,7 @@ const previewFuelData: FuelCalculation = {
 };
 
 const previewProjection = {
+  isReplay: false,
   fuelLevel: previewFuelData.fuelLevel,
   fuelLevelPct: previewFuelData.fuelLevel / 60,
   currentLap: previewFuelData.currentLap,

--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -3,6 +3,7 @@ import { useEffect, type ReactNode, useState } from 'react';
 import { FuelCalculator } from './FuelCalculator';
 import {
   DynamicTelemetrySelector,
+  ChannelSnapshotDecorator,
   TelemetryDecorator,
 } from '@irdashies/storybook';
 import { useFuelStore } from './FuelStore';
@@ -117,11 +118,43 @@ const previewFuelData: FuelCalculation = {
   maxQualify: null,
 };
 
+const previewProjection = {
+  fuelLevel: previewFuelData.fuelLevel,
+  fuelLevelPct: previewFuelData.fuelLevel / 60,
+  currentLap: previewFuelData.currentLap,
+  lapDistPct: 0.55,
+  currentLapUsage: previewFuelData.currentLapUsage ?? 0,
+  projectedLapUsage: previewFuelData.projectedLapUsage ?? 0,
+  lastLapUsage: previewFuelData.lastLapUsage,
+  sessionLapsRemain: previewFuelData.lapsRemaining,
+  sessionTimeRemain: 2700,
+  sessionTimeTotal: 3600,
+  sessionFlags: 0,
+  sessionState: 4,
+  sessionNum: 0,
+  sessionLaps: previewFuelData.totalLaps,
+  sessionType: 'Race',
+  isOnTrack: true,
+  fuelTankCapacity: 60,
+  completedLaps: [],
+  engine: {
+    accumulatedRefuel: 0,
+    isLapDistPctReset: false,
+    lapCrossingTime: 180,
+    lapStartFuel: 33.9,
+    lastLap: 2,
+    lastLapDistPct: 0.55,
+    lastSessionFlags: 0,
+    wasOnPitRoad: false,
+  },
+};
+
 export default {
   component: FuelCalculator,
   title: 'widgets/FuelCalculator',
   args: baselineArgs,
   decorators: [
+    ChannelSnapshotDecorator({ 'fuel.projection': previewProjection }),
     (Story, context) => (
       <OverlayFrame
         height={

--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -134,6 +134,8 @@ const previewProjection = {
   sessionState: 4,
   sessionNum: 0,
   sessionLaps: previewFuelData.totalLaps,
+  calculatedTotalRaceLaps: previewFuelData.totalLaps,
+  isFixedLapRace: true,
   sessionType: 'Race',
   isOnTrack: true,
   fuelTankCapacity: 60,

--- a/src/frontend/components/FuelCalculator/FuelCalculator.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.tsx
@@ -1,9 +1,5 @@
 import { useMemo, useState, useEffect } from 'react';
-import {
-  useSessionVisibility,
-  useTelemetryValue,
-  useDashboard,
-} from '@irdashies/context';
+import { useDashboard, useFuelProjectionSnapshot } from '@irdashies/context';
 import { useFuelCalculation } from './useFuelCalculation';
 import {
   FuelCalculatorHeader,
@@ -73,7 +69,21 @@ export const FuelCalculator = (props: FuelCalculatorProps) => {
 
   const { fuelUnits, safetyMargin } = settings;
 
-  const isSessionVisible = useSessionVisibility(settings.sessionVisibility);
+  const projection = useFuelProjectionSnapshot();
+  const visibilityKey = projection?.sessionType
+    ? {
+        Race: 'race',
+        'Lone Qualify': 'loneQualify',
+        'Open Qualify': 'openQualify',
+        Practice: 'practice',
+        'Offline Testing': 'offlineTesting',
+      }[projection.sessionType]
+    : undefined;
+  const isSessionVisible = visibilityKey
+    ? (settings.sessionVisibility?.[
+        visibilityKey as keyof typeof settings.sessionVisibility
+      ] ?? true)
+    : true;
 
   // Derived Settings based on General linkage
   // Use the full string so compact vs ultra can be distinguished downstream
@@ -149,12 +159,12 @@ export const FuelCalculator = (props: FuelCalculatorProps) => {
     return DEFAULT_FUEL_LAYOUT_TREE;
   }, [settings.layoutTree]);
 
-  const isOnTrack = useTelemetryValue('IsOnTrack');
+  const isOnTrack = projection?.isOnTrack ?? false;
 
   const calculatedFuelData = useFuelCalculation(safetyMargin, settings);
   const fuelData = props.previewData ?? calculatedFuelData;
 
-  const currentFuelLevel = useTelemetryValue('FuelLevel');
+  const currentFuelLevel = projection?.fuelLevel;
 
   const predictiveUsage = fuelData?.projectedLapUsage || 0;
   const qualifyConsumption = fuelData?.maxQualify || null;

--- a/src/frontend/components/FuelCalculator/FuelStore.tsx
+++ b/src/frontend/components/FuelCalculator/FuelStore.tsx
@@ -61,7 +61,6 @@ interface FuelStoreActions {
     isOnPitRoad: boolean
   ) => void;
 
-
   /**
    * Update just the lap distance percentage (for tracking lap crossing)
    */
@@ -94,6 +93,7 @@ interface FuelStoreActions {
   setQualifyConsumption: (val: number | null) => void;
   setContextInfo: (trackId?: string | number, carName?: string) => void;
   setLapHistory: (laps: FuelLapData[]) => void;
+  setProjectionLaps: (laps: readonly FuelLapData[]) => void;
 }
 
 type FuelStore = FuelStoreState & FuelStoreActions;
@@ -119,9 +119,80 @@ function sortLapsDescending(laps: FuelLapData[]): FuelLapData[] {
 /**
  * Main Zustand store for fuel calculations
  */
-export const useFuelStore = create<FuelStore>()(
-    (set, get) => ({
-      // Initial state
+export const useFuelStore = create<FuelStore>()((set, get) => ({
+  // Initial state
+  lapHistory: new Map(),
+  _sortedLapHistoryCache: null,
+  _oldestLapNumber: Infinity,
+  lastLap: 0,
+  lapStartFuel: 0,
+  lapCrossingTime: 0,
+  lastLapDistPct: 0,
+  sessionNum: -1,
+  wasOnPitRoad: false,
+  lastSessionFlags: 0,
+  qualifyConsumption: null,
+  accumulatedRefuel: 0,
+  trackId: undefined,
+  carName: undefined,
+
+  // Actions
+  addLapData: (lapData: FuelLapData) => {
+    set((state) => {
+      const newHistory = new Map(state.lapHistory);
+      newHistory.set(lapData.lapNumber, lapData);
+
+      // Track oldest lap number for efficient pruning
+      let oldestLapNumber = Math.min(state._oldestLapNumber, lapData.lapNumber);
+
+      // Prune if over limit - use tracked oldest lap number instead of searching
+      if (newHistory.size > MAX_LAP_HISTORY) {
+        newHistory.delete(oldestLapNumber);
+        // Find new oldest - only needed after deletion
+        oldestLapNumber = Infinity;
+        for (const key of newHistory.keys()) {
+          if (key < oldestLapNumber) {
+            oldestLapNumber = key;
+          }
+        }
+      }
+
+      return {
+        lapHistory: newHistory,
+        _sortedLapHistoryCache: null, // Invalidate cache
+        _oldestLapNumber: oldestLapNumber,
+        lastLap: lapData.lapNumber,
+      };
+    });
+  },
+
+  addRefuel: (amount: number) => {
+    set((state) => ({ accumulatedRefuel: state.accumulatedRefuel + amount }));
+  },
+
+  updateLapCrossing: (
+    lapDistPct: number,
+    fuelLevel: number,
+    sessionTime: number,
+    currentLap: number,
+    isOnPitRoad: boolean
+  ) => {
+    set({
+      lastLapDistPct: lapDistPct,
+      lapStartFuel: fuelLevel,
+      lapCrossingTime: sessionTime,
+      lastLap: currentLap,
+      wasOnPitRoad: isOnPitRoad,
+      accumulatedRefuel: 0, // Reset accumulated refuel for the new lap
+    });
+  },
+
+  updateLapDistPct: (lapDistPct: number) => {
+    set({ lastLapDistPct: lapDistPct });
+  },
+
+  clearAllData: () => {
+    set({
       lapHistory: new Map(),
       _sortedLapHistoryCache: null,
       _oldestLapNumber: Infinity,
@@ -129,164 +200,109 @@ export const useFuelStore = create<FuelStore>()(
       lapStartFuel: 0,
       lapCrossingTime: 0,
       lastLapDistPct: 0,
-      sessionNum: -1,
       wasOnPitRoad: false,
       lastSessionFlags: 0,
-      qualifyConsumption: null,
       accumulatedRefuel: 0,
-      trackId: undefined,
-      carName: undefined,
+      // qualifyConsumption is INTENTIONALLY preservation across session changes
+      // It should only be cleared if we detect a track change (handled in useFuelCalculation)
+      // or if we decide to add a hard reset button later.
+    });
+  },
 
-      // Actions
-      addLapData: (lapData: FuelLapData) => {
-        set((state) => {
-          const newHistory = new Map(state.lapHistory);
-          newHistory.set(lapData.lapNumber, lapData);
+  updateSessionInfo: (sessionNum: number) => {
+    // Don't clear data on session change - preserve fuel consumption data
+    // across warmup/qualifying/race within the same iRacing session
+    // Data will only be cleared when explicitly leaving the session
+    set({ sessionNum });
+  },
 
-          // Track oldest lap number for efficient pruning
-          let oldestLapNumber = Math.min(
-            state._oldestLapNumber,
-            lapData.lapNumber
-          );
+  getLapHistory: () => {
+    const state = get();
 
-          // Prune if over limit - use tracked oldest lap number instead of searching
-          if (newHistory.size > MAX_LAP_HISTORY) {
-            newHistory.delete(oldestLapNumber);
-            // Find new oldest - only needed after deletion
-            oldestLapNumber = Infinity;
-            for (const key of newHistory.keys()) {
-              if (key < oldestLapNumber) {
-                oldestLapNumber = key;
-              }
-            }
-          }
+    // Return cached version if available
+    if (state._sortedLapHistoryCache !== null) {
+      return state._sortedLapHistoryCache;
+    }
 
-          return {
-            lapHistory: newHistory,
-            _sortedLapHistoryCache: null, // Invalidate cache
-            _oldestLapNumber: oldestLapNumber,
-            lastLap: lapData.lapNumber,
-          };
-        });
-      },
+    // Build and cache sorted array
+    const sorted = sortLapsDescending(Array.from(state.lapHistory.values()));
 
-      addRefuel: (amount: number) => {
-        set((state) => ({ accumulatedRefuel: state.accumulatedRefuel + amount }));
-      },
+    // Note: We can't set state here as it would cause infinite loop
+    // The cache is primarily useful when accessed multiple times in same render
+    // For cross-render caching, we invalidate on addLapData
+    return sorted;
+  },
 
-      updateLapCrossing: (
-        lapDistPct: number,
-        fuelLevel: number,
-        sessionTime: number,
-        currentLap: number,
-        isOnPitRoad: boolean
-      ) => {
-        set({
-          lastLapDistPct: lapDistPct,
-          lapStartFuel: fuelLevel,
-          lapCrossingTime: sessionTime,
-          lastLap: currentLap,
-          wasOnPitRoad: isOnPitRoad,
-          accumulatedRefuel: 0, // Reset accumulated refuel for the new lap
-        });
-      },
+  getRecentLaps: (count: number) => {
+    const state = get();
 
-      updateLapDistPct: (lapDistPct: number) => {
-        set({ lastLapDistPct: lapDistPct });
-      },
+    // For small counts, it's faster to iterate the map directly
+    // than to sort the entire history
+    if (state.lapHistory.size <= count) {
+      return sortLapsDescending(Array.from(state.lapHistory.values()));
+    }
 
-      clearAllData: () => {
-        set({
-          lapHistory: new Map(),
-          _sortedLapHistoryCache: null,
-          _oldestLapNumber: Infinity,
-          lastLap: 0,
-          lapStartFuel: 0,
-          lapCrossingTime: 0,
-          lastLapDistPct: 0,
-          wasOnPitRoad: false,
-          lastSessionFlags: 0,
-          accumulatedRefuel: 0,
-          // qualifyConsumption is INTENTIONALLY preservation across session changes
-          // It should only be cleared if we detect a track change (handled in useFuelCalculation)
-          // or if we decide to add a hard reset button later.
-        });
-      },
+    // Use cached sorted array if available
+    if (state._sortedLapHistoryCache !== null) {
+      return state._sortedLapHistoryCache.slice(0, count);
+    }
 
-      updateSessionInfo: (sessionNum: number) => {
-        // Don't clear data on session change - preserve fuel consumption data
-        // across warmup/qualifying/race within the same iRacing session
-        // Data will only be cleared when explicitly leaving the session
-        set({ sessionNum });
-      },
+    // Otherwise get full sorted array and slice
+    return get().getLapHistory().slice(0, count);
+  },
 
-      getLapHistory: () => {
-        const state = get();
+  setQualifyConsumption: (val) => {
+    set({ qualifyConsumption: val });
+  },
 
-        // Return cached version if available
-        if (state._sortedLapHistoryCache !== null) {
-          return state._sortedLapHistoryCache;
+  setContextInfo: (trackId, carName) => {
+    set({ trackId, carName });
+  },
+
+  setLapHistory: (laps) => {
+    set(() => {
+      const newHistory = new Map();
+      let oldestLapNumber = Infinity;
+
+      laps.forEach((lap) => {
+        newHistory.set(lap.lapNumber, { ...lap, isHistorical: true });
+        if (lap.lapNumber < oldestLapNumber) {
+          oldestLapNumber = lap.lapNumber;
         }
+      });
 
-        // Build and cache sorted array
-        const sorted = sortLapsDescending(
-          Array.from(state.lapHistory.values())
-        );
+      return {
+        lapHistory: newHistory,
+        _sortedLapHistoryCache: null,
+        _oldestLapNumber: oldestLapNumber,
+        lastLap:
+          laps.length > 0 ? Math.max(...laps.map((l) => l.lapNumber)) : 0,
+      };
+    });
+  },
 
-        // Note: We can't set state here as it would cause infinite loop
-        // The cache is primarily useful when accessed multiple times in same render
-        // For cross-render caching, we invalidate on addLapData
-        return sorted;
-      },
-
-      getRecentLaps: (count: number) => {
-        const state = get();
-
-        // For small counts, it's faster to iterate the map directly
-        // than to sort the entire history
-        if (state.lapHistory.size <= count) {
-          return sortLapsDescending(Array.from(state.lapHistory.values()));
-        }
-
-        // Use cached sorted array if available
-        if (state._sortedLapHistoryCache !== null) {
-          return state._sortedLapHistoryCache.slice(0, count);
-        }
-
-        // Otherwise get full sorted array and slice
-        return get().getLapHistory().slice(0, count);
-      },
-
-      setQualifyConsumption: (val) => {
-        set({ qualifyConsumption: val });
-      },
-
-      setContextInfo: (trackId, carName) => {
-        set({ trackId, carName });
-      },
- 
-      setLapHistory: (laps) => {
-        set(() => {
-          const newHistory = new Map();
-          let oldestLapNumber = Infinity;
- 
-          laps.forEach((lap) => {
-            newHistory.set(lap.lapNumber, { ...lap, isHistorical: true });
-            if (lap.lapNumber < oldestLapNumber) {
-              oldestLapNumber = lap.lapNumber;
-            }
-          });
- 
-          return {
-            lapHistory: newHistory,
-            _sortedLapHistoryCache: null,
-            _oldestLapNumber: oldestLapNumber,
-            lastLap: laps.length > 0 ? Math.max(...laps.map((l) => l.lapNumber)) : 0,
-          };
-        });
-      },
-    })
-);
+  setProjectionLaps: (laps) => {
+    set((state) => {
+      const newHistory = new Map(
+        Array.from(state.lapHistory.entries()).filter(
+          ([, lap]) => lap.isHistorical
+        )
+      );
+      for (const lap of laps) {
+        newHistory.set(lap.lapNumber, { ...lap, isHistorical: false });
+      }
+      const lapNumbers = Array.from(newHistory.keys());
+      return {
+        lapHistory: newHistory,
+        _sortedLapHistoryCache: null,
+        _oldestLapNumber:
+          lapNumbers.length > 0 ? Math.min(...lapNumbers) : Infinity,
+        lastLap:
+          lapNumbers.length > 0 ? Math.max(...lapNumbers) : state.lastLap,
+      };
+    });
+  },
+}));
 
 // ============================================================================
 // Selectors for optimized component subscriptions
@@ -304,7 +320,7 @@ export const selectLapHistorySize = (state: FuelStore): number =>
  */
 export const selectLastLapData = (state: FuelStore): FuelLapData | null => {
   if (state.lapHistory.size === 0) return null;
-  
+
   // Use lastLap as the primary key, but if it doesn't exist in history (e.g. we just moved to next lap),
   // find the highest lap number actually present in the history.
   if (state.lastLap > 0 && state.lapHistory.has(state.lastLap)) {

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import type {
   ChannelBridge,
   ChannelName,
   ChannelPayloads,
+  FuelCalculatorBridge,
   FuelProjectionSnapshot,
 } from '@irdashies/types';
 import { defaultFuelCalculatorSettings } from './defaults';
@@ -11,6 +12,7 @@ import { useFuelCalculation } from './useFuelCalculation';
 import { useFuelStore } from './FuelStore';
 
 const projection: FuelProjectionSnapshot = {
+  isReplay: false,
   fuelLevel: 41.750274658203125,
   fuelLevelPct: 0.4,
   currentLap: 3,
@@ -95,5 +97,45 @@ describe('useFuelCalculation channel parity', () => {
     expect(result.current?.lastLapUsage).toBeCloseTo(3.6420249938964844);
     expect(result.current?.avgLaps).toBeCloseTo(3.6037120819091797);
     expect(result.current?.currentLap).toBe(3);
+  });
+
+  it('does not load or save live history for recorded replay', async () => {
+    const getHistoricalLaps = vi.fn(async () => []);
+    const saveLap = vi.fn(async () => undefined);
+    window.fuelCalculatorBridge = {
+      getHistoricalLaps,
+      saveLap,
+      clearHistory: vi.fn(async () => undefined),
+      clearAllHistory: vi.fn(async () => undefined),
+      getQualifyMax: vi.fn(async () => null),
+      saveQualifyMax: vi.fn(async () => undefined),
+      startNewLog: vi.fn(async () => undefined),
+      logData: vi.fn(async () => undefined),
+    } satisfies FuelCalculatorBridge;
+    window.channelBridge = {
+      subscribe: <K extends ChannelName>(
+        _channel: K,
+        callback: (payload: ChannelPayloads[K]) => void
+      ) => {
+        callback({
+          ...projection,
+          isReplay: true,
+          trackId: 'roadamerica full',
+          carName: 'bmwm4gt3',
+        } as ChannelPayloads[K]);
+        return () => undefined;
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useFuelCalculation(defaultFuelCalculatorSettings.safetyMargin, {
+        ...defaultFuelCalculatorSettings,
+        enableStorage: true,
+      })
+    );
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(getHistoricalLaps).not.toHaveBeenCalled();
+    expect(saveLap).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
@@ -27,6 +27,8 @@ const projection: FuelProjectionSnapshot = {
   sessionState: 4,
   sessionNum: 0,
   sessionLaps: 16,
+  calculatedTotalRaceLaps: 16,
+  isFixedLapRace: true,
   sessionType: 'Race',
   isOnTrack: true,
   fuelTankCapacity: 104,

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import type {
+  ChannelBridge,
+  ChannelName,
+  ChannelPayloads,
+  FuelProjectionSnapshot,
+} from '@irdashies/types';
+import { defaultFuelCalculatorSettings } from './defaults';
+import { useFuelCalculation } from './useFuelCalculation';
+import { useFuelStore } from './FuelStore';
+
+const projection: FuelProjectionSnapshot = {
+  fuelLevel: 41.750274658203125,
+  fuelLevelPct: 0.4,
+  currentLap: 3,
+  lapDistPct: 0.00005058342503616586,
+  currentLapUsage: 0,
+  projectedLapUsage: 3.77,
+  lastLapUsage: 3.6420249938964844,
+  sessionLapsRemain: 14,
+  sessionTimeRemain: 1200,
+  sessionTimeTotal: 1800,
+  sessionFlags: 268697600,
+  sessionState: 4,
+  sessionNum: 0,
+  sessionLaps: 16,
+  sessionType: 'Race',
+  isOnTrack: true,
+  fuelTankCapacity: 104,
+  completedLaps: [
+    {
+      lapNumber: 2,
+      fuelUsed: 3.6420249938964844,
+      lapTime: 131.3166666665473,
+      isGreenFlag: true,
+      isValidForCalc: true,
+      isOutLap: false,
+      isInLap: false,
+      wasTowed: false,
+      timestamp: 340270,
+      sessionNum: 0,
+    },
+    {
+      lapNumber: 1,
+      fuelUsed: 3.565399169921875,
+      lapTime: 139.73333333336973,
+      isGreenFlag: true,
+      isValidForCalc: true,
+      isOutLap: false,
+      isInLap: false,
+      wasTowed: false,
+      timestamp: 208971,
+      sessionNum: 0,
+    },
+  ],
+  engine: {
+    accumulatedRefuel: 0,
+    isLapDistPctReset: false,
+    lapCrossingTime: 431.2000005085652,
+    lapStartFuel: 41.750274658203125,
+    lastLap: 3,
+    lastLapDistPct: 0.00005058342503616586,
+    lastSessionFlags: 268697600,
+    wasOnPitRoad: false,
+  },
+};
+
+const bridge: ChannelBridge = {
+  subscribe: <K extends ChannelName>(
+    _channel: K,
+    callback: (payload: ChannelPayloads[K]) => void
+  ) => {
+    callback(projection as ChannelPayloads[K]);
+    return () => undefined;
+  },
+};
+
+describe('useFuelCalculation channel parity', () => {
+  beforeEach(() => {
+    useFuelStore.getState().clearAllData();
+    window.channelBridge = bridge;
+  });
+
+  it('uses the completed lap from the current snapshot at a lap crossing', async () => {
+    const { result } = renderHook(() =>
+      useFuelCalculation(defaultFuelCalculatorSettings.safetyMargin, {
+        ...defaultFuelCalculatorSettings,
+        enableStorage: false,
+        enableLogging: false,
+      })
+    );
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current?.lastLapUsage).toBeCloseTo(3.6420249938964844);
+    expect(result.current?.avgLaps).toBeCloseTo(3.6037120819091797);
+    expect(result.current?.currentLap).toBe(3);
+  });
+});

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import type {
   ChannelBridge,
   ChannelName,
@@ -124,7 +124,7 @@ describe('useFuelCalculation channel parity', () => {
           isReplay: true,
           trackId: 'roadamerica full',
           carName: 'bmwm4gt3',
-        } as ChannelPayloads[K]);
+        } as unknown as ChannelPayloads[K]);
         return () => undefined;
       },
     };
@@ -139,5 +139,104 @@ describe('useFuelCalculation channel parity', () => {
     await waitFor(() => expect(result.current).not.toBeNull());
     expect(getHistoricalLaps).not.toHaveBeenCalled();
     expect(saveLap).not.toHaveBeenCalled();
+  });
+
+  it('persists completed laps under the projection context', async () => {
+    const saveLap = vi.fn(async () => undefined);
+    window.fuelCalculatorBridge = {
+      getHistoricalLaps: vi.fn(async () => []),
+      saveLap,
+      clearHistory: vi.fn(async () => undefined),
+      clearAllHistory: vi.fn(async () => undefined),
+      getQualifyMax: vi.fn(async () => null),
+      saveQualifyMax: vi.fn(async () => undefined),
+      startNewLog: vi.fn(async () => undefined),
+      logData: vi.fn(async () => undefined),
+    } satisfies FuelCalculatorBridge;
+    useFuelStore.setState({ trackId: 'old-track', carName: 'old-car' });
+    window.channelBridge = {
+      subscribe: <K extends ChannelName>(
+        _channel: K,
+        callback: (payload: ChannelPayloads[K]) => void
+      ) => {
+        callback({
+          ...projection,
+          trackId: 'new-track',
+          carName: 'new-car',
+          completedLaps: projection.completedLaps.slice(0, 1),
+        } as unknown as ChannelPayloads[K]);
+        return () => undefined;
+      },
+    };
+
+    renderHook(() =>
+      useFuelCalculation(defaultFuelCalculatorSettings.safetyMargin, {
+        ...defaultFuelCalculatorSettings,
+        enableStorage: true,
+      })
+    );
+
+    await waitFor(() => expect(saveLap).toHaveBeenCalledOnce());
+    expect(saveLap).toHaveBeenCalledWith(
+      'new-track',
+      'new-car',
+      projection.completedLaps[0]
+    );
+  });
+
+  it('retries lap persistence after a failed save', async () => {
+    const saveLap = vi
+      .fn<FuelCalculatorBridge['saveLap']>()
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockResolvedValue(undefined);
+    window.fuelCalculatorBridge = {
+      getHistoricalLaps: vi.fn(async () => []),
+      saveLap,
+      clearHistory: vi.fn(async () => undefined),
+      clearAllHistory: vi.fn(async () => undefined),
+      getQualifyMax: vi.fn(async () => null),
+      saveQualifyMax: vi.fn(async () => undefined),
+      startNewLog: vi.fn(async () => undefined),
+      logData: vi.fn(async () => undefined),
+    } satisfies FuelCalculatorBridge;
+    const subscribers = new Set<(snapshot: FuelProjectionSnapshot) => void>();
+    const liveProjection = {
+      ...projection,
+      trackId: 'new-track',
+      carName: 'new-car',
+      completedLaps: projection.completedLaps.slice(0, 1),
+    };
+    window.channelBridge = {
+      subscribe: <K extends ChannelName>(
+        _channel: K,
+        callback: (payload: ChannelPayloads[K]) => void
+      ) => {
+        const typedCallback = callback as (
+          snapshot: FuelProjectionSnapshot
+        ) => void;
+        subscribers.add(typedCallback);
+        typedCallback(liveProjection);
+        return () => subscribers.delete(typedCallback);
+      },
+    };
+
+    renderHook(() =>
+      useFuelCalculation(defaultFuelCalculatorSettings.safetyMargin, {
+        ...defaultFuelCalculatorSettings,
+        enableStorage: true,
+      })
+    );
+    await waitFor(() => expect(saveLap).toHaveBeenCalledOnce());
+    await act(async () => {
+      await Promise.resolve();
+      subscribers.forEach((subscriber) =>
+        subscriber({
+          ...liveProjection,
+          completedLaps: [...liveProjection.completedLaps],
+        })
+      );
+    });
+
+    await waitFor(() => expect(saveLap).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -120,10 +120,13 @@ export function useFuelCalculation(
   useEffect(() => {
     const currentCarName = projection?.carName;
 
-    const currentContext =
+    const storageContext =
       trackId !== undefined && currentCarName !== undefined
         ? `${trackId}:${currentCarName}`
         : null;
+    const currentContext = storageContext
+      ? `${projection?.isReplay ? 'replay' : 'live'}:${storageContext}`
+      : null;
 
     const contextChanged =
       currentContext !== null && currentContext !== loadedContextRef.current;
@@ -144,8 +147,8 @@ export function useFuelCalculation(
       clearAllData();
       setQualifyConsumption(null);
 
-      if (settings?.enableStorage ?? true) {
-        const [tId, cName] = currentContext.split(':');
+      if ((settings?.enableStorage ?? true) && !projection?.isReplay) {
+        const [tId, cName] = storageContext?.split(':') ?? [];
         logger.info(
           `[FuelCalculator] Loading historical data for: Track=${tId}, Car=${cName}`
         );
@@ -193,6 +196,7 @@ export function useFuelCalculation(
     setQualifyConsumption,
     settings?.enableStorage,
     projection?.carName,
+    projection?.isReplay,
   ]);
 
   useEffect(() => {
@@ -205,6 +209,7 @@ export function useFuelCalculation(
   useEffect(() => {
     if (
       !(settings?.enableStorage ?? true) ||
+      projection?.isReplay ||
       storedTrackId === undefined ||
       storedCarName === undefined
     ) {
@@ -220,6 +225,7 @@ export function useFuelCalculation(
     }
   }, [
     projection?.completedLaps,
+    projection?.isReplay,
     settings?.enableStorage,
     storedCarName,
     storedTrackId,
@@ -265,7 +271,8 @@ export function useFuelCalculation(
           if (
             storedTrackId !== undefined &&
             storedCarName !== undefined &&
-            (settings?.enableStorage ?? true)
+            (settings?.enableStorage ?? true) &&
+            !projection?.isReplay
           ) {
             window.fuelCalculatorBridge.saveQualifyMax(
               storedTrackId,
@@ -285,6 +292,7 @@ export function useFuelCalculation(
     storedCarName,
     settings?.enableStorage,
     projection?.sessionType,
+    projection?.isReplay,
   ]);
 
   // Monitor for Race Finish

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -7,11 +7,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useFuelProjectionSnapshot } from '@irdashies/context';
-import {
-  useFuelStore,
-  selectLapHistorySize,
-  selectLastLapUsage,
-} from './FuelStore';
+import { useFuelStore, selectLapHistorySize } from './FuelStore';
 import type { FuelCalculation, FuelCalculatorSettings } from './types';
 import { useFuelLogger } from './useFuelLogger';
 import {
@@ -79,13 +75,10 @@ export function useFuelCalculation(
   );
 
   // Subscribe to lapStartFuel to calculate live usage
-  const lapStartFuel = useFuelStore((state) => state.lapStartFuel);
+  const lapStartFuel = projection?.engine.lapStartFuel ?? 0;
 
   // Subscribe to lap history size to trigger recalculation when laps are added
   const lapHistorySize = useFuelStore(selectLapHistorySize);
-
-  // Subscribe to last lap data directly to ensure immediate reactivity
-  const storeLastLapUsage = useFuelStore(selectLastLapUsage);
 
   // Ref to track the currently loaded context (Track + Car) to avoid redundant clears/loads
 
@@ -205,10 +198,7 @@ export function useFuelCalculation(
   useEffect(() => {
     if (!projection) return;
     const state = useFuelStore.getState();
-    const historical = state
-      .getLapHistory()
-      .filter((completed) => completed.isHistorical);
-    state.setLapHistory([...projection.completedLaps, ...historical]);
+    state.setProjectionLaps(projection.completedLaps);
     useFuelStore.setState(projection.engine);
   }, [projection]);
 
@@ -399,7 +389,23 @@ export function useFuelCalculation(
     }
 
     // Get lap history
-    const lapHistory = useFuelStore.getState().getLapHistory();
+    const liveLapNumbers = new Set(
+      projection?.completedLaps.map((completed) => completed.lapNumber) ?? []
+    );
+    const historicalLaps = useFuelStore
+      .getState()
+      .getLapHistory()
+      .filter(
+        (completed) =>
+          completed.isHistorical && !liveLapNumbers.has(completed.lapNumber)
+      );
+    const lapHistory = [
+      ...(projection?.completedLaps ?? []),
+      ...historicalLaps,
+    ].sort(
+      (a, b) =>
+        (b.timestamp ?? 0) - (a.timestamp ?? 0) || b.lapNumber - a.lapNumber
+    );
 
     if (lapHistory.length < 1) {
       return emptyCalculation;
@@ -454,11 +460,8 @@ export function useFuelCalculation(
     // Calculate averages - use reactive store value for immediate update
     // storeLastLapUsage is subscribed directly and updates immediately when addLapData is called
     const lastLapUsage =
-      storeLastLapUsage > 0
-        ? storeLastLapUsage
-        : lapHistory.length > 0
-          ? lapHistory[0].fuelUsed
-          : 0;
+      projection?.lastLapUsage ??
+      (lapHistory.length > 0 ? lapHistory[0].fuelUsed : 0);
 
     const avgLaps =
       lastLapsForAvg.length > 0
@@ -992,7 +995,6 @@ export function useFuelCalculation(
     qualifyConsumption,
     fuelTankCapacityFromSession,
     lapDistPct,
-    storeLastLapUsage,
     calculatedTotalRaceLaps,
     lapHistorySize,
     projection,

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -84,6 +84,7 @@ export function useFuelCalculation(
 
   const loadedContextRef = useRef<string | null>(null);
   const savedLapKeysRef = useRef(new Set<string>());
+  const pendingLapKeysRef = useRef(new Set<string>());
 
   // Race Finish Detection
 
@@ -141,6 +142,7 @@ export function useFuelCalculation(
       // Update ref immediately to prevent race conditions from additional renders
       loadedContextRef.current = currentContext;
       savedLapKeysRef.current.clear();
+      pendingLapKeysRef.current.clear();
 
       // ALWAYS clear current volatile data ONLY when context really changes to prevent leakage
       // This ONLY clears browser memory for the current session, NOT the database historical array.
@@ -207,25 +209,38 @@ export function useFuelCalculation(
   }, [projection]);
 
   useEffect(() => {
+    const persistence = window.fuelCalculatorBridge;
     if (
+      !persistence ||
       !(settings?.enableStorage ?? true) ||
       projection?.isReplay ||
-      storedTrackId === undefined ||
-      storedCarName === undefined
+      projection?.trackId === undefined ||
+      projection.carName === undefined ||
+      storedTrackId !== projection.trackId ||
+      storedCarName !== projection.carName
     ) {
       return;
     }
     for (const completed of projection?.completedLaps ?? []) {
-      const key = `${completed.sessionNum ?? -1}:${completed.lapNumber}:${completed.timestamp ?? 0}`;
-      if (savedLapKeysRef.current.has(key)) continue;
-      savedLapKeysRef.current.add(key);
-      window.fuelCalculatorBridge
-        ?.saveLap(storedTrackId, storedCarName, completed)
-        .catch(logger.error);
+      const key = `${projection.trackId}:${projection.carName}:${completed.sessionNum ?? -1}:${completed.lapNumber}:${completed.timestamp ?? 0}`;
+      if (
+        savedLapKeysRef.current.has(key) ||
+        pendingLapKeysRef.current.has(key)
+      ) {
+        continue;
+      }
+      pendingLapKeysRef.current.add(key);
+      persistence
+        .saveLap(projection.trackId, projection.carName, completed)
+        .then(() => savedLapKeysRef.current.add(key))
+        .catch(logger.error)
+        .finally(() => pendingLapKeysRef.current.delete(key));
     }
   }, [
     projection?.completedLaps,
+    projection?.carName,
     projection?.isReplay,
+    projection?.trackId,
     settings?.enableStorage,
     storedCarName,
     storedTrackId,

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -2,17 +2,11 @@
 /* eslint-disable no-useless-assignment */
 /**
  * Hook for calculating fuel metrics from telemetry data
- * Follows irdashies pattern using useTelemetryValues and Zustand store
+ * Applies renderer settings to the main-process fuel projection snapshot.
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import {
-  useSessionLaps,
-  useSessionStore,
-  useTelemetryValue,
-  useTotalRaceValue,
-} from '@irdashies/context';
-import { useStore } from 'zustand';
+import { useFuelProjectionSnapshot } from '@irdashies/context';
 import {
   useFuelStore,
   selectLapHistorySize,
@@ -21,17 +15,14 @@ import {
 import type { FuelCalculation, FuelCalculatorSettings } from './types';
 import { useFuelLogger } from './useFuelLogger';
 import {
-  validateLapData,
   calculateSimpleAverage,
   calculateAvgLapTime,
   findFuelMinMax,
   getGreenFlagLaps,
-  isGreenFlag,
   isFinalLap,
   isCheckeredFlag,
 } from './fuelCalculations';
 import logger from '@irdashies/utils/logger';
-import { FuelProjectionEngine } from '@irdashies/shared';
 
 /** Enable debug logging (set to true for testing/troubleshooting) */
 const DEBUG_LOGGING = false;
@@ -55,68 +46,28 @@ export function useFuelCalculation(
   safetyMargin = 0.3,
   settings?: FuelCalculatorSettings
 ): FuelCalculation | null {
-  const fuelLevel = useTelemetryValue('FuelLevel');
-  const fuelLevelPct = useTelemetryValue('FuelLevelPct');
-  const lap = useTelemetryValue('Lap');
-  const lapDistPct = useTelemetryValue('LapDistPct');
-  const sessionLapsRemain = useTelemetryValue('SessionLapsRemain');
-  const sessionTimeRemain = useTelemetryValue('SessionTimeRemain');
-  const sessionTimeTotal = useTelemetryValue('SessionTimeTotal');
-  const sessionFlags = useTelemetryValue('SessionFlags');
-  const sessionTime = useTelemetryValue('SessionTime');
-  const sessionNum = useTelemetryValue('SessionNum');
-  const sessionState = useTelemetryValue('SessionState');
-  const sessionLaps = useSessionLaps(sessionNum);
-  const onPitRoad = useTelemetryValue('OnPitRoad');
-  const isOnTrack = useTelemetryValue('IsOnTrack');
-
-  // Use centralized total race laps calculation
-  const { isFixedLapRace, totalRaceLaps: calculatedTotalRaceLaps } =
-    useTotalRaceValue();
-
-  // Check if current session is a Race
-  const sessions = useStore(
-    useSessionStore,
-    (state) => state.session?.SessionInfo?.Sessions
-  );
-  const isRace =
-    sessionNum !== undefined && sessions?.[sessionNum]?.SessionType === 'Race';
-
-  // Get fuel tank capacity from DriverInfo
-  const driverCarFuelMaxLtr = useStore(
-    useSessionStore,
-    (state) => state.session?.DriverInfo?.DriverCarFuelMaxLtr
-  );
-
-  // Get maximum fuel percentage allowed by session (e.g., 0.6 for 60% tank limit)
-  const driverCarMaxFuelPct = useStore(
-    useSessionStore,
-    (state) => state.session?.DriverInfo?.DriverCarMaxFuelPct
-  );
-
-  // Calculate actual tank capacity respecting session limits
-  const fuelTankCapacityFromSession =
-    driverCarFuelMaxLtr !== undefined && driverCarMaxFuelPct !== undefined
-      ? driverCarFuelMaxLtr * driverCarMaxFuelPct
-      : driverCarFuelMaxLtr;
-
-  // Get track ID to detect track changes
-  const rawTrackId = useStore(
-    useSessionStore,
-    (state) => state.session?.WeekendInfo?.TrackID
-  );
-  const trackName = useStore(
-    useSessionStore,
-    (state) => state.session?.WeekendInfo?.TrackName
-  );
-
-  // Use TrackName as primary key to prevent ID collisions
-  const trackId = trackName ?? rawTrackId;
+  const projection = useFuelProjectionSnapshot();
+  const fuelLevel = projection?.fuelLevel;
+  const fuelLevelPct = projection?.fuelLevelPct;
+  const lap = projection?.currentLap;
+  const lapDistPct = projection?.lapDistPct;
+  const sessionLapsRemain = projection?.sessionLapsRemain;
+  const sessionTimeRemain = projection?.sessionTimeRemain;
+  const sessionTimeTotal = projection?.sessionTimeTotal;
+  const sessionFlags = projection?.sessionFlags;
+  const sessionNum = projection?.sessionNum;
+  const sessionState = projection?.sessionState;
+  const sessionLaps = projection?.sessionLaps;
+  const isOnTrack = projection?.isOnTrack;
+  const isFixedLapRace = sessionLapsRemain !== TIMED_RACE_LAPS_REMAINING;
+  const calculatedTotalRaceLaps = 0;
+  const isRace = projection?.sessionType === 'Race';
+  const fuelTankCapacityFromSession = projection?.fuelTankCapacity;
+  const trackId = projection?.trackId;
 
   // Store actions (stable references)
   const updateSessionInfo = useFuelStore((state) => state.updateSessionInfo);
   const clearAllData = useFuelStore((state) => state.clearAllData);
-  const addLapData = useFuelStore((state) => state.addLapData);
   const setContextInfo = useFuelStore((state) => state.setContextInfo);
   const storedTrackId = useFuelStore((state) => state.trackId);
   const storedCarName = useFuelStore((state) => state.carName);
@@ -139,20 +90,7 @@ export function useFuelCalculation(
   // Ref to track the currently loaded context (Track + Car) to avoid redundant clears/loads
 
   const loadedContextRef = useRef<string | null>(null);
-
-  const fuelEngineRef = useRef<FuelProjectionEngine | null>(null);
-  if (fuelEngineRef.current === null) {
-    const initial = useFuelStore.getState();
-    fuelEngineRef.current = new FuelProjectionEngine(
-      { now: () => Date.now() },
-      {
-        debug: DEBUG_LOGGING
-          ? (message) => logger.debug(`[FuelCalculator] ${message}`)
-          : () => undefined,
-      },
-      initial
-    );
-  }
+  const savedLapKeysRef = useRef(new Set<string>());
 
   // Race Finish Detection
 
@@ -187,11 +125,7 @@ export function useFuelCalculation(
   }, [isOnTrack, settings?.enableLogging]);
 
   useEffect(() => {
-    const currentCarName = (
-      useSessionStore.getState().session?.DriverInfo as {
-        DriverCarName?: string;
-      }
-    )?.DriverCarName;
+    const currentCarName = projection?.carName;
 
     const currentContext =
       trackId !== undefined && currentCarName !== undefined
@@ -210,12 +144,12 @@ export function useFuelCalculation(
 
       // Update ref immediately to prevent race conditions from additional renders
       loadedContextRef.current = currentContext;
+      savedLapKeysRef.current.clear();
 
       // ALWAYS clear current volatile data ONLY when context really changes to prevent leakage
       // This ONLY clears browser memory for the current session, NOT the database historical array.
       clearAllData();
       setQualifyConsumption(null);
-      fuelEngineRef.current?.reset();
 
       if (settings?.enableStorage ?? true) {
         const [tId, cName] = currentContext.split(':');
@@ -265,78 +199,45 @@ export function useFuelCalculation(
     setContextInfo,
     setQualifyConsumption,
     settings?.enableStorage,
+    projection?.carName,
   ]);
 
-  const playerCarTowTime = useTelemetryValue('PlayerCarTowTime');
-
-  // Adapt telemetry subscriptions to the deterministic engine and execute its
-  // persistence commands outside the calculation core.
+  useEffect(() => {
+    if (!projection) return;
+    const state = useFuelStore.getState();
+    const historical = state
+      .getLapHistory()
+      .filter((completed) => completed.isHistorical);
+    state.setLapHistory([...projection.completedLaps, ...historical]);
+    useFuelStore.setState(projection.engine);
+  }, [projection]);
 
   useEffect(() => {
     if (
-      lapDistPct === undefined ||
-      fuelLevel === undefined ||
-      sessionTime === undefined ||
-      lap === undefined ||
-      sessionFlags === undefined ||
-      onPitRoad === undefined
-    )
+      !(settings?.enableStorage ?? true) ||
+      storedTrackId === undefined ||
+      storedCarName === undefined
+    ) {
       return;
-
-    const state = useFuelStore.getState();
-    const commands = fuelEngineRef.current?.onFrame(
-      {
-        fuelLevel,
-        lap,
-        lapDistPct,
-        onPitRoad: onPitRoad === 1,
-        playerCarTowTime: playerCarTowTime ?? 0,
-        sessionFlags,
-        sessionNum,
-        sessionTime,
-      },
-      state,
-      validateLapData,
-      isGreenFlag,
-      { persistLaps: settings?.enableStorage ?? true }
-    );
-    for (const command of commands ?? []) {
-      if (command.type === 'lapCompleted') {
-        addLapData(command.lap);
-      } else if (storedTrackId !== undefined && storedCarName !== undefined) {
-        window.fuelCalculatorBridge.saveLap(
-          storedTrackId,
-          storedCarName,
-          command.lap
-        );
-      }
     }
-    const engineState = fuelEngineRef.current?.snapshot();
-    if (engineState) {
-      useFuelStore.setState(engineState);
+    for (const completed of projection?.completedLaps ?? []) {
+      const key = `${completed.sessionNum ?? -1}:${completed.lapNumber}:${completed.timestamp ?? 0}`;
+      if (savedLapKeysRef.current.has(key)) continue;
+      savedLapKeysRef.current.add(key);
+      window.fuelCalculatorBridge
+        ?.saveLap(storedTrackId, storedCarName, completed)
+        .catch(logger.error);
     }
   }, [
-    lapDistPct,
-    fuelLevel,
-    sessionTime,
-    lap,
-    sessionFlags,
-    onPitRoad,
-    playerCarTowTime,
-    addLapData,
-    sessionNum,
-    storedTrackId,
-    storedCarName,
+    projection?.completedLaps,
     settings?.enableStorage,
+    storedCarName,
+    storedTrackId,
   ]);
 
   // Track Max Qualifying Consumption
   useEffect(() => {
-    const currentSessionType = useSessionStore
-      .getState()
-      .session?.SessionInfo?.Sessions?.find(
-        (s) => s.SessionNum === sessionNum
-      )?.SessionType;
+    const currentSessionType = projection?.sessionType;
 
     const isQualifying =
       currentSessionType && currentSessionType.includes('Qualify');
@@ -393,6 +294,7 @@ export function useFuelCalculation(
     storedTrackId,
     storedCarName,
     settings?.enableStorage,
+    projection?.sessionType,
   ]);
 
   // Monitor for Race Finish
@@ -859,21 +761,11 @@ export function useFuelCalculation(
     // Calculate fuel at finish
     const fuelAtFinish = fuelLevel - lapsRemaining * trendAdjustedConsumption;
 
-    const projectedLapUsage =
-      fuelEngineRef.current?.project({
-        currentLapUsage,
-        lapDistPct: lapDistPct || 0,
-        lastLapUsage,
-        avgConsumption: avgLaps,
-        qualifyConsumption,
-        lapStartFuel,
-        currentFuel: fuelLevel,
-        lap,
-      }) ?? 0;
+    const projectedLapUsage = projection?.projectedLapUsage ?? 0;
 
     // Detailed log for debug
     if (DEBUG_LOGGING) {
-      if (fuelEngineRef.current?.snapshot().isLapDistPctReset) {
+      if (projection?.engine.isLapDistPctReset) {
         logger.info(
           `[FuelCalculator] RESET STATE - lapDistPct: ${lapDistPct?.toFixed(4)}, ` +
             `Projection: ${projectedLapUsage.toFixed(3)}L, ` +
@@ -886,8 +778,7 @@ export function useFuelCalculation(
           tankCapacity: fuelTankCapacity,
           calculatedFromPct:
             fuelLevelPct && fuelLevelPct > 0 ? fuelLevel / fuelLevelPct : 'N/A',
-          driverCarFuelMaxLtr,
-          driverCarMaxFuelPct,
+          fuelTankCapacityFromSession,
           sessionLapsRemain,
           sessionTimeRemain,
           avgLapTime,
@@ -915,11 +806,7 @@ export function useFuelCalculation(
     let fuelStatus: 'safe' | 'caution' | 'danger' = 'safe';
 
     const currentFuelPctValue = (fuelLevelPct ?? 0) * 100;
-    const sessionType = useSessionStore
-      .getState()
-      .session?.SessionInfo?.Sessions?.find(
-        (s) => s.SessionNum === sessionNum
-      )?.SessionType;
+    const sessionType = projection?.sessionType;
 
     const isQualifyingOrPractice =
       sessionType &&
@@ -1099,8 +986,6 @@ export function useFuelCalculation(
     sessionTimeRemain,
     sessionTimeTotal,
     sessionFlags,
-    driverCarFuelMaxLtr,
-    driverCarMaxFuelPct,
     safetyMargin,
     lapStartFuel,
     settings,
@@ -1110,6 +995,7 @@ export function useFuelCalculation(
     storeLastLapUsage,
     calculatedTotalRaceLaps,
     lapHistorySize,
+    projection,
   ]);
 
   // Wrap calculation to apply overrides (Race Finish)
@@ -1152,8 +1038,7 @@ export function useFuelCalculation(
         storedTrackId,
         storedCarName,
         qualifyConsumption,
-        lapDistPctResetDetected:
-          fuelEngineRef.current?.snapshot().isLapDistPctReset ?? false,
+        lapDistPctResetDetected: projection?.engine.isLapDistPctReset ?? false,
       },
       calculation,
     }),
@@ -1171,6 +1056,7 @@ export function useFuelCalculation(
       storedTrackId,
       storedCarName,
       qualifyConsumption,
+      projection,
       calculation,
     ]
   );

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -55,8 +55,8 @@ export function useFuelCalculation(
   const sessionState = projection?.sessionState;
   const sessionLaps = projection?.sessionLaps;
   const isOnTrack = projection?.isOnTrack;
-  const isFixedLapRace = sessionLapsRemain !== TIMED_RACE_LAPS_REMAINING;
-  const calculatedTotalRaceLaps = 0;
+  const isFixedLapRace = projection?.isFixedLapRace ?? false;
+  const calculatedTotalRaceLaps = projection?.calculatedTotalRaceLaps ?? 0;
   const isRace = projection?.sessionType === 'Race';
   const fuelTankCapacityFromSession = projection?.fuelTankCapacity;
   const trackId = projection?.trackId;

--- a/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
+++ b/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  useTelemetryValue,
-  useSessionStore,
-  useTotalRaceLaps,
-} from '@irdashies/context';
-import { useStore } from 'zustand';
+import { useFuelProjectionSnapshot } from '@irdashies/context';
 import { fuelDisplayValue } from '../fuelCalculations';
 import type { FuelCalculation, FuelCalculatorSettings } from '../types';
 
@@ -41,21 +36,9 @@ export const FuelCalculatorConsumptionGrid: React.FC<
   liveFuelData,
   liveFuelLevel,
 }) => {
-  // Check if we are in a testing/practice session
-  // We need the current SessionNum to look up the SessionType in the SessionInfo array
-  const sessionNum = useTelemetryValue('SessionNum');
-  const sessionFlags = useTelemetryValue('SessionFlags');
-
-  const sessionType = useStore(
-    useSessionStore,
-    (state) =>
-      state.session?.SessionInfo?.Sessions?.find(
-        (s) => s.SessionNum === sessionNum
-      )?.SessionType
-  );
-
-  // Use shared hook for total race laps (handles timed races and leader lapping)
-  const { totalRaceLaps } = useTotalRaceLaps();
+  const projection = useFuelProjectionSnapshot();
+  const sessionFlags = projection?.sessionFlags;
+  const sessionType = projection?.sessionType;
 
   // Custom style handling for separate label/value sizes
   const widgetStyle =
@@ -95,7 +78,7 @@ export const FuelCalculatorConsumptionGrid: React.FC<
     sessionFlags && (sessionFlags & 0x0002 || sessionFlags & 0x0004);
 
   // If final lap/finished, we clamp the total race laps to the current lap (so it shows X / X)
-  let effectiveTotalLaps = Math.max(totalRaceLaps, currentLap);
+  let effectiveTotalLaps = Math.max(displayData?.totalLaps ?? 0, currentLap);
   if (isFinalLapOrFinished) {
     effectiveTotalLaps = currentLap;
   }

--- a/src/frontend/components/FuelCalculator/widgets/FuelCalculatorPitScenarios.tsx
+++ b/src/frontend/components/FuelCalculator/widgets/FuelCalculatorPitScenarios.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { FuelCalculation, FuelCalculatorSettings } from '../types';
-import { useTelemetryValue, useSessionType } from '@irdashies/context';
+import { useFuelProjectionSnapshot } from '@irdashies/context';
 
 interface FuelCalculatorWidgetProps {
   fuelData: FuelCalculation | null;
@@ -137,8 +137,7 @@ export const FuelCalculatorPitScenarios: React.FC<
       ? `${widgetStyle.fontSize}px`
       : '12px';
 
-  const sessionNum = useTelemetryValue('SessionNum');
-  const sessionType = useSessionType(sessionNum);
+  const sessionType = useFuelProjectionSnapshot()?.sessionType;
   const isTesting = sessionType === 'Offline Testing';
 
   // Determine visibility based on settings (default true if missing)

--- a/src/frontend/components/FuelCalculator/widgets/FuelCalculatorTargetMessage.tsx
+++ b/src/frontend/components/FuelCalculator/widgets/FuelCalculatorTargetMessage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { formatFuel } from '../fuelCalculations';
 import type { FuelCalculation, FuelCalculatorSettings } from '../types';
-import { useTelemetryValue, useSessionType } from '@irdashies/context';
+import { useFuelProjectionSnapshot } from '@irdashies/context';
 
 interface FuelCalculatorWidgetProps {
   fuelData: FuelCalculation | null;
@@ -29,8 +29,7 @@ export const FuelCalculatorTargetMessage: React.FC<
   customStyles,
   compactMode,
 }) => {
-  const sessionNum = useTelemetryValue('SessionNum');
-  const sessionType = useSessionType(sessionNum);
+  const sessionType = useFuelProjectionSnapshot()?.sessionType;
   const isTesting =
     sessionType === 'Offline Testing' || sessionType === 'Practice';
 

--- a/src/frontend/context/ChannelStore/index.ts
+++ b/src/frontend/context/ChannelStore/index.ts
@@ -1,2 +1,3 @@
 export * from './ChannelSnapshotStore';
 export * from './useChannelSnapshot';
+export * from './useFuelProjectionSnapshot';

--- a/src/frontend/context/ChannelStore/useFuelProjectionSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useFuelProjectionSnapshot.ts
@@ -1,0 +1,5 @@
+import type { ChannelBridge } from '@irdashies/types';
+import { useChannelSnapshot } from './useChannelSnapshot';
+
+export const useFuelProjectionSnapshot = (bridge?: ChannelBridge) =>
+  useChannelSnapshot('fuel.projection', undefined, bridge);

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,7 @@ app.on('ready', async () => {
   setupChromiumFlagsBridge();
 
   // Start component server for browser components
-  await startComponentServer(bridge, dashboardBridge);
+  await startComponentServer(bridge, dashboardBridge, channelBus);
 
   ipcMain.handle('getComponentServerPort', () => getComponentServerPort());
 

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -23,10 +23,24 @@ export interface FuelProjectionEngineSnapshot {
 
 export interface FuelProjectionSnapshot {
   fuelLevel: number;
+  fuelLevelPct: number;
   currentLap: number;
+  lapDistPct: number;
   currentLapUsage: number;
   projectedLapUsage: number;
   lastLapUsage: number;
+  sessionLapsRemain: number;
+  sessionTimeRemain: number;
+  sessionTimeTotal: number;
+  sessionFlags: number;
+  sessionState: number;
+  sessionNum: number;
+  sessionLaps: number | string;
+  sessionType?: string;
+  isOnTrack: boolean;
+  trackId?: string | number;
+  carName?: string;
+  fuelTankCapacity?: number;
   completedLaps: readonly FuelLapData[];
   engine: FuelProjectionEngineSnapshot;
 }

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -38,6 +38,8 @@ export interface FuelProjectionSnapshot {
   sessionState: number;
   sessionNum: number;
   sessionLaps: number | string;
+  calculatedTotalRaceLaps: number;
+  isFixedLapRace: boolean;
   sessionType?: string;
   isOnTrack: boolean;
   trackId?: string | number;

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -22,6 +22,8 @@ export interface FuelProjectionEngineSnapshot {
 }
 
 export interface FuelProjectionSnapshot {
+  /** True for recorded tape sources; recorded laps must not touch live storage. */
+  isReplay: boolean;
   fuelLevel: number;
   fuelLevelPct: number;
   currentLap: number;


### PR DESCRIPTION
## Description

Implements Phase 3 PR 5 from `docs/PHASE_3_CHANNEL_BRIDGE_PLAN.md` by migrating the Fuel Calculator renderer to the typed `fuel.projection` channel.

- expands the processor snapshot with the minimum live and session inputs needed by Fuel's settings-dependent display calculations
- adds `useFuelProjectionSnapshot()` and removes raw telemetry/session-store subscription hooks from the Fuel widget folder
- keeps lap-history and qualifying persistence at the renderer boundary while the processor owns live lap aggregation
- adds a reusable Storybook channel snapshot decorator and updates Fuel stories
- extends the browser WebSocket protocol with rate-aware, reference-counted channel subscriptions
- allows chronological curated tape playback to aggregate Fuel state while retaining the replay-scrub aggregation guard
- retains the legacy telemetry bridge for unmigrated widgets

Validation:

- `npm run lint -- --no-fix`
- `npm run test -- --no-coverage` — 1,149 passed, 1 skipped
- `npm run test:replay:curated` — 36,000 frames and 70 session revisions validated in 2.90s
- `npm run build-storybook`
- `npm run irsdk:replay:app:curated` — app build and launch smoke; visual Fuel verification remains pending

## Screenshots

### Before
No visual change intended; Fuel derived its live state directly from renderer telemetry and session stores.

### After
No visual change intended; Fuel renders from the typed `fuel.projection` snapshot in Electron and browser dashboards.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer fuel projection data, including fuel percentage, lap progress, session timing, track, car, and fuel capacity details.
  * Fuel Calculator views now use unified projection data for more consistent calculations, visibility, pit scenarios, and target guidance.
  * Added real-time channel communication for component displays with improved subscription handling.
  * Added accurate fuel projections during telemetry replay, including race-lap estimates.
* **Bug Fixes**
  * Preserved track and pit status values in projection snapshots.
  * Improved completed-lap history handling, duplicate prevention, and retry behavior for failed saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->