### PR TITLE
feat: move radio state to channel

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -30,7 +30,7 @@
 | **Phase 2a remaining items**                          | R1+R2 LANDED, R3 PENDING | `feat/phase-2a-integration` for R1+R2    | R1 (reference-lap fetch dedup) + R2 (post-debounce write log) landed 2026-05-19. R3 (Empty Dashboard substrate baseline test) is a test run, not code work — pending.                                                                                                                                                                                                     |
 | **Phase 2b — Architectural cleanup (remaining)**      | NOT STARTED              | —                                        | A1, A4, A5, A6, A7 completion, A9. Lower urgency now Standings memory issue is resolved                                                                                                                                                                                                                                                                                   |
 | **Phase 3 — Channel-based bridge**                    | LANDED; MEMORY GATE OPEN | PRs #646, #649–#652, #656, #658          | Typed rate-aware channels, per-window subscriptions, deterministic replay validation, Fuel processor/renderer migration, conditional legacy telemetry, and performance instrumentation are on `main`. The Fuel-only A/B removed legacy deliveries and reduced app-wide renderer wake-ups by 42.4%; both baseline and candidate still failed the memory-slope gate.        |
-| **Phase 4 — Main-process processors**                 | IN PROGRESS              | PRs #659–#665; `feat/radio-channel`      | Fuel, lap times, car speeds, reference laps, relative gaps, sector timing, Standings core state, and live positions are on `main`. Radio migration is in progress; session-bar migration and legacy telemetry removal or development-only restriction remain.                                                                                                             |
+| **Phase 4 — Main-process processors**                 | IN PROGRESS              | PRs #659–#666                            | Fuel, lap times, car speeds, reference laps, relative gaps, sector timing, Standings core state, and live positions are on `main`. Radio migration is in PR #666; session-bar migration and legacy telemetry removal or development-only restriction remain.                                                                                                              |
 | **Phase 5 — Worker-thread SDK loop**                  | NOT STARTED              | —                                        |                                                                                                                                                                                                                                                                                                                                                                           |
 | **Phase 6 — Native optimisations**                    | DEFERRED                 | —                                        | Only if Phase 4 profiling demands                                                                                                                                                                                                                                                                                                                                         |
 
@@ -273,7 +273,7 @@ Today every renderer wakes 25 times/sec regardless of what's mounted. A weather 
 - [x] SectorTimingProcessor — PR #663
 - [x] StandingsProcessor — PR #664
 - [x] Standings live-position projection — PR #665
-- [ ] Radio transmit state — `radio.snapshot`, event-driven and demand-activated; `feat/radio-channel` in progress
+- [ ] Radio transmit state — `radio.snapshot`, event-driven and demand-activated; PR #666 in review
 - [ ] Session-bar telemetry migration
 - [ ] Legacy `'telemetry'` channel removed or dev-only
 
@@ -466,7 +466,7 @@ LLM agents: read this file at the start of any session that touches the architec
 
 ## 6. Activity log
 
-- **2026-08-09** — PR #665 merged. Started the next explicit Phase 4 slice: move bursty `RadioTransmitCarIdx` state to a demand-activated, event-driven `radio.snapshot` channel while retaining renderer-configured icon persistence. Session-bar migration follows; legacy telemetry restriction/removal remains the Phase 4 exit step — `feat/radio-channel` — in progress
+- **2026-08-09** — PR #665 merged. Opened PR #666 for the next explicit Phase 4 slice: move bursty `RadioTransmitCarIdx` state to a demand-activated, event-driven `radio.snapshot` channel while retaining renderer-configured icon persistence. Session-bar migration follows; legacy telemetry restriction/removal remains the Phase 4 exit step — `feat/radio-channel` — in review
 
 - **2026-08-08** — Standings PR #664 merged. Opened PR #665 to move live in-class position calculation from renderer telemetry hooks into the demand-driven Standings processor with reusable projection buffers and conditional renderer subscriptions. Radio and session-bar telemetry remain after this slice — `feat/standings-live-positions` — in review
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -30,7 +30,7 @@
 | **Phase 2a remaining items**                          | R1+R2 LANDED, R3 PENDING | `feat/phase-2a-integration` for R1+R2    | R1 (reference-lap fetch dedup) + R2 (post-debounce write log) landed 2026-05-19. R3 (Empty Dashboard substrate baseline test) is a test run, not code work — pending.                                                                                                                                                                                                     |
 | **Phase 2b — Architectural cleanup (remaining)**      | NOT STARTED              | —                                        | A1, A4, A5, A6, A7 completion, A9. Lower urgency now Standings memory issue is resolved                                                                                                                                                                                                                                                                                   |
 | **Phase 3 — Channel-based bridge**                    | LANDED; MEMORY GATE OPEN | PRs #646, #649–#652, #656, #658          | Typed rate-aware channels, per-window subscriptions, deterministic replay validation, Fuel processor/renderer migration, conditional legacy telemetry, and performance instrumentation are on `main`. The Fuel-only A/B removed legacy deliveries and reduced app-wide renderer wake-ups by 42.4%; both baseline and candidate still failed the memory-slope gate.        |
-| **Phase 4 — Main-process processors**                 | IN PROGRESS              | PRs #659–#665                            | Fuel, lap times, car speeds, reference laps, relative gaps, sector timing, and Standings core state are on `main`. Standings live-position projection is in PR #665; radio/session-bar migration and legacy telemetry removal or development-only restriction remain.                                                                                                     |
+| **Phase 4 — Main-process processors**                 | IN PROGRESS              | PRs #659–#665; `feat/radio-channel`      | Fuel, lap times, car speeds, reference laps, relative gaps, sector timing, Standings core state, and live positions are on `main`. Radio migration is in progress; session-bar migration and legacy telemetry removal or development-only restriction remain.                                                                                                             |
 | **Phase 5 — Worker-thread SDK loop**                  | NOT STARTED              | —                                        |                                                                                                                                                                                                                                                                                                                                                                           |
 | **Phase 6 — Native optimisations**                    | DEFERRED                 | —                                        | Only if Phase 4 profiling demands                                                                                                                                                                                                                                                                                                                                         |
 
@@ -272,7 +272,9 @@ Today every renderer wakes 25 times/sec regardless of what's mounted. A weather 
 - [x] RelativeGapProcessor — PR #662
 - [x] SectorTimingProcessor — PR #663
 - [x] StandingsProcessor — PR #664
-- [ ] Standings live-position projection — PR #665 in review
+- [x] Standings live-position projection — PR #665
+- [ ] Radio transmit state — `radio.snapshot`, event-driven and demand-activated; `feat/radio-channel` in progress
+- [ ] Session-bar telemetry migration
 - [ ] Legacy `'telemetry'` channel removed or dev-only
 
 ### Phase 5 — Worker-thread SDK loop
@@ -463,6 +465,8 @@ LLM agents: read this file at the start of any session that touches the architec
 ---
 
 ## 6. Activity log
+
+- **2026-08-09** — PR #665 merged. Started the next explicit Phase 4 slice: move bursty `RadioTransmitCarIdx` state to a demand-activated, event-driven `radio.snapshot` channel while retaining renderer-configured icon persistence. Session-bar migration follows; legacy telemetry restriction/removal remains the Phase 4 exit step — `feat/radio-channel` — in progress
 
 - **2026-08-08** — Standings PR #664 merged. Opened PR #665 to move live in-class position calculation from renderer telemetry hooks into the demand-driven Standings processor with reusable projection buffers and conditional renderer subscriptions. Radio and session-bar telemetry remain after this slice — `feat/standings-live-positions` — in review
 

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -16,6 +16,7 @@ import { ReferenceLapRuntime } from '../../processors/referenceLapRuntime';
 import { RelativeGapRuntime } from '../../processors/relativeGapRuntime';
 import { SectorTimingRuntime } from '../../processors/sectorTimingRuntime';
 import { StandingsRuntime } from '../../processors/standingsRuntime';
+import { RadioRuntime } from '../../processors/radioRuntime';
 
 // Keys consumed by the renderer. Anything outside this set is dropped before
 // the telemetry object crosses the IPC boundary — reducing structured-clone
@@ -75,7 +76,6 @@ const TELEMETRY_ALLOWLIST = new Set<keyof Telemetry>([
   'LapDeltaToSessionLastlLap_OK',
   'Precipitation',
   'RPM',
-  'RadioTransmitCarIdx',
   'RelativeHumidity',
   'ReplayFrameNum',
   'SessionFlags',
@@ -204,6 +204,10 @@ export async function publishIRacingSDKEvents(
     lifecycle && channelBus
       ? new StandingsRuntime(channelBus, lifecycle, perfMetrics, isTapeReplay)
       : undefined;
+  const radioRuntime =
+    lifecycle && channelBus
+      ? new RadioRuntime(channelBus, lifecycle, perfMetrics, isTapeReplay)
+      : undefined;
 
   let shouldStop = false;
   let lastRunningState: boolean | undefined = undefined;
@@ -307,6 +311,7 @@ export async function publishIRacingSDKEvents(
           relativeGapRuntime?.onFrame(telemetry);
           sectorTimingRuntime?.onFrame(telemetry);
           standingsRuntime?.onFrame(telemetry);
+          radioRuntime?.onFrame(telemetry);
           if (
             perfTelemetryDeliveryEnabled &&
             overlayManager.hasLegacyStreamSubscribers('telemetry')
@@ -403,6 +408,7 @@ export async function publishIRacingSDKEvents(
       relativeGapRuntime?.dispose();
       sectorTimingRuntime?.dispose();
       standingsRuntime?.dispose();
+      radioRuntime?.dispose();
       referenceLapRuntime?.dispose();
       perfMetrics.stopReporting();
     },

--- a/src/app/bridge/iracingSdk/mock-data/mockSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/mock-data/mockSdkBridge.ts
@@ -8,6 +8,7 @@ import { ReferenceLapRuntime } from '../../../processors/referenceLapRuntime';
 import { RelativeGapRuntime } from '../../../processors/relativeGapRuntime';
 import { SectorTimingRuntime } from '../../../processors/sectorTimingRuntime';
 import { StandingsRuntime } from '../../../processors/standingsRuntime';
+import { RadioRuntime } from '../../../processors/radioRuntime';
 
 export async function publishIRacingSDKEvents(
   overlayManager: OverlayManager,
@@ -42,6 +43,9 @@ export async function publishIRacingSDKEvents(
   const standingsRuntime = channelBus
     ? new StandingsRuntime(channelBus, lifecycle, perfMetrics)
     : undefined;
+  const radioRuntime = channelBus
+    ? new RadioRuntime(channelBus, lifecycle, perfMetrics)
+    : undefined;
 
   bridge.onSessionData((session) => {
     carSpeedsRuntime?.onSession(session);
@@ -59,6 +63,7 @@ export async function publishIRacingSDKEvents(
     relativeGapRuntime?.onFrame(telemetry);
     sectorTimingRuntime?.onFrame(telemetry);
     standingsRuntime?.onFrame(telemetry);
+    radioRuntime?.onFrame(telemetry);
     perfMetrics.markStart('broadcast');
     overlayManager.publishMessage('telemetry', telemetry);
     perfMetrics.markEnd('broadcast');
@@ -78,6 +83,7 @@ export async function publishIRacingSDKEvents(
       relativeGapRuntime?.dispose();
       sectorTimingRuntime?.dispose();
       standingsRuntime?.dispose();
+      radioRuntime?.dispose();
       referenceLapRuntime?.dispose();
       perfMetrics.stopReporting();
       originalStop();

--- a/src/app/processors/RadioProcessor.spec.ts
+++ b/src/app/processors/RadioProcessor.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import type { Telemetry } from '@irdashies/types';
+import { RadioProcessor } from './RadioProcessor';
+
+const frame = (carIdxs: unknown) =>
+  ({ RadioTransmitCarIdx: { value: carIdxs } }) as Telemetry;
+
+describe('RadioProcessor', () => {
+  it('publishes only valid transmitting car indices when the signal changes', () => {
+    const processor = new RadioProcessor();
+    processor.onFrame(frame([-1]));
+    expect(processor.snapshot()).toEqual({
+      transmittingCarIdxs: [],
+      version: 0,
+    });
+
+    processor.onFrame(frame([-1, 5, 8]));
+    expect(processor.snapshot()).toEqual({
+      transmittingCarIdxs: [5, 8],
+      version: 1,
+    });
+    processor.onFrame(frame([-1, 5, 8]));
+    expect(processor.snapshot().version).toBe(1);
+    processor.onFrame(frame([-1]));
+    expect(processor.snapshot()).toEqual({
+      transmittingCarIdxs: [],
+      version: 2,
+    });
+  });
+
+  it('clears on lifecycle transitions and ignores replay scrubbing', () => {
+    const processor = new RadioProcessor();
+    processor.onFrame(frame([5]));
+    processor.onLifecycle({ type: 'sessionNumChange' });
+    expect(processor.snapshot().transmittingCarIdxs).toEqual([]);
+
+    processor.onLifecycle({ type: 'enter', replay: true });
+    processor.onFrame(frame([8]));
+    expect(processor.snapshot().transmittingCarIdxs).toEqual([]);
+
+    processor.onLifecycle({ type: 'enter', replay: false });
+    processor.onFrame(frame([8]));
+    expect(processor.snapshot().transmittingCarIdxs).toEqual([8]);
+  });
+});

--- a/src/app/processors/RadioProcessor.spec.ts
+++ b/src/app/processors/RadioProcessor.spec.ts
@@ -28,6 +28,20 @@ describe('RadioProcessor', () => {
     });
   });
 
+  it('does not republish reordered or duplicate transmitter indexes', () => {
+    const processor = new RadioProcessor();
+    processor.onFrame(frame([8, 5]));
+    expect(processor.snapshot()).toEqual({
+      transmittingCarIdxs: [5, 8],
+      version: 1,
+    });
+    processor.onFrame(frame([5, 5, 8]));
+    expect(processor.snapshot()).toEqual({
+      transmittingCarIdxs: [5, 8],
+      version: 1,
+    });
+  });
+
   it('clears on lifecycle transitions and ignores replay scrubbing', () => {
     const processor = new RadioProcessor();
     processor.onFrame(frame([5]));

--- a/src/app/processors/RadioProcessor.ts
+++ b/src/app/processors/RadioProcessor.ts
@@ -1,0 +1,63 @@
+import type {
+  RadioSnapshot,
+  Session,
+  SessionLifecycleEvent,
+  Telemetry,
+} from '@irdashies/types';
+import type { TelemetryProcessor } from './TelemetryProcessor';
+
+export class RadioProcessor implements TelemetryProcessor<RadioSnapshot> {
+  readonly channel = 'radio.snapshot';
+  readonly tickRateHz = 'event';
+
+  private enabled = true;
+  private readonly latest: RadioSnapshot = {
+    transmittingCarIdxs: [],
+    version: 0,
+  };
+
+  init(session: Session): void {
+    void session;
+  }
+
+  onFrame(frame: Telemetry): void {
+    if (!this.enabled) return;
+    const source = frame.RadioTransmitCarIdx?.value;
+    const target = this.latest.transmittingCarIdxs as number[];
+    let targetIndex = 0;
+    let changed = false;
+    if (Array.isArray(source)) {
+      for (const value of source) {
+        if (typeof value === 'number' && value >= 0) {
+          if (target[targetIndex] !== value) {
+            target[targetIndex] = value;
+            changed = true;
+          }
+          targetIndex += 1;
+        }
+      }
+    }
+    if (target.length !== targetIndex) changed = true;
+    target.length = targetIndex;
+    if (changed) this.latest.version += 1;
+  }
+
+  onLifecycle(event: SessionLifecycleEvent): void {
+    if (event.type === 'enter') {
+      this.enabled = !event.replay;
+      if (!this.enabled) this.reset();
+      return;
+    }
+    this.reset();
+  }
+
+  snapshot(): RadioSnapshot {
+    return this.latest;
+  }
+
+  private reset(): void {
+    if (this.latest.transmittingCarIdxs.length === 0) return;
+    (this.latest.transmittingCarIdxs as number[]).length = 0;
+    this.latest.version += 1;
+  }
+}

--- a/src/app/processors/RadioProcessor.ts
+++ b/src/app/processors/RadioProcessor.ts
@@ -11,6 +11,7 @@ export class RadioProcessor implements TelemetryProcessor<RadioSnapshot> {
   readonly tickRateHz = 'event';
 
   private enabled = true;
+  private readonly candidateCarIdxs: number[] = [];
   private readonly latest: RadioSnapshot = {
     transmittingCarIdxs: [],
     version: 0,
@@ -24,22 +25,28 @@ export class RadioProcessor implements TelemetryProcessor<RadioSnapshot> {
     if (!this.enabled) return;
     const source = frame.RadioTransmitCarIdx?.value;
     const target = this.latest.transmittingCarIdxs as number[];
-    let targetIndex = 0;
-    let changed = false;
+    const candidate = this.candidateCarIdxs;
+    candidate.length = 0;
     if (Array.isArray(source)) {
       for (const value of source) {
-        if (typeof value === 'number' && value >= 0) {
-          if (target[targetIndex] !== value) {
-            target[targetIndex] = value;
-            changed = true;
-          }
-          targetIndex += 1;
-        }
+        if (
+          typeof value === 'number' &&
+          value >= 0 &&
+          !candidate.includes(value)
+        )
+          candidate.push(value);
       }
     }
-    if (target.length !== targetIndex) changed = true;
-    target.length = targetIndex;
-    if (changed) this.latest.version += 1;
+    candidate.sort((a, b) => a - b);
+    let changed = target.length !== candidate.length;
+    for (let index = 0; index < candidate.length; index += 1) {
+      if (target[index] !== candidate[index]) changed = true;
+    }
+    if (!changed) return;
+    target.length = candidate.length;
+    for (let index = 0; index < candidate.length; index += 1)
+      target[index] = candidate[index];
+    this.latest.version += 1;
   }
 
   onLifecycle(event: SessionLifecycleEvent): void {

--- a/src/app/processors/radioRuntime.spec.ts
+++ b/src/app/processors/radioRuntime.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Telemetry } from '@irdashies/types';
+import { ChannelBus } from '../bridge/channelBridge';
+import { RadioRuntime } from './radioRuntime';
+
+const frame = (carIdxs: number[]) =>
+  ({ RadioTransmitCarIdx: { value: carIdxs } }) as Telemetry;
+const target = {
+  id: 1,
+  isDestroyed: () => false,
+  isVisible: () => true,
+  send: vi.fn(),
+};
+const metrics = () => ({ markStart: vi.fn(), markEnd: vi.fn() });
+
+describe('RadioRuntime', () => {
+  it('publishes changed radio state only while demanded', () => {
+    const bus = new ChannelBus();
+    const publish = vi.spyOn(bus, 'publish');
+    const runtime = new RadioRuntime(bus, undefined, metrics());
+    runtime.onFrame(frame([5]));
+    expect(publish).not.toHaveBeenCalled();
+
+    bus.subscribe(target, 'radio.snapshot');
+    runtime.onFrame(frame([5]));
+    runtime.onFrame(frame([5]));
+    expect(publish).toHaveBeenCalledOnce();
+    expect(publish).toHaveBeenCalledWith(
+      'radio.snapshot',
+      expect.objectContaining({ transmittingCarIdxs: [5] })
+    );
+
+    bus.unsubscribe(target.id, 'radio.snapshot');
+    runtime.onFrame(frame([8]));
+    expect(publish).toHaveBeenCalledOnce();
+  });
+
+  it('activates for subscribers that predate the runtime', () => {
+    const bus = new ChannelBus();
+    const publish = vi.spyOn(bus, 'publish');
+    bus.subscribe(target, 'radio.snapshot');
+    const runtime = new RadioRuntime(bus, undefined, metrics());
+    runtime.onFrame(frame([5]));
+    expect(publish).toHaveBeenCalledOnce();
+  });
+
+  it('clears cached state when disposed', () => {
+    const bus = new ChannelBus();
+    const clearSnapshot = vi.spyOn(bus, 'clearSnapshot');
+    bus.subscribe(target, 'radio.snapshot');
+    const runtime = new RadioRuntime(bus, undefined, metrics());
+    runtime.onFrame(frame([5]));
+    runtime.dispose();
+    expect(clearSnapshot).toHaveBeenLastCalledWith('radio.snapshot');
+  });
+});

--- a/src/app/processors/radioRuntime.ts
+++ b/src/app/processors/radioRuntime.ts
@@ -1,0 +1,100 @@
+import type { SessionLifecycleEvent, Telemetry } from '@irdashies/types';
+import type { ChannelBus } from '../bridge/channelBridge';
+import type { SessionLifecycle } from '../sessionLifecycle';
+import { RadioProcessor } from './RadioProcessor';
+
+interface PerformanceSections {
+  markStart(label: string): void;
+  markEnd(label: string): void;
+}
+
+export class RadioRuntime {
+  private processor?: RadioProcessor;
+  private replaySource?: boolean;
+  private publishedVersion = -1;
+  private readonly disconnects: (() => void)[];
+
+  constructor(
+    private readonly bus: ChannelBus,
+    lifecycle: SessionLifecycle | undefined,
+    private readonly metrics: PerformanceSections,
+    private readonly aggregateReplay = false
+  ) {
+    this.disconnects = [
+      bus.onSubscriberCountChanged((channel, count) => {
+        if (channel !== 'radio.snapshot') return;
+        if (count > 0) this.activate();
+        else this.deactivate();
+      }),
+    ];
+    if (lifecycle) {
+      this.disconnects.push(
+        lifecycle.onEnter(({ replay }) => {
+          this.replaySource = replay;
+          this.onLifecycle({
+            type: 'enter',
+            replay: replay && !this.aggregateReplay,
+          });
+        }),
+        lifecycle.onSessionNumChange(() =>
+          this.onLifecycle({ type: 'sessionNumChange' })
+        ),
+        lifecycle.onDisconnect(() => this.onLifecycle({ type: 'disconnect' }))
+      );
+    }
+    if (bus.subscriberCount('radio.snapshot') > 0) this.activate();
+  }
+
+  onFrame(frame: Telemetry): void {
+    if (!this.processor) return;
+    this.metrics.markStart('radioProcessing');
+    this.processor.onFrame(frame);
+    this.metrics.markEnd('radioProcessing');
+    this.publishIfChanged();
+  }
+
+  dispose(): void {
+    if (this.processor) {
+      this.processor.onLifecycle({ type: 'disconnect' });
+      this.publishIfChanged();
+    }
+    this.deactivate();
+    this.disconnects.forEach((disconnect) => disconnect());
+  }
+
+  private activate(): void {
+    if (this.processor) return;
+    this.bus.clearSnapshot('radio.snapshot');
+    this.processor = new RadioProcessor();
+    this.publishedVersion = -1;
+    if (this.replaySource !== undefined) {
+      this.processor.onLifecycle({
+        type: 'enter',
+        replay: this.replaySource && !this.aggregateReplay,
+      });
+    }
+  }
+
+  private deactivate(): void {
+    this.processor = undefined;
+    this.publishedVersion = -1;
+    this.bus.clearSnapshot('radio.snapshot');
+  }
+
+  private onLifecycle(event: SessionLifecycleEvent): void {
+    this.processor?.onLifecycle(event);
+    if (this.processor) this.publishIfChanged();
+    else this.bus.clearSnapshot('radio.snapshot');
+    if (event.type === 'disconnect') this.replaySource = undefined;
+  }
+
+  private publishIfChanged(): void {
+    if (!this.processor) return;
+    const snapshot = this.processor.snapshot();
+    if (snapshot.version === this.publishedVersion) return;
+    this.publishedVersion = snapshot.version;
+    this.metrics.markStart('radioPublication');
+    this.bus.publish('radio.snapshot', snapshot);
+    this.metrics.markEnd('radioPublication');
+  }
+}

--- a/src/frontend/components/Relative/widgetRuntimeDefinition.ts
+++ b/src/frontend/components/Relative/widgetRuntimeDefinition.ts
@@ -5,8 +5,10 @@ export default {
   legacyTelemetry: true,
   channels: [
     'lap-times.snapshot',
+    'radio.snapshot',
     'relative-gaps.snapshot',
     'standings.snapshot',
   ],
   ratePreset: 'gapTiming',
+  channelRates: { 'radio.snapshot': 25 },
 } satisfies WidgetRuntimeDefinition;

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.spec.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.spec.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, it, vi, expect, beforeEach, afterEach } from 'vitest';
-import { useTelemetryValues } from '@irdashies/context';
+import { useRadioSnapshot } from '@irdashies/context';
 import { useRadioActiveCarIdxs } from './useRadioActiveCarIdxs';
 
 vi.mock('@irdashies/context');
@@ -16,13 +16,19 @@ describe('useRadioActiveCarIdxs', () => {
   });
 
   it('passes the live value straight through when persistence is disabled', () => {
-    vi.mocked(useTelemetryValues).mockReturnValue([5] as number[]);
+    vi.mocked(useRadioSnapshot).mockReturnValue({
+      transmittingCarIdxs: [5],
+      version: 1,
+    });
     const { result } = renderHook(() => useRadioActiveCarIdxs(0));
     expect(result.current).toEqual([5]);
   });
 
   it('filters out the -1 idle sentinel', () => {
-    vi.mocked(useTelemetryValues).mockReturnValue([-1] as number[]);
+    vi.mocked(useRadioSnapshot).mockReturnValue({
+      transmittingCarIdxs: [],
+      version: 1,
+    });
     const { result } = renderHook(() => useRadioActiveCarIdxs(0));
     expect(result.current).toEqual([]);
   });
@@ -30,7 +36,10 @@ describe('useRadioActiveCarIdxs', () => {
   it('keeps a car active for the persistence window after it stops transmitting', () => {
     const { result, rerender } = renderHook(
       ({ value }) => {
-        vi.mocked(useTelemetryValues).mockReturnValue(value as number[]);
+        vi.mocked(useRadioSnapshot).mockReturnValue({
+          transmittingCarIdxs: value.filter((carIdx) => carIdx >= 0),
+          version: 1,
+        });
         return useRadioActiveCarIdxs(3000);
       },
       { initialProps: { value: [5] } }
@@ -59,7 +68,10 @@ describe('useRadioActiveCarIdxs', () => {
   it('refreshes the window each time a car is seen transmitting again', () => {
     const { result, rerender } = renderHook(
       ({ value }) => {
-        vi.mocked(useTelemetryValues).mockReturnValue(value as number[]);
+        vi.mocked(useRadioSnapshot).mockReturnValue({
+          transmittingCarIdxs: value.filter((carIdx) => carIdx >= 0),
+          version: 1,
+        });
         return useRadioActiveCarIdxs(3000);
       },
       { initialProps: { value: [5] } }
@@ -85,7 +97,10 @@ describe('useRadioActiveCarIdxs', () => {
   it('stays solidly lit while a car flip-flaps the radio rapidly', () => {
     const { result, rerender } = renderHook(
       ({ value }) => {
-        vi.mocked(useTelemetryValues).mockReturnValue(value as number[]);
+        vi.mocked(useRadioSnapshot).mockReturnValue({
+          transmittingCarIdxs: value.filter((carIdx) => carIdx >= 0),
+          version: 1,
+        });
         return useRadioActiveCarIdxs(3000);
       },
       { initialProps: { value: [5] } }

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.spec.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.spec.tsx
@@ -24,7 +24,7 @@ describe('useRadioActiveCarIdxs', () => {
     expect(result.current).toEqual([5]);
   });
 
-  it('filters out the -1 idle sentinel', () => {
+  it('returns no active cars for an empty radio snapshot', () => {
     vi.mocked(useRadioSnapshot).mockReturnValue({
       transmittingCarIdxs: [],
       version: 1,
@@ -61,6 +61,35 @@ describe('useRadioActiveCarIdxs', () => {
     // After the full window elapses, the car clears even with no new telemetry.
     act(() => {
       vi.advanceTimersByTime(2100);
+    });
+    expect(result.current).toEqual([]);
+  });
+
+  it('starts the persistence window when a long transmission ends', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => {
+        vi.mocked(useRadioSnapshot).mockReturnValue({
+          transmittingCarIdxs: value,
+          version: 1,
+        });
+        return useRadioActiveCarIdxs(3000);
+      },
+      { initialProps: { value: [5] } }
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(result.current).toEqual([5]);
+
+    rerender({ value: [] });
+    act(() => {
+      vi.advanceTimersByTime(2900);
+    });
+    expect(result.current).toEqual([5]);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
     });
     expect(result.current).toEqual([]);
   });

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.stories.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.stories.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import { SpeakerHighIcon } from '@phosphor-icons/react';
 import type { ChannelPayloads } from '@irdashies/types';
+import { TelemetryDecorator } from '@irdashies/storybook';
 import { useRadioActiveCarIdxs } from './useRadioActiveCarIdxs';
 
 const DEMO_CAR_IDX = 7;
@@ -18,26 +19,29 @@ const setRadioTransmit = (carIdxs: number[]) => {
 };
 
 const RadioChannelDecorator: Decorator = (Story) => {
-  const previousBridge = useRef(window.channelBridge);
-  window.channelBridge = {
-    subscribe: (channel, callback) => {
-      if (channel !== 'radio.snapshot') return () => undefined;
-      const subscriber = callback as (
-        snapshot: ChannelPayloads['radio.snapshot']
-      ) => void;
-      subscribers.add(subscriber);
-      subscriber({ transmittingCarIdxs: [], version });
-      return () => subscribers.delete(subscriber);
-    },
-  };
-  useEffect(
-    () => () => {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const previousBridge = window.channelBridge;
+    window.channelBridge = {
+      subscribe: (channel, callback, requestedRateHz) => {
+        if (channel !== 'radio.snapshot') {
+          return previousBridge?.subscribe(channel, callback, requestedRateHz);
+        }
+        const subscriber = callback as (
+          snapshot: ChannelPayloads['radio.snapshot']
+        ) => void;
+        subscribers.add(subscriber);
+        subscriber({ transmittingCarIdxs: [], version });
+        return () => subscribers.delete(subscriber);
+      },
+    };
+    setReady(true);
+    return () => {
       subscribers.clear();
-      window.channelBridge = previousBridge.current;
-    },
-    []
-  );
-  return <Story />;
+      window.channelBridge = previousBridge;
+    };
+  }, []);
+  return ready ? <Story /> : <></>;
 };
 
 type DemoMode = 'flip-flap' | 'single-burst';
@@ -62,7 +66,7 @@ const RadioDebounceHarness = ({
 
     if (mode === 'flip-flap') {
       // Rapidly key the radio on/off — the bug that used to make the icon
-      // strobe. Each "on" frame re-arms the debounce, so it stays solidly lit.
+      // strobe. Each completed burst starts a fresh persistence window.
       let on = false;
       const id = setInterval(() => {
         on = !on;
@@ -118,7 +122,7 @@ const RadioDebounceHarness = ({
 
       <p className="text-xs text-slate-400">
         {mode === 'flip-flap'
-          ? `Raw signal flips every 500ms, but the icon stays lit — each transmit frame re-arms the ${persistenceSeconds}s window.`
+          ? `Raw signal flips every 500ms, but each completed burst starts a fresh ${persistenceSeconds}s persistence window.`
           : `A single burst lights the icon, then it lingers for ${persistenceSeconds}s after the last transmit frame before clearing.`}
       </p>
     </div>
@@ -128,7 +132,7 @@ const RadioDebounceHarness = ({
 const meta: Meta<typeof RadioDebounceHarness> = {
   title: 'widgets/Standings/hooks/useRadioActiveCarIdxs',
   component: RadioDebounceHarness,
-  decorators: [RadioChannelDecorator],
+  decorators: [TelemetryDecorator(), RadioChannelDecorator],
 };
 
 export default meta;

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.stories.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.stories.tsx
@@ -1,22 +1,44 @@
-import { useEffect, useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useEffect, useRef, useState } from 'react';
+import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import { SpeakerHighIcon } from '@phosphor-icons/react';
-import { useTelemetryStore } from '@irdashies/context';
-import type { Telemetry } from '@irdashies/types';
+import type { ChannelPayloads } from '@irdashies/types';
 import { useRadioActiveCarIdxs } from './useRadioActiveCarIdxs';
 
 const DEMO_CAR_IDX = 7;
 
-// Push only the key the hook reads straight into the telemetry store.
-//
-// These stories intentionally do NOT use TelemetryDecorator: the mock bridge
-// streams a full telemetry frame at 60Hz and would clobber anything we inject
-// within ~16ms. Driving the store directly lets us flip-flap
-// RadioTransmitCarIdx deterministically and watch the *real* hook debounce it.
-const setRadioTransmit = (carIdxs: number[]) =>
-  useTelemetryStore.getState().setTelemetry({
-    RadioTransmitCarIdx: { value: carIdxs },
-  } as Telemetry);
+const subscribers = new Set<
+  (snapshot: ChannelPayloads['radio.snapshot']) => void
+>();
+let version = 0;
+const setRadioTransmit = (carIdxs: number[]) => {
+  version += 1;
+  subscribers.forEach((subscriber) =>
+    subscriber({ transmittingCarIdxs: carIdxs, version })
+  );
+};
+
+const RadioChannelDecorator: Decorator = (Story) => {
+  const previousBridge = useRef(window.channelBridge);
+  window.channelBridge = {
+    subscribe: (channel, callback) => {
+      if (channel !== 'radio.snapshot') return () => undefined;
+      const subscriber = callback as (
+        snapshot: ChannelPayloads['radio.snapshot']
+      ) => void;
+      subscribers.add(subscriber);
+      subscriber({ transmittingCarIdxs: [], version });
+      return () => subscribers.delete(subscriber);
+    },
+  };
+  useEffect(
+    () => () => {
+      subscribers.clear();
+      window.channelBridge = previousBridge.current;
+    },
+    []
+  );
+  return <Story />;
+};
 
 type DemoMode = 'flip-flap' | 'single-burst';
 
@@ -30,12 +52,12 @@ const RadioDebounceHarness = ({
   const [rawTransmitting, setRawTransmitting] = useState(false);
 
   useEffect(() => {
-    setRadioTransmit([-1]);
+    setRadioTransmit([]);
 
     const timers: ReturnType<typeof setTimeout>[] = [];
     const transmit = (on: boolean) => {
       setRawTransmitting(on);
-      setRadioTransmit(on ? [DEMO_CAR_IDX] : [-1]);
+      setRadioTransmit(on ? [DEMO_CAR_IDX] : []);
     };
 
     if (mode === 'flip-flap') {
@@ -48,7 +70,7 @@ const RadioDebounceHarness = ({
       }, 500);
       return () => {
         clearInterval(id);
-        useTelemetryStore.getState().resetTelemetry();
+        setRadioTransmit([]);
       };
     }
 
@@ -57,7 +79,7 @@ const RadioDebounceHarness = ({
     timers.push(setTimeout(() => transmit(false), 1600));
     return () => {
       timers.forEach(clearTimeout);
-      useTelemetryStore.getState().resetTelemetry();
+      setRadioTransmit([]);
     };
   }, [mode]);
 
@@ -106,6 +128,7 @@ const RadioDebounceHarness = ({
 const meta: Meta<typeof RadioDebounceHarness> = {
   title: 'widgets/Standings/hooks/useRadioActiveCarIdxs',
   component: RadioDebounceHarness,
+  decorators: [RadioChannelDecorator],
 };
 
 export default meta;

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.tsx
@@ -24,8 +24,9 @@ export const useRadioActiveCarIdxs = (persistenceMs: number): number[] => {
     [radioTransmitCarIdx]
   );
 
-  // carIdx -> timestamp the icon should clear (last transmit frame + window).
+  // carIdx -> timestamp the icon should clear (key-up + persistence window).
   const expiryRef = useRef<Map<number, number>>(new Map());
+  const previousTransmittingRef = useRef<readonly number[]>([]);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
   );
@@ -37,17 +38,24 @@ export const useRadioActiveCarIdxs = (persistenceMs: number): number[] => {
 
     if (persistenceMs <= 0) {
       expiry.clear();
+      previousTransmittingRef.current = transmitting;
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
       return;
     }
 
-    // (Re)stamp each heard car's clear deadline. Seeing a car again before its
-    // deadline simply pushes it out — this is the debounce that keeps the icon
-    // solidly lit through rapid flip-flapping.
+    // Start the full persistence window when a transmission ends. This matters
+    // when a driver talks longer than the configured window: stamping only the
+    // key-down event would let the deadline expire before key-up.
     const now = Date.now();
-    for (const carIdx of transmitting) {
-      expiry.set(carIdx, now + persistenceMs);
+    let transmissionEnded = false;
+    for (const carIdx of previousTransmittingRef.current) {
+      if (!transmitting.includes(carIdx)) {
+        expiry.set(carIdx, now + persistenceMs);
+        transmissionEnded = true;
+      }
     }
+    previousTransmittingRef.current = transmitting;
+    if (transmissionEnded) forceRender();
 
     // Schedule a re-render at the soonest deadline so the icon clears even on an
     // idle grid where no new telemetry arrives to trigger renders. Reschedules

--- a/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.tsx
+++ b/src/frontend/components/Standings/hooks/useRadioActiveCarIdxs.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useReducer, useRef } from 'react';
-import { useTelemetryValues } from '@irdashies/context';
+import { useRadioSnapshot } from '@irdashies/context';
+
+const EMPTY_CAR_IDXS: readonly number[] = [];
 
 /**
  * Tracks which car indices should show the radio/speaker icon.
@@ -14,12 +16,11 @@ import { useTelemetryValues } from '@irdashies/context';
  * When `persistenceMs <= 0` the live transmitting set is returned unchanged.
  */
 export const useRadioActiveCarIdxs = (persistenceMs: number): number[] => {
-  const radioTransmitCarIdx = useTelemetryValues<number[]>(
-    'RadioTransmitCarIdx'
-  );
+  const radioTransmitCarIdx =
+    useRadioSnapshot()?.transmittingCarIdxs ?? EMPTY_CAR_IDXS;
 
   const transmitting = useMemo(
-    () => radioTransmitCarIdx.filter((carIdx) => carIdx >= 0),
+    () => [...radioTransmitCarIdx],
     [radioTransmitCarIdx]
   );
 

--- a/src/frontend/components/Standings/widgetRuntimeDefinition.ts
+++ b/src/frontend/components/Standings/widgetRuntimeDefinition.ts
@@ -6,7 +6,9 @@ export default {
   channels: [
     'lap-times.snapshot',
     'reference-laps.snapshot',
+    'radio.snapshot',
     'standings.snapshot',
   ],
   ratePreset: 'gapTiming',
+  channelRates: { 'radio.snapshot': 25 },
 } satisfies WidgetRuntimeDefinition;

--- a/src/frontend/context/ChannelStore/index.ts
+++ b/src/frontend/context/ChannelStore/index.ts
@@ -3,6 +3,7 @@ export * from './useChannelSnapshot';
 export * from './useFuelProjectionSnapshot';
 export * from './useLapTimesSnapshot';
 export * from './useRelativeGapsSnapshot';
+export * from './useRadioSnapshot';
 export * from './useSectorTimingSnapshot';
 export * from './useStandingsSnapshot';
 export * from './useCarSpeedsSnapshot';

--- a/src/frontend/context/ChannelStore/useRadioSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useRadioSnapshot.ts
@@ -1,0 +1,10 @@
+import { useWidgetChannelRate } from '../../widgetRuntime';
+import { useChannelSnapshot } from './useChannelSnapshot';
+
+export const useRadioSnapshot = (enabled = true) =>
+  useChannelSnapshot(
+    'radio.snapshot',
+    useWidgetChannelRate('radio.snapshot'),
+    undefined,
+    enabled
+  );

--- a/src/frontend/widgetRuntime.spec.tsx
+++ b/src/frontend/widgetRuntime.spec.tsx
@@ -40,16 +40,20 @@ describe('widget runtime metadata', () => {
       channels: [
         'lap-times.snapshot',
         'reference-laps.snapshot',
+        'radio.snapshot',
         'standings.snapshot',
       ],
+      channelRates: { 'radio.snapshot': 25 },
     });
     expect(getWidgetRuntimeDefinition('relative')).toMatchObject({
       legacyTelemetry: true,
       channels: [
         'lap-times.snapshot',
+        'radio.snapshot',
         'relative-gaps.snapshot',
         'standings.snapshot',
       ],
+      channelRates: { 'radio.snapshot': 25 },
     });
   });
 

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -12,10 +12,17 @@ export interface ChannelPayloads {
   'fuel.projection': FuelProjectionSnapshot;
   'lap-times.snapshot': LapTimesSnapshot;
   'reference-laps.snapshot': ReferenceLapsSnapshot;
+  'radio.snapshot': RadioSnapshot;
   'relative-gaps.snapshot': RelativeGapsSnapshot;
   'sector-timing.snapshot': SectorTimingSnapshot;
   'standings.snapshot': StandingsSnapshot;
   'session.lifecycle': SessionLifecycleEvent;
+}
+
+export interface RadioSnapshot {
+  /** Cars transmitting on the current SDK frame, excluding the idle sentinel. */
+  transmittingCarIdxs: readonly number[];
+  version: number;
 }
 
 export interface StandingsSnapshot {
@@ -165,6 +172,11 @@ export const channelRegistry = {
     kind: 'snapshot',
     defaultRateHz: 5,
     maxRateHz: 5,
+  },
+  'radio.snapshot': {
+    kind: 'snapshot',
+    defaultRateHz: 25,
+    maxRateHz: 25,
   },
   'relative-gaps.snapshot': {
     kind: 'snapshot',

--- a/test-data/telemetry/ai-race-10min.golden.json
+++ b/test-data/telemetry/ai-race-10min.golden.json
@@ -7307,6 +7307,372 @@
           "revision": 78
         }
       }
+    },
+    {
+      "name": "radio-state",
+      "schemaVersion": 1,
+      "frameCount": 36000,
+      "rollingHash": "f010982c8e6f7d6956aaf679ad36d34171a14c72e338b40696b2a03302190516",
+      "checkpoints": {
+        "firstFrame": {
+          "transmittingCarIdxs": [],
+          "version": 0
+        },
+        "lastFrame": {
+          "transmittingCarIdxs": [],
+          "version": 0
+        },
+        "session:0": {
+          "sourceTick": -1,
+          "elapsedSeconds": 0.5,
+          "revision": 9
+        },
+        "session:1": {
+          "sourceTick": 5459,
+          "elapsedSeconds": 63.5,
+          "revision": 10
+        },
+        "session:2": {
+          "sourceTick": 8939,
+          "elapsedSeconds": 121.5,
+          "revision": 11
+        },
+        "session:3": {
+          "sourceTick": 13319,
+          "elapsedSeconds": 194.5,
+          "revision": 12
+        },
+        "session:4": {
+          "sourceTick": 13439,
+          "elapsedSeconds": 196.5,
+          "revision": 13
+        },
+        "session:5": {
+          "sourceTick": 13559,
+          "elapsedSeconds": 198.5,
+          "revision": 14
+        },
+        "session:6": {
+          "sourceTick": 13679,
+          "elapsedSeconds": 200.5,
+          "revision": 15
+        },
+        "session:7": {
+          "sourceTick": 13799,
+          "elapsedSeconds": 202.5,
+          "revision": 16
+        },
+        "session:8": {
+          "sourceTick": 13919,
+          "elapsedSeconds": 204.5,
+          "revision": 17
+        },
+        "session:9": {
+          "sourceTick": 14039,
+          "elapsedSeconds": 206.5,
+          "revision": 18
+        },
+        "session:10": {
+          "sourceTick": 14159,
+          "elapsedSeconds": 208.5,
+          "revision": 19
+        },
+        "session:11": {
+          "sourceTick": 14279,
+          "elapsedSeconds": 210.5,
+          "revision": 20
+        },
+        "session:12": {
+          "sourceTick": 14399,
+          "elapsedSeconds": 212.5,
+          "revision": 21
+        },
+        "session:13": {
+          "sourceTick": 14519,
+          "elapsedSeconds": 214.5,
+          "revision": 22
+        },
+        "session:14": {
+          "sourceTick": 20579,
+          "elapsedSeconds": 315.5,
+          "revision": 23
+        },
+        "session:15": {
+          "sourceTick": 20819,
+          "elapsedSeconds": 319.5,
+          "revision": 24
+        },
+        "session:16": {
+          "sourceTick": 20939,
+          "elapsedSeconds": 321.5,
+          "revision": 25
+        },
+        "session:17": {
+          "sourceTick": 21059,
+          "elapsedSeconds": 323.5,
+          "revision": 26
+        },
+        "session:18": {
+          "sourceTick": 21299,
+          "elapsedSeconds": 327.5,
+          "revision": 27
+        },
+        "session:19": {
+          "sourceTick": 21419,
+          "elapsedSeconds": 329.5,
+          "revision": 28
+        },
+        "session:20": {
+          "sourceTick": 21539,
+          "elapsedSeconds": 331.5,
+          "revision": 29
+        },
+        "session:21": {
+          "sourceTick": 21659,
+          "elapsedSeconds": 333.5,
+          "revision": 30
+        },
+        "session:22": {
+          "sourceTick": 21779,
+          "elapsedSeconds": 335.5,
+          "revision": 31
+        },
+        "session:23": {
+          "sourceTick": 21899,
+          "elapsedSeconds": 337.5,
+          "revision": 32
+        },
+        "session:24": {
+          "sourceTick": 22019,
+          "elapsedSeconds": 339.5,
+          "revision": 33
+        },
+        "session:25": {
+          "sourceTick": 22139,
+          "elapsedSeconds": 341.5,
+          "revision": 34
+        },
+        "session:26": {
+          "sourceTick": 22259,
+          "elapsedSeconds": 343.5,
+          "revision": 35
+        },
+        "session:27": {
+          "sourceTick": 22379,
+          "elapsedSeconds": 345.5,
+          "revision": 36
+        },
+        "session:28": {
+          "sourceTick": 22499,
+          "elapsedSeconds": 347.5,
+          "revision": 37
+        },
+        "session:29": {
+          "sourceTick": 22619,
+          "elapsedSeconds": 349.5,
+          "revision": 38
+        },
+        "session:30": {
+          "sourceTick": 22739,
+          "elapsedSeconds": 351.5,
+          "revision": 39
+        },
+        "session:31": {
+          "sourceTick": 27839,
+          "elapsedSeconds": 436.5,
+          "revision": 40
+        },
+        "session:32": {
+          "sourceTick": 27959,
+          "elapsedSeconds": 438.5,
+          "revision": 41
+        },
+        "session:33": {
+          "sourceTick": 28079,
+          "elapsedSeconds": 440.5,
+          "revision": 42
+        },
+        "session:34": {
+          "sourceTick": 28199,
+          "elapsedSeconds": 442.5,
+          "revision": 43
+        },
+        "session:35": {
+          "sourceTick": 28319,
+          "elapsedSeconds": 444.5,
+          "revision": 44
+        },
+        "session:36": {
+          "sourceTick": 28559,
+          "elapsedSeconds": 448.5,
+          "revision": 45
+        },
+        "session:37": {
+          "sourceTick": 28799,
+          "elapsedSeconds": 452.5,
+          "revision": 46
+        },
+        "session:38": {
+          "sourceTick": 28919,
+          "elapsedSeconds": 454.5,
+          "revision": 47
+        },
+        "session:39": {
+          "sourceTick": 29039,
+          "elapsedSeconds": 456.5,
+          "revision": 48
+        },
+        "session:40": {
+          "sourceTick": 29159,
+          "elapsedSeconds": 458.5,
+          "revision": 49
+        },
+        "session:41": {
+          "sourceTick": 29279,
+          "elapsedSeconds": 460.5,
+          "revision": 50
+        },
+        "session:42": {
+          "sourceTick": 29399,
+          "elapsedSeconds": 462.5,
+          "revision": 51
+        },
+        "session:43": {
+          "sourceTick": 29639,
+          "elapsedSeconds": 466.5,
+          "revision": 52
+        },
+        "session:44": {
+          "sourceTick": 29759,
+          "elapsedSeconds": 468.5,
+          "revision": 53
+        },
+        "session:45": {
+          "sourceTick": 29879,
+          "elapsedSeconds": 470.5,
+          "revision": 54
+        },
+        "session:46": {
+          "sourceTick": 29999,
+          "elapsedSeconds": 472.5,
+          "revision": 55
+        },
+        "session:47": {
+          "sourceTick": 30119,
+          "elapsedSeconds": 474.5,
+          "revision": 56
+        },
+        "session:48": {
+          "sourceTick": 30239,
+          "elapsedSeconds": 476.5,
+          "revision": 57
+        },
+        "session:49": {
+          "sourceTick": 30359,
+          "elapsedSeconds": 478.5,
+          "revision": 58
+        },
+        "session:50": {
+          "sourceTick": 30479,
+          "elapsedSeconds": 480.5,
+          "revision": 59
+        },
+        "session:51": {
+          "sourceTick": 34859,
+          "elapsedSeconds": 553.5,
+          "revision": 60
+        },
+        "session:52": {
+          "sourceTick": 35219,
+          "elapsedSeconds": 559.5,
+          "revision": 61
+        },
+        "session:53": {
+          "sourceTick": 35339,
+          "elapsedSeconds": 561.5,
+          "revision": 62
+        },
+        "session:54": {
+          "sourceTick": 35459,
+          "elapsedSeconds": 563.5,
+          "revision": 63
+        },
+        "session:55": {
+          "sourceTick": 35699,
+          "elapsedSeconds": 567.5,
+          "revision": 64
+        },
+        "session:56": {
+          "sourceTick": 36059,
+          "elapsedSeconds": 573.5,
+          "revision": 65
+        },
+        "session:57": {
+          "sourceTick": 36179,
+          "elapsedSeconds": 575.5,
+          "revision": 66
+        },
+        "session:58": {
+          "sourceTick": 36239,
+          "elapsedSeconds": 576.5,
+          "revision": 67
+        },
+        "session:59": {
+          "sourceTick": 36299,
+          "elapsedSeconds": 577.5,
+          "revision": 68
+        },
+        "session:60": {
+          "sourceTick": 36419,
+          "elapsedSeconds": 579.5,
+          "revision": 69
+        },
+        "session:61": {
+          "sourceTick": 36539,
+          "elapsedSeconds": 581.5,
+          "revision": 70
+        },
+        "session:62": {
+          "sourceTick": 36659,
+          "elapsedSeconds": 583.5,
+          "revision": 71
+        },
+        "session:63": {
+          "sourceTick": 36779,
+          "elapsedSeconds": 585.5,
+          "revision": 72
+        },
+        "session:64": {
+          "sourceTick": 36899,
+          "elapsedSeconds": 587.5,
+          "revision": 73
+        },
+        "session:65": {
+          "sourceTick": 37019,
+          "elapsedSeconds": 589.5,
+          "revision": 74
+        },
+        "session:66": {
+          "sourceTick": 37139,
+          "elapsedSeconds": 591.5,
+          "revision": 75
+        },
+        "session:67": {
+          "sourceTick": 37259,
+          "elapsedSeconds": 593.5,
+          "revision": 76
+        },
+        "session:68": {
+          "sourceTick": 37499,
+          "elapsedSeconds": 597.5,
+          "revision": 77
+        },
+        "session:69": {
+          "sourceTick": 37619,
+          "elapsedSeconds": 599.5,
+          "revision": 78
+        }
+      }
     }
   ]
 }

--- a/tools/telemetry-replay/radio-probe.ts
+++ b/tools/telemetry-replay/radio-probe.ts
@@ -1,0 +1,31 @@
+import type { RadioSnapshot, Telemetry } from '@irdashies/types';
+import { RadioProcessor } from '../../src/app/processors/RadioProcessor';
+import type { ReplayProbe, TelemetryFrame } from './validator';
+
+const telemetryFrom = (frame: TelemetryFrame): Telemetry =>
+  Object.fromEntries(
+    Object.entries(frame).map(([name, entry]) => [
+      name,
+      { value: Array.isArray(entry) ? entry : [entry] },
+    ])
+  ) as unknown as Telemetry;
+
+export const createRadioProbe = (): ReplayProbe<RadioSnapshot> => {
+  const processor = new RadioProcessor();
+  return {
+    name: 'radio-state',
+    schemaVersion: 1,
+    variables: ['RadioTransmitCarIdx'],
+    onFrame(frame) {
+      processor.onFrame(telemetryFrom(frame));
+      const snapshot = processor.snapshot();
+      return {
+        transmittingCarIdxs: [...snapshot.transmittingCarIdxs],
+        version: snapshot.version,
+      };
+    },
+    onDisconnect() {
+      processor.onLifecycle({ type: 'disconnect' });
+    },
+  };
+};

--- a/tools/telemetry-replay/run-curated-validation.ts
+++ b/tools/telemetry-replay/run-curated-validation.ts
@@ -15,6 +15,7 @@ import { createReferenceLapsProbe } from './reference-laps-probe';
 import { createRelativeGapsProbe } from './relative-gaps-probe';
 import { createSectorTimingProbe } from './sector-timing-probe';
 import { createStandingsProbe } from './standings-probe';
+import { createRadioProbe } from './radio-probe';
 
 const REPOSITORY_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -145,6 +146,7 @@ async function main(): Promise<void> {
       createRelativeGapsProbe(),
       createSectorTimingProbe(),
       createStandingsProbe(),
+      createRadioProbe(),
     ],
   });
   const golden = {


### PR DESCRIPTION
## Description

Phase 4 of the architecture plan: move `RadioTransmitCarIdx` from the legacy renderer telemetry firehose to a typed `radio.snapshot` channel.

This adds a demand-activated, event-driven main-process processor for live, curated-replay, and mock sources. Standings and Relative request the channel at 25 Hz so short push-to-talk bursts are not lost, but snapshots are published only when the transmitting-car set changes. The existing renderer-configured persistence timer remains responsible for keeping the radio icon stable after transmission ends.

`RadioTransmitCarIdx` is removed from the legacy IPC allowlist. The implementation plan now explicitly tracks radio migration, session-bar migration, and final legacy telemetry restriction/removal as separate Phase 4 steps.

Validation:

- `npm run lint -- --no-fix`
- `npm run test -- --no-coverage` — 1,199 passed, 1 skipped
- `npm run test:replay:curated:update`
- `npm run test:replay:curated` — 36,000 frames, 70 session revisions, 9 probes

The curated AI tape contains no microphone/radio activity. Its radio probe therefore validates only deterministic idle-state handling through the recorded replay pipeline. Positive key-up/key-down transitions, long-transmission persistence, lifecycle behavior, demand activation, and change-only publication are covered by focused processor, runtime, and hook tests; positive radio behavior has not been validated against a live iRacing session or a recorded radio-active tape.

Architecture checklist:

- [x] N1 — no new synchronous filesystem I/O
- [x] N2/N3 — no frontend-to-main or cross-widget imports
- [x] N4/R4.1 — no new IPC handler or bridge surface
- [x] R4.4/R4.5 — typed minimum-payload channel
- [x] R5.2/R14.1 — deterministic processor unit and recorded-fixture coverage
- [x] R13.1/R13.2 — measured hot path and reusable snapshot buffer

## Screenshots

### Before

No visual change intended. Radio icons read `RadioTransmitCarIdx` from the legacy renderer telemetry stream.

### After

No visual change intended. Radio icons preserve the same persistence behavior while reading `radio.snapshot`.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live radio transmission state for standings and relative widgets.
  * Radio activity now updates through a dedicated snapshot channel at up to 25 updates per second.
  * Added support for clearing radio state when sessions end or disconnect.

* **Bug Fixes**
  * Improved transmission indicators so persistence begins when a car stops transmitting, preventing unnecessary refreshes during long transmissions.
  * Improved handling of inactive, replay, and invalid radio states.

* **Documentation**
  * Updated implementation status to reflect completed live-position projection work and remaining radio/session-bar tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->