### PR TITLE
perf: condition legacy telemetry by widget

### DIFF
--- a/docs/PHASE_3_CHANNEL_BRIDGE_PLAN.md
+++ b/docs/PHASE_3_CHANNEL_BRIDGE_PLAN.md
@@ -218,6 +218,26 @@ Turn the completed Fuel migration into measurable renderer and IPC savings.
   - Renderer frames over 50 ms below 0.1%.
   - Steady-state app memory slope below 5 MB/min.
 
+#### Widget runtime metadata and rate guidance
+
+Runtime transport metadata is discovered from
+`src/frontend/components/*/widgetRuntimeDefinition.ts`. A migrated widget must
+explicitly set `legacyTelemetry: false` and list every typed channel it needs.
+Widgets without runtime metadata remain legacy consumers so incremental
+migrations fail safe.
+
+Choose the lowest named preset that preserves the widget's observable behavior:
+
+- `driverFocused` — 25 Hz for positional or rapidly changing driver data.
+- `gapTiming` — 5 Hz for projections, gaps, and sortable timing data.
+- `informational` — 1 Hz for weather and slowly changing labels.
+- `static` — event/snapshot delivery with no polling-rate request.
+
+Use `channelRates` on the widget runtime definition when one channel needs a
+different rate from the preset. Multiple consumers in one renderer are still
+coalesced at the highest requested rate. Full-rate input and precision-sensitive
+calculation paths must not be moved to a lower preset.
+
 ## 4. Validation Strategy
 
 ### Every PR

--- a/src/app/bridge/channelRendererBridge.ts
+++ b/src/app/bridge/channelRendererBridge.ts
@@ -10,6 +10,10 @@ import {
   CHANNEL_SUBSCRIBE,
   CHANNEL_UNSUBSCRIBE,
 } from './channelBridge';
+import {
+  isRendererPerfMetricsEnabled,
+  recordChannelCallback,
+} from '../rendererPerfMetrics';
 
 interface LocalConsumer {
   callback: (payload: never) => void;
@@ -31,7 +35,13 @@ export const createChannelRendererBridge = (): ChannelBridge => {
       const subscription = subscriptions.get(channel);
       if (!subscription) return;
       for (const consumer of subscription.consumers) {
+        if (!isRendererPerfMetricsEnabled()) {
+          consumer.callback(payload as never);
+          continue;
+        }
+        const start = performance.now();
         consumer.callback(payload as never);
+        recordChannelCallback(performance.now() - start);
       }
     }
   );

--- a/src/app/bridge/defineBridge.spec.ts
+++ b/src/app/bridge/defineBridge.spec.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handlers = vi.hoisted(
+  () => new Map<string, (event: unknown, key: unknown) => void>()
+);
+const removeHandler = vi.hoisted(() => vi.fn());
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: vi.fn() },
+  ipcRenderer: { invoke: vi.fn() },
+  ipcMain: {
+    handle: (
+      channel: string,
+      handler: (event: unknown, key: unknown) => void
+    ) => handlers.set(channel, handler),
+    removeHandler,
+  },
+}));
+
+import { defineRendererSubscriptionBridge } from './defineBridge';
+
+class FakeSender extends EventEmitter {
+  constructor(readonly id: number) {
+    super();
+  }
+}
+
+describe('defineRendererSubscriptionBridge', () => {
+  beforeEach(() => {
+    handlers.clear();
+    removeHandler.mockClear();
+  });
+
+  const setup = () =>
+    defineRendererSubscriptionBridge<'telemetry' | 'sessionData'>({
+      name: 'legacy-test',
+      isValidKey: (value): value is 'telemetry' | 'sessionData' =>
+        value === 'telemetry' || value === 'sessionData',
+    });
+
+  it('validates keys and tracks subscriptions by sender identity', () => {
+    const bridge = setup();
+    const sender = new FakeSender(7);
+    const subscribe = handlers.get('legacy-test:subscribe');
+
+    expect(() => subscribe?.({ sender }, 'invalid')).toThrow(
+      'Invalid legacy-test subscription'
+    );
+    subscribe?.({ sender }, 'telemetry');
+
+    expect(bridge.registry.has(7, 'telemetry')).toBe(true);
+    expect(bridge.registry.hasAny('telemetry')).toBe(true);
+  });
+
+  it.each(['did-start-loading', 'destroyed'])(
+    'cleans renderer state on %s',
+    (eventName) => {
+      const bridge = setup();
+      const sender = new FakeSender(9);
+      handlers.get('legacy-test:subscribe')?.({ sender }, 'sessionData');
+
+      sender.emit(eventName);
+
+      expect(bridge.registry.hasAny('sessionData')).toBe(false);
+    }
+  );
+
+  it('unregisters handlers and clears state when disposed', () => {
+    const bridge = setup();
+    const sender = new FakeSender(11);
+    handlers.get('legacy-test:subscribe')?.({ sender }, 'telemetry');
+
+    bridge.dispose();
+
+    expect(removeHandler).toHaveBeenCalledWith('legacy-test:subscribe');
+    expect(removeHandler).toHaveBeenCalledWith('legacy-test:unsubscribe');
+    expect(bridge.registry.hasAny('telemetry')).toBe(false);
+  });
+});

--- a/src/app/bridge/defineBridge.ts
+++ b/src/app/bridge/defineBridge.ts
@@ -1,7 +1,106 @@
-import { contextBridge } from 'electron';
+import { contextBridge, ipcMain, ipcRenderer } from 'electron';
 
 /** Exposes a typed preload API through Electron's isolated world boundary. */
 export const defineBridge = <I>(name: string, implementation: I): I => {
   contextBridge.exposeInMainWorld(name, implementation);
   return implementation;
+};
+
+export class RendererSubscriptionRegistry<K extends string> {
+  private readonly subscriptions = new Map<number, Set<K>>();
+
+  subscribe(rendererId: number, key: K): void {
+    let keys = this.subscriptions.get(rendererId);
+    if (!keys) {
+      keys = new Set();
+      this.subscriptions.set(rendererId, keys);
+    }
+    keys.add(key);
+  }
+
+  unsubscribe(rendererId: number, key: K): void {
+    const keys = this.subscriptions.get(rendererId);
+    keys?.delete(key);
+    if (keys?.size === 0) this.subscriptions.delete(rendererId);
+  }
+
+  removeRenderer(rendererId: number): void {
+    this.subscriptions.delete(rendererId);
+  }
+
+  has(rendererId: number, key: K): boolean {
+    return this.subscriptions.get(rendererId)?.has(key) ?? false;
+  }
+
+  hasAny(key: K): boolean {
+    for (const keys of this.subscriptions.values()) {
+      if (keys.has(key)) return true;
+    }
+    return false;
+  }
+
+  clear(): void {
+    this.subscriptions.clear();
+  }
+}
+
+const subscriptionChannels = (name: string) => ({
+  subscribe: `${name}:subscribe`,
+  unsubscribe: `${name}:unsubscribe`,
+});
+
+export const createSubscriptionBridgeClient = <K extends string>(
+  name: string
+) => {
+  const channels = subscriptionChannels(name);
+  return {
+    subscribe: (key: K) => ipcRenderer.invoke(channels.subscribe, key),
+    unsubscribe: (key: K) => ipcRenderer.invoke(channels.unsubscribe, key),
+  };
+};
+
+export const defineRendererSubscriptionBridge = <K extends string>(options: {
+  name: string;
+  isValidKey: (value: unknown) => value is K;
+}) => {
+  const channels = subscriptionChannels(options.name);
+  const registry = new RendererSubscriptionRegistry<K>();
+  const rendererCleanup = new Map<number, () => void>();
+
+  ipcMain.handle(channels.subscribe, (event, key: unknown) => {
+    if (!options.isValidKey(key)) {
+      throw new Error(`Invalid ${options.name} subscription`);
+    }
+    const rendererId = event.sender.id;
+    if (!rendererCleanup.has(rendererId)) {
+      const cleanup = () => {
+        event.sender.removeListener('destroyed', cleanup);
+        event.sender.removeListener('did-start-loading', cleanup);
+        rendererCleanup.delete(rendererId);
+        registry.removeRenderer(rendererId);
+      };
+      rendererCleanup.set(rendererId, cleanup);
+      event.sender.once('destroyed', cleanup);
+      event.sender.once('did-start-loading', cleanup);
+    }
+    registry.subscribe(rendererId, key);
+  });
+
+  ipcMain.handle(channels.unsubscribe, (event, key: unknown) => {
+    if (!options.isValidKey(key)) {
+      throw new Error(`Invalid ${options.name} unsubscribe`);
+    }
+    registry.unsubscribe(event.sender.id, key);
+  });
+
+  return {
+    registry,
+    dispose: () => {
+      ipcMain.removeHandler(channels.subscribe);
+      ipcMain.removeHandler(channels.unsubscribe);
+      for (const cleanup of rendererCleanup.values()) cleanup();
+      rendererCleanup.clear();
+      registry.clear();
+    },
+  };
 };

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -247,7 +247,10 @@ export async function publishIRacingSDKEvents(
           lifecycle?._onTelemetry(telemetry);
           perfMetrics.markEnd('lifecycleTelemetry');
           fuelProjectionRuntime?.onFrame(telemetry);
-          if (perfTelemetryDeliveryEnabled) {
+          if (
+            perfTelemetryDeliveryEnabled &&
+            overlayManager.hasLegacyStreamSubscribers('telemetry')
+          ) {
             perfMetrics.markStart('telemetryProjection');
             const rendererTelemetry = telemetryForRenderer(telemetry);
             perfMetrics.markEnd('telemetryProjection');

--- a/src/app/bridge/legacyRendererSubscriptions.ts
+++ b/src/app/bridge/legacyRendererSubscriptions.ts
@@ -1,29 +1,16 @@
-import { ipcMain } from 'electron';
-import type { OverlayManager } from '../overlayManager';
+import { defineRendererSubscriptionBridge } from './defineBridge';
 
-export const LEGACY_STREAM_SUBSCRIBE = 'legacy-stream:subscribe';
-export const LEGACY_STREAM_UNSUBSCRIBE = 'legacy-stream:unsubscribe';
+export const LEGACY_STREAM_BRIDGE = 'legacy-stream';
 
 export type LegacyRendererStream = 'telemetry' | 'sessionData';
 
-const isLegacyRendererStream = (
+export const isLegacyRendererStream = (
   value: unknown
 ): value is LegacyRendererStream =>
   value === 'telemetry' || value === 'sessionData';
 
-export const setupLegacyRendererSubscriptions = (
-  overlayManager: OverlayManager
-): void => {
-  ipcMain.handle(LEGACY_STREAM_SUBSCRIBE, (event, stream: unknown) => {
-    if (!isLegacyRendererStream(stream)) {
-      throw new Error('Invalid legacy renderer stream');
-    }
-    overlayManager.subscribeLegacyStream(event.sender.id, stream);
+export const setupLegacyRendererSubscriptions = () =>
+  defineRendererSubscriptionBridge<LegacyRendererStream>({
+    name: LEGACY_STREAM_BRIDGE,
+    isValidKey: isLegacyRendererStream,
   });
-  ipcMain.handle(LEGACY_STREAM_UNSUBSCRIBE, (event, stream: unknown) => {
-    if (!isLegacyRendererStream(stream)) {
-      throw new Error('Invalid legacy renderer stream');
-    }
-    overlayManager.unsubscribeLegacyStream(event.sender.id, stream);
-  });
-};

--- a/src/app/bridge/legacyRendererSubscriptions.ts
+++ b/src/app/bridge/legacyRendererSubscriptions.ts
@@ -1,0 +1,29 @@
+import { ipcMain } from 'electron';
+import type { OverlayManager } from '../overlayManager';
+
+export const LEGACY_STREAM_SUBSCRIBE = 'legacy-stream:subscribe';
+export const LEGACY_STREAM_UNSUBSCRIBE = 'legacy-stream:unsubscribe';
+
+export type LegacyRendererStream = 'telemetry' | 'sessionData';
+
+const isLegacyRendererStream = (
+  value: unknown
+): value is LegacyRendererStream =>
+  value === 'telemetry' || value === 'sessionData';
+
+export const setupLegacyRendererSubscriptions = (
+  overlayManager: OverlayManager
+): void => {
+  ipcMain.handle(LEGACY_STREAM_SUBSCRIBE, (event, stream: unknown) => {
+    if (!isLegacyRendererStream(stream)) {
+      throw new Error('Invalid legacy renderer stream');
+    }
+    overlayManager.subscribeLegacyStream(event.sender.id, stream);
+  });
+  ipcMain.handle(LEGACY_STREAM_UNSUBSCRIBE, (event, stream: unknown) => {
+    if (!isLegacyRendererStream(stream)) {
+      throw new Error('Invalid legacy renderer stream');
+    }
+    overlayManager.unsubscribeLegacyStream(event.sender.id, stream);
+  });
+};

--- a/src/app/bridge/rendererExposeBridge.ts
+++ b/src/app/bridge/rendererExposeBridge.ts
@@ -24,28 +24,30 @@ import {
   recordTelemetryCallback,
 } from '../rendererPerfMetrics';
 import {
-  LEGACY_STREAM_SUBSCRIBE,
-  LEGACY_STREAM_UNSUBSCRIBE,
+  LEGACY_STREAM_BRIDGE,
   type LegacyRendererStream,
 } from './legacyRendererSubscriptions';
+import { createSubscriptionBridgeClient, defineBridge } from './defineBridge';
 
 export function exposeBridge() {
+  const legacySubscriptions =
+    createSubscriptionBridgeClient<LegacyRendererStream>(LEGACY_STREAM_BRIDGE);
   const legacyListenerCounts = new Map<LegacyRendererStream, number>();
   const addLegacyListener = (stream: LegacyRendererStream) => {
     const count = legacyListenerCounts.get(stream) ?? 0;
     legacyListenerCounts.set(stream, count + 1);
-    if (count === 0) void ipcRenderer.invoke(LEGACY_STREAM_SUBSCRIBE, stream);
+    if (count === 0) void legacySubscriptions.subscribe(stream);
   };
   const removeLegacyListener = (stream: LegacyRendererStream) => {
     const count = legacyListenerCounts.get(stream) ?? 0;
     if (count <= 1) {
       legacyListenerCounts.delete(stream);
-      void ipcRenderer.invoke(LEGACY_STREAM_UNSUBSCRIBE, stream);
+      void legacySubscriptions.unsubscribe(stream);
       return;
     }
     legacyListenerCounts.set(stream, count - 1);
   };
-  contextBridge.exposeInMainWorld('irsdkBridge', {
+  defineBridge<IrSdkBridge>('irsdkBridge', {
     onTelemetry: (callback: (value: Telemetry) => void) => {
       const handler = (_: Electron.IpcRendererEvent, value: Telemetry) => {
         if (!isRendererPerfMetricsEnabled()) {
@@ -83,14 +85,14 @@ export function exposeBridge() {
     },
     stop: () => {
       for (const stream of legacyListenerCounts.keys()) {
-        void ipcRenderer.invoke(LEGACY_STREAM_UNSUBSCRIBE, stream);
+        void legacySubscriptions.unsubscribe(stream);
       }
       legacyListenerCounts.clear();
       ipcRenderer.removeAllListeners('telemetry');
       ipcRenderer.removeAllListeners('sessionData');
       ipcRenderer.removeAllListeners('runningState');
     },
-  } as IrSdkBridge);
+  });
 
   contextBridge.exposeInMainWorld('dashboardBridge', {
     onEditModeToggled: (callback: (value: boolean) => void) => {

--- a/src/app/bridge/rendererExposeBridge.ts
+++ b/src/app/bridge/rendererExposeBridge.ts
@@ -23,8 +23,28 @@ import {
   isRendererPerfMetricsEnabled,
   recordTelemetryCallback,
 } from '../rendererPerfMetrics';
+import {
+  LEGACY_STREAM_SUBSCRIBE,
+  LEGACY_STREAM_UNSUBSCRIBE,
+  type LegacyRendererStream,
+} from './legacyRendererSubscriptions';
 
 export function exposeBridge() {
+  const legacyListenerCounts = new Map<LegacyRendererStream, number>();
+  const addLegacyListener = (stream: LegacyRendererStream) => {
+    const count = legacyListenerCounts.get(stream) ?? 0;
+    legacyListenerCounts.set(stream, count + 1);
+    if (count === 0) void ipcRenderer.invoke(LEGACY_STREAM_SUBSCRIBE, stream);
+  };
+  const removeLegacyListener = (stream: LegacyRendererStream) => {
+    const count = legacyListenerCounts.get(stream) ?? 0;
+    if (count <= 1) {
+      legacyListenerCounts.delete(stream);
+      void ipcRenderer.invoke(LEGACY_STREAM_UNSUBSCRIBE, stream);
+      return;
+    }
+    legacyListenerCounts.set(stream, count - 1);
+  };
   contextBridge.exposeInMainWorld('irsdkBridge', {
     onTelemetry: (callback: (value: Telemetry) => void) => {
       const handler = (_: Electron.IpcRendererEvent, value: Telemetry) => {
@@ -36,15 +56,23 @@ export function exposeBridge() {
         callback(value);
         recordTelemetryCallback(performance.now() - start);
       };
+      addLegacyListener('telemetry');
       ipcRenderer.on('telemetry', handler);
-      return () => ipcRenderer.removeListener('telemetry', handler);
+      return () => {
+        ipcRenderer.removeListener('telemetry', handler);
+        removeLegacyListener('telemetry');
+      };
     },
     onSessionData: (callback: (value: Session) => void) => {
       const handler = (_: Electron.IpcRendererEvent, value: Session) => {
         callback(value);
       };
+      addLegacyListener('sessionData');
       ipcRenderer.on('sessionData', handler);
-      return () => ipcRenderer.removeListener('sessionData', handler);
+      return () => {
+        ipcRenderer.removeListener('sessionData', handler);
+        removeLegacyListener('sessionData');
+      };
     },
     onRunningState: (callback: (value: boolean) => void) => {
       const handler = (_: Electron.IpcRendererEvent, value: boolean) => {
@@ -54,6 +82,10 @@ export function exposeBridge() {
       return () => ipcRenderer.removeListener('runningState', handler);
     },
     stop: () => {
+      for (const stream of legacyListenerCounts.keys()) {
+        void ipcRenderer.invoke(LEGACY_STREAM_UNSUBSCRIBE, stream);
+      }
+      legacyListenerCounts.clear();
       ipcRenderer.removeAllListeners('telemetry');
       ipcRenderer.removeAllListeners('sessionData');
       ipcRenderer.removeAllListeners('runningState');

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -13,6 +13,7 @@ import { getChromiumFlags, parseCustomSwitches } from './storage/chromiumFlags';
 import { trackSettingsWindowMovement } from './trackWindowMovement';
 import logger from './logger';
 import { createRendererPerfArguments } from './perfRendererArguments';
+import type { LegacyRendererStream } from './bridge/legacyRendererSubscriptions';
 
 // used for Hot Module Replacement
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;
@@ -52,6 +53,10 @@ export class OverlayManager {
   private overlayAlwaysOnTop = true;
   private hasSingleInstanceLock = false;
   private onWindowReadyCallbacks = new Set<(windowId: string) => void>();
+  private legacyStreamSubscribers = new Map<
+    LegacyRendererStream,
+    Set<number>
+  >();
 
   /** Padding around the widget bounding box when shrink-wrapping */
   private static readonly SHRINK_WRAP_PADDING = 20;
@@ -249,11 +254,17 @@ export class OverlayManager {
     }
 
     this.displayWindows.set(display.id, browserWindow);
+    const rendererId = browserWindow.webContents.id;
+
+    browserWindow.webContents.on('did-start-loading', () => {
+      this.removeLegacyRenderer(rendererId);
+    });
 
     browserWindow.on('closed', () => {
       logger.info(`Display ${display.id} overlay window closed`);
       this.displayWindows.delete(display.id);
       this.displayBoundsInfo.delete(display.id);
+      this.removeLegacyRenderer(rendererId);
     });
 
     browserWindow.webContents.on('render-process-gone', (_event, details) => {
@@ -266,6 +277,7 @@ export class OverlayManager {
       // Clean up stale entry so recreate doesn't early-return
       this.displayWindows.delete(display.id);
       this.displayBoundsInfo.delete(display.id);
+      this.removeLegacyRenderer(rendererId);
 
       // Small delay so Electron can fully clean up before a new window is created
       setTimeout(() => {
@@ -546,6 +558,12 @@ export class OverlayManager {
     // Send to all display overlay windows
     for (const win of this.displayWindows.values()) {
       if (win.isDestroyed()) continue;
+      if (
+        (key === 'telemetry' || key === 'sessionData') &&
+        !this.legacyStreamSubscribers.get(key)?.has(win.webContents.id)
+      ) {
+        continue;
+      }
       try {
         win.webContents.send(key, value);
       } catch (e) {
@@ -568,6 +586,35 @@ export class OverlayManager {
       } catch (e) {
         logger.error(`Failed to send message ${key} to settings window`, e);
       }
+    }
+  }
+
+  public subscribeLegacyStream(
+    rendererId: number,
+    stream: LegacyRendererStream
+  ): void {
+    let subscribers = this.legacyStreamSubscribers.get(stream);
+    if (!subscribers) {
+      subscribers = new Set();
+      this.legacyStreamSubscribers.set(stream, subscribers);
+    }
+    subscribers.add(rendererId);
+  }
+
+  public unsubscribeLegacyStream(
+    rendererId: number,
+    stream: LegacyRendererStream
+  ): void {
+    this.legacyStreamSubscribers.get(stream)?.delete(rendererId);
+  }
+
+  public hasLegacyStreamSubscribers(stream: LegacyRendererStream): boolean {
+    return (this.legacyStreamSubscribers.get(stream)?.size ?? 0) > 0;
+  }
+
+  private removeLegacyRenderer(rendererId: number): void {
+    for (const subscribers of this.legacyStreamSubscribers.values()) {
+      subscribers.delete(rendererId);
     }
   }
 

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -13,7 +13,12 @@ import { getChromiumFlags, parseCustomSwitches } from './storage/chromiumFlags';
 import { trackSettingsWindowMovement } from './trackWindowMovement';
 import logger from './logger';
 import { createRendererPerfArguments } from './perfRendererArguments';
-import type { LegacyRendererStream } from './bridge/legacyRendererSubscriptions';
+
+type LegacyRendererStream = 'telemetry' | 'sessionData';
+interface LegacyStreamSubscriptions {
+  has(rendererId: number, stream: LegacyRendererStream): boolean;
+  hasAny(stream: LegacyRendererStream): boolean;
+}
 
 // used for Hot Module Replacement
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string;
@@ -53,10 +58,7 @@ export class OverlayManager {
   private overlayAlwaysOnTop = true;
   private hasSingleInstanceLock = false;
   private onWindowReadyCallbacks = new Set<(windowId: string) => void>();
-  private legacyStreamSubscribers = new Map<
-    LegacyRendererStream,
-    Set<number>
-  >();
+  private legacyStreamSubscriptions?: LegacyStreamSubscriptions;
 
   /** Padding around the widget bounding box when shrink-wrapping */
   private static readonly SHRINK_WRAP_PADDING = 20;
@@ -254,17 +256,10 @@ export class OverlayManager {
     }
 
     this.displayWindows.set(display.id, browserWindow);
-    const rendererId = browserWindow.webContents.id;
-
-    browserWindow.webContents.on('did-start-loading', () => {
-      this.removeLegacyRenderer(rendererId);
-    });
-
     browserWindow.on('closed', () => {
       logger.info(`Display ${display.id} overlay window closed`);
       this.displayWindows.delete(display.id);
       this.displayBoundsInfo.delete(display.id);
-      this.removeLegacyRenderer(rendererId);
     });
 
     browserWindow.webContents.on('render-process-gone', (_event, details) => {
@@ -277,7 +272,6 @@ export class OverlayManager {
       // Clean up stale entry so recreate doesn't early-return
       this.displayWindows.delete(display.id);
       this.displayBoundsInfo.delete(display.id);
-      this.removeLegacyRenderer(rendererId);
 
       // Small delay so Electron can fully clean up before a new window is created
       setTimeout(() => {
@@ -560,7 +554,7 @@ export class OverlayManager {
       if (win.isDestroyed()) continue;
       if (
         (key === 'telemetry' || key === 'sessionData') &&
-        !this.legacyStreamSubscribers.get(key)?.has(win.webContents.id)
+        !this.legacyStreamSubscriptions?.has(win.webContents.id, key)
       ) {
         continue;
       }
@@ -589,33 +583,14 @@ export class OverlayManager {
     }
   }
 
-  public subscribeLegacyStream(
-    rendererId: number,
-    stream: LegacyRendererStream
+  public setLegacyStreamSubscriptions(
+    subscriptions: LegacyStreamSubscriptions
   ): void {
-    let subscribers = this.legacyStreamSubscribers.get(stream);
-    if (!subscribers) {
-      subscribers = new Set();
-      this.legacyStreamSubscribers.set(stream, subscribers);
-    }
-    subscribers.add(rendererId);
-  }
-
-  public unsubscribeLegacyStream(
-    rendererId: number,
-    stream: LegacyRendererStream
-  ): void {
-    this.legacyStreamSubscribers.get(stream)?.delete(rendererId);
+    this.legacyStreamSubscriptions = subscriptions;
   }
 
   public hasLegacyStreamSubscribers(stream: LegacyRendererStream): boolean {
-    return (this.legacyStreamSubscribers.get(stream)?.size ?? 0) > 0;
-  }
-
-  private removeLegacyRenderer(rendererId: number): void {
-    for (const subscribers of this.legacyStreamSubscribers.values()) {
-      subscribers.delete(rendererId);
-    }
+    return this.legacyStreamSubscriptions?.hasAny(stream) ?? false;
   }
 
   /**

--- a/src/app/rendererPerfMetrics.ts
+++ b/src/app/rendererPerfMetrics.ts
@@ -6,6 +6,7 @@ import { readRendererPerfArguments } from './perfRendererArguments';
 export const PERF_RENDERER_LOG_PREFIX = '[PerfRenderer:JSON] ';
 
 let telemetryCallbackTimes: FixedSampleBuffer | undefined;
+let channelCallbackTimes: FixedSampleBuffer | undefined;
 
 export function isRendererPerfMetricsEnabled(): boolean {
   return telemetryCallbackTimes !== undefined;
@@ -13,6 +14,10 @@ export function isRendererPerfMetricsEnabled(): boolean {
 
 export function recordTelemetryCallback(durationMs: number): void {
   telemetryCallbackTimes?.add(durationMs);
+}
+
+export function recordChannelCallback(durationMs: number): void {
+  channelCallbackTimes?.add(durationMs);
 }
 
 export function startRendererPerfMetrics(): void {
@@ -27,6 +32,8 @@ export function startRendererPerfMetrics(): void {
   const frameTimes = new FixedSampleBuffer(4096);
   const callbackTimes = new FixedSampleBuffer(4096);
   telemetryCallbackTimes = callbackTimes;
+  const channelTimes = new FixedSampleBuffer(4096);
+  channelCallbackTimes = channelTimes;
   let intervalStart = performance.now();
   let previousFrameTime = 0;
   let framesOver25Ms = 0;
@@ -52,6 +59,7 @@ export function startRendererPerfMetrics(): void {
       intervalStart = now;
       previousFrameTime = 0;
       callbackTimes.reset();
+      channelTimes.reset();
       framesOver25Ms = 0;
       framesOver50Ms = 0;
       return;
@@ -68,6 +76,9 @@ export function startRendererPerfMetrics(): void {
       intervalMs: now - intervalStart,
       frameTimeMs: stats,
       telemetryCallbackMs: callbackTimes.summarize(),
+      channelCallbackMs: channelTimes.summarize(),
+      telemetryWakeups: callbackTimes.summarize().count,
+      channelWakeups: channelTimes.summarize().count,
       framesOver25Ms,
       framesOver50Ms,
     };
@@ -81,6 +92,7 @@ export function startRendererPerfMetrics(): void {
     intervalStart = now;
     frameTimes.reset();
     callbackTimes.reset();
+    channelTimes.reset();
     framesOver25Ms = 0;
     framesOver50Ms = 0;
   }, reportIntervalMs);

--- a/src/app/webserver/bridgeProxy.ts
+++ b/src/app/webserver/bridgeProxy.ts
@@ -22,6 +22,7 @@ export function createBridgeProxy(
   const wss = new WebSocketServer({ server: httpServer });
 
   const clients = new Set<WebSocket>();
+  const legacyStreams = new Map<WebSocket, Set<'telemetry' | 'sessionData'>>();
   let nextChannelTargetId = -1;
   let currentTelemetry: Telemetry | null = null;
   let currentSession: Session | null = null;
@@ -35,6 +36,12 @@ export function createBridgeProxy(
   const broadcast = (type: string, data: unknown) => {
     const message = JSON.stringify({ type, data });
     clients.forEach((client) => {
+      if (
+        (type === 'telemetry' || type === 'sessionData') &&
+        !legacyStreams.get(client)?.has(type as 'telemetry' | 'sessionData')
+      ) {
+        return;
+      }
       if (client.readyState === WebSocket.OPEN) {
         client.send(message);
       }
@@ -106,6 +113,7 @@ export function createBridgeProxy(
 
   wss.on('connection', (ws: WebSocket) => {
     clients.add(ws);
+    legacyStreams.set(ws, new Set());
     const channelTarget = {
       id: nextChannelTargetId--,
       isDestroyed: () => ws.readyState === WebSocket.CLOSED,
@@ -128,8 +136,6 @@ export function createBridgeProxy(
       JSON.stringify({
         type: 'initialState',
         data: {
-          telemetry: currentTelemetry,
-          sessionData: currentSession,
           isRunning,
           dashboard: currentDashboard,
           isDemoMode,
@@ -142,6 +148,27 @@ export function createBridgeProxy(
         const parsed = JSON.parse(message.toString());
 
         switch (parsed.type) {
+          case 'legacySubscribe': {
+            const stream = parsed.data?.stream;
+            if (stream !== 'telemetry' && stream !== 'sessionData') {
+              throw new Error('Invalid legacy stream subscription');
+            }
+            legacyStreams.get(ws)?.add(stream);
+            const current =
+              stream === 'telemetry' ? currentTelemetry : currentSession;
+            if (current !== null && ws.readyState === WebSocket.OPEN) {
+              ws.send(JSON.stringify({ type: stream, data: current }));
+            }
+            break;
+          }
+          case 'legacyUnsubscribe': {
+            const stream = parsed.data?.stream;
+            if (stream !== 'telemetry' && stream !== 'sessionData') {
+              throw new Error('Invalid legacy stream unsubscribe');
+            }
+            legacyStreams.get(ws)?.delete(stream);
+            break;
+          }
           case 'channelSubscribe': {
             const channel = parsed.data?.channel;
             const rate = parsed.data?.requestedRateHz;
@@ -331,6 +358,7 @@ export function createBridgeProxy(
 
     ws.on('close', () => {
       clients.delete(ws);
+      legacyStreams.delete(ws);
       channelBus?.removeRenderer(channelTarget.id);
 
       if (clients.size === 0) {

--- a/src/app/webserver/componentRenderer.spec.ts
+++ b/src/app/webserver/componentRenderer.spec.ts
@@ -147,4 +147,27 @@ describe('WebSocketBridge channels', () => {
 
     expect(callback).not.toHaveBeenCalled();
   });
+
+  it('subscribes to legacy streams only while a consumer exists', async () => {
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+
+    const bridge = new WebSocketBridge();
+    const connecting = bridge.connect('http://localhost:3000');
+    const socket = FakeWebSocket.latest;
+    socket?.onopen?.();
+    await connecting;
+
+    expect(socket?.sent).toEqual([]);
+    const unsubscribe = bridge.onTelemetry(vi.fn());
+    expect(JSON.parse(socket?.sent.at(-1) ?? '{}')).toEqual({
+      type: 'legacySubscribe',
+      data: { stream: 'telemetry' },
+    });
+
+    unsubscribe?.();
+    expect(JSON.parse(socket?.sent.at(-1) ?? '{}')).toEqual({
+      type: 'legacyUnsubscribe',
+      data: { stream: 'telemetry' },
+    });
+  });
 });

--- a/src/app/webserver/componentRenderer.tsx
+++ b/src/app/webserver/componentRenderer.tsx
@@ -266,6 +266,12 @@ export class WebSocketBridge implements IrSdkBridge, ChannelBridge {
           for (const channel of this.channelCallbacks.keys()) {
             this.sendChannelSubscription(channel);
           }
+          if (this.telemetryCallbacks.size > 0) {
+            this.sendLegacySubscription('telemetry', true);
+          }
+          if (this.sessionCallbacks.size > 0) {
+            this.sendLegacySubscription('sessionData', true);
+          }
           resolve();
         };
 
@@ -362,14 +368,41 @@ export class WebSocketBridge implements IrSdkBridge, ChannelBridge {
 
   onTelemetry(callback: (data: Telemetry) => void): (() => void) | undefined {
     if (!callback) return undefined;
+    const wasEmpty = this.telemetryCallbacks.size === 0;
     this.telemetryCallbacks.add(callback);
-    return () => this.telemetryCallbacks.delete(callback);
+    if (wasEmpty) this.sendLegacySubscription('telemetry', true);
+    return () => {
+      this.telemetryCallbacks.delete(callback);
+      if (this.telemetryCallbacks.size === 0) {
+        this.sendLegacySubscription('telemetry', false);
+      }
+    };
   }
 
   onSessionData(callback: (data: Session) => void): (() => void) | undefined {
     if (!callback) return undefined;
+    const wasEmpty = this.sessionCallbacks.size === 0;
     this.sessionCallbacks.add(callback);
-    return () => this.sessionCallbacks.delete(callback);
+    if (wasEmpty) this.sendLegacySubscription('sessionData', true);
+    return () => {
+      this.sessionCallbacks.delete(callback);
+      if (this.sessionCallbacks.size === 0) {
+        this.sendLegacySubscription('sessionData', false);
+      }
+    };
+  }
+
+  private sendLegacySubscription(
+    stream: 'telemetry' | 'sessionData',
+    subscribe: boolean
+  ): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    this.socket.send(
+      JSON.stringify({
+        type: subscribe ? 'legacySubscribe' : 'legacyUnsubscribe',
+        data: { stream },
+      })
+    );
   }
 
   onRunningState(

--- a/src/dashboard-view-entry.tsx
+++ b/src/dashboard-view-entry.tsx
@@ -5,13 +5,9 @@ import { createRoot } from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
 import { DashboardView } from './frontend/components/DashboardView/DashboardView';
 import { ThemeManager } from './frontend/components/ThemeManager/ThemeManager';
-import {
-  DashboardProvider,
-  RunningStateProvider,
-  SessionProvider,
-  TelemetryProvider,
-} from '@irdashies/context';
+import { DashboardProvider, RunningStateProvider } from '@irdashies/context';
 import type { DashboardBridge, FuelCalculatorBridge } from '@irdashies/types';
+import { RendererDataProviders } from './frontend/components/RendererDataProviders/RendererDataProviders';
 
 // Get profileId from URL params
 const urlParams = new URLSearchParams(window.location.search);
@@ -55,8 +51,7 @@ async function initializeDashboardView() {
         profileId={profileId}
       >
         <RunningStateProvider bridge={bridge}>
-          <SessionProvider bridge={bridge} />
-          <TelemetryProvider bridge={bridge} />
+          <RendererDataProviders browser />
           <ThemeManager>
             <DashboardView />
           </ThemeManager>

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -2,12 +2,9 @@
 import { createRoot } from 'react-dom/client';
 import { HashRouter, Route, Routes } from 'react-router-dom';
 import {
-  TelemetryProvider,
   DashboardProvider,
   RunningStateProvider,
   SessionProvider,
-  PitLaneProvider,
-  ReferenceStoreProvider,
 } from '@irdashies/context';
 import { Settings } from './components/Settings/Settings';
 import { ThemeManager } from './components/ThemeManager/ThemeManager';
@@ -15,6 +12,7 @@ import { HideUIWrapper } from './components/HideUIWrapper/HideUIWrapper';
 import { ProfileSwitchOverlay } from './components/ProfileSwitchOverlay/ProfileSwitchOverlay';
 import { OverlayContainer } from './components/OverlayContainer';
 import { ErrorBoundary } from './components/ErrorBoundary/ErrorBoundary';
+import { RendererDataProviders } from './components/RendererDataProviders/RendererDataProviders';
 
 /**
  * Check if this window is the settings window based on URL hash
@@ -71,10 +69,7 @@ const App = () => {
     <ErrorBoundary label="overlay" resetAfterMs={2000}>
       <DashboardProvider bridge={window.dashboardBridge}>
         <RunningStateProvider bridge={window.irsdkBridge}>
-          <SessionProvider bridge={window.irsdkBridge} />
-          <TelemetryProvider bridge={window.irsdkBridge} />
-          <PitLaneProvider bridge={window.pitLaneBridge} />
-          <ReferenceStoreProvider bridge={window.referenceLapsBridge} />
+          <RendererDataProviders />
           <OverlayApp />
         </RunningStateProvider>
       </DashboardProvider>

--- a/src/frontend/components/DashboardView/DashboardView.tsx
+++ b/src/frontend/components/DashboardView/DashboardView.tsx
@@ -15,6 +15,7 @@ import type { DashboardWidget } from '@irdashies/types';
 import { useDragWidget, useResizeWidget } from '../WidgetContainer';
 import { ResizeHandles } from '../WidgetContainer/ResizeHandle';
 import logger from '@irdashies/utils/logger';
+import { WidgetRuntimeProvider } from '../../widgetRuntime';
 
 interface WidgetPosition {
   x: number;
@@ -164,7 +165,9 @@ const DashboardWidgetItem = memo(
               }
             `}</style>
             <div className="widget-content w-full h-full">
-              <WidgetComponent {...widget.config} />
+              <WidgetRuntimeProvider widgetType={widget.type || widget.id}>
+                <WidgetComponent {...widget.config} />
+              </WidgetRuntimeProvider>
             </div>
           </div>
         </div>
@@ -223,8 +226,7 @@ export const DashboardView = () => {
     enabledWidgets.forEach((widget) => {
       const widgetConfig = widget.config as Record<string, unknown>;
       const browserPos = widgetConfig?.browserPosition as
-        | WidgetPosition
-        | undefined;
+        WidgetPosition | undefined;
 
       // Use saved browserPosition if available, otherwise use layout dimensions from Electron config
       if (browserPos && typeof browserPos.x === 'number') {

--- a/src/frontend/components/FuelCalculator/widgetRuntimeDefinition.ts
+++ b/src/frontend/components/FuelCalculator/widgetRuntimeDefinition.ts
@@ -1,0 +1,8 @@
+import type { WidgetRuntimeDefinition } from '../../widgetRuntime';
+
+export default {
+  id: 'fuel',
+  legacyTelemetry: false,
+  channels: ['fuel.projection'],
+  ratePreset: 'gapTiming',
+} satisfies WidgetRuntimeDefinition;

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -16,6 +16,7 @@ import { TopSpeedUpdater } from './TopSpeedUpdater';
 import { SessionTimingUpdater } from './SessionTimingUpdater';
 import { TrackTemperatureUpdater } from './TrackTemperatureUpdater';
 import { SessionBestLapUpdater } from './SessionBestLapUpdater';
+import { WidgetRuntimeProvider } from '../../widgetRuntime';
 
 export const OverlayContainer = memo(() => {
   const {
@@ -194,7 +195,9 @@ export const OverlayContainer = memo(() => {
                 label={`widget:${widget.type || widget.id}`}
                 resetAfterMs={2000}
               >
-                <WidgetComponent {...widget.config} />
+                <WidgetRuntimeProvider widgetType={widget.type || widget.id}>
+                  <WidgetComponent {...widget.config} />
+                </WidgetRuntimeProvider>
               </ErrorBoundary>
             ) : null}
           </WidgetContainer>

--- a/src/frontend/components/RendererDataProviders/RendererDataProviders.spec.tsx
+++ b/src/frontend/components/RendererDataProviders/RendererDataProviders.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DashboardLayout } from '@irdashies/types';
+
+let dashboard: DashboardLayout;
+
+vi.mock('@irdashies/context', () => ({
+  useDashboard: () => ({ currentDashboard: dashboard }),
+  SessionProvider: () => <div data-testid="session-provider" />,
+  TelemetryProvider: () => <div data-testid="telemetry-provider" />,
+  PitLaneProvider: () => <div data-testid="pitlane-provider" />,
+  ReferenceStoreProvider: () => <div data-testid="reference-provider" />,
+}));
+
+import { RendererDataProviders } from './RendererDataProviders';
+
+const layout = { x: 0, y: 0, width: 100, height: 100 };
+
+describe('RendererDataProviders', () => {
+  beforeEach(() => {
+    dashboard = { widgets: [] };
+  });
+
+  it('does not mount legacy providers for a Fuel-only renderer', () => {
+    dashboard.widgets = [{ id: 'fuel', enabled: true, layout }];
+
+    const { container } = render(<RendererDataProviders />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('preserves legacy providers when any unmigrated widget is enabled', () => {
+    dashboard.widgets = [
+      { id: 'fuel', enabled: true, layout },
+      { id: 'input', enabled: true, layout },
+    ];
+
+    render(<RendererDataProviders />);
+
+    expect(screen.getByTestId('telemetry-provider')).toBeInTheDocument();
+    expect(screen.getByTestId('session-provider')).toBeInTheDocument();
+  });
+});

--- a/src/frontend/components/RendererDataProviders/RendererDataProviders.tsx
+++ b/src/frontend/components/RendererDataProviders/RendererDataProviders.tsx
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import {
+  PitLaneProvider,
+  ReferenceStoreProvider,
+  SessionProvider,
+  TelemetryProvider,
+  useDashboard,
+} from '@irdashies/context';
+import { rendererNeedsLegacyTelemetry } from '../../widgetRuntime';
+
+const isWidgetOnDisplay = (
+  widget: { layout: { x: number; y: number; width: number; height: number } },
+  bounds: { x: number; y: number; width: number; height: number }
+) => {
+  const centerX = widget.layout.x + widget.layout.width / 2;
+  const centerY = widget.layout.y + widget.layout.height / 2;
+  return (
+    centerX >= bounds.x &&
+    centerX < bounds.x + bounds.width &&
+    centerY >= bounds.y &&
+    centerY < bounds.y + bounds.height
+  );
+};
+
+export const RendererDataProviders = ({
+  browser = false,
+}: {
+  browser?: boolean;
+}) => {
+  const { currentDashboard, containerBoundsInfo } = useDashboard();
+  const needsLegacyTelemetry = useMemo(() => {
+    const enabledWidgets =
+      currentDashboard?.widgets.filter((widget) => widget.enabled) ?? [];
+    const widgets =
+      browser || !containerBoundsInfo?.displayId
+        ? enabledWidgets
+        : enabledWidgets.filter((widget) => {
+            const displayBounds =
+              containerBoundsInfo.displayBounds ?? containerBoundsInfo.expected;
+            const onThisDisplay = isWidgetOnDisplay(widget, displayBounds);
+            const onAnyDisplay =
+              containerBoundsInfo.allDisplayBounds?.some((bounds) =>
+                isWidgetOnDisplay(widget, bounds)
+              ) ?? onThisDisplay;
+            return (
+              onThisDisplay || (containerBoundsInfo.isPrimary && !onAnyDisplay)
+            );
+          });
+    return rendererNeedsLegacyTelemetry(widgets);
+  }, [browser, containerBoundsInfo, currentDashboard?.widgets]);
+
+  if (!needsLegacyTelemetry) return null;
+
+  return (
+    <>
+      <SessionProvider bridge={window.irsdkBridge} />
+      <TelemetryProvider bridge={window.irsdkBridge} />
+      {window.pitLaneBridge ? (
+        <PitLaneProvider bridge={window.pitLaneBridge} />
+      ) : null}
+      {window.referenceLapsBridge ? (
+        <ReferenceStoreProvider bridge={window.referenceLapsBridge} />
+      ) : null}
+    </>
+  );
+};

--- a/src/frontend/context/ChannelStore/useChannelSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useChannelSnapshot.ts
@@ -5,15 +5,18 @@ import type {
   ChannelPayloads,
 } from '@irdashies/types';
 import { ChannelSnapshotStore } from './ChannelSnapshotStore';
+import { useWidgetChannelRate } from '../../widgetRuntime';
 
 export const useChannelSnapshot = <K extends ChannelName>(
   channel: K,
   rateHz?: number,
   bridge?: ChannelBridge
 ): ChannelPayloads[K] | undefined => {
+  const configuredRateHz = useWidgetChannelRate(channel);
+  const effectiveRateHz = rateHz ?? configuredRateHz;
   const store = useMemo(
-    () => new ChannelSnapshotStore(channel, rateHz, bridge),
-    [bridge, channel, rateHz]
+    () => new ChannelSnapshotStore(channel, effectiveRateHz, bridge),
+    [bridge, channel, effectiveRateHz]
   );
   return useSyncExternalStore(store.subscribe, store.getSnapshot);
 };

--- a/src/frontend/context/SessionStore/SessionProvider.tsx
+++ b/src/frontend/context/SessionStore/SessionProvider.tsx
@@ -15,7 +15,6 @@ export const SessionProvider = ({ bridge }: SessionProviderProps) => {
     if (bridge instanceof Promise) {
       bridge.then((resolved) => {
         if (cancelled) {
-          resolved.stop();
           return;
         }
         unsub = resolved.onSessionData((session) => {
@@ -25,7 +24,6 @@ export const SessionProvider = ({ bridge }: SessionProviderProps) => {
       return () => {
         cancelled = true;
         if (unsub) unsub();
-        bridge.then((resolved) => resolved.stop());
       };
     }
 
@@ -36,7 +34,6 @@ export const SessionProvider = ({ bridge }: SessionProviderProps) => {
     return () => {
       cancelled = true;
       if (unsub) unsub();
-      bridge.stop();
     };
   }, [bridge, setSession]);
 

--- a/src/frontend/context/TelemetryStore/TelemetryProvider.tsx
+++ b/src/frontend/context/TelemetryStore/TelemetryProvider.tsx
@@ -16,7 +16,6 @@ export const TelemetryProvider = ({ bridge }: TelemetryProviderProps) => {
     if (bridge instanceof Promise) {
       bridge.then((resolved) => {
         if (cancelled) {
-          resolved.stop();
           return;
         }
         unsub = resolved.onTelemetry((telemetry) => {
@@ -26,7 +25,6 @@ export const TelemetryProvider = ({ bridge }: TelemetryProviderProps) => {
       return () => {
         cancelled = true;
         if (unsub) unsub();
-        bridge.then((resolved) => resolved.stop());
       };
     }
 
@@ -37,7 +35,6 @@ export const TelemetryProvider = ({ bridge }: TelemetryProviderProps) => {
     return () => {
       cancelled = true;
       if (unsub) unsub();
-      bridge.stop();
     };
     // eslint-disable-next-line @eslint-react/exhaustive-deps
   }, [bridge]);

--- a/src/frontend/widgetRuntime.spec.tsx
+++ b/src/frontend/widgetRuntime.spec.tsx
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { DashboardWidget } from '@irdashies/types';
+import {
+  getWidgetRuntimeDefinition,
+  rendererNeedsLegacyTelemetry,
+  useWidgetChannelRate,
+  WidgetRuntimeProvider,
+} from './widgetRuntime';
+
+const widget = (id: string, type?: string): DashboardWidget => ({
+  id,
+  type,
+  enabled: true,
+  layout: { x: 0, y: 0, width: 100, height: 100 },
+});
+
+describe('widget runtime metadata', () => {
+  it('discovers Fuel as a channel-only widget', () => {
+    expect(getWidgetRuntimeDefinition('fuel')).toMatchObject({
+      legacyTelemetry: false,
+      channels: ['fuel.projection'],
+    });
+    expect(rendererNeedsLegacyTelemetry([widget('fuel')])).toBe(false);
+  });
+
+  it('keeps unknown and unmigrated widgets on the legacy path', () => {
+    expect(
+      rendererNeedsLegacyTelemetry([widget('fuel'), widget('input')])
+    ).toBe(true);
+    expect(rendererNeedsLegacyTelemetry([widget('instance', 'unknown')])).toBe(
+      true
+    );
+  });
+
+  it('maps the Fuel rate preset to its channel subscription', () => {
+    const { result } = renderHook(
+      () => useWidgetChannelRate('fuel.projection'),
+      {
+        wrapper: ({ children }) => (
+          <WidgetRuntimeProvider widgetType="fuel">
+            {children}
+          </WidgetRuntimeProvider>
+        ),
+      }
+    );
+
+    expect(result.current).toBe(5);
+  });
+});

--- a/src/frontend/widgetRuntime.tsx
+++ b/src/frontend/widgetRuntime.tsx
@@ -1,0 +1,83 @@
+import { createContext, type ReactNode, useContext, useMemo } from 'react';
+import type { ChannelName, DashboardWidget } from '@irdashies/types';
+
+export type WidgetRatePreset =
+  'driverFocused' | 'gapTiming' | 'informational' | 'static';
+
+const RATE_PRESETS: Readonly<Record<WidgetRatePreset, number | undefined>> = {
+  driverFocused: 25,
+  gapTiming: 5,
+  informational: 1,
+  static: undefined,
+};
+
+export interface WidgetRuntimeDefinition {
+  id: string;
+  legacyTelemetry?: boolean;
+  channels?: readonly ChannelName[];
+  ratePreset?: WidgetRatePreset;
+  channelRates?: Partial<Record<ChannelName, number>>;
+}
+
+interface WidgetRuntimeModule {
+  default: WidgetRuntimeDefinition;
+}
+
+const discoveredDefinitions = import.meta.glob<WidgetRuntimeModule>(
+  './components/*/widgetRuntimeDefinition.ts',
+  { eager: true }
+);
+
+const definitions = new Map<string, WidgetRuntimeDefinition>();
+for (const module of Object.values(discoveredDefinitions)) {
+  definitions.set(module.default.id, module.default);
+}
+
+const LEGACY_DEFINITION: WidgetRuntimeDefinition = {
+  id: 'legacy',
+  legacyTelemetry: true,
+};
+
+export const getWidgetRuntimeDefinition = (
+  widgetType: string
+): WidgetRuntimeDefinition => definitions.get(widgetType) ?? LEGACY_DEFINITION;
+
+export const widgetUsesLegacyTelemetry = (widget: DashboardWidget): boolean =>
+  getWidgetRuntimeDefinition(widget.type || widget.id).legacyTelemetry !==
+  false;
+
+export const rendererNeedsLegacyTelemetry = (
+  widgets: readonly DashboardWidget[]
+): boolean => widgets.some(widgetUsesLegacyTelemetry);
+
+const WidgetRuntimeContext = createContext<WidgetRuntimeDefinition | undefined>(
+  undefined
+);
+
+export const WidgetRuntimeProvider = ({
+  widgetType,
+  children,
+}: {
+  widgetType: string;
+  children: ReactNode;
+}) => {
+  const definition = getWidgetRuntimeDefinition(widgetType);
+  return (
+    <WidgetRuntimeContext.Provider value={definition}>
+      {children}
+    </WidgetRuntimeContext.Provider>
+  );
+};
+
+export const useWidgetChannelRate = (
+  channel: ChannelName
+): number | undefined => {
+  const definition = useContext(WidgetRuntimeContext);
+  return useMemo(() => {
+    const override = definition?.channelRates?.[channel];
+    if (override !== undefined) return override;
+    return definition?.ratePreset
+      ? RATE_PRESETS[definition.ratePreset]
+      : undefined;
+  }, [channel, definition]);
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -55,6 +55,7 @@ overlayManager.setupAutoStart();
 let keybindingManager: KeybindingManager | undefined;
 const channelBus = new ChannelBus();
 let disconnectLifecycleChannel: (() => void) | undefined;
+let disposeLegacySubscriptions: (() => void) | undefined;
 
 app.on('ready', async () => {
   // Don't start services if we don't have the single instance lock
@@ -76,7 +77,9 @@ app.on('ready', async () => {
   }
 
   setupChannelBridge(channelBus);
-  setupLegacyRendererSubscriptions(overlayManager);
+  const legacySubscriptions = setupLegacyRendererSubscriptions();
+  disposeLegacySubscriptions = legacySubscriptions.dispose;
+  overlayManager.setLegacyStreamSubscriptions(legacySubscriptions.registry);
   disconnectLifecycleChannel = connectSessionLifecycleChannel(
     getSessionLifecycle(),
     channelBus
@@ -153,6 +156,7 @@ app.on('before-quit', () => {
   overlayManager.markQuitting();
   keybindingManager?.stopGamepad();
   disconnectLifecycleChannel?.();
+  disposeLegacySubscriptions?.();
   channelBus.dispose();
   // Synchronous flush so any pending debounced reference-lap write completes
   // before the process exits.

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import { setupChromiumFlagsBridge } from './app/bridge/chromiumFlagsBridge';
 import { createPerfDashboard, getPerfRunConfig } from './app/perfRunConfig';
 import { ChannelBus, setupChannelBridge } from './app/bridge/channelBridge';
 import { connectSessionLifecycleChannel } from './app/bridge/sessionLifecycleChannel';
+import { setupLegacyRendererSubscriptions } from './app/bridge/legacyRendererSubscriptions';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) app.quit();
@@ -75,6 +76,7 @@ app.on('ready', async () => {
   }
 
   setupChannelBridge(channelBus);
+  setupLegacyRendererSubscriptions(overlayManager);
   disconnectLifecycleChannel = connectSessionLifecycleChannel(
     getSessionLifecycle(),
     channelBus

--- a/src/types/performance.ts
+++ b/src/types/performance.ts
@@ -20,6 +20,9 @@ export interface RendererPerfSample {
   intervalMs: number;
   frameTimeMs: NumericSampleStats;
   telemetryCallbackMs?: NumericSampleStats;
+  channelCallbackMs?: NumericSampleStats;
+  telemetryWakeups?: number;
+  channelWakeups?: number;
   framesOver25Ms: number;
   framesOver50Ms: number;
 }

--- a/tools/perf/analyze.ts
+++ b/tools/perf/analyze.ts
@@ -120,6 +120,8 @@ export interface PerfSummary {
     frameTimeP99MeanMs: number;
     worstFrameMs: number;
     telemetryCallbackRateHz: number;
+    channelCallbackRateHz: number;
+    totalWakeupRateHz: number;
     telemetryCallbackP99MeanMs: number;
     telemetryCallbackP99WorstMs: number;
     framesOver25MsPercent: number;
@@ -247,6 +249,18 @@ export function summarizeCapture(
     renderer
       .filter((sample) => sample.telemetryCallbackMs !== undefined)
       .reduce((sum, sample) => sum + sample.intervalMs, 0) / 1000;
+  const rendererSeconds =
+    renderer.reduce((sum, sample) => sum + sample.intervalMs, 0) / 1000;
+  const telemetryWakeups = renderer.reduce(
+    (sum, sample) =>
+      sum + (sample.telemetryWakeups ?? sample.telemetryCallbackMs?.count ?? 0),
+    0
+  );
+  const channelWakeups = renderer.reduce(
+    (sum, sample) =>
+      sum + (sample.channelWakeups ?? sample.channelCallbackMs?.count ?? 0),
+    0
+  );
   const processTelemetry = effectiveMain
     .map((sample) => sample.sections.processTelemetry)
     .filter((value): value is SectionStats => value !== undefined);
@@ -537,6 +551,12 @@ export function summarizeCapture(
               (sum, stats) => sum + stats.count,
               0
             ) / rendererTelemetrySeconds,
+      channelCallbackRateHz:
+        rendererSeconds === 0 ? 0 : channelWakeups / rendererSeconds,
+      totalWakeupRateHz:
+        rendererSeconds === 0
+          ? 0
+          : (telemetryWakeups + channelWakeups) / rendererSeconds,
       telemetryCallbackP99MeanMs: weightedAverage(
         rendererTelemetryCallbacks.map((stats) => ({
           value: stats.p99,


### PR DESCRIPTION
## Description

Completes Phase 3 PR 6 from `docs/PHASE_3_CHANNEL_BRIDGE_PLAN.md` by turning the Fuel channel migration into real transport savings.

- Adds self-discovered widget runtime metadata with named update-rate presets and per-channel overrides.
- Declares Fuel as a `fuel.projection`-only consumer at 5 Hz; unknown and unmigrated widgets conservatively remain on the legacy path.
- Mounts telemetry, session, pit-lane, and reference-lap providers only in renderers containing a legacy widget.
- Adds renderer-scoped legacy stream subscriptions for Electron IPC and browser/WebSocket dashboards.
- Skips legacy telemetry projection and broadcast work when no overlay renderer subscribes.
- Adds separate legacy telemetry, typed-channel, and total renderer wake-up rates to performance captures.

This preserves mixed dashboards and browser sources while ensuring a Fuel-only display receives no full telemetry or session snapshots. The authoritative Windows baseline/candidate performance capture remains to be run before this draft is marked ready.

Validation:

- `npm run lint -- --quiet`
- `npm run test -- --no-coverage` — 1,165 passed, 1 skipped
- `npm run test:replay:curated` — 36,000 frames and 70 session revisions validated in 2.73 s

## Screenshots

No visual changes.

### Before

A Fuel-only renderer mounted the global telemetry/session providers and received the full legacy telemetry firehose at 25 Hz.

### After

A Fuel-only renderer subscribes only to `fuel.projection` at 5 Hz. Mixed and unmigrated dashboards retain their existing legacy streams.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
