### PR TITLE
fix: keep the settings window reachable when displays change

### DIFF
--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -10,7 +10,10 @@ import { Notification } from 'electron';
 import { readData, writeData } from './storage/storage';
 import { getDashboard } from './storage/dashboards';
 import { getChromiumFlags, parseCustomSwitches } from './storage/chromiumFlags';
-import { trackSettingsWindowMovement } from './trackWindowMovement';
+import {
+  markCorrectedBounds,
+  trackSettingsWindowMovement,
+} from './trackWindowMovement';
 import { sanitizeWindowBounds } from './windowBounds';
 import logger from './logger';
 import { createRendererPerfArguments } from './perfRendererArguments';
@@ -890,7 +893,13 @@ export class OverlayManager {
     // Reveal the window once its content is ready, unless it should start
     // minimized to the system tray (the "Start minimized" general setting).
     browserWindow.once('ready-to-show', () => {
-      if (browserWindow.isDestroyed() || startHidden) return;
+      if (browserWindow.isDestroyed()) return;
+
+      // Runs before the startHidden check: a window that starts in the tray is
+      // shown later, and would otherwise be revealed somewhere unreachable.
+      ensureWindowOnScreen(browserWindow);
+
+      if (startHidden) return;
       browserWindow.show();
       browserWindow.focus();
     });
@@ -934,6 +943,41 @@ export class OverlayManager {
 
     return browserWindow;
   }
+}
+
+/**
+ * Correct a window that has ended up where no display covers it.
+ *
+ * Validating the saved bounds on the way in only guards the restore path. This
+ * checks where the window actually landed, so it also catches a window placed
+ * off-screen by something other than a stale saved position — Electron's own
+ * default placement, or a display set that was not fully enumerated when the
+ * window was created. #539 was reported on a freshly installed Windows with no
+ * saved bounds at all, which the restore-path check cannot explain, so the
+ * guard is deliberately cause-agnostic: it asks only whether the window can be
+ * reached, never why it could not be.
+ */
+function ensureWindowOnScreen(browserWindow: BrowserWindow): void {
+  const actual = browserWindow.getBounds();
+  const corrected = sanitizeWindowBounds(
+    actual,
+    screen.getAllDisplays().map((display) => display.workArea),
+    screen.getPrimaryDisplay().workArea
+  );
+
+  if (!corrected) return;
+  if (corrected.x === actual.x && corrected.y === actual.y) return;
+
+  logger.warn(
+    `[OverlayManager] Settings window opened off-screen at x=${actual.x}, ` +
+      `y=${actual.y}; moved to x=${corrected.x}, y=${corrected.y}`
+  );
+
+  // Flagged before the move so the saved position survives it. Rescuing a
+  // window must not overwrite where the user put it, or reconnecting the
+  // monitor would no longer bring it back.
+  markCorrectedBounds(browserWindow, corrected);
+  browserWindow.setBounds(corrected);
 }
 
 function loadWindowBounds(): Electron.Rectangle | undefined {

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -11,6 +11,7 @@ import { readData, writeData } from './storage/storage';
 import { getDashboard } from './storage/dashboards';
 import { getChromiumFlags, parseCustomSwitches } from './storage/chromiumFlags';
 import { trackSettingsWindowMovement } from './trackWindowMovement';
+import { sanitizeWindowBounds } from './windowBounds';
 import logger from './logger';
 import { createRendererPerfArguments } from './perfRendererArguments';
 
@@ -936,5 +937,25 @@ export class OverlayManager {
 }
 
 function loadWindowBounds(): Electron.Rectangle | undefined {
-  return readData<Electron.Rectangle>('settingsWindowBounds');
+  const saved = readData<Electron.Rectangle>('settingsWindowBounds');
+  if (!saved) return undefined;
+
+  // Saved bounds outlive the display arrangement that produced them, so they
+  // are validated against the displays connected right now — otherwise a
+  // window saved on a monitor that has since been unplugged or rearranged is
+  // restored somewhere unreachable.
+  const bounds = sanitizeWindowBounds(
+    saved,
+    screen.getAllDisplays().map((display) => display.workArea),
+    screen.getPrimaryDisplay().workArea
+  );
+
+  if (bounds && (bounds.x !== saved.x || bounds.y !== saved.y)) {
+    logger.info(
+      `[OverlayManager] Saved settings window bounds were off-screen ` +
+        `(x=${saved.x}, y=${saved.y}); moved to x=${bounds.x}, y=${bounds.y}`
+    );
+  }
+
+  return bounds;
 }

--- a/src/app/trackWindowMovement.spec.ts
+++ b/src/app/trackWindowMovement.spec.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserWindow } from 'electron';
+import {
+  markCorrectedBounds,
+  trackSettingsWindowMovement,
+} from './trackWindowMovement';
+import { writeData } from './storage/storage';
+
+vi.mock('./storage/storage', () => ({ writeData: vi.fn() }));
+
+const DEBOUNCE_MS = 200;
+
+/**
+ * Minimal stand-in for the parts of BrowserWindow this module uses: it records
+ * the handlers registered for 'moved' and 'resized' so a test can raise them,
+ * and returns whatever bounds the test last set.
+ */
+function fakeWindow(initial: Electron.Rectangle) {
+  const handlers: Record<string, (() => void)[]> = {};
+  let bounds = initial;
+
+  const win = {
+    on: (event: string, handler: () => void) => {
+      (handlers[event] ??= []).push(handler);
+      return win;
+    },
+    getBounds: () => bounds,
+  };
+
+  return {
+    win: win as unknown as BrowserWindow,
+    setBounds: (next: Electron.Rectangle) => {
+      bounds = next;
+    },
+    emit: (event: string) => (handlers[event] ?? []).forEach((h) => h()),
+  };
+}
+
+const ON_SCREEN = { x: 100, y: 100, width: 800, height: 700 };
+const OFF_SCREEN = { x: -20000, y: 250, width: 800, height: 700 };
+const RESCUED = { x: 622, y: 200, width: 800, height: 700 };
+
+describe('trackSettingsWindowMovement', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.mocked(writeData).mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('saves bounds after the user moves the window', () => {
+    const { win, setBounds, emit } = fakeWindow(ON_SCREEN);
+    trackSettingsWindowMovement(win);
+
+    setBounds({ ...ON_SCREEN, x: 300 });
+    emit('moved');
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(writeData).toHaveBeenCalledWith('settingsWindowBounds', {
+      ...ON_SCREEN,
+      x: 300,
+    });
+  });
+
+  it('saves bounds after the user resizes the window', () => {
+    const { win, setBounds, emit } = fakeWindow(ON_SCREEN);
+    trackSettingsWindowMovement(win);
+
+    setBounds({ ...ON_SCREEN, width: 900 });
+    emit('resized');
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(writeData).toHaveBeenCalledOnce();
+  });
+
+  it('debounces a burst of events into one save', () => {
+    const { win, setBounds, emit } = fakeWindow(ON_SCREEN);
+    trackSettingsWindowMovement(win);
+
+    setBounds({ ...ON_SCREEN, x: 200 });
+    emit('moved');
+    emit('moved');
+    emit('moved');
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(writeData).toHaveBeenCalledOnce();
+  });
+
+  it('does not persist a position the app corrected to', () => {
+    // The window was saved off-screen, so startup rescues it. That rescue must
+    // not overwrite the saved position, or reconnecting the monitor would no
+    // longer bring the window back to where the user had put it.
+    const { win, setBounds, emit } = fakeWindow(OFF_SCREEN);
+    trackSettingsWindowMovement(win);
+
+    markCorrectedBounds(win, RESCUED);
+    setBounds(RESCUED);
+    // Raised explicitly. Electron does not currently emit these for a
+    // programmatic setBounds, so the saved position survives today by accident;
+    // this asserts it survives even if that changes.
+    emit('moved');
+    emit('resized');
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(writeData).not.toHaveBeenCalled();
+  });
+
+  it('resumes saving once the user moves the window themselves', () => {
+    const { win, setBounds, emit } = fakeWindow(OFF_SCREEN);
+    trackSettingsWindowMovement(win);
+
+    markCorrectedBounds(win, RESCUED);
+    setBounds(RESCUED);
+    emit('moved');
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+    expect(writeData).not.toHaveBeenCalled();
+
+    // The user drags it somewhere of their own choosing.
+    const chosen = { ...RESCUED, x: 900, y: 400 };
+    setBounds(chosen);
+    emit('moved');
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(writeData).toHaveBeenCalledWith('settingsWindowBounds', chosen);
+  });
+
+  it('only suppresses the window that was corrected', () => {
+    const a = fakeWindow(ON_SCREEN);
+    const b = fakeWindow(ON_SCREEN);
+    trackSettingsWindowMovement(a.win);
+    trackSettingsWindowMovement(b.win);
+
+    markCorrectedBounds(a.win, RESCUED);
+    a.setBounds(RESCUED);
+    b.setBounds(RESCUED);
+
+    a.emit('moved');
+    b.emit('moved');
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(writeData).toHaveBeenCalledOnce();
+    expect(writeData).toHaveBeenCalledWith('settingsWindowBounds', RESCUED);
+  });
+});

--- a/src/app/trackWindowMovement.ts
+++ b/src/app/trackWindowMovement.ts
@@ -4,6 +4,38 @@ import { writeData } from './storage/storage';
 const DEBOUNCE_MS = 200;
 
 /**
+ * Bounds the app itself moved a window to, as opposed to the user dragging it.
+ *
+ * A window rescued from off-screen is repositioned with `setBounds`. If that
+ * were persisted it would overwrite the position the user actually chose, and
+ * reconnecting the monitor would no longer bring the window back — turning a
+ * temporary rescue into a permanent move.
+ *
+ * A programmatic `setBounds` does not currently raise `moved` or `resized`, so
+ * nothing is persisted anyway. That is Electron's present behaviour rather than
+ * a guarantee, and nothing else pins it. Recording the corrected rectangle and
+ * declining to save it makes the outcome deliberate instead of incidental.
+ *
+ * A WeakMap so a destroyed window takes its entry with it.
+ */
+const correctedBounds = new WeakMap<BrowserWindow, Electron.Rectangle>();
+
+const sameRect = (a: Electron.Rectangle, b: Electron.Rectangle): boolean =>
+  a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
+
+/**
+ * Record that this window was moved by the app rather than by the user, so the
+ * resulting position is not written back to disk. Call it alongside the
+ * `setBounds` that performs the correction.
+ */
+export const markCorrectedBounds = (
+  browserWindow: BrowserWindow,
+  bounds: Electron.Rectangle
+): void => {
+  correctedBounds.set(browserWindow, { ...bounds });
+};
+
+/**
  * Track settings window position and size changes
  */
 export const trackSettingsWindowMovement = (browserWindow: BrowserWindow) => {
@@ -22,5 +54,14 @@ export const trackSettingsWindowMovement = (browserWindow: BrowserWindow) => {
 
 function saveSettingsWindowBounds(browserWindow: BrowserWindow): void {
   const bounds = browserWindow.getBounds();
+
+  // Compared by value rather than suppressed with a flag and a timer: there is
+  // no assumption about when, or whether, the event arrives after setBounds.
+  // A user who drags the window to exactly the corrected position is not saved
+  // either, which costs nothing — that position is on-screen and the next
+  // launch would place the window there regardless.
+  const corrected = correctedBounds.get(browserWindow);
+  if (corrected && sameRect(bounds, corrected)) return;
+
   writeData('settingsWindowBounds', bounds);
 }

--- a/src/app/windowBounds.spec.ts
+++ b/src/app/windowBounds.spec.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MIN_VISIBLE_HEIGHT,
+  MIN_VISIBLE_WIDTH,
+  intersection,
+  isReachable,
+  sanitizeWindowBounds,
+  type Rect,
+} from './windowBounds';
+
+// Mirrors a real multi-monitor arrangement: a primary display at the origin
+// with monitors to its left, so off-screen coordinates are negative.
+const PRIMARY: Rect = { x: 0, y: 0, width: 2048, height: 1152 };
+const LEFT: Rect = { x: -2048, y: 0, width: 2048, height: 1152 };
+const FAR_LEFT: Rect = { x: -5488, y: 0, width: 3440, height: 1440 };
+const DISPLAYS = [FAR_LEFT, LEFT, PRIMARY];
+
+describe('intersection', () => {
+  it('returns the overlapping rectangle', () => {
+    expect(
+      intersection(
+        { x: 0, y: 0, width: 100, height: 100 },
+        { x: 50, y: 50, width: 100, height: 100 }
+      )
+    ).toEqual({ x: 50, y: 50, width: 50, height: 50 });
+  });
+
+  it('returns null for disjoint rectangles', () => {
+    expect(
+      intersection(
+        { x: 0, y: 0, width: 10, height: 10 },
+        { x: 100, y: 100, width: 10, height: 10 }
+      )
+    ).toBeNull();
+  });
+
+  it('returns null for rectangles that only share an edge', () => {
+    expect(
+      intersection(
+        { x: 0, y: 0, width: 10, height: 10 },
+        { x: 10, y: 0, width: 10, height: 10 }
+      )
+    ).toBeNull();
+  });
+});
+
+describe('isReachable', () => {
+  it('accepts a window fully inside a display', () => {
+    expect(
+      isReachable({ x: 100, y: 100, width: 800, height: 700 }, DISPLAYS)
+    ).toBe(true);
+  });
+
+  it('accepts a window on a negative-coordinate display', () => {
+    expect(
+      isReachable({ x: -1114, y: 250, width: 801, height: 702 }, DISPLAYS)
+    ).toBe(true);
+  });
+
+  it('accepts a window straddling two displays', () => {
+    expect(
+      isReachable({ x: -200, y: 100, width: 800, height: 700 }, DISPLAYS)
+    ).toBe(true);
+  });
+
+  it('rejects a window entirely off every display', () => {
+    expect(
+      isReachable({ x: -20000, y: 250, width: 801, height: 702 }, DISPLAYS)
+    ).toBe(false);
+  });
+
+  it('rejects a window overlapping by only a narrow vertical strip', () => {
+    // A 10px-wide sliver lands on the far-left display's LEFT edge — the only
+    // outer edge in this arrangement, since the three displays are contiguous
+    // and a window near an inner edge simply lands on the neighbour. Its area
+    // (10 x 702) clears any sane area threshold, which is why the check is on
+    // both dimensions rather than area.
+    const slivered: Rect = {
+      x: FAR_LEFT.x - 801 + 10,
+      y: 100,
+      width: 801,
+      height: 702,
+    };
+    const overlap = intersection(slivered, FAR_LEFT);
+
+    expect(overlap?.width).toBe(10);
+    expect(overlap?.width).toBeLessThan(MIN_VISIBLE_WIDTH);
+    expect((overlap as Rect).width * (overlap as Rect).height).toBeGreaterThan(
+      MIN_VISIBLE_WIDTH * MIN_VISIBLE_HEIGHT
+    );
+    expect(isReachable(slivered, DISPLAYS)).toBe(false);
+  });
+
+  it('rejects a window overlapping by only a short horizontal strip', () => {
+    const slivered: Rect = { x: 100, y: -702 + 10, width: 801, height: 702 };
+    expect(intersection(slivered, PRIMARY)?.height).toBe(10);
+    expect(isReachable(slivered, DISPLAYS)).toBe(false);
+  });
+
+  it('does not reject a window smaller than the minimum visible area', () => {
+    const tiny: Rect = { x: 10, y: 10, width: 40, height: 20 };
+    expect(tiny.width).toBeLessThan(MIN_VISIBLE_WIDTH);
+    expect(tiny.height).toBeLessThan(MIN_VISIBLE_HEIGHT);
+    expect(isReachable(tiny, DISPLAYS)).toBe(true);
+  });
+});
+
+describe('sanitizeWindowBounds', () => {
+  it('returns undefined when nothing was saved', () => {
+    expect(sanitizeWindowBounds(undefined, DISPLAYS, PRIMARY)).toBeUndefined();
+  });
+
+  it('passes through bounds that are still reachable', () => {
+    const saved: Rect = { x: -1114, y: 250, width: 801, height: 702 };
+    expect(sanitizeWindowBounds(saved, DISPLAYS, PRIMARY)).toEqual(saved);
+  });
+
+  it('recovers a window left off-screen by a display change', () => {
+    // The reported failure: bounds saved against a monitor that is no longer
+    // connected, restored where no display covers them.
+    const saved: Rect = { x: -1114, y: 250, width: 801, height: 702 };
+    const result = sanitizeWindowBounds(saved, [PRIMARY], PRIMARY);
+
+    expect(result).toBeDefined();
+    expect(isReachable(result as Rect, [PRIMARY])).toBe(true);
+    // Size is preserved; only the position moves.
+    expect(result).toMatchObject({ width: 801, height: 702 });
+  });
+
+  it('centres the recovered window on the primary display', () => {
+    const saved: Rect = { x: -20000, y: 250, width: 800, height: 700 };
+    expect(sanitizeWindowBounds(saved, DISPLAYS, PRIMARY)).toEqual({
+      x: (2048 - 800) / 2,
+      y: (1152 - 700) / 2,
+      width: 800,
+      height: 700,
+    });
+  });
+
+  it('shrinks a window larger than the primary display', () => {
+    const saved: Rect = { x: -20000, y: 0, width: 4000, height: 3000 };
+    expect(sanitizeWindowBounds(saved, DISPLAYS, PRIMARY)).toEqual({
+      x: 0,
+      y: 0,
+      width: PRIMARY.width,
+      height: PRIMARY.height,
+    });
+  });
+
+  it.each([
+    ['NaN x', { x: NaN, y: 0, width: 800, height: 700 }],
+    ['infinite y', { x: 0, y: Infinity, width: 800, height: 700 }],
+    ['zero width', { x: 0, y: 0, width: 0, height: 700 }],
+    ['negative height', { x: 0, y: 0, width: 800, height: -700 }],
+  ])('discards malformed bounds (%s)', (_label, saved) => {
+    expect(
+      sanitizeWindowBounds(saved as Rect, DISPLAYS, PRIMARY)
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when no displays are reported', () => {
+    const saved: Rect = { x: 0, y: 0, width: 800, height: 700 };
+    expect(sanitizeWindowBounds(saved, [], undefined)).toBeUndefined();
+  });
+});

--- a/src/app/windowBounds.ts
+++ b/src/app/windowBounds.ts
@@ -1,0 +1,106 @@
+/**
+ * Validation for window bounds restored from disk.
+ *
+ * Saved bounds outlive the display arrangement that produced them: a window
+ * moved onto a monitor at x=-1920 keeps those coordinates after that monitor
+ * is unplugged or rearranged, and is then restored somewhere no display
+ * covers — visible to the window manager but unreachable by the user.
+ *
+ * Deliberately free of Electron imports so it can be unit tested directly.
+ * Callers pass display rectangles in the same coordinate space as the saved
+ * bounds; Electron's `screen` API reports DIP for both, so pass `workArea`
+ * (which excludes the taskbar) rather than `bounds`.
+ */
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * A restored window must expose at least this much of itself on some display.
+ * Roughly a grabbable strip of title bar — enough to drag the window back into
+ * view, without rejecting a window the user deliberately parked mostly
+ * off-screen.
+ */
+export const MIN_VISIBLE_WIDTH = 120;
+export const MIN_VISIBLE_HEIGHT = 40;
+
+const isPositiveFinite = (n: number): boolean => Number.isFinite(n) && n > 0;
+
+const isValidRect = (rect: Rect): boolean =>
+  Number.isFinite(rect.x) &&
+  Number.isFinite(rect.y) &&
+  isPositiveFinite(rect.width) &&
+  isPositiveFinite(rect.height);
+
+/**
+ * The overlapping rectangle between two rectangles, or null when they do not
+ * intersect. Rectangles that merely share an edge do not intersect.
+ */
+export const intersection = (a: Rect, b: Rect): Rect | null => {
+  const x = Math.max(a.x, b.x);
+  const y = Math.max(a.y, b.y);
+  const width = Math.min(a.x + a.width, b.x + b.width) - x;
+  const height = Math.min(a.y + a.height, b.y + b.height) - y;
+  if (width <= 0 || height <= 0) return null;
+  return { x, y, width, height };
+};
+
+/**
+ * True when the rectangle overlaps some display by at least the minimum
+ * grabbable strip.
+ *
+ * Both dimensions are checked rather than the overlap area: a 10px-wide strip
+ * of a tall window clears any reasonable area threshold while being useless to
+ * grab. The requirement is capped by the window's own size so a window smaller
+ * than the minimum is not rejected outright.
+ */
+export const isReachable = (bounds: Rect, displays: Rect[]): boolean => {
+  const requiredWidth = Math.min(MIN_VISIBLE_WIDTH, bounds.width);
+  const requiredHeight = Math.min(MIN_VISIBLE_HEIGHT, bounds.height);
+  return displays.some((display) => {
+    const overlap = intersection(bounds, display);
+    return (
+      !!overlap &&
+      overlap.width >= requiredWidth &&
+      overlap.height >= requiredHeight
+    );
+  });
+};
+
+/**
+ * Move a rectangle wholly inside a target display, shrinking it first if it is
+ * larger than the target.
+ */
+const fitWithin = (bounds: Rect, target: Rect): Rect => {
+  const width = Math.min(bounds.width, target.width);
+  const height = Math.min(bounds.height, target.height);
+  return {
+    width,
+    height,
+    x: Math.round(target.x + (target.width - width) / 2),
+    y: Math.round(target.y + (target.height - height) / 2),
+  };
+};
+
+/**
+ * Validate bounds restored from disk against the displays connected right now.
+ *
+ * Returns the saved bounds unchanged when the window would still be reachable,
+ * a rectangle centred on the primary display when it would not, and
+ * `undefined` when there is nothing usable to restore — letting the caller fall
+ * back to its own defaults.
+ */
+export const sanitizeWindowBounds = (
+  saved: Rect | undefined,
+  displays: Rect[],
+  primary: Rect | undefined
+): Rect | undefined => {
+  if (!saved || !isValidRect(saved)) return undefined;
+  if (displays.length > 0 && isReachable(saved, displays)) return saved;
+  if (!primary || !isValidRect(primary)) return undefined;
+  return fitWithin(saved, primary);
+};


### PR DESCRIPTION
## Description

The settings window position is saved whenever you move it and restored verbatim on the next launch, with no check that the coordinates still land on a connected display. Move the window onto a second monitor, then unplug or rearrange that monitor, and the window is restored where nothing covers it — visible to the window manager, but unreachable, with no way back short of hand-editing `config.json`.

Reproduced on Windows 11 without editing any config: with settings-window bounds of `x=-1114` that the app's own move tracking had written during normal use, disabling the secondary monitors left the window at `x=-1114` — entirely off the only remaining display, reported visible, and unreachable.

The fix has two halves:

**Validate what is restored.** `sanitizeWindowBounds` checks saved bounds against the displays present at startup. Bounds that would still be reachable pass through untouched; bounds that would not are re-centred on the primary display's work area, preserving the saved size where it fits; malformed values are discarded so the existing defaults apply. The saved value itself is left alone, so reconnecting the monitor returns the window to where the user had put it.

**Check where the window actually landed.** Validating the restore path only guards one route. On `ready-to-show` the window's real bounds are tested against the connected displays, and anything unreachable is moved onto the primary. That also covers Electron's own default placement and a display set not fully enumerated at creation — without needing to know which occurred. It runs before the `startMinimized` early return, since a window that starts in the tray is revealed later.

Reachability is measured on both dimensions of the overlap rather than its area: a 10px-wide strip of a 700px-tall window clears any sane area threshold while being useless to grab.

### Relationship to #539

This does **not** demonstrably fix #539, and is marked `Refs` rather than `Fixes` deliberately. The reporter has since confirmed their case occurred on a freshly installed Windows — where there are no saved bounds to validate — and they can no longer reproduce it. So the restore-path bug cannot be what they hit. The second half of this change defends against the symptom regardless of cause, which should cover them, but that is unproven and shouldn't be claimed as a fix. Worth leaving the issue open for someone who can reproduce it.

### Note on the Discord checklist item

Raised on Discord, but no one has replied yet, so it has been mentioned rather than genuinely discussed. Flagging that explicitly rather than letting the ticked box imply more than happened. Happy to hold this PR if there is appetite to talk it through first.

### Scope deliberately left alone

`trackWindowMovement.ts` still saves off-screen bounds without complaint. Validating on load is the correct layer — displays change between sessions, so save-time validation cannot help — but noting it so it does not read as an oversight.

### How this was tested

Windows 11, four displays spanning `x=-5488..4096`, including monitors at negative coordinates.

- **Real reproduction:** genuine saved bounds plus a real monitor removal → window unreachable on unpatched code, recovered at `x=1320` with the fix. Positions read via `GetWindowRect` rather than app logs.
- **The post-creation guard:** with the restore-path check temporarily bypassed so the window really was created at `x=-20000`, it fired and moved the window to `x=622`.
- **No false positives:** ordinary launch with a window legitimately on a negative-coordinate monitor — the guard stays silent and the window is untouched.
- 20 unit tests covering negative-coordinate arrangements, windows straddling two displays, slivered overlaps in both axes, windows larger than the target display, and malformed input.
- `npm run lint`, `npm test` and `npm run build-storybook` all pass locally.

`src/app/overlayManager.ts` has no spec file, so the validation lives in `windowBounds.ts` with no Electron imports and is unit tested directly. It is the first test coverage in that area.

## Screenshots

No visual change; this is a window placement fix. Terminal behaviour:

### Before

```
irDashies    Visible=True    X=-1114   Y=250   801x702     <- off every display
```

### After

```
[OverlayManager] Saved settings window bounds were off-screen (x=-1114, y=250); moved to x=1320, y=345

irDashies    Visible=True    X=1320    Y=345   801x702     <- centred and reachable
```

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

Refs #539


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved settings window placement across single- and multi-monitor setups.
  - Automatically restores windows that are off-screen, partially visible, oversized, or positioned on unavailable displays.
  - Preserves valid window positions while safely recovering malformed or unreachable saved settings.
  - Prevents automatic repositioning from overwriting the user’s saved window location.
  - Improved handling of displays with negative coordinates and other complex multi-monitor arrangements.
  - Corrected window movements are no longer unnecessarily saved as new user preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->