### PR TITLE
perf: share channel snapshot selectors

### DIFF
--- a/src/frontend/context/ChannelStore/ChannelSnapshotStore.bench.spec.ts
+++ b/src/frontend/context/ChannelStore/ChannelSnapshotStore.bench.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ChannelBridge, RadioSnapshot } from '@irdashies/types';
+import { ChannelSnapshotStore } from './ChannelSnapshotStore';
+
+describe('ChannelSnapshotStore fixed-size microbenchmark', () => {
+  it('bounds selector callbacks and selection allocations by consumer cadence', () => {
+    const fastConsumerCount = 32;
+    const slowConsumerCount = 32;
+    const frameCount = 251;
+    let now = 0;
+    let publish: ((snapshot: RadioSnapshot) => void) | undefined;
+    const bridgeSubscribe = vi.fn(
+      (_channel: string, callback: (snapshot: RadioSnapshot) => void) => {
+        publish = callback;
+        return vi.fn();
+      }
+    );
+    const bridge = { subscribe: bridgeSubscribe } as unknown as ChannelBridge;
+    const store = new ChannelSnapshotStore('radio.snapshot', bridge, {
+      now: () => now,
+    });
+    let selectorCallbacks = 0;
+    let selectionAllocations = 0;
+    let notifications = 0;
+    const subscribeConsumer = (rateHz: number) => {
+      const selection = store.createSelection(
+        (snapshot) => {
+          selectorCallbacks += 1;
+          selectionAllocations += 1;
+          return { activeCount: snapshot.transmittingCarIdxs.length };
+        },
+        (previous, next) => previous.activeCount === next.activeCount,
+        rateHz
+      );
+      selection.subscribe(() => {
+        notifications += 1;
+      });
+    };
+
+    for (let index = 0; index < fastConsumerCount; index += 1) {
+      subscribeConsumer(25);
+    }
+    for (let index = 0; index < slowConsumerCount; index += 1) {
+      subscribeConsumer(5);
+    }
+    for (let frame = 0; frame < frameCount; frame += 1) {
+      now = frame * 40;
+      publish?.({ transmittingCarIdxs: [4], version: frame });
+    }
+
+    const expectedFastEvaluations = fastConsumerCount * frameCount;
+    const expectedSlowEvaluations = slowConsumerCount * 51;
+    const expectedEvaluations =
+      expectedFastEvaluations + expectedSlowEvaluations;
+    expect(bridgeSubscribe).toHaveBeenCalledOnce();
+    expect(selectorCallbacks).toBe(expectedEvaluations);
+    expect(selectionAllocations).toBe(expectedEvaluations);
+    expect(notifications).toBe(fastConsumerCount + slowConsumerCount);
+  });
+});

--- a/src/frontend/context/ChannelStore/ChannelSnapshotStore.spec.ts
+++ b/src/frontend/context/ChannelStore/ChannelSnapshotStore.spec.ts
@@ -1,56 +1,224 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { ChannelBridge, SessionLifecycleEvent } from '@irdashies/types';
+import type {
+  ChannelBridge,
+  ChannelPayloads,
+  RadioSnapshot,
+} from '@irdashies/types';
 import { ChannelSnapshotStore } from './ChannelSnapshotStore';
 
+const radioSnapshot = (
+  version: number,
+  transmittingCarIdxs: readonly number[] = []
+): RadioSnapshot => ({ transmittingCarIdxs, version });
+
+const createBridge = () => {
+  let publish: ((payload: RadioSnapshot) => void) | undefined;
+  const activeUnsubscribes = new Set<ReturnType<typeof vi.fn>>();
+  const activeCounts: number[] = [];
+  const subscribe = vi.fn(
+    (
+      _channel: string,
+      callback: (payload: RadioSnapshot) => void,
+      rateHz?: number
+    ) => {
+      void rateHz;
+      publish = callback;
+      const unsubscribe = vi.fn();
+      unsubscribe.mockImplementation(() => {
+        activeUnsubscribes.delete(unsubscribe);
+        activeCounts.push(activeUnsubscribes.size);
+      });
+      activeUnsubscribes.add(unsubscribe);
+      activeCounts.push(activeUnsubscribes.size);
+      return unsubscribe;
+    }
+  );
+  return {
+    bridge: { subscribe } as unknown as ChannelBridge,
+    subscribe,
+    publish: (snapshot: RadioSnapshot) => publish?.(snapshot),
+    activeUnsubscribes,
+    activeCounts,
+  };
+};
+
 describe('ChannelSnapshotStore', () => {
-  it('shares one bridge subscription and disconnects the final listener', () => {
-    let publish: ((payload: SessionLifecycleEvent) => void) | undefined;
-    const unsubscribe = vi.fn();
-    const subscribe = vi.fn(
-      (
-        _channel: string,
-        callback: (payload: SessionLifecycleEvent) => void
-      ) => {
-        publish = callback;
-        return unsubscribe;
-      }
+  it('shares one active bridge subscription across selections', () => {
+    const source = createBridge();
+    const store = new ChannelSnapshotStore('radio.snapshot', source.bridge);
+    const first = store.createSelection((snapshot) => snapshot.version);
+    const second = store.createSelection(
+      (snapshot) => snapshot.transmittingCarIdxs
     );
-    const bridge = { subscribe } as unknown as ChannelBridge;
-    const store = new ChannelSnapshotStore(
-      'session.lifecycle',
-      undefined,
-      bridge
-    );
-    const first = vi.fn();
-    const second = vi.fn();
+    const firstListener = vi.fn();
+    const secondListener = vi.fn();
 
-    const removeFirst = store.subscribe(first);
-    const removeSecond = store.subscribe(second);
-    publish?.({ type: 'enter', replay: true });
+    const removeFirst = first.subscribe(firstListener);
+    const removeSecond = second.subscribe(secondListener);
+    source.publish(radioSnapshot(1, [4]));
 
-    expect(first).toHaveBeenCalledOnce();
-    expect(second).toHaveBeenCalledOnce();
-    expect(store.getSnapshot()).toEqual({ type: 'enter', replay: true });
+    expect(source.subscribe).toHaveBeenCalledOnce();
+    expect(source.activeUnsubscribes).toHaveLength(1);
+    expect(firstListener).toHaveBeenCalledOnce();
+    expect(secondListener).toHaveBeenCalledOnce();
     removeFirst();
-    expect(unsubscribe).not.toHaveBeenCalled();
+    expect(source.activeUnsubscribes).toHaveLength(1);
     removeSecond();
-    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(source.activeUnsubscribes).toHaveLength(0);
+    source.publish(radioSnapshot(2, [8]));
+    expect(firstListener).toHaveBeenCalledOnce();
+    expect(secondListener).toHaveBeenCalledOnce();
   });
 
-  it('does not subscribe to the bridge when disabled', () => {
-    const bridge = {
-      subscribe: vi.fn(() => vi.fn()),
-    } as unknown as ChannelBridge;
-    const store = new ChannelSnapshotStore(
-      'session.lifecycle',
-      undefined,
-      bridge,
-      false
+  it('does not evaluate a slow selection at the fast selection cadence', () => {
+    let now = 0;
+    const source = createBridge();
+    const store = new ChannelSnapshotStore('radio.snapshot', source.bridge, {
+      now: () => now,
+    });
+    const fastSelector = vi.fn((snapshot: RadioSnapshot) => snapshot.version);
+    const slowSelector = vi.fn((snapshot: RadioSnapshot) => snapshot.version);
+    const fastListener = vi.fn();
+    const slowListener = vi.fn();
+    const fast = store.createSelection(fastSelector, Object.is, 25);
+    const slow = store.createSelection(slowSelector, Object.is, 5);
+
+    fast.subscribe(fastListener);
+    slow.subscribe(slowListener);
+    source.publish(radioSnapshot(0));
+    for (let version = 1; version <= 5; version += 1) {
+      now = version * 40;
+      source.publish(radioSnapshot(version));
+    }
+
+    expect(fastSelector).toHaveBeenCalledTimes(6);
+    expect(fastListener).toHaveBeenCalledTimes(6);
+    expect(slowSelector).toHaveBeenCalledTimes(2);
+    expect(slowListener).toHaveBeenCalledTimes(2);
+    expect(source.subscribe.mock.calls.map((call) => call[2])).toEqual([25]);
+  });
+
+  it('uses custom equality to suppress unchanged notifications', () => {
+    let now = 0;
+    const source = createBridge();
+    const store = new ChannelSnapshotStore('radio.snapshot', source.bridge, {
+      now: () => now,
+    });
+    const listener = vi.fn();
+    const selection = store.createSelection(
+      (snapshot) => [...snapshot.transmittingCarIdxs],
+      (previous, next) =>
+        previous.length === next.length &&
+        previous.every((value, index) => value === next[index])
+    );
+    selection.subscribe(listener);
+
+    source.publish(radioSnapshot(1, [2, 7]));
+    now = 40;
+    source.publish(radioSnapshot(2, [2, 7]));
+    now = 80;
+    source.publish(radioSnapshot(3, [2, 8]));
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(selection.getSnapshot()).toEqual([2, 8]);
+  });
+
+  it('refreshes a replaced selector from cache without notifying listeners', () => {
+    const source = createBridge();
+    const store = new ChannelSnapshotStore('radio.snapshot', source.bridge);
+    const listener = vi.fn();
+    const selection = store.createSelection(
+      (snapshot) => snapshot.transmittingCarIdxs[0]
+    );
+    selection.subscribe(listener);
+    source.publish(radioSnapshot(1, [3, 9]));
+
+    selection.updateSelector(
+      (snapshot) => snapshot.transmittingCarIdxs[1],
+      Object.is
     );
 
-    const unsubscribe = store.subscribe(vi.fn());
+    expect(selection.getSnapshot()).toBe(9);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(source.subscribe).toHaveBeenCalledOnce();
+  });
 
-    expect(bridge.subscribe).not.toHaveBeenCalled();
-    unsubscribe();
+  it('isolates selector, equality, listener, and reporter exceptions', () => {
+    let now = 0;
+    const source = createBridge();
+    const onError = vi.fn(() => {
+      throw new Error('reporter failed');
+    });
+    const store = new ChannelSnapshotStore('radio.snapshot', source.bridge, {
+      now: () => now,
+      onError,
+    });
+    const broken = store.createSelection((snapshot) => {
+      if (snapshot.version === 2) throw new Error('selector failed');
+      return snapshot.version;
+    });
+    const brokenEquality = store.createSelection(
+      (snapshot) => snapshot.version,
+      () => {
+        throw new Error('equality failed');
+      }
+    );
+    const healthy = store.createSelection((snapshot) => snapshot.version);
+    const brokenListener = vi.fn(() => {
+      throw new Error('listener failed');
+    });
+    const equalityListener = vi.fn();
+    const healthyListener = vi.fn();
+    broken.subscribe(brokenListener);
+    brokenEquality.subscribe(equalityListener);
+    healthy.subscribe(healthyListener);
+
+    source.publish(radioSnapshot(1));
+    now = 40;
+    source.publish(radioSnapshot(2));
+
+    expect(brokenListener).toHaveBeenCalledOnce();
+    expect(equalityListener).toHaveBeenCalledOnce();
+    expect(healthyListener).toHaveBeenCalledTimes(2);
+    expect(healthy.getSnapshot()).toBe(2);
+    expect(onError).toHaveBeenCalledTimes(3);
+  });
+
+  it('downgrades bridge demand as faster selections leave', () => {
+    const source = createBridge();
+    const store = new ChannelSnapshotStore('radio.snapshot', source.bridge);
+    const slow = store.createSelection(
+      (snapshot) => snapshot.version,
+      Object.is,
+      5
+    );
+    const fast = store.createSelection(
+      (snapshot) => snapshot.version,
+      Object.is,
+      25
+    );
+
+    const removeSlow = slow.subscribe(vi.fn());
+    const removeFast = fast.subscribe(vi.fn());
+    removeFast();
+
+    expect(source.subscribe.mock.calls.map((call) => call[2])).toEqual([
+      5, 25, 5,
+    ]);
+    expect(source.activeUnsubscribes).toHaveLength(1);
+    expect(source.activeCounts).not.toContain(0);
+    removeSlow();
+    expect(source.activeUnsubscribes).toHaveLength(0);
+  });
+
+  it('accepts snapshots through the typed channel payload contract', () => {
+    const source = createBridge();
+    const store = new ChannelSnapshotStore('radio.snapshot', source.bridge);
+    const selection = store.createSelection(
+      (snapshot: ChannelPayloads['radio.snapshot']) => snapshot.version
+    );
+    selection.subscribe(vi.fn());
+    source.publish(radioSnapshot(4));
+    expect(selection.getSnapshot()).toBe(4);
   });
 });

--- a/src/frontend/context/ChannelStore/ChannelSnapshotStore.ts
+++ b/src/frontend/context/ChannelStore/ChannelSnapshotStore.ts
@@ -1,43 +1,281 @@
-import type {
-  ChannelBridge,
-  ChannelName,
-  ChannelPayloads,
+import {
+  channelRegistry,
+  type ChannelBridge,
+  type ChannelName,
+  type ChannelPayloads,
 } from '@irdashies/types';
+import logger from '@irdashies/utils/logger';
 
 type ChangeListener = () => void;
 
+export type ChannelSelector<K extends ChannelName, Selected> = (
+  snapshot: ChannelPayloads[K]
+) => Selected;
+
+export type ChannelEquality<Selected> = (
+  previous: Selected,
+  next: Selected
+) => boolean;
+
+interface ChannelSelection<K extends ChannelName> {
+  readonly rateHz?: number;
+  evaluate(
+    snapshot: ChannelPayloads[K],
+    now: number,
+    notify: boolean,
+    recordCadence?: boolean
+  ): void;
+  refresh(now: number): void;
+  isDue(now: number, defaultRateHz?: number, deliveryRateHz?: number): boolean;
+  reset(): void;
+}
+
+interface ChannelSnapshotStoreOptions {
+  now?: () => number;
+  onError?: (error: unknown) => void;
+}
+
+export class ChannelSelectionStore<
+  K extends ChannelName,
+  Selected,
+> implements ChannelSelection<K> {
+  private selected: Selected | undefined;
+  private hasSelection = false;
+  private lastEvaluatedAt?: number;
+  private lastEvaluatedSnapshot?: ChannelPayloads[K];
+  private readonly listeners = new Set<ChangeListener>();
+  private selector: ChannelSelector<K, Selected>;
+  private equality: ChannelEquality<Selected>;
+
+  constructor(
+    private readonly parent: ChannelSnapshotStore<K>,
+    selector: ChannelSelector<K, Selected>,
+    equality: ChannelEquality<Selected>,
+    readonly rateHz?: number,
+    private readonly enabled = true
+  ) {
+    this.selector = selector;
+    this.equality = equality;
+  }
+
+  getSnapshot = (): Selected | undefined => this.selected;
+
+  subscribe = (listener: ChangeListener): (() => void) => {
+    if (!this.enabled) return () => undefined;
+    this.listeners.add(listener);
+    if (this.listeners.size === 1) this.parent.add(this);
+
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      this.listeners.delete(listener);
+      if (this.listeners.size === 0) this.parent.remove(this);
+    };
+  };
+
+  updateSelector(
+    selector: ChannelSelector<K, Selected>,
+    equality: ChannelEquality<Selected>
+  ): void {
+    if (this.selector === selector && this.equality === equality) return;
+    this.selector = selector;
+    this.equality = equality;
+    this.parent.refresh(this);
+  }
+
+  evaluate(
+    snapshot: ChannelPayloads[K],
+    now: number,
+    notify: boolean,
+    recordCadence = true
+  ): void {
+    if (recordCadence) this.lastEvaluatedAt = now;
+    this.lastEvaluatedSnapshot = snapshot;
+    let next: Selected;
+    try {
+      next = this.selector(snapshot);
+    } catch (error) {
+      this.parent.report(error);
+      return;
+    }
+
+    if (this.hasSelection) {
+      try {
+        if (this.equality(this.selected as Selected, next)) return;
+      } catch (error) {
+        this.parent.report(error);
+        return;
+      }
+    }
+
+    this.selected = next;
+    this.hasSelection = true;
+    if (!notify) return;
+    for (const listener of this.listeners) {
+      try {
+        listener();
+      } catch (error) {
+        this.parent.report(error);
+      }
+    }
+  }
+
+  refresh(now: number): void {
+    if (this.lastEvaluatedSnapshot === undefined) return;
+    this.evaluate(this.lastEvaluatedSnapshot, now, false, false);
+  }
+
+  isDue(now: number, defaultRateHz?: number, deliveryRateHz?: number): boolean {
+    const effectiveRateHz = this.rateHz ?? defaultRateHz;
+    // The bridge already enforces the aggregate (fastest) delivery rate.
+    // Locally throttle only slower selections so the fastest selection is not
+    // double-throttled and replayed snapshots are never dropped.
+    if (
+      effectiveRateHz === undefined ||
+      deliveryRateHz === undefined ||
+      effectiveRateHz >= deliveryRateHz ||
+      this.lastEvaluatedAt === undefined
+    ) {
+      return true;
+    }
+    return now - this.lastEvaluatedAt >= 1000 / effectiveRateHz;
+  }
+
+  reset(): void {
+    this.selected = undefined;
+    this.hasSelection = false;
+    this.lastEvaluatedAt = undefined;
+    this.lastEvaluatedSnapshot = undefined;
+  }
+}
+
 export class ChannelSnapshotStore<K extends ChannelName> {
   private snapshot: ChannelPayloads[K] | undefined;
-  private readonly listeners = new Set<ChangeListener>();
+  private readonly selections = new Set<ChannelSelection<K>>();
   private unsubscribeBridge?: () => void;
+  private subscribedRateHz?: number;
+  private readonly now: () => number;
+  private readonly onError: (error: unknown) => void;
 
   constructor(
     private readonly channel: K,
-    private readonly rateHz?: number,
-    private readonly bridge: ChannelBridge = window.channelBridge,
-    private readonly enabled = true
-  ) {}
+    private readonly bridge: ChannelBridge,
+    options: ChannelSnapshotStoreOptions = {}
+  ) {
+    this.now = options.now ?? (() => performance.now());
+    this.onError =
+      options.onError ??
+      ((error) => logger.error(`Channel selector failed: ${channel}`, error));
+  }
 
-  getSnapshot = (): ChannelPayloads[K] | undefined => this.snapshot;
+  createSelection<Selected>(
+    selector: ChannelSelector<K, Selected>,
+    equality: ChannelEquality<Selected> = Object.is,
+    rateHz?: number,
+    enabled = true
+  ): ChannelSelectionStore<K, Selected> {
+    return new ChannelSelectionStore(this, selector, equality, rateHz, enabled);
+  }
 
-  subscribe = (listener: ChangeListener): (() => void) => {
-    this.listeners.add(listener);
-    if (this.enabled && this.listeners.size === 1) {
-      this.unsubscribeBridge = this.bridge.subscribe(
-        this.channel,
-        (snapshot) => {
-          this.snapshot = snapshot;
-          for (const currentListener of this.listeners) currentListener();
-        },
-        this.rateHz
-      );
+  add(selection: ChannelSelection<K>): void {
+    this.selections.add(selection);
+    if (this.snapshot !== undefined) {
+      selection.evaluate(this.snapshot, this.now(), false);
     }
-    return () => {
-      this.listeners.delete(listener);
-      if (this.listeners.size === 0) {
-        this.unsubscribeBridge?.();
-        this.unsubscribeBridge = undefined;
-      }
-    };
+    this.syncBridgeSubscription();
+  }
+
+  remove(selection: ChannelSelection<K>): void {
+    if (!this.selections.delete(selection)) return;
+    selection.reset();
+    this.syncBridgeSubscription();
+    if (this.selections.size === 0) this.snapshot = undefined;
+  }
+
+  refresh(selection: ChannelSelection<K>): void {
+    if (!this.selections.has(selection)) return;
+    selection.refresh(this.now());
+  }
+
+  report(error: unknown): void {
+    try {
+      this.onError(error);
+    } catch {
+      // Error reporting must not break delivery to other channel consumers.
+    }
+  }
+
+  private receive = (snapshot: ChannelPayloads[K]): void => {
+    if (this.selections.size === 0) return;
+    this.snapshot = snapshot;
+    const now = this.now();
+    const definition = channelRegistry[this.channel];
+    const defaultRateHz =
+      definition.kind === 'snapshot' ? definition.defaultRateHz : undefined;
+    for (const selection of this.selections) {
+      if (!selection.isDue(now, defaultRateHz, this.subscribedRateHz)) continue;
+      selection.evaluate(snapshot, now, true);
+    }
   };
+
+  private syncBridgeSubscription(): void {
+    if (this.selections.size === 0) {
+      this.unsubscribeBridge?.();
+      this.unsubscribeBridge = undefined;
+      this.subscribedRateHz = undefined;
+      return;
+    }
+
+    const requestedRateHz = this.aggregateRateHz();
+    if (this.unsubscribeBridge && this.subscribedRateHz === requestedRateHz) {
+      return;
+    }
+
+    const previousUnsubscribe = this.unsubscribeBridge;
+    const nextUnsubscribe = this.bridge.subscribe(
+      this.channel,
+      this.receive,
+      requestedRateHz
+    );
+    this.unsubscribeBridge = nextUnsubscribe;
+    this.subscribedRateHz = requestedRateHz;
+    previousUnsubscribe?.();
+  }
+
+  private aggregateRateHz(): number | undefined {
+    const definition = channelRegistry[this.channel];
+    const defaultRateHz =
+      definition.kind === 'snapshot' ? definition.defaultRateHz : undefined;
+    let requestedRateHz: number | undefined;
+    for (const selection of this.selections) {
+      const currentRateHz = selection.rateHz ?? defaultRateHz;
+      if (
+        currentRateHz !== undefined &&
+        (requestedRateHz === undefined || currentRateHz > requestedRateHz)
+      ) {
+        requestedRateHz = currentRateHz;
+      }
+    }
+    return requestedRateHz;
+  }
 }
+
+const storesByBridge = new WeakMap<ChannelBridge, Map<ChannelName, unknown>>();
+
+export const getChannelSnapshotStore = <K extends ChannelName>(
+  channel: K,
+  bridge: ChannelBridge
+): ChannelSnapshotStore<K> => {
+  let stores = storesByBridge.get(bridge);
+  if (!stores) {
+    stores = new Map();
+    storesByBridge.set(bridge, stores);
+  }
+  let store = stores.get(channel) as ChannelSnapshotStore<K> | undefined;
+  if (!store) {
+    store = new ChannelSnapshotStore(channel, bridge);
+    stores.set(channel, store);
+  }
+  return store;
+};

--- a/src/frontend/context/ChannelStore/useChannelSnapshot.spec.tsx
+++ b/src/frontend/context/ChannelStore/useChannelSnapshot.spec.tsx
@@ -1,26 +1,208 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import type { ChannelBridge } from '@irdashies/types';
-import { useChannelSnapshot } from './useChannelSnapshot';
+import type {
+  ChannelBridge,
+  ChannelPayloads,
+  RadioSnapshot,
+} from '@irdashies/types';
+import { useChannelSelector, useChannelSnapshot } from './useChannelSnapshot';
 
-describe('useChannelSnapshot', () => {
-  it('subscribes and unsubscribes as enabled changes', () => {
-    const unsubscribe = vi.fn();
-    const bridge = {
-      subscribe: vi.fn(() => unsubscribe),
-    } as unknown as ChannelBridge;
+const createBridge = () => {
+  let publish: ((payload: RadioSnapshot) => void) | undefined;
+  const unsubscribe = vi.fn();
+  const subscribe = vi.fn(
+    (_channel: string, callback: (payload: RadioSnapshot) => void) => {
+      publish = callback;
+      return unsubscribe;
+    }
+  );
+  return {
+    bridge: { subscribe } as unknown as ChannelBridge,
+    subscribe,
+    unsubscribe,
+    publish: (snapshot: RadioSnapshot) => publish?.(snapshot),
+  };
+};
+
+const radioSnapshot = (
+  version: number,
+  transmittingCarIdxs: readonly number[] = []
+): ChannelPayloads['radio.snapshot'] => ({ transmittingCarIdxs, version });
+
+describe('channel snapshot hooks', () => {
+  it('uses one bridge subscription for multiple hooks on the same channel', () => {
+    const source = createBridge();
+    const { result, unmount } = renderHook(() => {
+      const version = useChannelSelector(
+        'radio.snapshot',
+        (snapshot) => snapshot.version,
+        { bridge: source.bridge }
+      );
+      const activeCount = useChannelSelector(
+        'radio.snapshot',
+        (snapshot) => snapshot.transmittingCarIdxs.length,
+        { bridge: source.bridge }
+      );
+      return { version, activeCount };
+    });
+
+    expect(source.subscribe).toHaveBeenCalledOnce();
+    act(() => source.publish(radioSnapshot(3, [1, 2])));
+    expect(result.current).toEqual({ version: 3, activeCount: 2 });
+    unmount();
+    expect(source.unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('does not rerender when an unrelated snapshot field changes', () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const source = createBridge();
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useChannelSelector(
+        'radio.snapshot',
+        (snapshot) => snapshot.transmittingCarIdxs.length,
+        { bridge: source.bridge }
+      );
+    });
+
+    act(() => source.publish(radioSnapshot(1, [7])));
+    expect(result.current).toBe(1);
+    const rendersAfterInitialSnapshot = renders;
+    now = 40;
+    act(() => source.publish(radioSnapshot(2, [9])));
+
+    expect(renders).toBe(rendersAfterInitialSnapshot);
+    nowSpy.mockRestore();
+  });
+
+  it('applies custom equality without requiring a stable inline selector', () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const source = createBridge();
+    let renders = 0;
+    const equality = (previous: readonly number[], next: readonly number[]) =>
+      previous.length === next.length &&
+      previous.every((value, index) => value === next[index]);
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useChannelSelector(
+        'radio.snapshot',
+        (snapshot) => [...snapshot.transmittingCarIdxs],
+        { bridge: source.bridge, equality }
+      );
+    });
+
+    act(() => source.publish(radioSnapshot(1, [2, 4])));
+    expect(result.current).toEqual([2, 4]);
+    const rendersAfterInitialSnapshot = renders;
+    now = 40;
+    act(() => source.publish(radioSnapshot(2, [2, 4])));
+
+    expect(renders).toBe(rendersAfterInitialSnapshot);
+    expect(source.subscribe).toHaveBeenCalledOnce();
+    nowSpy.mockRestore();
+  });
+
+  it('does not evaluate a slow selector when a fast selector rerenders their component', () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const source = createBridge();
+    const fastSelector = vi.fn((snapshot: RadioSnapshot) => snapshot.version);
+    const slowSelector = vi.fn((snapshot: RadioSnapshot) => snapshot.version);
+    const { result } = renderHook(() => ({
+      fast: useChannelSelector('radio.snapshot', fastSelector, {
+        bridge: source.bridge,
+        rateHz: 25,
+      }),
+      slow: useChannelSelector('radio.snapshot', slowSelector, {
+        bridge: source.bridge,
+        rateHz: 5,
+      }),
+    }));
+
+    act(() => source.publish(radioSnapshot(0)));
+    now = 40;
+    act(() => source.publish(radioSnapshot(1)));
+
+    expect(result.current).toEqual({ fast: 1, slow: 0 });
+    expect(fastSelector).toHaveBeenCalledTimes(2);
+    expect(slowSelector).toHaveBeenCalledOnce();
+    expect(source.subscribe).toHaveBeenCalledOnce();
+    nowSpy.mockRestore();
+  });
+
+  it('does not expose newer snapshots through an inline slow selector rerender', () => {
+    let now = 0;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const source = createBridge();
+    const slowEvaluations: number[] = [];
+    const { result } = renderHook(() => ({
+      fast: useChannelSelector(
+        'radio.snapshot',
+        (snapshot) => snapshot.version,
+        { bridge: source.bridge, rateHz: 25 }
+      ),
+      slow: useChannelSelector(
+        'radio.snapshot',
+        (snapshot) => {
+          slowEvaluations.push(snapshot.version);
+          return snapshot.version;
+        },
+        { bridge: source.bridge, rateHz: 5 }
+      ),
+    }));
+
+    act(() => source.publish(radioSnapshot(0)));
+    now = 40;
+    act(() => source.publish(radioSnapshot(1)));
+
+    expect(result.current).toEqual({ fast: 1, slow: 0 });
+    expect(slowEvaluations).not.toContain(1);
+    nowSpy.mockRestore();
+  });
+
+  it('refreshes a selector that closes over changed props from the cached snapshot', () => {
+    const source = createBridge();
+    let renders = 0;
+    const { result, rerender } = renderHook(
+      ({ index }) => {
+        renders += 1;
+        return useChannelSelector(
+          'radio.snapshot',
+          (snapshot) => snapshot.transmittingCarIdxs[index],
+          { bridge: source.bridge }
+        );
+      },
+      { initialProps: { index: 0 } }
+    );
+    act(() => source.publish(radioSnapshot(1, [4, 8])));
+    expect(result.current).toBe(4);
+    const rendersBeforeSelectorChange = renders;
+
+    rerender({ index: 1 });
+
+    expect(result.current).toBe(8);
+    expect(renders).toBe(rendersBeforeSelectorChange + 1);
+    expect(source.subscribe).toHaveBeenCalledOnce();
+    expect(source.unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it('subscribes and unsubscribes safely as enabled changes', () => {
+    const source = createBridge();
     const { rerender, unmount } = renderHook(
       ({ enabled }) =>
-        useChannelSnapshot('lap-times.snapshot', undefined, bridge, enabled),
+        useChannelSnapshot('radio.snapshot', undefined, source.bridge, enabled),
       { initialProps: { enabled: false } }
     );
 
-    expect(bridge.subscribe).not.toHaveBeenCalled();
+    expect(source.subscribe).not.toHaveBeenCalled();
     rerender({ enabled: true });
-    expect(bridge.subscribe).toHaveBeenCalledOnce();
+    expect(source.subscribe).toHaveBeenCalledOnce();
     rerender({ enabled: false });
-    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(source.unsubscribe).toHaveBeenCalledOnce();
     unmount();
-    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(source.unsubscribe).toHaveBeenCalledOnce();
   });
 });

--- a/src/frontend/context/ChannelStore/useChannelSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useChannelSnapshot.ts
@@ -4,20 +4,55 @@ import type {
   ChannelName,
   ChannelPayloads,
 } from '@irdashies/types';
-import { ChannelSnapshotStore } from './ChannelSnapshotStore';
+import {
+  getChannelSnapshotStore,
+  type ChannelEquality,
+  type ChannelSelector,
+} from './ChannelSnapshotStore';
 import { useWidgetChannelRate } from '../../widgetRuntime';
+
+export interface ChannelSelectorOptions<Selected> {
+  rateHz?: number;
+  bridge?: ChannelBridge;
+  enabled?: boolean;
+  equality?: ChannelEquality<Selected>;
+}
+
+export const useChannelSelector = <K extends ChannelName, Selected>(
+  channel: K,
+  selector: ChannelSelector<K, Selected>,
+  options: ChannelSelectorOptions<Selected> = {}
+): Selected | undefined => {
+  const configuredRateHz = useWidgetChannelRate(channel);
+  const effectiveRateHz = options.rateHz ?? configuredRateHz;
+  const effectiveBridge = options.bridge ?? window.channelBridge;
+  const enabled = options.enabled ?? true;
+  const equality = options.equality ?? Object.is;
+  const store = useMemo(
+    () => getChannelSnapshotStore(channel, effectiveBridge),
+    [channel, effectiveBridge]
+  );
+  const selection = useMemo(
+    () => store.createSelection(selector, equality, effectiveRateHz, enabled),
+    // Selector/equality references are updated below without replacing the
+    // subscription. Inline selectors therefore do not churn bridge demand.
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+    [store, effectiveRateHz, enabled]
+  );
+  selection.updateSelector(selector, equality);
+  return useSyncExternalStore(selection.subscribe, selection.getSnapshot);
+};
+
+const selectSnapshot = <Snapshot>(snapshot: Snapshot): Snapshot => snapshot;
 
 export const useChannelSnapshot = <K extends ChannelName>(
   channel: K,
   rateHz?: number,
   bridge?: ChannelBridge,
   enabled = true
-): ChannelPayloads[K] | undefined => {
-  const configuredRateHz = useWidgetChannelRate(channel);
-  const effectiveRateHz = rateHz ?? configuredRateHz;
-  const store = useMemo(
-    () => new ChannelSnapshotStore(channel, effectiveRateHz, bridge, enabled),
-    [bridge, channel, effectiveRateHz, enabled]
-  );
-  return useSyncExternalStore(store.subscribe, store.getSnapshot);
-};
+): ChannelPayloads[K] | undefined =>
+  useChannelSelector(channel, selectSnapshot, {
+    rateHz,
+    bridge,
+    enabled,
+  });

--- a/src/frontend/context/ChannelStore/useRadioSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useRadioSnapshot.ts
@@ -1,10 +1,4 @@
-import { useWidgetChannelRate } from '../../widgetRuntime';
 import { useChannelSnapshot } from './useChannelSnapshot';
 
 export const useRadioSnapshot = (enabled = true) =>
-  useChannelSnapshot(
-    'radio.snapshot',
-    useWidgetChannelRate('radio.snapshot'),
-    undefined,
-    enabled
-  );
+  useChannelSnapshot('radio.snapshot', undefined, undefined, enabled);

--- a/src/frontend/context/ChannelStore/useSessionTimingSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useSessionTimingSnapshot.ts
@@ -1,10 +1,4 @@
-import { useWidgetChannelRate } from '../../widgetRuntime';
 import { useChannelSnapshot } from './useChannelSnapshot';
 
 export const useSessionTimingSnapshot = (enabled = true) =>
-  useChannelSnapshot(
-    'session-timing.snapshot',
-    useWidgetChannelRate('session-timing.snapshot'),
-    undefined,
-    enabled
-  );
+  useChannelSnapshot('session-timing.snapshot', undefined, undefined, enabled);

--- a/src/frontend/context/ChannelStore/useStandingsSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useStandingsSnapshot.ts
@@ -1,10 +1,4 @@
-import { useWidgetChannelRate } from '../../widgetRuntime';
 import { useChannelSnapshot } from './useChannelSnapshot';
 
 export const useStandingsSnapshot = (enabled = true) =>
-  useChannelSnapshot(
-    'standings.snapshot',
-    useWidgetChannelRate('standings.snapshot'),
-    undefined,
-    enabled
-  );
+  useChannelSnapshot('standings.snapshot', undefined, undefined, enabled);

--- a/src/runtimeBoundaryReplay.spec.ts
+++ b/src/runtimeBoundaryReplay.spec.ts
@@ -6,13 +6,15 @@ import type {
   Session,
   Telemetry,
 } from '@irdashies/types';
-import { channelRegistry } from '@irdashies/types';
 import { CHANNEL_DELIVERY, ChannelBus } from './app/bridge/channelBridge';
 import { createDefaultProcessorHost } from './app/processors/processorRegistry';
 import type { ProcessorHost } from './app/processors/ProcessorHost';
 import { createSessionLifecycle } from './app/sessionLifecycle';
 import type { SessionLifecycle } from './app/sessionLifecycle';
-import { ChannelSnapshotStore } from './frontend/context/ChannelStore/ChannelSnapshotStore';
+import {
+  ChannelSelectionStore,
+  ChannelSnapshotStore,
+} from './frontend/context/ChannelStore/ChannelSnapshotStore';
 
 const SNAPSHOT_CHANNELS = [
   'car-speeds.snapshot',
@@ -207,7 +209,13 @@ class SyntheticSourceAdapter {
 }
 
 interface RendererStores {
-  readonly stores: Map<SnapshotChannel, ChannelSnapshotStore<SnapshotChannel>>;
+  readonly stores: Map<
+    SnapshotChannel,
+    ChannelSelectionStore<
+      SnapshotChannel,
+      ChannelPayloads[SnapshotChannel]
+    >
+  >;
   readonly changes: Map<SnapshotChannel, ReturnType<typeof vi.fn>>;
   snapshot<K extends SnapshotChannel>(
     channel: K
@@ -221,21 +229,20 @@ const attachStores = (
 ): RendererStores => {
   const stores = new Map<
     SnapshotChannel,
-    ChannelSnapshotStore<SnapshotChannel>
+    ChannelSelectionStore<
+      SnapshotChannel,
+      ChannelPayloads[SnapshotChannel]
+    >
   >();
   const changes = new Map<SnapshotChannel, ReturnType<typeof vi.fn>>();
   const unsubscribes: (() => void)[] = [];
   for (const channel of channels) {
-    const definition = channelRegistry[channel];
-    const store = new ChannelSnapshotStore(
-      channel,
-      definition.maxRateHz,
-      bridge
-    );
+    const store = new ChannelSnapshotStore(channel, bridge);
+    const selection = store.createSelection((snapshot) => snapshot);
     const listener = vi.fn();
-    stores.set(channel, store);
+    stores.set(channel, selection);
     changes.set(channel, listener);
-    unsubscribes.push(store.subscribe(listener));
+    unsubscribes.push(selection.subscribe(listener));
   }
   return {
     stores,


### PR DESCRIPTION
## Description

Introduces one shared snapshot store per renderer/channel plus typed selectors and custom equality, replacing one bridge subscription per hook instance.

- shares a single active bridge subscription across all consumers of the same channel
- adds `useChannelSelector` with typed selectors and custom equality
- preserves independent per-consumer cadence so fast consumers do not evaluate slower selectors early
- suppresses notifications and React renders when selected fields are unchanged
- safely handles enable/disable, unmount, stale callbacks, and selector/equality identity changes
- isolates selector, equality, listener, and error-reporter exceptions
- removes duplicated widget-rate hook calls in channel-specific hooks
- adds deterministic fanout/cadence tests and a fixed-size callback/allocation microbenchmark

This is the Phase 4.1 renderer fanout optimization, stacked on the Wave 1 channel-contract corrections in PR #672.

Validation:

- `npm run lint -- --quiet`
- Full Vitest suite: 1,240 passed, 1 skipped
- ChannelStore suite: 14 passed
- deterministic fixed-size selector microbenchmark
- `git diff --check`

No live iRacing session or React DevTools profile was used yet; packaged profiling remains the integration evidence gate.

## Screenshots

### Before

Not applicable — renderer subscription/store refactor.

### After

Not applicable — no visual changes.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

### Architecture pre-PR checklist

- [x] N1/N4 — no filesystem or IPC-boundary changes
- [x] N2/N3 — renderer layering and widget boundaries preserved
- [x] R4.4/R4.6 — typed channel subscriptions remain per renderer
- [x] R7.1 — widgets remain channel consumers
- [x] R13.2 — fanout behavior has deterministic callback/allocation coverage
- [x] R14.2 — selector, equality, lifecycle, and cadence behavior is tested
- [x] Relevant phase: Phase 4.1 shared renderer selectors
