### PR TITLE
refactor: give speed conversion a single home

### DIFF
--- a/src/frontend/components/Battle/Battle.tsx
+++ b/src/frontend/components/Battle/Battle.tsx
@@ -1,4 +1,6 @@
 import { memo, useMemo } from 'react';
+import { resolveSpeedUnit, speedFromKph } from '@irdashies/utils/units';
+import type { SpeedUnit } from '@irdashies/utils/units';
 import {
   useDrivingState,
   useSessionVisibility,
@@ -87,7 +89,7 @@ interface BattleRowProps {
   stintLaps?: number;
   lastTimeFormat?: import('@irdashies/types').TimeFormat;
   speedKph?: number;
-  isMetricSpeed?: boolean;
+  speedUnit?: SpeedUnit;
   rowIndex: number;
 }
 
@@ -107,7 +109,7 @@ const BattleRow = memo(
     stintLaps,
     lastTimeFormat = 'mixed',
     speedKph,
-    isMetricSpeed = true,
+    speedUnit = 'km/h',
     rowIndex,
   }: BattleRowProps) => {
     const onTrack = entry?.onTrack ?? true;
@@ -216,7 +218,7 @@ const BattleRow = memo(
       } else if (key === 'speed' && settings?.speed?.enabled) {
         const displaySpeed =
           speedKph != null && speedKph > 0
-            ? Math.round(isMetricSpeed ? speedKph : speedKph / 1.60934)
+            ? Math.round(speedFromKph(speedKph, speedUnit))
             : null;
         cols.push(
           <td
@@ -385,10 +387,11 @@ export const Battle = () => {
 
   // Speed: derived from CarIdxLapDistPct movement, in km/h.
   const carSpeeds = useCarIdxSpeed();
-  const displayUnits = useTelemetryValue('DisplayUnits'); // 0 = imperial, 1 = metric
-  const speedUnit = settings?.speed?.unit ?? 'auto';
-  const isMetricSpeed =
-    speedUnit === 'auto' ? displayUnits === 1 : speedUnit === 'km/h';
+  const displayUnits = useTelemetryValue('DisplayUnits');
+  const resolvedSpeedUnit = resolveSpeedUnit(
+    settings?.speed?.unit,
+    displayUnits
+  );
 
   const stintLaps = (carIdx: number) => {
     const currentLap = carLaps?.[carIdx] ?? 0;
@@ -449,7 +452,7 @@ export const Battle = () => {
             speedKph={
               aheadEntry != null ? carSpeeds[aheadEntry.carIdx] : undefined
             }
-            isMetricSpeed={isMetricSpeed}
+            speedUnit={resolvedSpeedUnit}
             rowIndex={0}
           />
           <BattleRow
@@ -468,7 +471,7 @@ export const Battle = () => {
             speedKph={
               playerEntry != null ? carSpeeds[playerEntry.carIdx] : undefined
             }
-            isMetricSpeed={isMetricSpeed}
+            speedUnit={resolvedSpeedUnit}
             rowIndex={1}
           />
           <BattleRow
@@ -496,7 +499,7 @@ export const Battle = () => {
             speedKph={
               behindEntry != null ? carSpeeds[behindEntry.carIdx] : undefined
             }
-            isMetricSpeed={isMetricSpeed}
+            speedUnit={resolvedSpeedUnit}
             rowIndex={2}
           />
         </tbody>

--- a/src/frontend/components/Input/InputGear/InputGear.tsx
+++ b/src/frontend/components/Input/InputGear/InputGear.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { resolveSpeedUnit, speedFromMs } from '@irdashies/utils/units';
 
 export interface InputGearProps {
   gear?: number;
@@ -16,10 +17,14 @@ export interface InputGearProps {
 
 export const InputGear = memo(
   ({ gear, speedMs, unit, settings }: InputGearProps) => {
-    const isMetric =
-      (unit === 1 && settings.unit === 'auto') || settings.unit === 'km/h';
-    const speed = (speedMs ?? 0) * (isMetric ? 3.6 : 2.23694);
-    const displayUnit = isMetric ? 'km/h' : 'mph';
+    // 'none' is vestigial — the settings UI only offers auto/mph/km/h — but the
+    // type still permits it, and it previously fell through to mph. Kept that
+    // way rather than quietly changing behaviour for a hand-edited config.
+    const displayUnit = resolveSpeedUnit(
+      settings.unit === 'none' ? 'mph' : settings.unit,
+      unit
+    );
+    const speed = speedFromMs(speedMs ?? 0, displayUnit);
     let gearText;
     switch (gear) {
       case -1:

--- a/src/frontend/components/PitlaneHelper/hooks/usePitSpeed.tsx
+++ b/src/frontend/components/PitlaneHelper/hooks/usePitSpeed.tsx
@@ -1,5 +1,10 @@
 import { useMemo } from 'react';
 import { useTelemetryValue, useSessionStore } from '@irdashies/context';
+import {
+  kphFromSpeed,
+  speedFromKph,
+  speedFromMs,
+} from '@irdashies/utils/units';
 
 export interface PitSpeedResult {
   deltaKph: number;
@@ -24,13 +29,15 @@ export const usePitSpeed = (): PitSpeedResult => {
     const limitValue = parseFloat(limitString.split(' ')[0]);
     const limitUnit = limitString.split(' ')[1]?.toLowerCase();
 
-    // Determine limit in both units
-    const limitKph = limitUnit === 'mph' ? limitValue * 1.60934 : limitValue;
-    const limitMph = limitUnit === 'kph' ? limitValue / 1.60934 : limitValue;
+    // Determine limit in both units. iRacing writes the limit in whichever unit
+    // the track uses, so normalise via km/h rather than trusting one of them.
+    const limitKph =
+      limitUnit === 'mph' ? kphFromSpeed(limitValue, 'mph') : limitValue;
+    const limitMph = speedFromKph(limitKph, 'mph');
 
     // Current speed (convert m/s to km/h and mph)
-    const speedKph = speed * 3.6;
-    const speedMph = speed * 2.23694;
+    const speedKph = speedFromMs(speed, 'km/h');
+    const speedMph = speedFromMs(speed, 'mph');
 
     // Calculate deltas
     const deltaKph = speedKph - limitKph;

--- a/src/frontend/components/RejoinIndicator/RejoinIndicator.tsx
+++ b/src/frontend/components/RejoinIndicator/RejoinIndicator.tsx
@@ -16,6 +16,7 @@ import { useDriverRelatives } from '../Standings/hooks/useDriverRelatives';
 import { useRejoinSettings } from './hooks/useRejoinSettings';
 import { getDemoRejoinData } from './demoData';
 import type { Standings } from '../Standings/createStandings';
+import { speedFromMs } from '@irdashies/utils/units';
 
 export const RejoinIndicator = () => {
   const { isDemoMode } = useDashboard();
@@ -78,7 +79,7 @@ export const RejoinIndicator = () => {
   }
 
   // Read telemetry and computed car speed for the focused car index
-  const speedKmH = (carSpeedForPlayer ?? 0) * 3.6;
+  const speedKmH = speedFromMs(carSpeedForPlayer ?? 0, 'km/h');
 
   const gap = Math.abs(carBehind?.delta ?? Number.POSITIVE_INFINITY);
   const gapLabel = Number.isFinite(gap) ? gap.toFixed(1) : '--';

--- a/src/frontend/components/Standings/components/SessionBar/components/TopSpeedItem/TopSpeedItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/components/TopSpeedItem/TopSpeedItem.tsx
@@ -5,6 +5,7 @@ import {
   useSessionBestTopSpeed,
   useTelemetryValue,
 } from '@irdashies/context';
+import { resolveSpeedUnit, speedFromMs } from '@irdashies/utils/units';
 import { sessionBarItemWrapperClass } from '../../sessionBarItemWrapperClass';
 import type { SessionBarItemProps } from '../../sessionBarItemTypes';
 
@@ -13,16 +14,14 @@ export const TopSpeedItem = memo(({ standalone }: SessionBarItemProps) => {
   const lastLapTopSpeedMs = useLastLapTopSpeed();
   const sessionBestTopSpeedMs = useSessionBestTopSpeed();
 
-  const isMetric = displayUnits === 1;
-  const factor = isMetric ? 3.6 : 2.23694;
-  const unit = isMetric ? 'km/h' : 'mph';
+  const unit = resolveSpeedUnit('auto', displayUnits);
   const last =
     lastLapTopSpeedMs !== null
-      ? `${(lastLapTopSpeedMs * factor).toFixed(0)} ${unit}`
+      ? `${speedFromMs(lastLapTopSpeedMs, unit).toFixed(0)} ${unit}`
       : '—';
   const best =
     sessionBestTopSpeedMs !== null
-      ? (sessionBestTopSpeedMs * factor).toFixed(0)
+      ? speedFromMs(sessionBestTopSpeedMs, unit).toFixed(0)
       : null;
 
   return (

--- a/src/frontend/components/Standings/components/SessionBar/components/WindItem/WindItem.tsx
+++ b/src/frontend/components/Standings/components/SessionBar/components/WindItem/WindItem.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { useTelemetryValue, useThrottledWeather } from '@irdashies/context';
+import { resolveSpeedUnit, speedFromMs } from '@irdashies/utils/units';
 import { WindArrow } from '../../../../../shared/WindArrow';
 import { sessionBarItemWrapperClass } from '../../sessionBarItemWrapperClass';
 import type { SessionBarItemProps } from '../../sessionBarItemTypes';
@@ -10,11 +11,11 @@ export const WindItem = memo(
     const { windDirection, windVelocity, windYaw } = useThrottledWeather();
     const relativeWindDirection = (windDirection ?? 0) - (windYaw ?? 0);
 
-    const isMetric = displayUnits === 1;
+    const speedUnit = resolveSpeedUnit('auto', displayUnits);
     const speedPosition = settings?.wind?.speedPosition ?? 'right';
     const speed =
       windVelocity !== undefined
-        ? Math.round(windVelocity * (isMetric ? 3.6 : 2.23694))
+        ? Math.round(speedFromMs(windVelocity, speedUnit))
         : '-';
     const speedEl = <span>{speed}</span>;
     const arrowEl = (

--- a/src/frontend/components/Weather/WindDirection/WindDirection.tsx
+++ b/src/frontend/components/Weather/WindDirection/WindDirection.tsx
@@ -1,6 +1,7 @@
 import { WindIcon } from '@phosphor-icons/react';
 import { memo, useRef, useEffect, useState } from 'react';
 import { getWindIntensityClass } from '../../../domain/weather/wind';
+import { speedFromMs } from '@irdashies/utils/units';
 
 export interface WindDirectionProps {
   speedMs?: number;
@@ -46,7 +47,7 @@ export const WindDirection = memo(
     // Convert m/s to user's preferred unit
     const speed =
       speedMs !== undefined
-        ? speedMs * (metric ? 3.6 : 2.23694) // km/h or mph
+        ? speedFromMs(speedMs, metric ? 'km/h' : 'mph')
         : undefined;
 
     const [normalizedAngle, setNormalizedAngle] = useState<number>(0);

--- a/src/frontend/components/Wind/WindDirection/WindDirection.tsx
+++ b/src/frontend/components/Wind/WindDirection/WindDirection.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { getWindIntensityClass } from '../../../domain/weather/wind';
+import { speedFromMs } from '@irdashies/utils/units';
 
 export interface WindDirectionProps {
   speedMs?: number;
@@ -10,7 +11,9 @@ export interface WindDirectionProps {
 export const WindDirection = memo(
   ({ speedMs, direction, metric = true }: WindDirectionProps) => {
     const speed =
-      speedMs !== undefined ? speedMs * (metric ? 3.6 : 2.23694) : undefined;
+      speedMs !== undefined
+        ? speedFromMs(speedMs, metric ? 'km/h' : 'mph')
+        : undefined;
     const [normalizedAngle, setNormalizedAngle] = useState(0);
     const prevAngleRef = useRef(0);
     const containerRef = useRef<HTMLDivElement | null>(null);

--- a/src/frontend/context/CarSpeedStore/CarSpeedsStore.tsx
+++ b/src/frontend/context/CarSpeedStore/CarSpeedsStore.tsx
@@ -1,5 +1,6 @@
 import type { Telemetry } from '@irdashies/types';
 import { create, useStore } from 'zustand';
+import { speedFromMs } from '@irdashies/utils/units';
 
 export interface CarSpeedBuffer {
   lastLapDistPct: number[];
@@ -65,7 +66,9 @@ export const useCarSpeedsStore = create<CarSpeedsState>((set, get) => ({
         if (wentBackwards && startedNewLap) distancePercent += 1.0;
 
         const distance = trackLength * distancePercent; // meters
-        const speed = deltaTime > 0 ? (distance / deltaTime) * 3.6 : 0; // m/s to km/h
+        // Stored in km/h throughout; converted here once from m/s.
+        const speed =
+          deltaTime > 0 ? speedFromMs(distance / deltaTime, 'km/h') : 0;
         if (!newHistory[idx]) newHistory[idx] = [];
         newHistory[idx].push(speed);
         if (newHistory[idx].length > SPEED_AVG_WINDOW) newHistory[idx].shift();

--- a/src/frontend/domain/weather/wind.ts
+++ b/src/frontend/domain/weather/wind.ts
@@ -1,3 +1,5 @@
+import { msFromSpeed } from '@irdashies/utils/units';
+
 export interface WindDemoData {
   speedMs: number;
   direction: number;
@@ -18,7 +20,7 @@ export const getDemoWindData = (
   metric: boolean
 ): WindDemoData => {
   const demoValue = WIND_DEMO_VALUES[index % WIND_DEMO_VALUES.length];
-  const speedMs = demoValue.speed / (metric ? 3.6 : 2.23694);
+  const speedMs = msFromSpeed(demoValue.speed, metric ? 'km/h' : 'mph');
 
   return {
     speedMs,

--- a/src/frontend/utils/units.spec.ts
+++ b/src/frontend/utils/units.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import {
+  IRACING_UNITS_METRIC,
+  kphFromSpeed,
+  msFromSpeed,
+  resolveSpeedUnit,
+  speedFromKph,
+  speedFromMs,
+} from './units';
+
+describe('resolveSpeedUnit', () => {
+  it('follows iRacing when the setting is auto', () => {
+    expect(resolveSpeedUnit('auto', IRACING_UNITS_METRIC)).toBe('km/h');
+    expect(resolveSpeedUnit('auto', 0)).toBe('mph');
+  });
+
+  it('follows iRacing when there is no setting at all', () => {
+    // Widgets that predate having a unit setting, and any that never add one.
+    expect(resolveSpeedUnit(undefined, IRACING_UNITS_METRIC)).toBe('km/h');
+    expect(resolveSpeedUnit(undefined, 0)).toBe('mph');
+  });
+
+  it('lets an explicit setting override iRacing', () => {
+    expect(resolveSpeedUnit('mph', IRACING_UNITS_METRIC)).toBe('mph');
+    expect(resolveSpeedUnit('km/h', 0)).toBe('km/h');
+  });
+
+  it('falls back to mph when DisplayUnits is missing', () => {
+    // Telemetry can be absent before a session connects. Imperial matches
+    // iRacing's own default for an unset value rather than inventing one.
+    expect(resolveSpeedUnit('auto', undefined)).toBe('mph');
+  });
+});
+
+describe('speedFromMs', () => {
+  it('converts to km/h', () => {
+    expect(speedFromMs(10, 'km/h')).toBeCloseTo(36, 5);
+  });
+
+  it('converts to mph', () => {
+    expect(speedFromMs(10, 'mph')).toBeCloseTo(22.3694, 4);
+  });
+
+  it('leaves zero alone in both units', () => {
+    expect(speedFromMs(0, 'km/h')).toBe(0);
+    expect(speedFromMs(0, 'mph')).toBe(0);
+  });
+});
+
+describe('speedFromKph', () => {
+  it('passes km/h through untouched', () => {
+    expect(speedFromKph(100, 'km/h')).toBe(100);
+  });
+
+  it('converts km/h to mph', () => {
+    expect(speedFromKph(160.934, 'mph')).toBeCloseTo(100, 3);
+  });
+});
+
+describe('kphFromSpeed', () => {
+  it('passes km/h through untouched', () => {
+    expect(kphFromSpeed(100, 'km/h')).toBe(100);
+  });
+
+  it('converts mph back to km/h', () => {
+    expect(kphFromSpeed(100, 'mph')).toBeCloseTo(160.934, 3);
+  });
+
+  it('round-trips with speedFromKph', () => {
+    const kph = 137.5;
+    expect(kphFromSpeed(speedFromKph(kph, 'mph'), 'mph')).toBeCloseTo(kph, 6);
+  });
+});
+
+describe('msFromSpeed', () => {
+  it('inverts speedFromMs in km/h', () => {
+    expect(msFromSpeed(speedFromMs(27.5, 'km/h'), 'km/h')).toBeCloseTo(27.5, 6);
+  });
+
+  it('inverts speedFromMs in mph', () => {
+    expect(msFromSpeed(speedFromMs(27.5, 'mph'), 'mph')).toBeCloseTo(27.5, 6);
+  });
+});
+
+describe('agreement between the two speed sources', () => {
+  it('m/s and km/h paths give the same mph', () => {
+    // The old duplicated constants were 2.23694 in one place and 3.6 / 1.60934
+    // in another. They agree to within a rounding error, but nothing enforced
+    // that; a single source means they cannot drift apart.
+    const ms = 42;
+    const viaMs = speedFromMs(ms, 'mph');
+    const viaKph = speedFromKph(speedFromMs(ms, 'km/h'), 'mph');
+    expect(viaMs).toBeCloseTo(viaKph, 3);
+  });
+});

--- a/src/frontend/utils/units.ts
+++ b/src/frontend/utils/units.ts
@@ -1,0 +1,73 @@
+/**
+ * Speed unit conversion and resolution.
+ *
+ * Speed was the one quantity without a shared home: temperature has
+ * `formatTemperature`, fuel has `formatFuel`, but every widget showing a speed
+ * carried its own copy of the factors — `3.6` and `2.23694` in four places,
+ * `1.60934` in two more, `0.621371` in another. Same numbers, written out each
+ * time, with nothing keeping them consistent.
+ *
+ * The `'auto'` resolution was duplicated alongside them: read iRacing's
+ * `DisplayUnits`, fall back to it when the widget's own setting says `'auto'`.
+ * That is here too, so a widget added later gets both halves for free rather
+ * than reinventing them — and, in practice, rather than shipping metric-only
+ * because reinventing it was easy to skip.
+ */
+
+export type SpeedUnit = 'km/h' | 'mph';
+
+/**
+ * iRacing's `DisplayUnits` telemetry channel: 0 = imperial, 1 = metric.
+ * Named because `displayUnits === 1` on its own reads as a magic number.
+ */
+export const IRACING_UNITS_METRIC = 1;
+
+/** m/s to km/h. */
+const MS_TO_KPH = 3.6;
+/** m/s to mph. */
+const MS_TO_MPH = 2.23694;
+/** km/h in one mph. */
+const KPH_PER_MPH = 1.60934;
+
+/**
+ * Resolve a widget's unit setting against iRacing's own display setting.
+ *
+ * `'auto'`, `undefined`, and anything unrecognised follow iRacing. An explicit
+ * `'km/h'` or `'mph'` wins, which is the point of having the setting at all.
+ */
+export const resolveSpeedUnit = (
+  setting: SpeedUnit | 'auto' | undefined,
+  displayUnits: number | undefined
+): SpeedUnit => {
+  if (setting === 'km/h' || setting === 'mph') return setting;
+  return displayUnits === IRACING_UNITS_METRIC ? 'km/h' : 'mph';
+};
+
+/**
+ * Convert m/s — the unit almost every iRacing speed channel reports in — to the
+ * display unit.
+ */
+export const speedFromMs = (speedMs: number, unit: SpeedUnit): number =>
+  speedMs * (unit === 'km/h' ? MS_TO_KPH : MS_TO_MPH);
+
+/**
+ * Convert a km/h value to the display unit. For the few places already holding
+ * km/h rather than m/s.
+ */
+export const speedFromKph = (speedKph: number, unit: SpeedUnit): number =>
+  unit === 'km/h' ? speedKph : speedKph / KPH_PER_MPH;
+
+/**
+ * Convert a value in the display unit back to km/h, for comparing against
+ * something stored in km/h — a pit limit entered in mph, say.
+ */
+export const kphFromSpeed = (speed: number, unit: SpeedUnit): number =>
+  unit === 'km/h' ? speed : speed * KPH_PER_MPH;
+
+/**
+ * Convert a value in the display unit back to m/s, the inverse of
+ * `speedFromMs`. Used where a figure written in display units has to be fed
+ * back into something expecting raw telemetry, such as fixture data.
+ */
+export const msFromSpeed = (speed: number, unit: SpeedUnit): number =>
+  speed / (unit === 'km/h' ? MS_TO_KPH : MS_TO_MPH);


### PR DESCRIPTION
## Description

Temperature has `formatTemperature` and fuel has `formatFuel`, but speed had no shared helper — so every widget showing a speed carried its own copy of the factors:

| constant | where |
| --- | --- |
| `3.6` / `2.23694` | `InputGear`, `usePitSpeed`, `TopSpeedItem`, `WindItem`, both `WindDirection`s, `CarSpeedsStore`, `domain/weather/wind` |
| `1.60934` | `Battle`, `usePitSpeed` |

The `'auto'` resolution was duplicated alongside them — read iRacing's `DisplayUnits`, fall back to it when the widget's own setting says `'auto'` — in every widget offering the choice. A widget added later has to reinvent both halves, and reinventing the second one is easy to skip; that is how a new widget ends up metric-only.

Adds `src/frontend/utils/units.ts` with the conversions and `resolveSpeedUnit`, and moves every production call site onto it. No raw speed constant is left outside that file. The ones still in specs are expected values, which should stay independent of the implementation.

### Behaviour

No intended change. Two places worth calling out because they are not pure substitutions:

- **`Battle`'s row component took an `isMetricSpeed` boolean.** It now takes a `SpeedUnit`, so the row no longer has to know how a boolean maps onto a unit label.
- **`InputGear`'s setting type permits `'none'`**, which the settings UI does not offer and which previously fell through to mph. Kept exactly that way rather than quietly changing behaviour for a hand-edited config.

### Why now

Two things made this worth doing rather than leaving:

- The Gantry PR (#654) shipped kph-only, and that is not really an oversight — there was no shared helper to reach for, and eight other widgets had already made the same call. With this in place a widget gets both halves for free.
- It shrinks the per-widget surface slightly ahead of the channel migration: these are presentational one-liners, so there is less incidental code to carry across. Only `CarSpeedsStore` and `usePitSpeed` sit near that work, and both are a single line here.

## Screenshots

No visual change — same numbers, same units, same labels. Pure refactor.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

New tests cover both conversion directions, the `'auto'` and explicit-override paths, the missing-`DisplayUnits` fallback, and that the m/s and km/h routes agree — the two constant pairs matched to a rounding error before, but nothing enforced it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent speed-unit handling across battle displays, pit-lane guidance, standings, car speed, wind indicators, and rejoin information.
  * Speed displays now support automatic or explicit km/h and mph selection based on settings and telemetry.
* **Bug Fixes**
  * Improved accuracy and consistency when converting speeds between meters per second, km/h, and mph.
  * Preserved expected fallback behavior when unit information is unavailable.
* **Tests**
  * Added coverage for unit selection, conversions, fallbacks, zero values, and round-trip accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->