### PR TITLE
fix: allow the telemetry replay runner to start on Windows

### DIFF
--- a/tools/run-telemetry-replay.mjs
+++ b/tools/run-telemetry-replay.mjs
@@ -31,18 +31,25 @@ if (!input) {
     process.stderr.write('--input must be an .irdt telemetry tape\n');
     process.exitCode = 2;
   } else {
-    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-    const child = spawn(npmCommand, ['start'], {
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        IRDASHIES_TELEMETRY_REPLAY: path.resolve(input),
-        IRDASHIES_TELEMETRY_REPLAY_SPEED: speedText,
-        IRDASHIES_TELEMETRY_REPLAY_LOOP: arguments_.includes('--loop')
-          ? '1'
-          : '0',
-      },
-    });
+    const env = {
+      ...process.env,
+      IRDASHIES_TELEMETRY_REPLAY: path.resolve(input),
+      IRDASHIES_TELEMETRY_REPLAY_SPEED: speedText,
+      IRDASHIES_TELEMETRY_REPLAY_LOOP: arguments_.includes('--loop')
+        ? '1'
+        : '0',
+    };
+    // Node refuses to spawn .cmd/.bat without a shell (the CVE-2024-27980
+    // mitigation, Node >= 18.20 / 20.12), so Windows needs one or the spawn
+    // throws EINVAL. The command goes in as a single string rather than a
+    // command plus argument vector because Node 24 emits DEP0190 whenever a
+    // non-empty args array meets shell: true. Nothing user-supplied reaches
+    // the command line either way — the tape path and speed travel through
+    // env, so the shell has nothing extra to re-parse.
+    const child =
+      process.platform === 'win32'
+        ? spawn('npm.cmd start', { shell: true, stdio: 'inherit', env })
+        : spawn('npm', ['start'], { stdio: 'inherit', env });
     child.on('error', (error) => {
       process.stderr.write(`Could not start irDashies: ${error.message}\n`);
       process.exitCode = 1;


### PR DESCRIPTION
## Description

`npm run irsdk:replay:app` fails immediately on Windows with `Error: spawn EINVAL`. The replay workflow exists so the app can be exercised without a live iRacing session, so it failing on Windows means it is unusable on the only platform iRacing runs on.

Node has refused to spawn `.cmd` and `.bat` files without a shell since 18.20 / 20.12 (the CVE-2024-27980 mitigation), and the runner spawns `npm.cmd`. The spawn throws *synchronously*, before the `child.on('error')` handler can turn it into a readable message, so the failure surfaces as a raw stack trace rather than the intended "Could not start irDashies".

This requests a shell on Windows and passes the command as a single string rather than a command plus argument vector:

```js
const child =
  process.platform === 'win32'
    ? spawn('npm.cmd start', { shell: true, stdio: 'inherit', env })
    : spawn('npm', ['start'], { stdio: 'inherit', env });
```

The string form matters on this project's supported runtime. Node 24 emits `DEP0190` whenever a non-empty argument vector meets `shell: true`:

```
[DEP0190] DeprecationWarning: Passing args to a child process with shell option
true can lead to security vulnerabilities, as the arguments are not escaped,
only concatenated.
```

The warning is unconditional — it never inspects the arguments, so even a correct-by-construction call prints it on every launch. Since `engines` is `>=24`, `.nvmrc` is `24`, and all CI workflows pin Node 24, the naive `shell: true` form would warn on every Windows launch on the supported configuration. Passing the command as a string avoids it. POSIX keeps the plain argument vector and no shell at all.

Nothing user-supplied reaches a command line either way: the command is the constant `npm.cmd start`, and the tape path and speed travel through the environment, so the shell has nothing extra to re-parse.

### Scope

On POSIX this is a no-op. The spawn triple is unchanged from `main` — command `npm`, args `['start']`, option keys `env` and `stdio`, with no `shell` key on either side. Only the Windows branch changes behaviour.

Confirmed rather than assumed: on macOS with Node 24.19.0, a stub over `node:child_process` captured the `(command, args, options)` triple on `main` and on this commit, and the two captures are byte-identical.

### How this was tested

Windows 11, Node 24.19.0, npm 11.17.0.

- **Against a stubbed `npm.cmd` on `PATH`:** the child receives argv exactly `['start']` with `IRDASHIES_TELEMETRY_REPLAY`, `_SPEED` and `_LOOP` intact, and no deprecation warning is emitted.
- **Injection check:** a tape path containing spaces, `&`, and an embedded quote arrives at the child byte-for-byte unmodified — `cmd.exe` never re-parses it, because it travels in the environment rather than on the command line.
- **Validation paths:** missing `--input`, a non-`.irdt` extension, and an out-of-range `--speed` all still exit 2 without spawning.
- **End to end:** `npm run irsdk:replay:app:curated` launches the app and reaches `[iracingSdkBridge] telemetry replay is running`.
- `npm run lint`, `npm test`, and `npm run build-storybook` all pass locally.

Also exercised on macOS 26.6 (arm64) with Node 24.19.0: the app launches, the three validation paths exit 2, and no deprecation is emitted even under `--throw-deprecation`.

Not tested against a live iRacing session — this path does not touch the SDK, and the replay runner exists specifically to avoid needing one.

## Screenshots

No visual change; this is a CLI launcher fix. Terminal behaviour before and after:

### Before

```
node:internal/child_process:458
    throw new ErrnoException(err, 'spawn');
          ^

Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:458:11)
    at spawn (node:child_process:813:9)
    at file:///.../tools/run-telemetry-replay.mjs:36:7 {
  errno: -4071,
  code: 'EINVAL',
  syscall: 'spawn'
}

Node.js v24.19.0
```

### After

```
> irdashies@0.9.0 irsdk:replay:app:curated
> node tools/run-telemetry-replay.mjs --input test-data/telemetry/ai-race-10min.irdt --loop

> irdashies@0.9.0 start
> electron-forge start --enable-logging

> [iracingSdkBridge] Loading iRacing SDK bridge...
> [iracingSdkBridge] telemetry replay is running
> [sessionLifecycle] Driver joined: carIdx=0
  ... (40 drivers loaded from the tape)
> [sessionLifecycle] Driver joined: carIdx=39
> [OverlayManager] Creating window for display ... (PRIMARY)
```

No `DEP0190` and no `EINVAL` appear anywhere in the launch output.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemetry replay startup reliability on Windows.
  * Preserved replay configuration when launching the telemetry process across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->