### PR TITLE
feat: move driver controls to channels

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -30,7 +30,7 @@
 | **Phase 2a remaining items**                          | R1+R2 LANDED, R3 PENDING | `feat/phase-2a-integration` for R1+R2    | R1 (reference-lap fetch dedup) + R2 (post-debounce write log) landed 2026-05-19. R3 (Empty Dashboard substrate baseline test) is a test run, not code work — pending.                                                                                                                                                                                                     |
 | **Phase 2b — Architectural cleanup (remaining)**      | NOT STARTED              | —                                        | A1, A4, A5, A6, A7 completion, A9. Lower urgency now Standings memory issue is resolved                                                                                                                                                                                                                                                                                   |
 | **Phase 3 — Channel-based bridge**                    | LANDED; MEMORY GATE OPEN | PRs #646, #649–#652, #656, #658          | Typed rate-aware channels, per-window subscriptions, deterministic replay validation, Fuel processor/renderer migration, conditional legacy telemetry, and performance instrumentation are on `main`. The Fuel-only A/B removed legacy deliveries and reduced app-wide renderer wake-ups by 42.4%; both baseline and candidate still failed the memory-slope gate.        |
-| **Phase 4 — Main-process processors**                 | IN PROGRESS              | PRs #659–#667                            | Fuel, lap times, car speeds, reference laps, relative gaps, sector timing, Standings core state, live positions, and radio are on `main`. The complete Session Bar migration is in PR #667; legacy telemetry removal or development-only restriction remains.                                                                                                             |
+| **Phase 4 — Main-process processors**                 | IN PROGRESS              | PRs #659–#667                            | The planned derived processors and complete Session Bar migration are on `main`. Four final slices migrate direct telemetry consumers, then remove the legacy renderer firehose; the first slice is Input and Tachometer via `driver-controls.snapshot`.                                                                                                                  |
 | **Phase 5 — Worker-thread SDK loop**                  | NOT STARTED              | —                                        |                                                                                                                                                                                                                                                                                                                                                                           |
 | **Phase 6 — Native optimisations**                    | DEFERRED                 | —                                        | Only if Phase 4 profiling demands                                                                                                                                                                                                                                                                                                                                         |
 
@@ -274,10 +274,14 @@ Today every renderer wakes 25 times/sec regardless of what's mounted. A weather 
 - [x] StandingsProcessor — PR #664
 - [x] Standings live-position projection — PR #665
 - [x] Radio transmit state — `radio.snapshot`, event-driven and demand-activated; PR #666
-- [ ] Session-bar telemetry migration
-  - [ ] Shared race/session timing projection — `session-timing.snapshot`, demand-driven at 5 Hz; PR #667 in review
-  - [ ] Auxiliary items (weather, fuel/units, brake bias, incidents, lap results, player position, and top speed) — `session-bar.snapshot`; PR #667 in review
-- [ ] Legacy `'telemetry'` channel removed or dev-only
+- [x] Session-bar telemetry migration — PR #667
+  - [x] Shared race/session timing projection — `session-timing.snapshot`, demand-driven at 5 Hz
+  - [x] Auxiliary items (weather, fuel/units, brake bias, incidents, lap results, player position, and top speed) — `session-bar.snapshot`
+- [ ] Direct telemetry migration and legacy removal
+  1. [ ] Input and Tachometer — full-precision `driver-controls.snapshot`; `feat/driver-controls-channel` in progress
+  2. [ ] Positional, pit-state, and warning consumers — Pitlane Helper, maps, Battle/Relative helpers, Blind Spot, Rejoin, Faster/Slow Car
+  3. [ ] Remaining low-frequency consumers plus an explicit development-only path for Telemetry Inspector
+  4. [ ] Delete the legacy `'telemetry'` IPC/store/provider infrastructure, run the complete replay suite, and re-profile
 
 ### Phase 5 — Worker-thread SDK loop
 
@@ -468,7 +472,8 @@ LLM agents: read this file at the start of any session that touches the architec
 
 ## 6. Activity log
 
-- **2026-08-09** — PR #666 merged. Opened PR #667 for the complete Session Bar migration: shared race/session timing plus auxiliary weather, fuel, incident, lap-result, position, and top-speed data now use demand-driven snapshots wired for live/tape and mock sources. Legacy telemetry restriction remains the next Phase 4 step — `feat/session-bar-channel` — in review
+- **2026-08-09** — PR #667 merged. Started the first of four final Phase 4 slices: Input and Tachometer move to a full-precision, demand-driven `driver-controls.snapshot`; positional/warning consumers, low-frequency/debug consumers, and final legacy deletion follow as separate reviewable PRs — `feat/driver-controls-channel` — implementation
+- **2026-08-09** — PR #666 merged. Opened PR #667 for the complete Session Bar migration: shared race/session timing plus auxiliary weather, fuel, incident, lap-result, position, and top-speed data now use demand-driven snapshots wired for live/tape and mock sources — `feat/session-bar-channel` — merged as PR #667
 
 - **2026-08-09** — PR #665 merged. Opened PR #666 for the next explicit Phase 4 slice: move bursty `RadioTransmitCarIdx` state to a demand-activated, event-driven `radio.snapshot` channel while retaining renderer-configured icon persistence. Session-bar migration follows; legacy telemetry restriction/removal remains the Phase 4 exit step — `feat/radio-channel` — in review
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -278,7 +278,7 @@ Today every renderer wakes 25 times/sec regardless of what's mounted. A weather 
   - [x] Shared race/session timing projection — `session-timing.snapshot`, demand-driven at 5 Hz
   - [x] Auxiliary items (weather, fuel/units, brake bias, incidents, lap results, player position, and top speed) — `session-bar.snapshot`
 - [ ] Direct telemetry migration and legacy removal
-  1. [ ] Input and Tachometer — full-precision `driver-controls.snapshot`; `feat/driver-controls-channel` in progress
+  1. [ ] Input and Tachometer — full-precision `driver-controls.snapshot`; PR #668 in review
   2. [ ] Positional, pit-state, and warning consumers — Pitlane Helper, maps, Battle/Relative helpers, Blind Spot, Rejoin, Faster/Slow Car
   3. [ ] Remaining low-frequency consumers plus an explicit development-only path for Telemetry Inspector
   4. [ ] Delete the legacy `'telemetry'` IPC/store/provider infrastructure, run the complete replay suite, and re-profile
@@ -472,7 +472,7 @@ LLM agents: read this file at the start of any session that touches the architec
 
 ## 6. Activity log
 
-- **2026-08-09** — PR #667 merged. Started the first of four final Phase 4 slices: Input and Tachometer move to a full-precision, demand-driven `driver-controls.snapshot`; positional/warning consumers, low-frequency/debug consumers, and final legacy deletion follow as separate reviewable PRs — `feat/driver-controls-channel` — implementation
+- **2026-08-09** — PR #667 merged. Opened PR #668 for the first of four final Phase 4 slices: Input and Tachometer move to a full-precision, demand-driven `driver-controls.snapshot`; positional/warning consumers, low-frequency/debug consumers, and final legacy deletion follow as separate reviewable PRs — `feat/driver-controls-channel` — in review
 - **2026-08-09** — PR #666 merged. Opened PR #667 for the complete Session Bar migration: shared race/session timing plus auxiliary weather, fuel, incident, lap-result, position, and top-speed data now use demand-driven snapshots wired for live/tape and mock sources — `feat/session-bar-channel` — merged as PR #667
 
 - **2026-08-09** — PR #665 merged. Opened PR #666 for the next explicit Phase 4 slice: move bursty `RadioTransmitCarIdx` state to a demand-activated, event-driven `radio.snapshot` channel while retaining renderer-configured icon persistence. Session-bar migration follows; legacy telemetry restriction/removal remains the Phase 4 exit step — `feat/radio-channel` — in review

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -19,6 +19,7 @@ import { StandingsRuntime } from '../../processors/standingsRuntime';
 import { RadioRuntime } from '../../processors/radioRuntime';
 import { SessionTimingRuntime } from '../../processors/sessionTimingRuntime';
 import { SessionBarRuntime } from '../../processors/sessionBarRuntime';
+import { DriverControlsRuntime } from '../../processors/driverControlsRuntime';
 
 // Keys consumed by the renderer. Anything outside this set is dropped before
 // the telemetry object crosses the IPC boundary — reducing structured-clone
@@ -223,6 +224,9 @@ export async function publishIRacingSDKEvents(
   const sessionBarRuntime = channelBus
     ? new SessionBarRuntime(channelBus, lifecycle, perfMetrics, isTapeReplay)
     : undefined;
+  const driverControlsRuntime = channelBus
+    ? new DriverControlsRuntime(channelBus, lifecycle, perfMetrics)
+    : undefined;
 
   let shouldStop = false;
   let lastRunningState: boolean | undefined = undefined;
@@ -329,6 +333,7 @@ export async function publishIRacingSDKEvents(
           radioRuntime?.onFrame(telemetry);
           sessionTimingRuntime?.onFrame(telemetry);
           sessionBarRuntime?.onFrame(telemetry);
+          driverControlsRuntime?.onFrame(telemetry);
           if (
             perfTelemetryDeliveryEnabled &&
             overlayManager.hasLegacyStreamSubscribers('telemetry')
@@ -365,6 +370,7 @@ export async function publishIRacingSDKEvents(
             standingsRuntime?.onSession(session);
             sessionTimingRuntime?.onSession(session);
             sessionBarRuntime?.onSession(session);
+            driverControlsRuntime?.onSession(session);
             overlayManager.publishMessage('sessionData', session);
             sessionCallbacks.forEach((callback) => callback(session));
             perfMetrics.markEnd('sessionPublish');
@@ -430,6 +436,7 @@ export async function publishIRacingSDKEvents(
       radioRuntime?.dispose();
       sessionTimingRuntime?.dispose();
       sessionBarRuntime?.dispose();
+      driverControlsRuntime?.dispose();
       referenceLapRuntime?.dispose();
       perfMetrics.stopReporting();
     },

--- a/src/app/bridge/iracingSdk/mock-data/mockSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/mock-data/mockSdkBridge.ts
@@ -12,6 +12,7 @@ import { RadioRuntime } from '../../../processors/radioRuntime';
 import { SessionTimingRuntime } from '../../../processors/sessionTimingRuntime';
 import { LapTimesRuntime } from '../../../processors/lapTimesRuntime';
 import { SessionBarRuntime } from '../../../processors/sessionBarRuntime';
+import { DriverControlsRuntime } from '../../../processors/driverControlsRuntime';
 
 export async function publishIRacingSDKEvents(
   overlayManager: OverlayManager,
@@ -64,6 +65,9 @@ export async function publishIRacingSDKEvents(
   const sessionBarRuntime = channelBus
     ? new SessionBarRuntime(channelBus, lifecycle, perfMetrics)
     : undefined;
+  const driverControlsRuntime = channelBus
+    ? new DriverControlsRuntime(channelBus, lifecycle, perfMetrics)
+    : undefined;
 
   bridge.onSessionData((session) => {
     carSpeedsRuntime?.onSession(session);
@@ -73,6 +77,7 @@ export async function publishIRacingSDKEvents(
     standingsRuntime?.onSession(session);
     sessionTimingRuntime?.onSession(session);
     sessionBarRuntime?.onSession(session);
+    driverControlsRuntime?.onSession(session);
     overlayManager.publishMessage('sessionData', session);
   });
 
@@ -87,6 +92,7 @@ export async function publishIRacingSDKEvents(
     radioRuntime?.onFrame(telemetry);
     sessionTimingRuntime?.onFrame(telemetry);
     sessionBarRuntime?.onFrame(telemetry);
+    driverControlsRuntime?.onFrame(telemetry);
     perfMetrics.markStart('broadcast');
     overlayManager.publishMessage('telemetry', telemetry);
     perfMetrics.markEnd('broadcast');
@@ -110,6 +116,7 @@ export async function publishIRacingSDKEvents(
       radioRuntime?.dispose();
       sessionTimingRuntime?.dispose();
       sessionBarRuntime?.dispose();
+      driverControlsRuntime?.dispose();
       referenceLapRuntime?.dispose();
       perfMetrics.stopReporting();
       originalStop();

--- a/src/app/processors/DriverControlsProcessor.spec.ts
+++ b/src/app/processors/DriverControlsProcessor.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { Session, Telemetry } from '@irdashies/types';
+import { DriverControlsProcessor } from './DriverControlsProcessor';
+
+const frame = (values: Record<string, number | boolean>): Telemetry =>
+  Object.fromEntries(
+    Object.entries(values).map(([key, current]) => [key, { value: [current] }])
+  ) as unknown as Telemetry;
+
+describe('DriverControlsProcessor', () => {
+  it('projects full-precision input and engine values', () => {
+    const processor = new DriverControlsProcessor();
+    processor.init({} as Session);
+    processor.onFrame(
+      frame({
+        Brake: 0.123456,
+        BrakeRaw: 0.223456,
+        Throttle: 0.765432,
+        Clutch: 0.25,
+        Gear: 3,
+        Speed: 52.4,
+        SteeringWheelAngle: -0.4321,
+        BrakeABSactive: true,
+        RPM: 6342,
+      })
+    );
+
+    expect(processor.snapshot()).toMatchObject({
+      brake: 0.123456,
+      brakeRaw: 0.223456,
+      throttle: 0.765432,
+      clutch: 0.25,
+      gear: 3,
+      speed: 52.4,
+      steeringWheelAngle: -0.4321,
+      brakeAbsActive: true,
+      rpm: 6342,
+      version: 1,
+    });
+  });
+
+  it('publishes only changes and resets at lifecycle boundaries', () => {
+    const processor = new DriverControlsProcessor();
+    const telemetry = frame({ Gear: 2, RPM: 5000 });
+    processor.onFrame(telemetry);
+    expect(processor.snapshot().version).toBe(1);
+    processor.onFrame(telemetry);
+    expect(processor.snapshot().version).toBe(1);
+
+    processor.onLifecycle({ type: 'sessionNumChange' });
+    expect(processor.snapshot()).toMatchObject({
+      gear: undefined,
+      rpm: undefined,
+      version: 2,
+    });
+  });
+});

--- a/src/app/processors/DriverControlsProcessor.ts
+++ b/src/app/processors/DriverControlsProcessor.ts
@@ -1,0 +1,104 @@
+import type {
+  DriverControlsSnapshot,
+  Session,
+  SessionLifecycleEvent,
+  Telemetry,
+} from '@irdashies/types';
+import type { TelemetryProcessor } from './TelemetryProcessor';
+
+const rawValue = (frame: Telemetry, key: string): unknown =>
+  (frame as unknown as Record<string, { value?: unknown[] } | undefined>)[key]
+    ?.value?.[0];
+
+const numberValue = (frame: Telemetry, key: string): number | undefined => {
+  const current = rawValue(frame, key);
+  return typeof current === 'number' ? current : undefined;
+};
+
+const booleanValue = (frame: Telemetry, key: string): boolean | undefined => {
+  const current = rawValue(frame, key);
+  return typeof current === 'boolean' ? current : undefined;
+};
+
+export class DriverControlsProcessor implements TelemetryProcessor<DriverControlsSnapshot> {
+  readonly channel = 'driver-controls.snapshot';
+  readonly tickRateHz = 60;
+
+  private readonly latest: DriverControlsSnapshot = { version: 0 };
+
+  init(session: Session): void {
+    const shiftRpm = session.DriverInfo?.DriverCarSLShiftRPM;
+    const blinkRpm = session.DriverInfo?.DriverCarSLBlinkRPM;
+    const shiftChanged = this.set('shiftRpm', shiftRpm);
+    const blinkChanged = this.set('blinkRpm', blinkRpm);
+    if (shiftChanged || blinkChanged) this.latest.version += 1;
+  }
+
+  onFrame(frame: Telemetry): void {
+    let changed = false;
+    changed = this.set('brake', numberValue(frame, 'Brake')) || changed;
+    changed = this.set('brakeRaw', numberValue(frame, 'BrakeRaw')) || changed;
+    changed = this.set('throttle', numberValue(frame, 'Throttle')) || changed;
+    changed =
+      this.set('throttleRaw', numberValue(frame, 'ThrottleRaw')) || changed;
+    changed = this.set('clutch', numberValue(frame, 'Clutch')) || changed;
+    changed = this.set('clutchRaw', numberValue(frame, 'ClutchRaw')) || changed;
+    changed = this.set('gear', numberValue(frame, 'Gear')) || changed;
+    changed = this.set('speed', numberValue(frame, 'Speed')) || changed;
+    changed =
+      this.set('displayUnits', numberValue(frame, 'DisplayUnits')) || changed;
+    changed =
+      this.set(
+        'steeringWheelAngle',
+        numberValue(frame, 'SteeringWheelAngle')
+      ) || changed;
+    changed =
+      this.set('brakeAbsActive', booleanValue(frame, 'BrakeABSactive')) ||
+      changed;
+    changed = this.set('rpm', numberValue(frame, 'RPM')) || changed;
+    changed =
+      this.set('shiftGrindRpm', numberValue(frame, 'ShiftGrindRPM')) || changed;
+    changed = this.set('oilTemp', numberValue(frame, 'OilTemp')) || changed;
+    changed = this.set('waterTemp', numberValue(frame, 'WaterTemp')) || changed;
+    changed =
+      this.set('engineWarnings', numberValue(frame, 'EngineWarnings')) ||
+      changed;
+    if (changed) this.latest.version += 1;
+  }
+
+  onLifecycle(event: SessionLifecycleEvent): void {
+    if (event.type === 'enter') return;
+    this.latest.brake = undefined;
+    this.latest.brakeRaw = undefined;
+    this.latest.throttle = undefined;
+    this.latest.throttleRaw = undefined;
+    this.latest.clutch = undefined;
+    this.latest.clutchRaw = undefined;
+    this.latest.gear = undefined;
+    this.latest.speed = undefined;
+    this.latest.displayUnits = undefined;
+    this.latest.steeringWheelAngle = undefined;
+    this.latest.brakeAbsActive = undefined;
+    this.latest.rpm = undefined;
+    this.latest.shiftGrindRpm = undefined;
+    this.latest.oilTemp = undefined;
+    this.latest.waterTemp = undefined;
+    this.latest.engineWarnings = undefined;
+    this.latest.shiftRpm = undefined;
+    this.latest.blinkRpm = undefined;
+    this.latest.version += 1;
+  }
+
+  snapshot(): DriverControlsSnapshot {
+    return this.latest;
+  }
+
+  private set<K extends Exclude<keyof DriverControlsSnapshot, 'version'>>(
+    key: K,
+    value: DriverControlsSnapshot[K]
+  ): boolean {
+    if (this.latest[key] === value) return false;
+    this.latest[key] = value;
+    return true;
+  }
+}

--- a/src/app/processors/driverControlsRuntime.spec.ts
+++ b/src/app/processors/driverControlsRuntime.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Telemetry } from '@irdashies/types';
+import { ChannelBus } from '../bridge/channelBridge';
+import { DriverControlsRuntime } from './driverControlsRuntime';
+
+const frame = (gear: number, rpm: number) =>
+  ({ Gear: { value: [gear] }, RPM: { value: [rpm] } }) as Telemetry;
+const target = {
+  id: 1,
+  isDestroyed: () => false,
+  isVisible: () => true,
+  send: vi.fn(),
+};
+const metrics = () => ({ markStart: vi.fn(), markEnd: vi.fn() });
+
+describe('DriverControlsRuntime', () => {
+  it('publishes changed controls only while demanded', () => {
+    const bus = new ChannelBus();
+    const publish = vi.spyOn(bus, 'publish');
+    const runtime = new DriverControlsRuntime(bus, undefined, metrics());
+    runtime.onFrame(frame(2, 5000));
+    expect(publish).not.toHaveBeenCalled();
+
+    bus.subscribe(target, 'driver-controls.snapshot');
+    runtime.onFrame(frame(2, 5000));
+    runtime.onFrame(frame(2, 5000));
+    expect(publish).toHaveBeenCalledOnce();
+    expect(publish).toHaveBeenCalledWith(
+      'driver-controls.snapshot',
+      expect.objectContaining({ gear: 2, rpm: 5000 })
+    );
+
+    bus.unsubscribe(target.id, 'driver-controls.snapshot');
+    runtime.onFrame(frame(3, 6000));
+    expect(publish).toHaveBeenCalledOnce();
+  });
+
+  it('activates for subscribers that predate the runtime', () => {
+    const bus = new ChannelBus();
+    const publish = vi.spyOn(bus, 'publish');
+    bus.subscribe(target, 'driver-controls.snapshot');
+    const runtime = new DriverControlsRuntime(bus, undefined, metrics());
+    runtime.onFrame(frame(4, 6500));
+    expect(publish).toHaveBeenCalledOnce();
+  });
+
+  it('publishes a reset and clears cached state when disposed', () => {
+    const bus = new ChannelBus();
+    const publish = vi.spyOn(bus, 'publish');
+    const clearSnapshot = vi.spyOn(bus, 'clearSnapshot');
+    bus.subscribe(target, 'driver-controls.snapshot');
+    const runtime = new DriverControlsRuntime(bus, undefined, metrics());
+    runtime.onFrame(frame(4, 6500));
+    runtime.dispose();
+    expect(publish).toHaveBeenLastCalledWith(
+      'driver-controls.snapshot',
+      expect.objectContaining({ gear: undefined, rpm: undefined })
+    );
+    expect(clearSnapshot).toHaveBeenLastCalledWith('driver-controls.snapshot');
+  });
+});

--- a/src/app/processors/driverControlsRuntime.ts
+++ b/src/app/processors/driverControlsRuntime.ts
@@ -1,0 +1,97 @@
+import type {
+  Session,
+  SessionLifecycleEvent,
+  Telemetry,
+} from '@irdashies/types';
+import type { ChannelBus } from '../bridge/channelBridge';
+import type { SessionLifecycle } from '../sessionLifecycle';
+import { DriverControlsProcessor } from './DriverControlsProcessor';
+
+interface PerformanceSections {
+  markStart(label: string): void;
+  markEnd(label: string): void;
+}
+
+export class DriverControlsRuntime {
+  private processor?: DriverControlsProcessor;
+  private latestSession?: Session;
+  private publishedVersion = -1;
+  private readonly disconnects: (() => void)[];
+
+  constructor(
+    private readonly bus: ChannelBus,
+    lifecycle: SessionLifecycle | undefined,
+    private readonly metrics: PerformanceSections
+  ) {
+    this.disconnects = [
+      bus.onSubscriberCountChanged((channel, count) => {
+        if (channel !== 'driver-controls.snapshot') return;
+        if (count > 0) this.activate();
+        else this.deactivate();
+      }),
+    ];
+    if (lifecycle) {
+      this.disconnects.push(
+        lifecycle.onSessionNumChange(() =>
+          this.onLifecycle({ type: 'sessionNumChange' })
+        ),
+        lifecycle.onDisconnect(() => this.onLifecycle({ type: 'disconnect' }))
+      );
+    }
+    if (bus.subscriberCount('driver-controls.snapshot') > 0) this.activate();
+  }
+
+  onFrame(frame: Telemetry): void {
+    if (!this.processor) return;
+    this.metrics.markStart('driverControlsProcessing');
+    this.processor.onFrame(frame);
+    this.metrics.markEnd('driverControlsProcessing');
+    this.publishIfChanged();
+  }
+
+  onSession(session: Session): void {
+    this.latestSession = session;
+    this.processor?.init(session);
+    this.publishIfChanged();
+  }
+
+  dispose(): void {
+    if (this.processor) {
+      this.processor.onLifecycle({ type: 'disconnect' });
+      this.publishIfChanged();
+    }
+    this.deactivate();
+    this.disconnects.forEach((disconnect) => disconnect());
+  }
+
+  private activate(): void {
+    if (this.processor) return;
+    this.bus.clearSnapshot('driver-controls.snapshot');
+    this.processor = new DriverControlsProcessor();
+    this.publishedVersion = -1;
+    if (this.latestSession) this.processor.init(this.latestSession);
+  }
+
+  private deactivate(): void {
+    this.processor = undefined;
+    this.publishedVersion = -1;
+    this.bus.clearSnapshot('driver-controls.snapshot');
+  }
+
+  private onLifecycle(event: SessionLifecycleEvent): void {
+    this.processor?.onLifecycle(event);
+    if (this.processor) this.publishIfChanged();
+    else this.bus.clearSnapshot('driver-controls.snapshot');
+    if (event.type === 'disconnect') this.latestSession = undefined;
+  }
+
+  private publishIfChanged(): void {
+    if (!this.processor) return;
+    const snapshot = this.processor.snapshot();
+    if (snapshot.version === this.publishedVersion) return;
+    this.publishedVersion = snapshot.version;
+    this.metrics.markStart('driverControlsPublication');
+    this.bus.publish('driver-controls.snapshot', snapshot);
+    this.metrics.markEnd('driverControlsPublication');
+  }
+}

--- a/src/frontend/components/Input/Input.stories.tsx
+++ b/src/frontend/components/Input/Input.stories.tsx
@@ -3,12 +3,27 @@ import { Input } from './Input';
 import {
   TelemetryDecorator,
   TelemetryDecoratorWithConfig,
+  ChannelSnapshotDecorator,
 } from '@irdashies/storybook';
+
+const driverControls = ChannelSnapshotDecorator({
+  'driver-controls.snapshot': {
+    brake: 0.35,
+    throttle: 0.72,
+    clutch: 0.9,
+    gear: 4,
+    speed: 48,
+    displayUnits: 1,
+    steeringWheelAngle: 0.15,
+    brakeAbsActive: false,
+    version: 1,
+  },
+});
 
 const meta: Meta<typeof Input> = {
   component: Input,
   title: 'widgets/Input',
-  decorators: [TelemetryDecorator()],
+  decorators: [TelemetryDecorator(), driverControls],
 };
 export default meta;
 
@@ -36,6 +51,7 @@ export const Bigger: Story = {
 
 export const WithConfig: Story = {
   decorators: [
+    driverControls,
     TelemetryDecoratorWithConfig(undefined, {
       input: {
         trace: { enabled: false },

--- a/src/frontend/components/Input/hooks/useInputs.tsx
+++ b/src/frontend/components/Input/hooks/useInputs.tsx
@@ -1,14 +1,15 @@
-import { useTelemetryValue } from '@irdashies/context';
+import { useDriverControlsSnapshot } from '@irdashies/context';
 
 export const useInputs = (useRawValues: boolean) => {
-  const brake = useTelemetryValue(useRawValues ? 'BrakeRaw' : 'Brake');
-  const throttle = useTelemetryValue(useRawValues ? 'ThrottleRaw' : 'Throttle');
-  const clutchRaw = useTelemetryValue(useRawValues ? 'ClutchRaw' : 'Clutch');
-  const gear = useTelemetryValue('Gear');
-  const speed = useTelemetryValue('Speed');
-  const unit = useTelemetryValue('DisplayUnits');
-  const steer = useTelemetryValue('SteeringWheelAngle');
-  const brakeAbsActive = useTelemetryValue<boolean>('BrakeABSactive');
+  const snapshot = useDriverControlsSnapshot();
+  const brake = useRawValues ? snapshot?.brakeRaw : snapshot?.brake;
+  const throttle = useRawValues ? snapshot?.throttleRaw : snapshot?.throttle;
+  const clutchRaw = useRawValues ? snapshot?.clutchRaw : snapshot?.clutch;
+  const gear = snapshot?.gear;
+  const speed = snapshot?.speed;
+  const unit = snapshot?.displayUnits;
+  const steer = snapshot?.steeringWheelAngle;
+  const brakeAbsActive = snapshot?.brakeAbsActive;
 
   // 0=disengaged (pedal pressed) to 1=fully engaged (pedal not pressed) so we need to invert it
   const clutch = clutchRaw !== undefined ? 1 - clutchRaw : undefined;

--- a/src/frontend/components/Input/widgetRuntimeDefinition.ts
+++ b/src/frontend/components/Input/widgetRuntimeDefinition.ts
@@ -1,0 +1,9 @@
+import type { WidgetRuntimeDefinition } from '../../widgetRuntime';
+
+export default {
+  id: 'input',
+  legacyTelemetry: false,
+  channels: ['driver-controls.snapshot'],
+  ratePreset: 'driverFocused',
+  channelRates: { 'driver-controls.snapshot': 60 },
+} satisfies WidgetRuntimeDefinition;

--- a/src/frontend/components/RendererDataProviders/RendererDataProviders.spec.tsx
+++ b/src/frontend/components/RendererDataProviders/RendererDataProviders.spec.tsx
@@ -32,7 +32,7 @@ describe('RendererDataProviders', () => {
   it('preserves legacy providers when any unmigrated widget is enabled', () => {
     dashboard.widgets = [
       { id: 'fuel', enabled: true, layout },
-      { id: 'input', enabled: true, layout },
+      { id: 'pitlanehelper', enabled: true, layout },
     ];
 
     render(<RendererDataProviders />);

--- a/src/frontend/components/Tachometer/Tachometer.stories.tsx
+++ b/src/frontend/components/Tachometer/Tachometer.stories.tsx
@@ -1,11 +1,29 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Tachometer } from './Tachometer';
-import { TelemetryDecorator } from '@irdashies/storybook';
+import {
+  ChannelSnapshotDecorator,
+  TelemetryDecorator,
+} from '@irdashies/storybook';
 
 const meta: Meta<typeof Tachometer> = {
   component: Tachometer,
   title: 'widgets/Tachometer/components/Widget',
-  decorators: [TelemetryDecorator()],
+  decorators: [
+    TelemetryDecorator(),
+    ChannelSnapshotDecorator({
+      'driver-controls.snapshot': {
+        gear: 4,
+        rpm: 6200,
+        shiftGrindRpm: 7600,
+        shiftRpm: 6900,
+        blinkRpm: 7400,
+        oilTemp: 105,
+        waterTemp: 92,
+        engineWarnings: 0,
+        version: 1,
+      },
+    }),
+  ],
 };
 export default meta;
 

--- a/src/frontend/components/Tachometer/hooks/useCarTachometerData.spec.tsx
+++ b/src/frontend/components/Tachometer/hooks/useCarTachometerData.spec.tsx
@@ -10,14 +10,16 @@ vi.mock('@irdashies/context', async (importOriginal) => {
     ...actual,
     useSessionStore: vi.fn(),
     useDriverCarIdx: vi.fn(),
-    useTelemetryValue: vi.fn(),
+    useDriverControlsSnapshot: vi.fn(),
   };
 });
 vi.mock('../../../utils/carData');
 
 const mockUseSessionStore = vi.mocked(Context.useSessionStore);
 const mockUseDriverCarIdx = vi.mocked(Context.useDriverCarIdx);
-const mockUseTelemetryValue = vi.mocked(Context.useTelemetryValue);
+const mockUseDriverControlsSnapshot = vi.mocked(
+  Context.useDriverControlsSnapshot
+);
 
 describe('useCarTachometerData', () => {
   beforeEach(() => {
@@ -25,7 +27,7 @@ describe('useCarTachometerData', () => {
 
     // Default mocks
     mockUseDriverCarIdx.mockReturnValue(0);
-    mockUseTelemetryValue.mockReturnValue(1); // Gear 1
+    mockUseDriverControlsSnapshot.mockReturnValue({ gear: 1, version: 1 });
     mockUseSessionStore.mockReturnValue({
       session: {
         DriverInfo: {

--- a/src/frontend/components/Tachometer/hooks/useCarTachometerData.tsx
+++ b/src/frontend/components/Tachometer/hooks/useCarTachometerData.tsx
@@ -1,21 +1,15 @@
 import { useEffect, useState, useCallback } from 'react';
-import {
-  useSessionStore,
-  useDriverCarIdx,
-  useTelemetryValue,
-} from '@irdashies/context';
+import { useSessionStore, useDriverCarIdx } from '@irdashies/context';
 import { loadCarData, getGearKey, type CarData } from '../../../utils/carData';
 
 /**
  * Hook for car-specific tachometer data from lovely-car-data
  */
-export const useCarTachometerData = () => {
+export const useCarTachometerData = (gear = 0) => {
   const [carData, setCarData] = useState<CarData | null>(null);
 
   const driverCarIdx = useDriverCarIdx();
   const session = useSessionStore((state) => state.session);
-  const gear = useTelemetryValue('Gear') ?? 0;
-
   // Get current car path and game
   const carPath = session?.DriverInfo?.Drivers?.find(
     (driver) => driver.CarIdx === driverCarIdx

--- a/src/frontend/components/Tachometer/hooks/useCustomShiftPoints.spec.tsx
+++ b/src/frontend/components/Tachometer/hooks/useCustomShiftPoints.spec.tsx
@@ -10,12 +10,14 @@ vi.mock('@irdashies/context', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@irdashies/context')>();
   return {
     ...actual,
-    useTelemetryValue: vi.fn(),
+    useDriverControlsSnapshot: vi.fn(),
   };
 });
 vi.mock('./useCarTachometerData');
 
-const mockUseTelemetryValue = vi.mocked(Context.useTelemetryValue);
+const mockUseDriverControlsSnapshot = vi.mocked(
+  Context.useDriverControlsSnapshot
+);
 const mockUseCarTachometerData = vi.mocked(
   CarTachometerData.useCarTachometerData
 );
@@ -25,10 +27,10 @@ describe('useCustomShiftPoints', () => {
     vi.clearAllMocks();
 
     // Default mocks
-    mockUseTelemetryValue.mockImplementation((key) => {
-      if (key === 'Gear') return 1;
-      if (key === 'RPM') return 6500;
-      return 0;
+    mockUseDriverControlsSnapshot.mockReturnValue({
+      gear: 1,
+      rpm: 6500,
+      version: 1,
     });
 
     mockUseCarTachometerData.mockReturnValue({
@@ -88,10 +90,10 @@ describe('useCustomShiftPoints', () => {
   });
 
   it('does not show shift indicator when RPM below custom shift point', () => {
-    mockUseTelemetryValue.mockImplementation((key) => {
-      if (key === 'Gear') return 1;
-      if (key === 'RPM') return 5500; // Below shift point
-      return 0;
+    mockUseDriverControlsSnapshot.mockReturnValue({
+      gear: 1,
+      rpm: 5500,
+      version: 2,
     });
 
     const settings: ShiftPointSettings = {
@@ -118,10 +120,10 @@ describe('useCustomShiftPoints', () => {
   });
 
   it('does not show shift indicator in neutral or reverse', () => {
-    mockUseTelemetryValue.mockImplementation((key) => {
-      if (key === 'Gear') return 0; // Neutral
-      if (key === 'RPM') return 6500;
-      return 0;
+    mockUseDriverControlsSnapshot.mockReturnValue({
+      gear: 0,
+      rpm: 6500,
+      version: 2,
     });
 
     const settings: ShiftPointSettings = {

--- a/src/frontend/components/Tachometer/hooks/useCustomShiftPoints.tsx
+++ b/src/frontend/components/Tachometer/hooks/useCustomShiftPoints.tsx
@@ -1,4 +1,4 @@
-import { useTelemetryValue } from '@irdashies/context';
+import { useDriverControlsSnapshot } from '@irdashies/context';
 import { useCarTachometerData } from './useCarTachometerData';
 import type { ShiftPointSettings } from '@irdashies/types';
 
@@ -6,9 +6,10 @@ import type { ShiftPointSettings } from '@irdashies/types';
  * Hook for custom shift point logic
  */
 export const useCustomShiftPoints = (settings?: ShiftPointSettings) => {
-  const { carData } = useCarTachometerData();
-  const gear = useTelemetryValue('Gear') ?? 0;
-  const rpm = useTelemetryValue('RPM') ?? 0;
+  const snapshot = useDriverControlsSnapshot();
+  const gear = snapshot?.gear ?? 0;
+  const rpm = snapshot?.rpm ?? 0;
+  const { carData } = useCarTachometerData(gear);
 
   // Get current car's shift config (only if enabled)
   const carConfig = carData && settings?.carConfigs[carData.carId];

--- a/src/frontend/components/Tachometer/hooks/useTachometerData.tsx
+++ b/src/frontend/components/Tachometer/hooks/useTachometerData.tsx
@@ -1,5 +1,4 @@
-import { useTelemetryValue, useSessionStore } from '@irdashies/context';
-import type { Telemetry } from '@irdashies/types';
+import { useDriverControlsSnapshot, useSessionStore } from '@irdashies/context';
 import { useCarTachometerData } from './useCarTachometerData';
 
 /**
@@ -7,13 +6,14 @@ import { useCarTachometerData } from './useCarTachometerData';
  * Encapsulates all RPM and shift light logic with car-specific data integration.
  */
 export const useTachometerData = () => {
-  const rpm = useTelemetryValue('RPM') ?? 0;
-  const gear = useTelemetryValue('Gear') ?? 1;
-  const shiftGrindRpm = useTelemetryValue('ShiftGrindRPM') ?? 0;
-  const oilTemp = useTelemetryValue('OilTemp') ?? 0;
-  const waterTemp = useTelemetryValue('WaterTemp') ?? 0;
-  const engineWarnings = useTelemetryValue('EngineWarnings') ?? 0;
-  const { carData, gearRpmThresholds, hasCarData } = useCarTachometerData();
+  const snapshot = useDriverControlsSnapshot();
+  const rpm = snapshot?.rpm ?? 0;
+  const gear = snapshot?.gear ?? 1;
+  const shiftGrindRpm = snapshot?.shiftGrindRpm ?? 0;
+  const oilTemp = snapshot?.oilTemp ?? 0;
+  const waterTemp = snapshot?.waterTemp ?? 0;
+  const engineWarnings = snapshot?.engineWarnings ?? 0;
+  const { carData, gearRpmThresholds, hasCarData } = useCarTachometerData(gear);
 
   // Get car-specific redline from session data
   const driverCarRedLine = useSessionStore(
@@ -35,11 +35,9 @@ export const useTachometerData = () => {
     (shiftGrindRpm > 0 ? shiftGrindRpm : null) || // Second: telemetry shift grind RPM
     7500; // Conservative fallback for safety
 
-  // iRacing shift lights telemetry values
-  const shiftRpm =
-    useTelemetryValue('DriverCarSLShiftRPM' as keyof Telemetry) ?? 0; // Purple LEDs
-  const blinkRpm =
-    useTelemetryValue('DriverCarSLBlinkRPM' as keyof Telemetry) ?? 0; // Blinking LEDs
+  // iRacing shift-light thresholds projected from session data
+  const shiftRpm = snapshot?.shiftRpm ?? 0; // Purple LEDs
+  const blinkRpm = snapshot?.blinkRpm ?? 0; // Blinking LEDs
 
   return {
     rpm,

--- a/src/frontend/components/Tachometer/widgetRuntimeDefinition.ts
+++ b/src/frontend/components/Tachometer/widgetRuntimeDefinition.ts
@@ -1,0 +1,8 @@
+import type { WidgetRuntimeDefinition } from '../../widgetRuntime';
+
+export default {
+  id: 'tachometer',
+  legacyTelemetry: false,
+  channels: ['driver-controls.snapshot'],
+  ratePreset: 'driverFocused',
+} satisfies WidgetRuntimeDefinition;

--- a/src/frontend/context/ChannelStore/index.ts
+++ b/src/frontend/context/ChannelStore/index.ts
@@ -9,3 +9,4 @@ export * from './useSessionBarSnapshot';
 export * from './useSectorTimingSnapshot';
 export * from './useStandingsSnapshot';
 export * from './useCarSpeedsSnapshot';
+export * from './useDriverControlsSnapshot';

--- a/src/frontend/context/ChannelStore/useDriverControlsSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useDriverControlsSnapshot.ts
@@ -1,0 +1,7 @@
+import type { ChannelBridge } from '@irdashies/types';
+import { useChannelSnapshot } from './useChannelSnapshot';
+
+export const useDriverControlsSnapshot = (
+  enabled = true,
+  bridge?: ChannelBridge
+) => useChannelSnapshot('driver-controls.snapshot', undefined, bridge, enabled);

--- a/src/frontend/widgetRuntime.spec.tsx
+++ b/src/frontend/widgetRuntime.spec.tsx
@@ -27,11 +27,26 @@ describe('widget runtime metadata', () => {
 
   it('keeps unknown and unmigrated widgets on the legacy path', () => {
     expect(
-      rendererNeedsLegacyTelemetry([widget('fuel'), widget('input')])
+      rendererNeedsLegacyTelemetry([widget('fuel'), widget('pitlanehelper')])
     ).toBe(true);
     expect(rendererNeedsLegacyTelemetry([widget('instance', 'unknown')])).toBe(
       true
     );
+  });
+
+  it('discovers Input and Tachometer as driver-control channel consumers', () => {
+    expect(getWidgetRuntimeDefinition('input')).toMatchObject({
+      legacyTelemetry: false,
+      channels: ['driver-controls.snapshot'],
+      channelRates: { 'driver-controls.snapshot': 60 },
+    });
+    expect(getWidgetRuntimeDefinition('tachometer')).toMatchObject({
+      legacyTelemetry: false,
+      channels: ['driver-controls.snapshot'],
+    });
+    expect(
+      rendererNeedsLegacyTelemetry([widget('input'), widget('tachometer')])
+    ).toBe(false);
   });
 
   it('declares lap-time channels without prematurely removing legacy data', () => {

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -9,6 +9,7 @@ export type SessionLifecycleEvent =
 
 export interface ChannelPayloads {
   'car-speeds.snapshot': CarSpeedsSnapshot;
+  'driver-controls.snapshot': DriverControlsSnapshot;
   'fuel.projection': FuelProjectionSnapshot;
   'lap-times.snapshot': LapTimesSnapshot;
   'reference-laps.snapshot': ReferenceLapsSnapshot;
@@ -19,6 +20,28 @@ export interface ChannelPayloads {
   'session-bar.snapshot': SessionBarSnapshot;
   'standings.snapshot': StandingsSnapshot;
   'session.lifecycle': SessionLifecycleEvent;
+}
+
+export interface DriverControlsSnapshot {
+  brake?: number;
+  brakeRaw?: number;
+  throttle?: number;
+  throttleRaw?: number;
+  clutch?: number;
+  clutchRaw?: number;
+  gear?: number;
+  speed?: number;
+  displayUnits?: number;
+  steeringWheelAngle?: number;
+  brakeAbsActive?: boolean;
+  rpm?: number;
+  shiftGrindRpm?: number;
+  oilTemp?: number;
+  waterTemp?: number;
+  engineWarnings?: number;
+  shiftRpm?: number;
+  blinkRpm?: number;
+  version: number;
 }
 
 export interface SessionBarSnapshot {
@@ -212,6 +235,11 @@ export const channelRegistry = {
     kind: 'snapshot',
     defaultRateHz: 10,
     maxRateHz: 25,
+  },
+  'driver-controls.snapshot': {
+    kind: 'snapshot',
+    defaultRateHz: 25,
+    maxRateHz: 60,
   },
   'fuel.projection': {
     kind: 'snapshot',

--- a/test-data/telemetry/ai-race-10min.golden.json
+++ b/test-data/telemetry/ai-race-10min.golden.json
@@ -8581,6 +8581,404 @@
           "revision": 78
         }
       }
+    },
+    {
+      "name": "driver-controls-state",
+      "schemaVersion": 1,
+      "frameCount": 36000,
+      "rollingHash": "7071b8dfaf24514ec82a48bf9b0e2124a362aa201754dbbc910a65e9893b0859",
+      "checkpoints": {
+        "firstFrame": {
+          "version": 1,
+          "brake": 1,
+          "brakeRaw": 0,
+          "throttle": 0.11245375126600266,
+          "throttleRaw": 0.11245376616716385,
+          "clutch": 0,
+          "clutchRaw": 1,
+          "gear": 0,
+          "speed": 0.00012638090993277729,
+          "displayUnits": 1,
+          "steeringWheelAngle": -0.04800163954496384,
+          "brakeAbsActive": false,
+          "rpm": 2411.995361328125,
+          "shiftGrindRpm": 0,
+          "oilTemp": 79.14369201660156,
+          "waterTemp": 77.29645538330078,
+          "engineWarnings": 0
+        },
+        "lastFrame": {
+          "version": 36001,
+          "brake": 0,
+          "brakeRaw": 0,
+          "throttle": 1,
+          "throttleRaw": 1,
+          "clutch": 1,
+          "clutchRaw": 1,
+          "gear": 5,
+          "speed": 62.47682571411133,
+          "displayUnits": 1,
+          "steeringWheelAngle": -0.0068572452291846275,
+          "brakeAbsActive": false,
+          "rpm": 6217.0322265625,
+          "shiftGrindRpm": 0,
+          "oilTemp": 99.28093719482422,
+          "waterTemp": 93.57464599609375,
+          "engineWarnings": 0,
+          "shiftRpm": 6800,
+          "blinkRpm": 7200
+        },
+        "session:0": {
+          "sourceTick": -1,
+          "elapsedSeconds": 0.5,
+          "revision": 9
+        },
+        "session:1": {
+          "sourceTick": 5459,
+          "elapsedSeconds": 63.5,
+          "revision": 10
+        },
+        "session:2": {
+          "sourceTick": 8939,
+          "elapsedSeconds": 121.5,
+          "revision": 11
+        },
+        "session:3": {
+          "sourceTick": 13319,
+          "elapsedSeconds": 194.5,
+          "revision": 12
+        },
+        "session:4": {
+          "sourceTick": 13439,
+          "elapsedSeconds": 196.5,
+          "revision": 13
+        },
+        "session:5": {
+          "sourceTick": 13559,
+          "elapsedSeconds": 198.5,
+          "revision": 14
+        },
+        "session:6": {
+          "sourceTick": 13679,
+          "elapsedSeconds": 200.5,
+          "revision": 15
+        },
+        "session:7": {
+          "sourceTick": 13799,
+          "elapsedSeconds": 202.5,
+          "revision": 16
+        },
+        "session:8": {
+          "sourceTick": 13919,
+          "elapsedSeconds": 204.5,
+          "revision": 17
+        },
+        "session:9": {
+          "sourceTick": 14039,
+          "elapsedSeconds": 206.5,
+          "revision": 18
+        },
+        "session:10": {
+          "sourceTick": 14159,
+          "elapsedSeconds": 208.5,
+          "revision": 19
+        },
+        "session:11": {
+          "sourceTick": 14279,
+          "elapsedSeconds": 210.5,
+          "revision": 20
+        },
+        "session:12": {
+          "sourceTick": 14399,
+          "elapsedSeconds": 212.5,
+          "revision": 21
+        },
+        "session:13": {
+          "sourceTick": 14519,
+          "elapsedSeconds": 214.5,
+          "revision": 22
+        },
+        "session:14": {
+          "sourceTick": 20579,
+          "elapsedSeconds": 315.5,
+          "revision": 23
+        },
+        "session:15": {
+          "sourceTick": 20819,
+          "elapsedSeconds": 319.5,
+          "revision": 24
+        },
+        "session:16": {
+          "sourceTick": 20939,
+          "elapsedSeconds": 321.5,
+          "revision": 25
+        },
+        "session:17": {
+          "sourceTick": 21059,
+          "elapsedSeconds": 323.5,
+          "revision": 26
+        },
+        "session:18": {
+          "sourceTick": 21299,
+          "elapsedSeconds": 327.5,
+          "revision": 27
+        },
+        "session:19": {
+          "sourceTick": 21419,
+          "elapsedSeconds": 329.5,
+          "revision": 28
+        },
+        "session:20": {
+          "sourceTick": 21539,
+          "elapsedSeconds": 331.5,
+          "revision": 29
+        },
+        "session:21": {
+          "sourceTick": 21659,
+          "elapsedSeconds": 333.5,
+          "revision": 30
+        },
+        "session:22": {
+          "sourceTick": 21779,
+          "elapsedSeconds": 335.5,
+          "revision": 31
+        },
+        "session:23": {
+          "sourceTick": 21899,
+          "elapsedSeconds": 337.5,
+          "revision": 32
+        },
+        "session:24": {
+          "sourceTick": 22019,
+          "elapsedSeconds": 339.5,
+          "revision": 33
+        },
+        "session:25": {
+          "sourceTick": 22139,
+          "elapsedSeconds": 341.5,
+          "revision": 34
+        },
+        "session:26": {
+          "sourceTick": 22259,
+          "elapsedSeconds": 343.5,
+          "revision": 35
+        },
+        "session:27": {
+          "sourceTick": 22379,
+          "elapsedSeconds": 345.5,
+          "revision": 36
+        },
+        "session:28": {
+          "sourceTick": 22499,
+          "elapsedSeconds": 347.5,
+          "revision": 37
+        },
+        "session:29": {
+          "sourceTick": 22619,
+          "elapsedSeconds": 349.5,
+          "revision": 38
+        },
+        "session:30": {
+          "sourceTick": 22739,
+          "elapsedSeconds": 351.5,
+          "revision": 39
+        },
+        "session:31": {
+          "sourceTick": 27839,
+          "elapsedSeconds": 436.5,
+          "revision": 40
+        },
+        "session:32": {
+          "sourceTick": 27959,
+          "elapsedSeconds": 438.5,
+          "revision": 41
+        },
+        "session:33": {
+          "sourceTick": 28079,
+          "elapsedSeconds": 440.5,
+          "revision": 42
+        },
+        "session:34": {
+          "sourceTick": 28199,
+          "elapsedSeconds": 442.5,
+          "revision": 43
+        },
+        "session:35": {
+          "sourceTick": 28319,
+          "elapsedSeconds": 444.5,
+          "revision": 44
+        },
+        "session:36": {
+          "sourceTick": 28559,
+          "elapsedSeconds": 448.5,
+          "revision": 45
+        },
+        "session:37": {
+          "sourceTick": 28799,
+          "elapsedSeconds": 452.5,
+          "revision": 46
+        },
+        "session:38": {
+          "sourceTick": 28919,
+          "elapsedSeconds": 454.5,
+          "revision": 47
+        },
+        "session:39": {
+          "sourceTick": 29039,
+          "elapsedSeconds": 456.5,
+          "revision": 48
+        },
+        "session:40": {
+          "sourceTick": 29159,
+          "elapsedSeconds": 458.5,
+          "revision": 49
+        },
+        "session:41": {
+          "sourceTick": 29279,
+          "elapsedSeconds": 460.5,
+          "revision": 50
+        },
+        "session:42": {
+          "sourceTick": 29399,
+          "elapsedSeconds": 462.5,
+          "revision": 51
+        },
+        "session:43": {
+          "sourceTick": 29639,
+          "elapsedSeconds": 466.5,
+          "revision": 52
+        },
+        "session:44": {
+          "sourceTick": 29759,
+          "elapsedSeconds": 468.5,
+          "revision": 53
+        },
+        "session:45": {
+          "sourceTick": 29879,
+          "elapsedSeconds": 470.5,
+          "revision": 54
+        },
+        "session:46": {
+          "sourceTick": 29999,
+          "elapsedSeconds": 472.5,
+          "revision": 55
+        },
+        "session:47": {
+          "sourceTick": 30119,
+          "elapsedSeconds": 474.5,
+          "revision": 56
+        },
+        "session:48": {
+          "sourceTick": 30239,
+          "elapsedSeconds": 476.5,
+          "revision": 57
+        },
+        "session:49": {
+          "sourceTick": 30359,
+          "elapsedSeconds": 478.5,
+          "revision": 58
+        },
+        "session:50": {
+          "sourceTick": 30479,
+          "elapsedSeconds": 480.5,
+          "revision": 59
+        },
+        "session:51": {
+          "sourceTick": 34859,
+          "elapsedSeconds": 553.5,
+          "revision": 60
+        },
+        "session:52": {
+          "sourceTick": 35219,
+          "elapsedSeconds": 559.5,
+          "revision": 61
+        },
+        "session:53": {
+          "sourceTick": 35339,
+          "elapsedSeconds": 561.5,
+          "revision": 62
+        },
+        "session:54": {
+          "sourceTick": 35459,
+          "elapsedSeconds": 563.5,
+          "revision": 63
+        },
+        "session:55": {
+          "sourceTick": 35699,
+          "elapsedSeconds": 567.5,
+          "revision": 64
+        },
+        "session:56": {
+          "sourceTick": 36059,
+          "elapsedSeconds": 573.5,
+          "revision": 65
+        },
+        "session:57": {
+          "sourceTick": 36179,
+          "elapsedSeconds": 575.5,
+          "revision": 66
+        },
+        "session:58": {
+          "sourceTick": 36239,
+          "elapsedSeconds": 576.5,
+          "revision": 67
+        },
+        "session:59": {
+          "sourceTick": 36299,
+          "elapsedSeconds": 577.5,
+          "revision": 68
+        },
+        "session:60": {
+          "sourceTick": 36419,
+          "elapsedSeconds": 579.5,
+          "revision": 69
+        },
+        "session:61": {
+          "sourceTick": 36539,
+          "elapsedSeconds": 581.5,
+          "revision": 70
+        },
+        "session:62": {
+          "sourceTick": 36659,
+          "elapsedSeconds": 583.5,
+          "revision": 71
+        },
+        "session:63": {
+          "sourceTick": 36779,
+          "elapsedSeconds": 585.5,
+          "revision": 72
+        },
+        "session:64": {
+          "sourceTick": 36899,
+          "elapsedSeconds": 587.5,
+          "revision": 73
+        },
+        "session:65": {
+          "sourceTick": 37019,
+          "elapsedSeconds": 589.5,
+          "revision": 74
+        },
+        "session:66": {
+          "sourceTick": 37139,
+          "elapsedSeconds": 591.5,
+          "revision": 75
+        },
+        "session:67": {
+          "sourceTick": 37259,
+          "elapsedSeconds": 593.5,
+          "revision": 76
+        },
+        "session:68": {
+          "sourceTick": 37499,
+          "elapsedSeconds": 597.5,
+          "revision": 77
+        },
+        "session:69": {
+          "sourceTick": 37619,
+          "elapsedSeconds": 599.5,
+          "revision": 78
+        }
+      }
     }
   ]
 }

--- a/tools/telemetry-replay/driver-controls-probe.ts
+++ b/tools/telemetry-replay/driver-controls-probe.ts
@@ -1,0 +1,53 @@
+import * as yaml from 'js-yaml';
+import type {
+  DriverControlsSnapshot,
+  Session,
+  Telemetry,
+} from '@irdashies/types';
+import { DriverControlsProcessor } from '../../src/app/processors/DriverControlsProcessor';
+import type { ReplayProbe, TelemetryFrame } from './validator';
+
+const telemetryFrom = (frame: TelemetryFrame): Telemetry =>
+  Object.fromEntries(
+    Object.entries(frame).map(([name, entry]) => [
+      name,
+      { value: Array.isArray(entry) ? entry : [entry] },
+    ])
+  ) as unknown as Telemetry;
+
+export const createDriverControlsProbe =
+  (): ReplayProbe<DriverControlsSnapshot> => {
+    const processor = new DriverControlsProcessor();
+    return {
+      name: 'driver-controls-state',
+      schemaVersion: 1,
+      variables: [
+        'Brake',
+        'BrakeRaw',
+        'Throttle',
+        'ThrottleRaw',
+        'Clutch',
+        'ClutchRaw',
+        'Gear',
+        'Speed',
+        'DisplayUnits',
+        'SteeringWheelAngle',
+        'BrakeABSactive',
+        'RPM',
+        'ShiftGrindRPM',
+        'OilTemp',
+        'WaterTemp',
+        'EngineWarnings',
+      ],
+      onSessionInfo(text) {
+        processor.init(yaml.load(text, { json: true }) as Session);
+      },
+      onFrame(frame) {
+        processor.onFrame(telemetryFrom(frame));
+        return { ...processor.snapshot() };
+      },
+      onDisconnect() {
+        processor.onLifecycle({ type: 'disconnect' });
+      },
+    };
+  };

--- a/tools/telemetry-replay/run-curated-validation.ts
+++ b/tools/telemetry-replay/run-curated-validation.ts
@@ -18,6 +18,7 @@ import { createStandingsProbe } from './standings-probe';
 import { createRadioProbe } from './radio-probe';
 import { createSessionTimingProbe } from './session-timing-probe';
 import { createSessionBarProbe } from './session-bar-probe';
+import { createDriverControlsProbe } from './driver-controls-probe';
 
 const REPOSITORY_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -151,6 +152,7 @@ async function main(): Promise<void> {
       createRadioProbe(),
       createSessionTimingProbe(),
       createSessionBarProbe(),
+      createDriverControlsProbe(),
     ],
   });
   const golden = {


### PR DESCRIPTION
## Description

Phase 4 follow-up to `docs/ARCHITECTURE_REVIEW.md`.

Moves the Input and Tachometer widgets off the legacy renderer-wide telemetry firehose and onto a typed, demand-driven `driver-controls.snapshot` channel. The main-process processor projects the minimum full-precision input and engine values required by those widgets, publishes only changed state, and is active only while a renderer subscribes.

The runtime is wired through both live/tape and mock sources. Input requests the channel at up to 60 Hz, while Tachometer uses its driver-focused rate. Shift-light thresholds are sourced from session data instead of the previous invalid telemetry-key casts. Storybook fixtures and the curated replay validator now seed and validate the new snapshot.

The implementation plan now records the four remaining Phase 4 slices: this driver-controls migration, positional/warning consumers, low-frequency/debug consumers, and final legacy telemetry deletion with re-profiling.

Validation:

- `npm run lint -- --no-fix`
- `npm run test -- --no-coverage` — 1,218 passed, 1 skipped
- `npm run test:replay:curated` — 36,000 frames, 70 session revisions, 12 probes
- `git diff --check`

Architecture pre-PR checklist:

- [x] N1 — no new synchronous filesystem access
- [x] N2 — no frontend imports from `src/app`
- [x] N3 — no cross-widget imports
- [x] N4 — no new IPC handlers
- [x] R2.1/R2.2 — full precision retained for driver inputs
- [x] R3.1 — no new renderer session-derived store
- [x] R4.1 — existing typed channel bridge used
- [x] R6.1 — no storage changes
- [x] R7.1 — widget runtime metadata updated without registry god-file changes
- [x] R8.1 — no settings shape changes
- [x] R10.1 — no native changes
- [x] R11.1 — no direct console logging
- [x] R13.1 — processor and publication paths are performance-instrumented
- [x] R14.1 — processor/runtime tests and curated replay coverage added
- [x] Storybook snapshots updated for both affected widgets

## Screenshots

No visual changes expected; Input and Tachometer retain their existing presentation.

### Before

Input and Tachometer subscribed to the legacy renderer-wide telemetry store.

### After

Input and Tachometer consume `driver-controls.snapshot`; renderers containing only migrated widgets no longer require legacy telemetry.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
