### PR TITLE
perf: add evidence-aware channel benchmarks

### DIFF
--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -13,6 +13,8 @@ without changing the saved dashboard:
 - iRacing-reported FPS, foreground/background CPU usage, and GPU usage
 - irDashies total and per-process CPU and working-set memory
 - telemetry tick cadence and `processTelemetry` / IPC broadcast percentiles
+- per-channel processor executions, publications, deliveries, and effective rates
+- active-widget input coverage and observed channel change rates
 - native telemetry/session reads, lifecycle work, payload projection, session
   publication, and renderer telemetry-callback percentiles
 - Electron main-process event-loop stalls
@@ -94,6 +96,19 @@ npm run perf:run -- --mode empty --scenario replay-empty-off --duration-seconds 
 npm run perf:run -- --mode empty --scenario replay-empty-on --duration-seconds 420 --telemetry-delivery on --replay-input $replay
 ```
 
+`--telemetry-delivery` controls only the dedicated raw Telemetry Inspector
+stream. To isolate typed channel delivery while keeping subscribers and
+processors active, use `--channel-delivery`:
+
+```powershell
+npm run perf:run -- --mode full --scenario channels-off --duration-seconds 420 --channel-delivery off --replay-input $replay
+npm run perf:run -- --mode full --scenario channels-on --duration-seconds 420 --channel-delivery on --replay-input $replay
+```
+
+The off run still records processor executions and channel publications. It
+suppresses snapshot seeding, coalescing timers, structured cloning, IPC sends,
+and renderer callbacks, making the on/off delta attributable to delivery.
+
 ### 3. Full dashboard
 
 This loads the current dashboard, but omits the settings and gamepad-host
@@ -121,6 +136,46 @@ npm run perf:run -- --mode full --widgets map --scenario replay-map --duration-s
 
 Use the widget type from `WidgetIndex.tsx`, not a widget instance ID.
 
+The runner reads each selected widget's `widgetRuntimeDefinition.ts` and embeds
+its declared input channels in the structured scenario metadata. The analyzer
+reports whether every declared channel was exercised and its publication
+(change) and delivery rates. A memory claim is inconclusive when an active
+widget's declared inputs did not change during the measured window.
+
+## Visibility phases
+
+Use a fixed visibility schedule to verify that hidden windows stop channel
+demand and resume cleanly. If `--duration-seconds` is omitted, the phase
+durations determine the capture duration.
+
+```powershell
+npm run perf:run -- --mode full --scenario visibility-demand --visibility-phases visible:120,hidden:120,visible:120 --replay-input $replay
+```
+
+The app emits one capture-origin marker after overlays are created. Phase zero
+and the fixed-duration timer start from that same origin; analyzer window
+offsets are relative to it rather than process startup or the first periodic
+report. Each transition is also written as a structured visibility marker.
+
+Evidence is evaluated per phase. Visible phases require at least one
+publication from every declared active-widget input. Hidden phases instead
+require zero demand-driven processor executions and zero channel deliveries.
+Intervals that straddle a transition are excluded from that phase's evidence
+so visible work cannot be attributed to the hidden phase.
+
+## Scenario metadata
+
+Record the conditions required to reproduce the run:
+
+```powershell
+npm run perf:run -- --target packaged --mode full --scenario phase4-full --duration-seconds 420 --replay-input $replay --field-count 59 --class-count 4 --display-geometry 7680x1440 --fps-cap 120 --sync-mode gsync
+```
+
+The runner always records target, live/replay mode, requested and active widget
+types, channel/Inspector delivery modes, telemetry payload mode, and widget
+input requirements. The optional field count, class count, display geometry,
+FPS cap, and sync mode flags complete the controlled-workload record.
+
 ## Analyse and compare
 
 Each run writes `perf-results/<run-id>.log`. Analyse a single run:
@@ -135,6 +190,20 @@ Compare the empty or full dashboard against the observer:
 npm run perf:analyze -- perf-results/<candidate>.log --baseline perf-results/<observer>.log --warmup-seconds 60
 ```
 
+Use a fixed interval when the relevant workload occupies only part of the
+capture:
+
+```powershell
+npm run perf:analyze -- perf-results/<candidate>.log --baseline perf-results/<baseline>.log --warmup-seconds 0 --analysis-start-seconds 120 --analysis-end-seconds 360
+```
+
+Analysis rejects inconclusive evidence by default after writing the summary.
+It exits non-zero when the measured interval is shorter than five minutes,
+private bytes are incomplete or too sparsely sampled, scenario/widget metadata
+is missing or inconsistent, or a visibility phase violates its workload
+expectations. Use `--allow-inconclusive` only for exploratory inspection of a
+partial run.
+
 The analyzer writes adjacent `.summary.json` and `.summary.md` files. Its
 initial regression gates are:
 
@@ -144,11 +213,21 @@ initial regression gates are:
 | iRacing sampled FPS p1 mean vs observer | no worse than -5% |
 | `processTelemetry` p99 mean             |            < 3 ms |
 | Minimum interval telemetry rate         |          >= 20 Hz |
-| Steady-state app memory slope           |        < 5 MB/min |
+| Steady-state app private-memory slope   |        < 5 MB/min |
 | Renderer frames over 50 ms              |            < 0.1% |
 
 Treat a failed gate as a signal to inspect, not proof of causality. Repeat any
 failed A/B pair once before making an architectural decision.
+
+Private memory is the acceptance metric because aggregate working set includes
+shared Chromium pages and can double-count them across processes. Working-set
+slope remains in the report as diagnostic context. The private-memory gate is
+reported as **INCONCLUSIVE**, never pass/fail, unless the analysis contains at
+least five minutes of private-byte samples covering every included Electron
+process, at least two observations with adequate span and no gap over 60
+seconds, consistent scenario metadata, and valid per-phase channel evidence.
+When either side of an A/B comparison is inconclusive, every comparison check
+is reported as **INCONCLUSIVE**.
 
 ## Live-session benchmark
 

--- a/src/app/bridge/channelBridge.spec.ts
+++ b/src/app/bridge/channelBridge.spec.ts
@@ -160,6 +160,22 @@ describe('ChannelBus', () => {
     expect(bus.metricsSnapshot()).toEqual({
       publications: { '9:event': 2 },
       deliveries: { '9:event': 2 },
+      channelPublications: { event: 2 },
+      channelDeliveries: { event: 2 },
+    });
+  });
+
+  it('keeps processor demand and publication counts with delivery disabled', () => {
+    const target = createTarget();
+    const bus = new ChannelBus({ registry, deliveryEnabled: false });
+    bus.subscribe(target, 'snapshot');
+    bus.publish('snapshot', 1);
+
+    expect(bus.subscriberCount('snapshot')).toBe(1);
+    expect(target.send).not.toHaveBeenCalled();
+    expect(bus.metricsSnapshot()).toMatchObject({
+      channelPublications: { snapshot: 1 },
+      channelDeliveries: {},
     });
   });
 

--- a/src/app/bridge/channelBridge.ts
+++ b/src/app/bridge/channelBridge.ts
@@ -25,6 +25,7 @@ interface ChannelBusOptions {
   registry?: Readonly<Record<string, ChannelDefinition>>;
   now?: () => number;
   schedule?: (callback: () => void, delayMs: number) => TimerHandle;
+  deliveryEnabled?: boolean;
   onPublish?: (rendererId: number, channel: string) => void;
   onDeliver?: (rendererId: number, channel: string) => void;
 }
@@ -43,6 +44,8 @@ interface Subscription {
 export interface ChannelBusMetricsSnapshot {
   publications: Readonly<Record<string, number>>;
   deliveries: Readonly<Record<string, number>>;
+  channelPublications: Readonly<Record<string, number>>;
+  channelDeliveries: Readonly<Record<string, number>>;
 }
 
 const systemSchedule = (callback: () => void, delayMs: number): TimerHandle => {
@@ -59,10 +62,13 @@ export class ChannelBus {
   ) => TimerHandle;
   private readonly onPublish?: (rendererId: number, channel: string) => void;
   private readonly onDeliver?: (rendererId: number, channel: string) => void;
+  private readonly deliveryEnabled: boolean;
   private readonly subscriptions = new Map<string, Map<number, Subscription>>();
   private readonly latestSnapshots = new Map<string, unknown>();
   private readonly publicationCounts = new Map<string, number>();
   private readonly deliveryCounts = new Map<string, number>();
+  private readonly channelPublicationCounts = new Map<string, number>();
+  private readonly channelDeliveryCounts = new Map<string, number>();
   private readonly subscriberCountListeners =
     new Set<SubscriberCountListener>();
 
@@ -70,6 +76,7 @@ export class ChannelBus {
     this.registry = options.registry ?? channelRegistry;
     this.now = options.now ?? (() => performance.now());
     this.schedule = options.schedule ?? systemSchedule;
+    this.deliveryEnabled = options.deliveryEnabled ?? true;
     this.onPublish = options.onPublish;
     this.onDeliver = options.onDeliver;
   }
@@ -116,6 +123,7 @@ export class ChannelBus {
     }
 
     if (
+      this.deliveryEnabled &&
       active &&
       definition.kind === 'snapshot' &&
       hadCachedSnapshotBeforeSubscribe
@@ -139,6 +147,7 @@ export class ChannelBus {
   publish(channel: string, payload: unknown): void;
   publish(channel: string, payload: unknown): void {
     const definition = this.definition(channel);
+    this.incrementChannel(this.channelPublicationCounts, channel);
     const subscribers = this.subscriptions.get(channel);
     const hasRegisteredSubscribers = (subscribers?.size ?? 0) > 0;
     if (
@@ -148,7 +157,7 @@ export class ChannelBus {
       this.latestSnapshots.set(channel, payload);
     }
 
-    if (!subscribers) return;
+    if (!subscribers || !this.deliveryEnabled) return;
     for (const [rendererId, subscription] of subscribers) {
       if (subscription.target.isDestroyed()) {
         this.remove(channel, rendererId);
@@ -229,6 +238,8 @@ export class ChannelBus {
     return {
       publications: Object.fromEntries(this.publicationCounts),
       deliveries: Object.fromEntries(this.deliveryCounts),
+      channelPublications: Object.fromEntries(this.channelPublicationCounts),
+      channelDeliveries: Object.fromEntries(this.channelDeliveryCounts),
     };
   }
 
@@ -316,6 +327,7 @@ export class ChannelBus {
     subscription.lastDeliveredAt = this.now();
     this.onDeliver?.(subscription.target.id, channel);
     this.increment(this.deliveryCounts, subscription.target.id, channel);
+    this.incrementChannel(this.channelDeliveryCounts, channel);
   }
 
   private increment(
@@ -325,6 +337,13 @@ export class ChannelBus {
   ): void {
     const key = `${rendererId}:${channel}`;
     counters.set(key, (counters.get(key) ?? 0) + 1);
+  }
+
+  private incrementChannel(
+    counters: Map<string, number>,
+    channel: string
+  ): void {
+    counters.set(channel, (counters.get(channel) ?? 0) + 1);
   }
 
   private remove(channel: string, rendererId: number): void {

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -146,7 +146,7 @@ export async function publishIRacingSDKEvents(
   const isTapeReplay = Boolean(process.env.IRDASHIES_TELEMETRY_REPLAY);
   const sourceName = isTapeReplay ? 'telemetry replay' : 'iRacing';
 
-  const perfMetrics = new TelemetryPerfMetrics();
+  const perfMetrics = new TelemetryPerfMetrics(undefined, channelBus);
   perfMetrics.startReporting();
   const referenceLapStorage = channelBus
     ? await import('../../storage/referenceLaps')

--- a/src/app/bridge/iracingSdk/mock-data/mockSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/mock-data/mockSdkBridge.ts
@@ -11,7 +11,7 @@ export async function publishIRacingSDKEvents(
   lifecycle?: SessionLifecycle,
   channelBus?: ChannelBus
 ) {
-  const perfMetrics = new TelemetryPerfMetrics();
+  const perfMetrics = new TelemetryPerfMetrics(undefined, channelBus);
   let lastInspectorTelemetryPublishTime = Number.NEGATIVE_INFINITY;
   perfMetrics.startReporting();
 

--- a/src/app/perfMetrics.spec.ts
+++ b/src/app/perfMetrics.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { sumCompletePrivateMemoryMB } from './perfMetrics';
+
+describe('performance process memory coverage', () => {
+  it('sums private bytes only when every included process reports them', () => {
+    expect(sumCompletePrivateMemoryMB([1024, 2048])).toBe(3);
+    expect(sumCompletePrivateMemoryMB([1024, undefined])).toBeUndefined();
+    expect(sumCompletePrivateMemoryMB([])).toBeUndefined();
+  });
+});

--- a/src/app/perfMetrics.ts
+++ b/src/app/perfMetrics.ts
@@ -11,6 +11,7 @@
 import { monitorEventLoopDelay, performance } from 'node:perf_hooks';
 import { app, BrowserWindow } from 'electron';
 import type { NumericSampleStats, Telemetry } from '@irdashies/types';
+import type { ChannelBusMetricsSnapshot } from './bridge/channelBridge';
 import { FixedSampleBuffer } from '../shared/performanceSamples';
 import logger from './logger';
 
@@ -59,10 +60,47 @@ export interface PerfReport {
   totalAppCpuPercent?: number;
   totalAppMemoryMB?: number;
   totalAppPrivateMemoryMB?: number;
+  scenarioMetadata?: Record<string, unknown>;
+  channelMetrics?: {
+    processorExecutions: Record<string, number>;
+    publications: Record<string, number>;
+    deliveries: Record<string, number>;
+  };
 }
+
+interface ChannelMetricsSource {
+  metricsSnapshot(): ChannelBusMetricsSnapshot;
+}
+
+const PROCESSOR_CHANNELS: Readonly<Record<string, string>> = {
+  carSpeedsProcessing: 'car-speeds.snapshot',
+  driverControlsProcessing: 'driver-controls.snapshot',
+  fuelProjectionProcessing: 'fuel.projection',
+  lapLogProcessing: 'lap-log.snapshot',
+  lapTimesProcessing: 'lap-times.snapshot',
+  radioProcessing: 'radio.snapshot',
+  referenceLapProcessing: 'reference-laps.snapshot',
+  relativeGapProcessing: 'relative-gaps.snapshot',
+  sectorTimingProcessing: 'sector-timing.snapshot',
+  sessionBarProcessing: 'session-bar.snapshot',
+  sessionTimingProcessing: 'session-timing.snapshot',
+  standingsProcessing: 'standings.snapshot',
+  trackStateProcessing: 'track-state.snapshot',
+};
 
 const DEFAULT_REPORT_INTERVAL_MS = 10_000;
 export const PERF_MAIN_LOG_PREFIX = '[PerfMetrics:JSON] ';
+
+export const sumCompletePrivateMemoryMB = (
+  privateBytes: readonly (number | undefined)[]
+): number | undefined =>
+  privateBytes.length > 0 &&
+  privateBytes.every(
+    (value): value is number =>
+      typeof value === 'number' && Number.isFinite(value) && value >= 0
+  )
+    ? privateBytes.reduce((sum, value) => sum + (value ?? 0), 0) / 1024
+    : undefined;
 
 class SectionBuffer {
   private samples = new FixedSampleBuffer();
@@ -107,8 +145,13 @@ export class TelemetryPerfMetrics {
   private lastCpuUsage: NodeJS.CpuUsage = { user: 0, system: 0 };
   private tickCount = 0;
   private _enabled: boolean;
+  private previousChannelPublications: Readonly<Record<string, number>> = {};
+  private previousChannelDeliveries: Readonly<Record<string, number>> = {};
 
-  constructor(enabled?: boolean) {
+  constructor(
+    enabled?: boolean,
+    private readonly channelMetricsSource?: ChannelMetricsSource
+  ) {
     this._enabled = enabled ?? process.env.PERF_METRICS === '1';
   }
 
@@ -128,6 +171,10 @@ export class TelemetryPerfMetrics {
     this.lastTickTime = 0;
     this.lastCpuUsage = process.cpuUsage();
     this.eventLoopDelay.enable();
+    const channelMetrics = this.channelMetricsSource?.metricsSnapshot();
+    this.previousChannelPublications =
+      channelMetrics?.channelPublications ?? {};
+    this.previousChannelDeliveries = channelMetrics?.channelDeliveries ?? {};
     this.reportTimer = setInterval(() => {
       const report = this.report();
       this.logReport(report);
@@ -213,6 +260,8 @@ export class TelemetryPerfMetrics {
       totalAppCpuPercent: totalCpu,
       totalAppMemoryMB: totalMemory,
       totalAppPrivateMemoryMB: totalPrivateMemory,
+      scenarioMetadata: this.scenarioMetadata(),
+      channelMetrics: this.channelMetrics(sections),
     };
 
     this.lastReportTime = now;
@@ -240,6 +289,68 @@ export class TelemetryPerfMetrics {
     return buf;
   }
 
+  private scenarioMetadata(): Record<string, unknown> | undefined {
+    try {
+      const configured = JSON.parse(
+        process.env.PERF_SCENARIO_METADATA ?? '{}'
+      ) as unknown;
+      const metadata =
+        typeof configured === 'object' && configured !== null
+          ? (configured as Record<string, unknown>)
+          : {};
+      const activeWidgetTypes = JSON.parse(
+        process.env.PERF_ACTIVE_WIDGET_TYPES ?? '[]'
+      ) as unknown;
+      return {
+        ...metadata,
+        activeWidgetTypes: Array.isArray(activeWidgetTypes)
+          ? activeWidgetTypes.filter(
+              (value): value is string => typeof value === 'string'
+            )
+          : [],
+      };
+    } catch {
+      return undefined;
+    }
+  }
+
+  private channelMetrics(
+    sections: Record<string, SectionStats>
+  ): PerfReport['channelMetrics'] {
+    if (!this.channelMetricsSource) return undefined;
+    const current = this.channelMetricsSource.metricsSnapshot();
+    const difference = (
+      values: Readonly<Record<string, number>>,
+      previous: Readonly<Record<string, number>>
+    ): Record<string, number> =>
+      Object.fromEntries(
+        Object.entries(values).map(([key, value]) => [
+          key,
+          Math.max(0, value - (previous[key] ?? 0)),
+        ])
+      );
+    const publications = difference(
+      current.channelPublications,
+      this.previousChannelPublications
+    );
+    const deliveries = difference(
+      current.channelDeliveries,
+      this.previousChannelDeliveries
+    );
+    this.previousChannelPublications = current.channelPublications;
+    this.previousChannelDeliveries = current.channelDeliveries;
+    return {
+      processorExecutions: Object.fromEntries(
+        Object.entries(PROCESSOR_CHANNELS).map(([section, channel]) => [
+          channel,
+          sections[section]?.count ?? 0,
+        ])
+      ),
+      publications,
+      deliveries,
+    };
+  }
+
   private observeIRacing(telemetry: Telemetry): void {
     this.iracingFrameRate.add(telemetry.FrameRate?.value?.[0]);
     const percentage = (value: number | undefined): number | undefined =>
@@ -260,8 +371,9 @@ export class TelemetryPerfMetrics {
       const processes: ProcessMetrics[] = [];
       let totalCpu = 0;
       let totalMemory = 0;
-      let totalPrivateMemory = 0;
-      let hasPrivateMemory = false;
+      const totalPrivateMemory = sumCompletePrivateMemoryMB(
+        metrics.map((metric) => metric.memory.privateBytes)
+      );
 
       const pidToWindowName = new Map<number, string>();
       try {
@@ -294,11 +406,6 @@ export class TelemetryPerfMetrics {
 
         totalCpu += cpuPercent;
         totalMemory += memoryMB;
-        if (privateMemoryMB !== undefined) {
-          totalPrivateMemory += privateMemoryMB;
-          hasPrivateMemory = true;
-        }
-
         let name = metric.name || undefined;
         if (metric.type === 'Tab' && pidToWindowName.has(metric.pid)) {
           name = pidToWindowName.get(metric.pid);
@@ -320,7 +427,7 @@ export class TelemetryPerfMetrics {
         processes,
         totalCpu,
         totalMemory,
-        totalPrivateMemory: hasPrivateMemory ? totalPrivateMemory : undefined,
+        totalPrivateMemory,
       };
     } catch {
       return {

--- a/src/app/perfRunConfig.spec.ts
+++ b/src/app/perfRunConfig.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { DashboardLayout } from '@irdashies/types';
-import { createPerfDashboard, getPerfRunConfig } from './perfRunConfig';
+import {
+  activePerfWidgetTypes,
+  createPerfDashboard,
+  getPerfRunConfig,
+} from './perfRunConfig';
 
 const dashboard: DashboardLayout = {
   widgets: [
@@ -28,6 +32,8 @@ describe('performance run configuration', () => {
         PERF_DURATION_SECONDS: '60',
         PERF_TELEMETRY_DELIVERY: 'off',
         PERF_TELEMETRY_PAYLOAD: 'raw',
+        PERF_CHANNEL_DELIVERY: 'off',
+        PERF_VISIBILITY_PHASES: 'visible:120,hidden:90,bad:10,visible:0',
       })
     ).toMatchObject({
       enabled: true,
@@ -36,6 +42,11 @@ describe('performance run configuration', () => {
       durationSeconds: 60,
       telemetryDelivery: 'off',
       telemetryPayload: 'raw',
+      channelDelivery: 'off',
+      visibilityPhases: [
+        { visibility: 'visible', durationSeconds: 120 },
+        { visibility: 'hidden', durationSeconds: 90 },
+      ],
     });
 
     expect(
@@ -55,6 +66,8 @@ describe('performance run configuration', () => {
       durationSeconds: 0,
       telemetryDelivery: 'on',
       telemetryPayload: 'allowlisted',
+      channelDelivery: 'on',
+      visibilityPhases: [],
     });
 
     expect(result.widgets.every((widget) => !widget.enabled)).toBe(true);
@@ -70,11 +83,14 @@ describe('performance run configuration', () => {
       durationSeconds: 0,
       telemetryDelivery: 'on',
       telemetryPayload: 'allowlisted',
+      channelDelivery: 'on',
+      visibilityPhases: [],
     });
 
     expect(result.widgets.map((widget) => widget.enabled)).toEqual([
       true,
       false,
     ]);
+    expect(activePerfWidgetTypes(result)).toEqual(['standings']);
   });
 });

--- a/src/app/perfRunConfig.ts
+++ b/src/app/perfRunConfig.ts
@@ -2,8 +2,15 @@ import type { DashboardLayout } from '@irdashies/types';
 
 export const PERF_REPLAY_READY_LOG_MARKER =
   '[PerfRun] Ready for replay publisher';
+export const PERF_VISIBILITY_LOG_PREFIX = '[PerfVisibility:JSON] ';
+export const PERF_CAPTURE_ORIGIN_LOG_PREFIX = '[PerfRunOrigin:JSON] ';
 
 export type PerfOverlayMode = 'full' | 'empty' | 'observer';
+
+export interface PerfVisibilityPhase {
+  visibility: 'visible' | 'hidden';
+  durationSeconds: number;
+}
 
 export interface PerfRunConfig {
   enabled: boolean;
@@ -13,6 +20,8 @@ export interface PerfRunConfig {
   durationSeconds: number;
   telemetryDelivery: 'on' | 'off';
   telemetryPayload: 'allowlisted' | 'raw';
+  channelDelivery: 'on' | 'off';
+  visibilityPhases: PerfVisibilityPhase[];
 }
 
 const PERF_OVERLAY_MODES = new Set<PerfOverlayMode>([
@@ -40,6 +49,17 @@ export function getPerfRunConfig(
     requestedDuration <= 86_400
       ? requestedDuration
       : 0;
+  const visibilityPhases = (env.PERF_VISIBILITY_PHASES ?? '')
+    .split(',')
+    .map((entry) => entry.trim().match(/^(visible|hidden):(\d+)$/))
+    .filter((match): match is RegExpMatchArray => match !== null)
+    .map((match) => ({
+      visibility: match[1] as PerfVisibilityPhase['visibility'],
+      durationSeconds: Number(match[2]),
+    }))
+    .filter(
+      (phase) => phase.durationSeconds >= 10 && phase.durationSeconds <= 86_400
+    );
 
   return {
     enabled: env.PERF_METRICS === '1',
@@ -54,7 +74,19 @@ export function getPerfRunConfig(
     telemetryDelivery: env.PERF_TELEMETRY_DELIVERY === 'off' ? 'off' : 'on',
     telemetryPayload:
       env.PERF_TELEMETRY_PAYLOAD === 'raw' ? 'raw' : 'allowlisted',
+    channelDelivery: env.PERF_CHANNEL_DELIVERY === 'off' ? 'off' : 'on',
+    visibilityPhases,
   };
+}
+
+export function activePerfWidgetTypes(dashboard: DashboardLayout): string[] {
+  return [
+    ...new Set(
+      dashboard.widgets
+        .filter((widget) => widget.enabled)
+        .map((widget) => widget.type ?? widget.id)
+    ),
+  ].sort();
 }
 
 export function createPerfDashboard(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain } from 'electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
 import log from './app/logger';
 import {
   iRacingSDKSetup,
@@ -30,7 +30,13 @@ import {
   flushReferenceLapsOnShutdown,
 } from './app/storage/referenceLaps';
 import { setupChromiumFlagsBridge } from './app/bridge/chromiumFlagsBridge';
-import { createPerfDashboard, getPerfRunConfig } from './app/perfRunConfig';
+import {
+  activePerfWidgetTypes,
+  createPerfDashboard,
+  getPerfRunConfig,
+  PERF_CAPTURE_ORIGIN_LOG_PREFIX,
+  PERF_VISIBILITY_LOG_PREFIX,
+} from './app/perfRunConfig';
 import { ChannelBus, setupChannelBridge } from './app/bridge/channelBridge';
 import { connectSessionLifecycleChannel } from './app/bridge/sessionLifecycleChannel';
 import { setupRendererDataSubscriptions } from './app/bridge/rendererDataSubscriptions';
@@ -52,7 +58,9 @@ overlayManager.setupAutoStart();
 
 // Hoisted so the quit handler can tear down the WebHID host window cleanly.
 let keybindingManager: KeybindingManager | undefined;
-const channelBus = new ChannelBus();
+const channelBus = new ChannelBus({
+  deliveryEnabled: !perfRun.enabled || perfRun.channelDelivery === 'on',
+});
 let disconnectLifecycleChannel: (() => void) | undefined;
 let disposeRendererDataSubscriptions: (() => void) | undefined;
 
@@ -65,14 +73,16 @@ app.on('ready', async () => {
 
   if (perfRun.enabled) {
     log.info('[PerfRun] Configuration', perfRun);
-    if (perfRun.durationSeconds > 0) {
-      setTimeout(() => {
-        log.info(
-          `[PerfRun] Completed fixed ${perfRun.durationSeconds}s capture`
-        );
-        app.quit();
-      }, perfRun.durationSeconds * 1000);
-    }
+  }
+
+  // Resolve benchmark metadata before metrics reporting starts so every
+  // interval carries the same active-widget workload description.
+  const dashboard = getOrCreateDefaultDashboard();
+  const runDashboard = createPerfDashboard(dashboard, perfRun);
+  if (perfRun.enabled) {
+    process.env.PERF_ACTIVE_WIDGET_TYPES = JSON.stringify(
+      activePerfWidgetTypes(runDashboard)
+    );
   }
 
   setupChannelBridge(channelBus);
@@ -90,7 +100,6 @@ app.on('ready', async () => {
   // Perform one-time cleanup of old reference laps
   validateReferenceLapFile();
 
-  const dashboard = getOrCreateDefaultDashboard();
   const bridge = getCurrentBridge();
 
   // Setup IPC bridges
@@ -105,7 +114,6 @@ app.on('ready', async () => {
 
   ipcMain.handle('getComponentServerPort', () => getComponentServerPort());
 
-  const runDashboard = createPerfDashboard(dashboard, perfRun);
   if (!perfRun.enabled || perfRun.overlayMode !== 'observer') {
     // Empty mode keeps the normal overlay window count/bounds while the
     // renderer receives a dashboard with every widget disabled. This isolates
@@ -116,6 +124,49 @@ app.on('ready', async () => {
         : runDashboard;
     overlayManager.createOverlays(windowDashboard, {
       createSettingsWindow: !perfRun.enabled,
+    });
+  }
+
+  if (perfRun.enabled) {
+    const captureOriginMs = Date.now();
+    const captureOrigin = new Date(captureOriginMs).toISOString();
+    log.info(
+      `${PERF_CAPTURE_ORIGIN_LOG_PREFIX}${JSON.stringify({
+        timestamp: captureOrigin,
+        runId: process.env.PERF_RUN_ID ?? 'manual',
+      })}`
+    );
+    if (perfRun.durationSeconds > 0) {
+      setTimeout(() => {
+        log.info(
+          `[PerfRun] Completed fixed ${perfRun.durationSeconds}s capture`
+        );
+        app.quit();
+      }, perfRun.durationSeconds * 1000);
+    }
+
+    let phaseStartSeconds = 0;
+    perfRun.visibilityPhases.forEach((phase, index) => {
+      const applyPhase = () => {
+        for (const window of BrowserWindow.getAllWindows()) {
+          if (window.isDestroyed()) continue;
+          if (phase.visibility === 'hidden') window.hide();
+          else window.showInactive();
+        }
+        log.info(
+          `${PERF_VISIBILITY_LOG_PREFIX}${JSON.stringify({
+            timestamp:
+              index === 0 ? captureOrigin : new Date().toISOString(),
+            runId: process.env.PERF_RUN_ID ?? 'manual',
+            index,
+            visibility: phase.visibility,
+            durationSeconds: phase.durationSeconds,
+          })}`
+        );
+      };
+      if (index === 0) applyPhase();
+      else setTimeout(applyPhase, phaseStartSeconds * 1000);
+      phaseStartSeconds += phase.durationSeconds;
     });
   }
 

--- a/tools/perf/analyze.spec.ts
+++ b/tools/perf/analyze.spec.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
-import type { NumericSampleStats } from '../../src/types/performance';
-import { compareSummaries, parsePerfLog, summarizeCapture } from './analyze';
+import type {
+  NumericSampleStats,
+  RendererPerfSample,
+} from '../../src/types/performance';
+import {
+  compareSummaries,
+  parseCliArgs,
+  parsePerfLog,
+  summarizeCapture,
+} from './analyze';
 
 const stats = (
   avg: number,
@@ -17,12 +25,19 @@ const stats = (
   ...overrides,
 });
 
-function mainSample(seconds: number, memoryMB: number, fps = 100) {
+function mainSample(
+  seconds: number,
+  memoryMB: number,
+  fps = 100,
+  privateMemoryMB = memoryMB,
+  intervalMs?: number
+) {
   return {
     timestamp: new Date(seconds * 1000).toISOString(),
     runId: 'run',
     scenario: 'full',
     overlayMode: 'full',
+    intervalMs,
     tickRateHz: 24,
     sections: {
       processTelemetry: { count: 100, avgMs: 1, maxMs: 4, p99Ms: 2 },
@@ -37,78 +52,304 @@ function mainSample(seconds: number, memoryMB: number, fps = 100) {
     },
     totalAppCpuPercent: 12,
     totalAppMemoryMB: memoryMB,
+    totalAppPrivateMemoryMB: privateMemoryMB,
+    scenarioMetadata: {
+      activeWidgetTypes: ['standings'],
+      widgetInputRequirements: {
+        standings: ['standings.snapshot'],
+      },
+    },
+    channelMetrics: {
+      processorExecutions: { 'standings.snapshot': 100 },
+      publications: { 'standings.snapshot': 20 },
+      deliveries: { 'standings.snapshot': 20 },
+    },
   };
 }
 
+type TestMainSample = Omit<
+  ReturnType<typeof mainSample>,
+  'totalAppPrivateMemoryMB'
+> & {
+  totalAppPrivateMemoryMB?: number;
+};
+
+const capture = (
+  main: TestMainSample[],
+  visibility: {
+    timestamp: string;
+    runId: string;
+    index: number;
+    visibility: 'visible' | 'hidden';
+    durationSeconds: number;
+  }[] = [],
+  originSeconds = 0
+) => ({
+  main,
+  renderer: [] as RendererPerfSample[],
+  visibility,
+  origins: [
+    {
+      timestamp: new Date(originSeconds * 1000).toISOString(),
+      runId: 'run',
+    },
+  ],
+});
+
+const conclusiveSamples = (fps = 100) =>
+  Array.from({ length: 6 }, (_, index) =>
+    mainSample(index * 60, 100 + index, fps, 200 + index * 2)
+  );
+
 describe('performance analysis', () => {
   it('parses structured records mixed with normal logs', () => {
-    const main = mainSample(0, 100);
+    const main = mainSample(5, 100, 100, 100, 5000);
     const contents = [
       'normal output',
+      '[PerfRunOrigin:JSON] {"timestamp":"1970-01-01T00:00:00.000Z","runId":"run"}',
       `[PerfMetrics:JSON] ${JSON.stringify(main)}`,
-      '[PerfRenderer:JSON] {"timestamp":"1970-01-01T00:00:00.000Z","frameTimeMs":{"count":1,"avg":16,"min":16,"max":16,"p1":16,"p50":16,"p95":16,"p99":16},"framesOver25Ms":0,"framesOver50Ms":0}',
+      '[PerfRenderer:JSON] {"timestamp":"1970-01-01T00:00:05.000Z","intervalMs":5000,"frameTimeMs":{"count":1,"avg":16,"min":16,"max":16,"p1":16,"p50":16,"p95":16,"p99":16},"framesOver25Ms":0,"framesOver50Ms":0}',
+      '[PerfVisibility:JSON] {"timestamp":"1970-01-01T00:00:00.000Z","runId":"run","index":0,"visibility":"visible","durationSeconds":60}',
     ].join('\n');
 
     expect(parsePerfLog(contents)).toMatchObject({
       main: [main],
       renderer: [{ framesOver50Ms: 0 }],
+      visibility: [{ visibility: 'visible' }],
+      origins: [{ runId: 'run' }],
     });
   });
 
   it('summarizes memory slope and telemetry metrics', () => {
     const summary = summarizeCapture(
-      {
-        main: [mainSample(0, 100), mainSample(60, 102), mainSample(120, 104)],
-        renderer: [],
-      },
+      capture([
+        mainSample(0, 100),
+        mainSample(60, 102),
+        mainSample(120, 104),
+      ]),
       0
     );
 
     expect(summary.app.memorySlopeMBPerMinute).toBeCloseTo(2);
+    expect(summary.app.privateMemorySlopeMBPerMinute).toBeCloseTo(2);
     expect(summary.iracing.averageFps).toBe(100);
     expect(summary.telemetry.processTelemetryP99MeanMs).toBe(2);
+    expect(summary.widgetInputs.standings.inputs['standings.snapshot']).toEqual(
+      expect.objectContaining({ observed: true })
+    );
   });
 
   it('summarizes renderer telemetry callback cost and rate', () => {
-    const summary = summarizeCapture(
+    const input = capture([
+      mainSample(5, 100, 100, 100, 5000),
+      mainSample(10, 100, 100, 100, 5000),
+    ]);
+    input.renderer = [
       {
-        main: [mainSample(0, 100), mainSample(5, 100)],
-        renderer: [
-          {
-            schemaVersion: 1,
-            timestamp: new Date(0).toISOString(),
-            runId: 'run',
-            scenario: 'full',
-            pid: 1,
-            route: '/',
-            visibilityState: 'visible',
-            intervalMs: 5000,
-            frameTimeMs: stats(16),
-            telemetryCallbackMs: stats(0.2, { count: 100, p99: 0.7 }),
-            framesOver25Ms: 0,
-            framesOver50Ms: 0,
-          },
-        ],
+        schemaVersion: 1,
+        timestamp: new Date(5_000).toISOString(),
+        runId: 'run',
+        scenario: 'full',
+        pid: 1,
+        route: '/',
+        visibilityState: 'visible',
+        intervalMs: 5000,
+        frameTimeMs: stats(16),
+        telemetryCallbackMs: stats(0.2, { count: 100, p99: 0.7 }),
+        framesOver25Ms: 0,
+        framesOver50Ms: 0,
       },
-      0
-    );
+    ];
+    const summary = summarizeCapture(input, 0);
 
     expect(summary.renderer.telemetryCallbackRateHz).toBe(20);
     expect(summary.renderer.telemetryCallbackP99MeanMs).toBe(0.7);
   });
 
-  it('flags a material iRacing FPS regression', () => {
-    const baseline = summarizeCapture(
-      { main: [mainSample(0, 100, 100)], renderer: [] },
-      0
-    );
-    const candidate = summarizeCapture(
-      { main: [mainSample(0, 100, 90)], renderer: [] },
-      0
-    );
+  it('flags a material iRacing FPS regression with conclusive evidence', () => {
+    const baseline = summarizeCapture(capture(conclusiveSamples(100)), 0);
+    const candidate = summarizeCapture(capture(conclusiveSamples(90)), 0);
 
     const comparison = compareSummaries(baseline, candidate);
     expect(comparison.delta.averageFpsPercent).toBe(-10);
     expect(comparison.checks[0].passed).toBe(false);
+  });
+
+  it('anchors fixed windows to the explicit origin and includes overlapping intervals', () => {
+    const summary = summarizeCapture(
+      capture(
+        [
+          mainSample(100, 50, 100, 50, 10_000),
+          mainSample(105, 100, 100, 100, 10_000),
+          mainSample(115, 102, 100, 102, 10_000),
+        ],
+        [],
+        100
+      ),
+      0,
+      { startSeconds: 0, endSeconds: 12 }
+    );
+
+    expect(summary.sampleCount).toBe(2);
+    expect(summary.durationMinutes).toBeCloseTo(0.2);
+    expect(summary.analysisWindow).toEqual({
+      startSeconds: 0,
+      endSeconds: 12,
+    });
+  });
+
+  it('uses private memory as the conclusive memory gate', () => {
+    const samples = Array.from({ length: 6 }, (_, index) =>
+      mainSample(index * 60, 100 + index * 100, 100, 200 + index * 2)
+    );
+    const summary = summarizeCapture(capture(samples), 0);
+    const comparison = compareSummaries(summary, summary);
+    const memoryCheck = comparison.checks.find((check) =>
+      check.name.includes('private-memory')
+    );
+
+    expect(summary.evidence.conclusive).toBe(true);
+    expect(summary.app.memorySlopeMBPerMinute).toBeCloseTo(100);
+    expect(summary.app.privateMemorySlopeMBPerMinute).toBeCloseTo(2);
+    expect(memoryCheck?.passed).toBe(true);
+  });
+
+  it('marks all checks inconclusive when private bytes are missing', () => {
+    const samples = conclusiveSamples().map((sample) => ({
+      ...sample,
+      totalAppPrivateMemoryMB: undefined,
+    }));
+    const summary = summarizeCapture(capture(samples), 0);
+    const comparison = compareSummaries(summary, summary);
+
+    expect(summary.evidence.privateMemoryAvailable).toBe(false);
+    expect(summary.evidence.conclusive).toBe(false);
+    expect(comparison.checks.every((check) => check.passed === null)).toBe(true);
+  });
+
+  it('requires publication rather than processor execution for visible coverage', () => {
+    const samples = conclusiveSamples().map((sample) => ({
+      ...sample,
+      channelMetrics: {
+        ...sample.channelMetrics,
+        publications: { 'standings.snapshot': 0 },
+      },
+    }));
+    const summary = summarizeCapture(capture(samples), 0);
+
+    expect(summary.widgetInputs.standings.covered).toBe(false);
+    expect(summary.evidence.inputCoverageComplete).toBe(false);
+    expect(summary.phaseEvidence[0].reasons).toContain(
+      'one or more active widget inputs did not publish'
+    );
+  });
+
+  it('accepts visible changes and zero hidden execution/delivery per phase', () => {
+    const visibility = [
+      {
+        timestamp: new Date(0).toISOString(),
+        runId: 'run',
+        index: 0,
+        visibility: 'visible' as const,
+        durationSeconds: 300,
+      },
+      {
+        timestamp: new Date(300_000).toISOString(),
+        runId: 'run',
+        index: 1,
+        visibility: 'hidden' as const,
+        durationSeconds: 300,
+      },
+    ];
+    const samples = Array.from({ length: 10 }, (_, index) => {
+      const seconds = (index + 1) * 60;
+      const sample = mainSample(seconds, 100 + index, 100, 200 + index, 60_000);
+      return seconds <= 300
+        ? sample
+        : {
+            ...sample,
+            channelMetrics: {
+              processorExecutions: { 'standings.snapshot': 0 },
+              publications: { 'standings.snapshot': 0 },
+              deliveries: { 'standings.snapshot': 0 },
+            },
+          };
+    });
+    const summary = summarizeCapture(capture(samples, visibility), 0);
+
+    expect(summary.phaseEvidence).toEqual([
+      expect.objectContaining({ expectedBehaviorSatisfied: true }),
+      expect.objectContaining({ expectedBehaviorSatisfied: true }),
+    ]);
+    expect(summary.evidence.inputCoverageComplete).toBe(true);
+    expect(summary.evidence.conclusive).toBe(true);
+  });
+
+  it('rejects processor activity during a hidden phase', () => {
+    const samples = conclusiveSamples().map((sample) => ({
+      ...sample,
+      channelMetrics: {
+        processorExecutions: { 'standings.snapshot': 1 },
+        publications: { 'standings.snapshot': 0 },
+        deliveries: { 'standings.snapshot': 0 },
+      },
+    }));
+    const visibility = [
+      {
+        timestamp: new Date(0).toISOString(),
+        runId: 'run',
+        index: 0,
+        visibility: 'hidden' as const,
+        durationSeconds: 301,
+      },
+    ];
+    const summary = summarizeCapture(capture(samples, visibility), 0);
+
+    expect(summary.phaseEvidence[0].expectedBehaviorSatisfied).toBe(false);
+    expect(summary.phaseEvidence[0].reasons).toContain(
+      'hidden phase executed demand-driven processors'
+    );
+  });
+
+  it('rejects inconsistent scenario metadata', () => {
+    const samples = conclusiveSamples();
+    samples[1] = {
+      ...samples[1],
+      scenarioMetadata: {
+        ...samples[1].scenarioMetadata,
+        activeWidgetTypes: [],
+      },
+    };
+    const summary = summarizeCapture(capture(samples), 0);
+
+    expect(summary.evidence.scenarioMetadataConsistent).toBe(false);
+    expect(summary.evidence.conclusive).toBe(false);
+  });
+
+  it('rejects one private observation and excessive sample gaps', () => {
+    const oneSample = summarizeCapture(
+      capture([mainSample(300, 100, 100, 100, 300_000)]),
+      0
+    );
+    const sparse = summarizeCapture(
+      capture([
+        mainSample(60, 100, 100, 100, 60_000),
+        mainSample(360, 102, 100, 102, 300_000),
+      ]),
+      0
+    );
+
+    expect(oneSample.evidence.privateMemorySampleCount).toBe(1);
+    expect(oneSample.evidence.privateMemorySamplingAdequate).toBe(false);
+    expect(oneSample.app.privateMemorySlopeMBPerMinute).toBeNaN();
+    expect(sparse.evidence.privateMemoryMaxGapSeconds).toBe(300);
+    expect(sparse.evidence.privateMemorySamplingAdequate).toBe(false);
+  });
+
+  it('requires conclusive evidence by default in the CLI', () => {
+    expect(parseCliArgs(['candidate.log']).requireConclusive).toBe(true);
+    expect(
+      parseCliArgs(['candidate.log', '--allow-inconclusive']).requireConclusive
+    ).toBe(false);
   });
 });

--- a/tools/perf/analyze.ts
+++ b/tools/perf/analyze.ts
@@ -8,6 +8,12 @@ import type {
 
 const MAIN_PREFIX = '[PerfMetrics:JSON] ';
 const RENDERER_PREFIX = '[PerfRenderer:JSON] ';
+const VISIBILITY_PREFIX = '[PerfVisibility:JSON] ';
+const ORIGIN_PREFIX = '[PerfRunOrigin:JSON] ';
+const MIN_ANALYSIS_SECONDS = 300;
+const MIN_PRIVATE_OBSERVATIONS = 2;
+const MIN_PRIVATE_SPAN_RATIO = 0.8;
+const MAX_PRIVATE_SAMPLE_GAP_SECONDS = 60;
 
 interface SectionStats {
   count: number;
@@ -21,6 +27,7 @@ interface MainPerfSample {
   runId: string;
   scenario: string;
   overlayMode: string;
+  intervalMs?: number;
   tickRateHz: number;
   sections: Record<string, SectionStats>;
   eventLoopDelayMs: { mean: number; max: number; p99: number };
@@ -33,6 +40,12 @@ interface MainPerfSample {
   totalAppCpuPercent?: number;
   totalAppMemoryMB?: number;
   totalAppPrivateMemoryMB?: number;
+  scenarioMetadata?: Record<string, unknown>;
+  channelMetrics?: {
+    processorExecutions: Record<string, number>;
+    publications: Record<string, number>;
+    deliveries: Record<string, number>;
+  };
   processes?: {
     pid: number;
     type: string;
@@ -43,9 +56,29 @@ interface MainPerfSample {
   }[];
 }
 
+interface VisibilityMarker {
+  timestamp: string;
+  runId: string;
+  index: number;
+  visibility: 'visible' | 'hidden';
+  durationSeconds: number;
+}
+
+interface RunOriginMarker {
+  timestamp: string;
+  runId: string;
+}
+
 export interface PerfCapture {
   main: MainPerfSample[];
   renderer: RendererPerfSample[];
+  visibility?: VisibilityMarker[];
+  origins?: RunOriginMarker[];
+}
+
+export interface AnalysisWindow {
+  startSeconds?: number;
+  endSeconds?: number;
 }
 
 export interface PerfSummary {
@@ -54,6 +87,21 @@ export interface PerfSummary {
   overlayMode: string;
   durationMinutes: number;
   sampleCount: number;
+  analysisWindow: {
+    startSeconds: number;
+    endSeconds?: number;
+  };
+  scenarioMetadata: Record<string, unknown>;
+  visibilityPhases: VisibilityMarker[];
+  phaseEvidence: {
+    index: number;
+    visibility: 'visible' | 'hidden';
+    startSeconds: number;
+    durationSeconds: number;
+    sampleCount: number;
+    expectedBehaviorSatisfied: boolean;
+    reasons: string[];
+  }[];
   iracing: {
     averageFps: number;
     meanOnePercentLowFps: number;
@@ -127,6 +175,45 @@ export interface PerfSummary {
     framesOver25MsPercent: number;
     framesOver50MsPercent: number;
   };
+  channels: Record<
+    string,
+    {
+      processorExecutions: number;
+      publications: number;
+      deliveries: number;
+      processorRateHz: number;
+      publicationRateHz: number;
+      deliveryRateHz: number;
+    }
+  >;
+  widgetInputs: Record<
+    string,
+    {
+      covered: boolean;
+      inputs: Record<
+        string,
+        {
+          observed: boolean;
+          changeRateHz: number;
+          deliveryRateHz: number;
+        }
+      >;
+    }
+  >;
+  evidence: {
+    runOriginAvailable: boolean;
+    privateMemoryAvailable: boolean;
+    privateMemorySampleCount: number;
+    privateMemorySpanSeconds: number;
+    privateMemoryMaxGapSeconds: number;
+    privateMemorySamplingAdequate: boolean;
+    scenarioMetadataConsistent: boolean;
+    inputCoverageAvailable: boolean;
+    inputCoverageComplete: boolean;
+    durationSufficient: boolean;
+    conclusive: boolean;
+    inconclusiveReasons: string[];
+  };
 }
 
 export interface PerfComparison {
@@ -160,7 +247,12 @@ function extractJson<T>(line: string, prefix: string): T | undefined {
 }
 
 export function parsePerfLog(contents: string): PerfCapture {
-  const capture: PerfCapture = { main: [], renderer: [] };
+  const capture: PerfCapture = {
+    main: [],
+    renderer: [],
+    visibility: [],
+    origins: [],
+  };
   for (const line of contents.split(/\r?\n/)) {
     const main = extractJson<MainPerfSample>(line, MAIN_PREFIX);
     if (main) {
@@ -169,7 +261,19 @@ export function parsePerfLog(contents: string): PerfCapture {
     }
 
     const renderer = extractJson<RendererPerfSample>(line, RENDERER_PREFIX);
-    if (renderer) capture.renderer.push(renderer);
+    if (renderer) {
+      capture.renderer.push(renderer);
+      continue;
+    }
+
+    const visibility = extractJson<VisibilityMarker>(line, VISIBILITY_PREFIX);
+    if (visibility) {
+      capture.visibility?.push(visibility);
+      continue;
+    }
+
+    const origin = extractJson<RunOriginMarker>(line, ORIGIN_PREFIX);
+    if (origin) capture.origins?.push(origin);
   }
   return capture;
 }
@@ -199,7 +303,7 @@ function maximum(values: number[]): number {
 function linearSlopePerMinute(
   samples: { timestamp: string; value: number }[]
 ): number {
-  if (samples.length < 2) return 0;
+  if (samples.length < 2) return Number.NaN;
   const start = Date.parse(samples[0].timestamp);
   const points = samples.map((sample) => ({
     x: (Date.parse(sample.timestamp) - start) / 60_000,
@@ -213,28 +317,180 @@ function linearSlopePerMinute(
     numerator += (point.x - xMean) * (point.y - yMean);
     denominator += (point.x - xMean) ** 2;
   }
-  return denominator === 0 ? 0 : numerator / denominator;
+  return denominator === 0 ? Number.NaN : numerator / denominator;
 }
+
+interface IntervalBounds {
+  start: number;
+  end: number;
+}
+
+const sampleBounds = (
+  sample: { timestamp: string; intervalMs?: number }
+): IntervalBounds => {
+  const end = Date.parse(sample.timestamp);
+  return {
+    start: end - Math.max(0, sample.intervalMs ?? 0),
+    end,
+  };
+};
+
+const overlaps = (
+  bounds: IntervalBounds,
+  start: number,
+  end: number
+): boolean =>
+  bounds.start === bounds.end
+    ? bounds.end >= start && bounds.end < end
+    : bounds.end > start && bounds.start < end;
+
+const coveredDurationSeconds = (
+  samples: readonly MainPerfSample[],
+  start: number,
+  end: number
+): number => {
+  const intervals = samples
+    .map(sampleBounds)
+    .map((bounds) => ({
+      start: Math.max(start, bounds.start),
+      end: Math.min(end, bounds.end),
+    }))
+    .filter((bounds) => bounds.end > bounds.start)
+    .sort((left, right) => left.start - right.start);
+  let coveredMs = 0;
+  let currentStart: number | undefined;
+  let currentEnd: number | undefined;
+  for (const interval of intervals) {
+    if (currentStart === undefined || currentEnd === undefined) {
+      currentStart = interval.start;
+      currentEnd = interval.end;
+      continue;
+    }
+    if (interval.start <= currentEnd) {
+      currentEnd = Math.max(currentEnd, interval.end);
+      continue;
+    }
+    coveredMs += currentEnd - currentStart;
+    currentStart = interval.start;
+    currentEnd = interval.end;
+  }
+  if (currentStart !== undefined && currentEnd !== undefined) {
+    coveredMs += currentEnd - currentStart;
+  }
+  return coveredMs / 1000;
+};
+
+type ChannelMetricField = keyof NonNullable<
+  MainPerfSample['channelMetrics']
+>;
+
+const channelCount = (
+  samples: readonly MainPerfSample[],
+  field: ChannelMetricField,
+  channel: string
+): number =>
+  samples.reduce(
+    (sum, sample) => sum + (sample.channelMetrics?.[field][channel] ?? 0),
+    0
+  );
+
+const summarizeChannels = (
+  samples: readonly MainPerfSample[],
+  durationSeconds: number
+): PerfSummary['channels'] => {
+  const channelNames = new Set<string>();
+  for (const sample of samples) {
+    for (const metric of [
+      sample.channelMetrics?.processorExecutions,
+      sample.channelMetrics?.publications,
+      sample.channelMetrics?.deliveries,
+    ]) {
+      for (const channel of Object.keys(metric ?? {})) {
+        channelNames.add(channel);
+      }
+    }
+  }
+  const divisor = durationSeconds > 0 ? durationSeconds : 1;
+  return Object.fromEntries(
+    [...channelNames].sort().map((channel) => {
+      const processorExecutions = channelCount(
+        samples,
+        'processorExecutions',
+        channel
+      );
+      const publications = channelCount(samples, 'publications', channel);
+      const deliveries = channelCount(samples, 'deliveries', channel);
+      return [
+        channel,
+        {
+          processorExecutions,
+          publications,
+          deliveries,
+          processorRateHz: processorExecutions / divisor,
+          publicationRateHz: publications / divisor,
+          deliveryRateHz: deliveries / divisor,
+        },
+      ];
+    })
+  );
+};
 
 export function summarizeCapture(
   capture: PerfCapture,
-  warmupSeconds = 30
+  warmupSeconds = 30,
+  analysisWindow: AnalysisWindow = {}
 ): PerfSummary {
   if (capture.main.length === 0) {
     throw new Error('No structured PerfMetrics samples were found in the log.');
   }
 
-  const firstTimestamp = Date.parse(capture.main[0].timestamp);
-  const warmupCutoff = firstTimestamp + warmupSeconds * 1000;
-  const main = capture.main.filter(
-    (sample) => Date.parse(sample.timestamp) >= warmupCutoff
+  const validOrigins = (capture.origins ?? []).filter((origin) =>
+    Number.isFinite(Date.parse(origin.timestamp))
   );
-  const effectiveMain = main.length > 0 ? main : capture.main;
-  const earliest = Date.parse(effectiveMain[0].timestamp);
-  const latest = Date.parse(effectiveMain[effectiveMain.length - 1].timestamp);
-  const renderer = capture.renderer.filter((sample) => {
+  const runOriginAvailable = validOrigins.length === 1;
+  const originTimestamp = runOriginAvailable
+    ? Date.parse(validOrigins[0].timestamp)
+    : Date.parse(capture.main[0].timestamp);
+  const startSeconds = Math.max(
+    warmupSeconds,
+    analysisWindow.startSeconds ?? 0
+  );
+  const analysisStart = originTimestamp + startSeconds * 1000;
+  const configuredAnalysisEnd =
+    analysisWindow.endSeconds === undefined
+      ? undefined
+      : originTimestamp + analysisWindow.endSeconds * 1000;
+  if (
+    configuredAnalysisEnd !== undefined &&
+    configuredAnalysisEnd <= analysisStart
+  ) {
+    throw new Error('Analysis end must be later than the analysis start.');
+  }
+  const lastSampleEnd = Math.max(
+    ...capture.main.map((sample) => Date.parse(sample.timestamp))
+  );
+  const analysisEnd = configuredAnalysisEnd ?? lastSampleEnd + 1;
+  const main = capture.main.filter(
+    (sample) => overlaps(sampleBounds(sample), analysisStart, analysisEnd)
+  );
+  if (main.length === 0) {
+    throw new Error('No PerfMetrics samples fall inside the analysis window.');
+  }
+  const effectiveMain = main;
+  const pointMain = effectiveMain.filter((sample) => {
     const timestamp = Date.parse(sample.timestamp);
-    return timestamp >= earliest && timestamp <= latest;
+    return timestamp >= analysisStart && timestamp <= analysisEnd;
+  });
+  const earliest = Math.max(
+    analysisStart,
+    Math.min(...effectiveMain.map((sample) => sampleBounds(sample).start))
+  );
+  const latest = Math.min(
+    analysisEnd,
+    Math.max(...effectiveMain.map((sample) => sampleBounds(sample).end))
+  );
+  const renderer = capture.renderer.filter((sample) => {
+    return overlaps(sampleBounds(sample), analysisStart, analysisEnd);
   });
 
   const iracingStats = effectiveMain.map((sample) => sample.iracing.frameRate);
@@ -305,12 +561,264 @@ export function summarizeCapture(
     }
   }
 
+  const reportedDurationSeconds = coveredDurationSeconds(
+    effectiveMain,
+    analysisStart,
+    analysisEnd
+  );
+  const durationSeconds =
+    reportedDurationSeconds > 0
+      ? reportedDurationSeconds
+      : Math.max(0, (latest - earliest) / 1000);
+  const metadataEntries = effectiveMain
+    .map((sample) => sample.scenarioMetadata)
+    .filter(
+      (metadata): metadata is Record<string, unknown> => metadata !== undefined
+    );
+  const serializedMetadata = new Set(
+    metadataEntries.map((metadata) => JSON.stringify(metadata))
+  );
+  const scenarioMetadataConsistent =
+    metadataEntries.length === effectiveMain.length &&
+    serializedMetadata.size === 1;
+  const scenarioMetadata = metadataEntries[0] ?? {};
+  const activeWidgetTypes = Array.isArray(scenarioMetadata.activeWidgetTypes)
+    ? scenarioMetadata.activeWidgetTypes.filter(
+        (value): value is string => typeof value === 'string'
+      )
+    : [];
+  const rawRequirements = scenarioMetadata.widgetInputRequirements;
+  const widgetInputRequirements =
+    typeof rawRequirements === 'object' && rawRequirements !== null
+      ? (rawRequirements as Record<string, unknown>)
+      : undefined;
+  const channels = summarizeChannels(effectiveMain, durationSeconds);
+  const configuredPhases = (capture.visibility ?? [])
+    .map((marker) => {
+      const start = Date.parse(marker.timestamp);
+      return {
+        marker,
+        start,
+        end: start + marker.durationSeconds * 1000,
+      };
+    })
+    .filter(
+      (phase) =>
+        Number.isFinite(phase.start) &&
+        phase.end > analysisStart &&
+        phase.start < analysisEnd
+    );
+  const hasVisibilitySchedule = (capture.visibility ?? []).length > 0;
+  const phaseWindows =
+    hasVisibilitySchedule
+      ? configuredPhases.map((phase) => ({
+          index: phase.marker.index,
+          visibility: phase.marker.visibility,
+          start: Math.max(analysisStart, phase.start),
+          end: Math.min(analysisEnd, phase.end),
+        }))
+      : [
+          {
+            index: 0,
+            visibility: 'visible' as const,
+            start: analysisStart,
+            end: analysisEnd,
+          },
+        ];
+  const samplesForPhase = (phase: (typeof phaseWindows)[number]) =>
+    effectiveMain.filter((sample) => {
+      const bounds = sampleBounds(sample);
+      return bounds.start >= phase.start && bounds.end <= phase.end;
+    });
+  const requiredChannels = [
+    ...new Set(
+      activeWidgetTypes.flatMap((widget) => {
+        const configured = widgetInputRequirements?.[widget];
+        return Array.isArray(configured)
+          ? configured.filter(
+              (value): value is string => typeof value === 'string'
+            )
+          : [];
+      })
+    ),
+  ];
+  const phaseEvidence = phaseWindows.map((phase) => {
+    const samples = samplesForPhase(phase);
+    const phaseDurationSeconds = Math.max(0, (phase.end - phase.start) / 1000);
+    const phaseChannels = summarizeChannels(samples, phaseDurationSeconds);
+    const hasMetrics =
+      samples.length > 0 &&
+      samples.every((sample) => sample.channelMetrics !== undefined);
+    const visibleInputsChanged = requiredChannels.every(
+      (channel) => (phaseChannels[channel]?.publications ?? 0) > 0
+    );
+    const hiddenProcessorExecutions = Object.values(phaseChannels).reduce(
+      (sum, channel) => sum + channel.processorExecutions,
+      0
+    );
+    const hiddenDeliveries = Object.values(phaseChannels).reduce(
+      (sum, channel) => sum + channel.deliveries,
+      0
+    );
+    const reasons = [
+      ...(samples.length === 0
+        ? ['phase has no fully-contained metric intervals']
+        : []),
+      ...(!hasMetrics ? ['phase channel metrics are incomplete'] : []),
+      ...(phase.visibility === 'visible' && !visibleInputsChanged
+        ? ['one or more active widget inputs did not publish']
+        : []),
+      ...(phase.visibility === 'hidden' && hiddenProcessorExecutions > 0
+        ? ['hidden phase executed demand-driven processors']
+        : []),
+      ...(phase.visibility === 'hidden' && hiddenDeliveries > 0
+        ? ['hidden phase delivered channel snapshots']
+        : []),
+    ];
+    return {
+      index: phase.index,
+      visibility: phase.visibility,
+      startSeconds: (phase.start - originTimestamp) / 1000,
+      durationSeconds: phaseDurationSeconds,
+      sampleCount: samples.length,
+      expectedBehaviorSatisfied: reasons.length === 0,
+      reasons,
+    };
+  });
+  const visiblePhaseSamples = [
+    ...new Set(
+      phaseWindows
+        .filter((phase) => phase.visibility === 'visible')
+        .flatMap(samplesForPhase)
+    ),
+  ];
+  const visibleDurationSeconds = phaseWindows
+    .filter((phase) => phase.visibility === 'visible')
+    .reduce((sum, phase) => sum + (phase.end - phase.start) / 1000, 0);
+  const visibleChannels = summarizeChannels(
+    visiblePhaseSamples,
+    visibleDurationSeconds
+  );
+  const widgetInputs: PerfSummary['widgetInputs'] = Object.fromEntries(
+    activeWidgetTypes.map((widget) => {
+      const configuredInputs = widgetInputRequirements?.[widget];
+      const inputs = Array.isArray(configuredInputs)
+        ? configuredInputs.filter(
+            (value): value is string => typeof value === 'string'
+          )
+        : [];
+      const inputCoverage = Object.fromEntries(
+        inputs.map((channel) => {
+          const metrics = visibleChannels[channel];
+          return [
+            channel,
+            {
+              observed: (metrics?.publications ?? 0) > 0,
+              changeRateHz: metrics?.publicationRateHz ?? 0,
+              deliveryRateHz: metrics?.deliveryRateHz ?? 0,
+            },
+          ];
+        })
+      );
+      return [
+        widget,
+        {
+          covered:
+            visiblePhaseSamples.length === 0 ||
+            inputs.length === 0 ||
+            Object.values(inputCoverage).every((input) => input.observed),
+          inputs: inputCoverage,
+        },
+      ];
+    })
+  );
+  const privateMemoryAvailable =
+    pointMain.length > 0 &&
+    pointMain.every(
+      (sample) =>
+        typeof sample.totalAppPrivateMemoryMB === 'number' &&
+        Number.isFinite(sample.totalAppPrivateMemoryMB)
+    );
+  const privateTimestamps = pointMain
+    .filter(
+      (sample) =>
+        typeof sample.totalAppPrivateMemoryMB === 'number' &&
+        Number.isFinite(sample.totalAppPrivateMemoryMB)
+    )
+    .map((sample) => Date.parse(sample.timestamp))
+    .filter(Number.isFinite)
+    .sort((left, right) => left - right);
+  const privateMemorySampleCount = privateTimestamps.length;
+  const firstPrivateTimestamp = privateTimestamps[0] ?? 0;
+  const lastPrivateTimestamp = privateTimestamps.at(-1) ?? 0;
+  const privateMemorySpanSeconds =
+    privateMemorySampleCount >= 2
+      ? (lastPrivateTimestamp - firstPrivateTimestamp) / 1000
+      : 0;
+  const privateMemoryMaxGapSeconds = maximum(
+    privateTimestamps.slice(1).map(
+      (timestamp, index) => (timestamp - privateTimestamps[index]) / 1000
+    )
+  );
+  const requiredPrivateSpanSeconds =
+    Math.min(durationSeconds, MIN_ANALYSIS_SECONDS) * MIN_PRIVATE_SPAN_RATIO;
+  const privateMemorySamplingAdequate =
+    privateMemoryAvailable &&
+    privateMemorySampleCount >= MIN_PRIVATE_OBSERVATIONS &&
+    privateMemorySpanSeconds >= requiredPrivateSpanSeconds &&
+    privateMemoryMaxGapSeconds <= MAX_PRIVATE_SAMPLE_GAP_SECONDS;
+  const inputCoverageAvailable =
+    scenarioMetadataConsistent &&
+    Array.isArray(scenarioMetadata.activeWidgetTypes) &&
+    widgetInputRequirements !== undefined &&
+    activeWidgetTypes.every((widget) =>
+      Object.prototype.hasOwnProperty.call(widgetInputRequirements, widget)
+    ) &&
+    phaseWindows.length > 0 &&
+    phaseWindows.every((phase) => samplesForPhase(phase).length > 0) &&
+    effectiveMain.every((sample) => sample.channelMetrics !== undefined);
+  const inputCoverageComplete =
+    inputCoverageAvailable &&
+    phaseEvidence.every((phase) => phase.expectedBehaviorSatisfied);
+  const durationSufficient = durationSeconds >= MIN_ANALYSIS_SECONDS;
+  const inconclusiveReasons = [
+    ...(!runOriginAvailable
+      ? ['a single explicit capture origin is unavailable']
+      : []),
+    ...(!scenarioMetadataConsistent
+      ? ['scenario metadata is missing or inconsistent']
+      : []),
+    ...(!durationSufficient
+      ? ['analysis duration is shorter than five minutes']
+      : []),
+    ...(!privateMemoryAvailable
+      ? ['private-memory samples are unavailable or incomplete']
+      : !privateMemorySamplingAdequate
+        ? ['private-memory sampling span or cadence is insufficient']
+      : []),
+    ...(!inputCoverageAvailable
+      ? ['widget input coverage metadata is unavailable']
+      : !inputCoverageComplete
+        ? ['one or more visibility phases violated workload expectations']
+        : []),
+  ];
+
   return {
     runId: effectiveMain[0].runId,
     scenario: effectiveMain[0].scenario,
     overlayMode: effectiveMain[0].overlayMode,
-    durationMinutes: (latest - earliest) / 60_000,
+    durationMinutes: durationSeconds / 60,
     sampleCount: effectiveMain.length,
+    analysisWindow: {
+      startSeconds,
+      endSeconds: analysisWindow.endSeconds,
+    },
+    scenarioMetadata,
+    // Keep the complete schedule in the summary. The first visibility marker
+    // is normally emitted before the first interval report, so filtering by
+    // sample timestamps would incorrectly drop the opening phase.
+    visibilityPhases: capture.visibility ?? [],
+    phaseEvidence,
     iracing: {
       averageFps: weightedAverage(
         iracingStats.map((stats) => ({
@@ -446,10 +954,12 @@ export function summarizeCapture(
         }))
       ),
       privateMemorySlopeMBPerMinute: linearSlopePerMinute(
-        effectiveMain.map((sample) => ({
-          timestamp: sample.timestamp,
-          value: sample.totalAppPrivateMemoryMB ?? 0,
-        }))
+        privateMemorySamplingAdequate
+          ? pointMain.map((sample) => ({
+              timestamp: sample.timestamp,
+              value: sample.totalAppPrivateMemoryMB as number,
+            }))
+          : []
       ),
     },
     processes: [...processGroups.entries()]
@@ -579,6 +1089,22 @@ export function summarizeCapture(
               rendererFrameCount) *
             100,
     },
+    channels,
+    widgetInputs,
+    evidence: {
+      runOriginAvailable,
+      privateMemoryAvailable,
+      privateMemorySampleCount,
+      privateMemorySpanSeconds,
+      privateMemoryMaxGapSeconds,
+      privateMemorySamplingAdequate,
+      scenarioMetadataConsistent,
+      inputCoverageAvailable,
+      inputCoverageComplete,
+      durationSufficient,
+      conclusive: inconclusiveReasons.length === 0,
+      inconclusiveReasons,
+    },
   };
 }
 
@@ -599,6 +1125,21 @@ export function compareSummaries(
     baseline.iracing.meanOnePercentLowFps,
     candidate.iracing.meanOnePercentLowFps
   );
+  const comparisonConclusive =
+    baseline.evidence.conclusive && candidate.evidence.conclusive;
+  const verdict = (passed: boolean): boolean | null =>
+    comparisonConclusive ? passed : null;
+  const evidenceTarget = (target: string): string =>
+    comparisonConclusive
+      ? target
+      : `inconclusive: ${[
+          ...baseline.evidence.inconclusiveReasons.map(
+            (reason) => `baseline ${reason}`
+          ),
+          ...candidate.evidence.inconclusiveReasons.map(
+            (reason) => `candidate ${reason}`
+          ),
+        ].join('; ')}`;
 
   return {
     baseline,
@@ -618,43 +1159,39 @@ export function compareSummaries(
     checks: [
       {
         name: 'iRacing average FPS regression',
-        passed: averageFpsPercent >= -2,
+        passed: verdict(averageFpsPercent >= -2),
         actual: averageFpsPercent,
-        target: '>= -2%',
+        target: evidenceTarget('>= -2%'),
       },
       {
         name: 'iRacing sampled FPS p1 regression',
-        passed: onePercentLowFpsPercent >= -5,
+        passed: verdict(onePercentLowFpsPercent >= -5),
         actual: onePercentLowFpsPercent,
-        target: '>= -5%',
+        target: evidenceTarget('>= -5%'),
       },
       {
         name: 'Telemetry processing p99',
-        passed: candidate.telemetry.processTelemetryP99MeanMs < 3,
+        passed: verdict(candidate.telemetry.processTelemetryP99MeanMs < 3),
         actual: candidate.telemetry.processTelemetryP99MeanMs,
-        target: '< 3 ms',
+        target: evidenceTarget('< 3 ms'),
       },
       {
         name: 'Telemetry tick rate',
-        passed: candidate.telemetry.minimumTickRateHz >= 20,
+        passed: verdict(candidate.telemetry.minimumTickRateHz >= 20),
         actual: candidate.telemetry.minimumTickRateHz,
-        target: '>= 20 Hz',
+        target: evidenceTarget('>= 20 Hz'),
       },
       {
-        name: 'Steady-state memory slope',
-        passed:
-          candidate.durationMinutes >= 5
-            ? candidate.app.memorySlopeMBPerMinute < 5
-            : null,
-        actual: candidate.app.memorySlopeMBPerMinute,
-        target:
-          candidate.durationMinutes >= 5 ? '< 5 MB/min' : 'requires >= 5 min',
+        name: 'Steady-state private-memory slope',
+        passed: verdict(candidate.app.privateMemorySlopeMBPerMinute < 5),
+        actual: candidate.app.privateMemorySlopeMBPerMinute,
+        target: evidenceTarget('< 5 MB/min'),
       },
       {
         name: 'Renderer frames over 50 ms',
-        passed: candidate.renderer.framesOver50MsPercent < 0.1,
+        passed: verdict(candidate.renderer.framesOver50MsPercent < 0.1),
         actual: candidate.renderer.framesOver50MsPercent,
-        target: '< 0.1%',
+        target: evidenceTarget('< 0.1%'),
       },
     ],
   };
@@ -677,6 +1214,41 @@ export function summaryMarkdown(summary: PerfSummary): string {
         `| ${process.name} | ${format(process.averageCpuPercent)}% | ${format(process.averageMemoryMB)} | ${format(process.memorySlopeMBPerMinute)} | ${format(process.averagePrivateMemoryMB)} | ${format(process.privateMemorySlopeMBPerMinute)} |`
     )
     .join('\n');
+  const channels = Object.entries(summary.channels)
+    .map(
+      ([channel, metrics]) =>
+        `| ${channel} | ${metrics.processorExecutions} | ${metrics.publications} | ${metrics.deliveries} | ${format(metrics.processorRateHz)} | ${format(metrics.publicationRateHz)} | ${format(metrics.deliveryRateHz)} |`
+    )
+    .join('\n');
+  const widgetInputs = Object.entries(summary.widgetInputs)
+    .flatMap(([widget, coverage]) => {
+      const entries = Object.entries(coverage.inputs);
+      if (entries.length === 0) {
+        return [
+          `| ${widget} | n/a | ${coverage.covered ? 'YES' : 'NO'} | 0 | 0 |`,
+        ];
+      }
+      return entries.map(
+        ([channel, input]) =>
+          `| ${widget} | ${channel} | ${input.observed ? 'YES' : 'NO'} | ${format(input.changeRateHz)} | ${format(input.deliveryRateHz)} |`
+      );
+    })
+    .join('\n');
+  const visibility = summary.visibilityPhases
+    .map(
+      (phase) =>
+        `| ${phase.index} | ${phase.visibility} | ${phase.durationSeconds} | ${phase.timestamp} |`
+    )
+    .join('\n');
+  const phaseEvidence = summary.phaseEvidence
+    .map(
+      (phase) =>
+        `| ${phase.index} | ${phase.visibility} | ${format(phase.startSeconds)} | ${format(phase.durationSeconds)} | ${phase.sampleCount} | ${phase.expectedBehaviorSatisfied ? 'PASS' : 'INCONCLUSIVE'} | ${phase.reasons.join('; ')} |`
+    )
+    .join('\n');
+  const evidenceStatus = summary.evidence.conclusive
+    ? 'CONCLUSIVE'
+    : `INCONCLUSIVE — ${summary.evidence.inconclusiveReasons.join('; ')}`;
 
   return `# irDashies performance run
 
@@ -684,7 +1256,10 @@ export function summaryMarkdown(summary: PerfSummary): string {
 - Scenario: \`${summary.scenario}\`
 - Overlay mode: \`${summary.overlayMode}\`
 - Analysed duration: ${format(summary.durationMinutes)} min
+- Analysis window: ${format(summary.analysisWindow.startSeconds)}s to ${summary.analysisWindow.endSeconds === undefined ? 'end' : `${format(summary.analysisWindow.endSeconds)}s`}
 - Main samples: ${summary.sampleCount}
+- Evidence: **${evidenceStatus}**
+- Scenario metadata: \`${JSON.stringify(summary.scenarioMetadata)}\`
 
 | Metric | Result |
 | --- | ---: |
@@ -714,6 +1289,30 @@ export function summaryMarkdown(summary: PerfSummary): string {
 | Renderer frames over 25 / 50 ms | ${format(summary.renderer.framesOver25MsPercent, 3)}% / ${format(summary.renderer.framesOver50MsPercent, 3)}% |
 | Worst renderer frame | ${format(summary.renderer.worstFrameMs)} ms |
 
+## Channel activity
+
+| Channel | Processor executions | Publications | Deliveries | Processor Hz | Change Hz | Delivery Hz |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+${channels}
+
+## Widget input coverage
+
+| Widget | Input channel | Observed | Change Hz | Delivery Hz |
+| --- | --- | --- | ---: | ---: |
+${widgetInputs}
+
+## Visibility phases
+
+| Phase | Visibility | Duration seconds | Marker timestamp |
+| ---: | --- | ---: | --- |
+${visibility}
+
+## Visibility evidence
+
+| Phase | Visibility | Start seconds | Duration seconds | Complete intervals | Expected behavior | Reasons |
+| ---: | --- | ---: | ---: | ---: | --- | --- |
+${phaseEvidence}
+
 ## Timed hot-path sections
 
 | Section | Operations | Average | Mean interval p99 | Worst interval p99 |
@@ -730,10 +1329,14 @@ ${processes}
 
 export function comparisonMarkdown(comparison: PerfComparison): string {
   const { baseline, candidate, delta } = comparison;
+  const evidenceStatus =
+    baseline.evidence.conclusive && candidate.evidence.conclusive
+      ? 'CONCLUSIVE'
+      : 'INCONCLUSIVE';
   const checks = comparison.checks
     .map(
       (check) =>
-        `| ${check.name} | ${check.passed === null ? 'SKIP' : check.passed ? 'PASS' : 'FAIL'} | ${format(check.actual, 3)} | ${check.target} |`
+        `| ${check.name} | ${check.passed === null ? 'INCONCLUSIVE' : check.passed ? 'PASS' : 'FAIL'} | ${format(check.actual, 3)} | ${check.target} |`
     )
     .join('\n');
 
@@ -741,6 +1344,7 @@ export function comparisonMarkdown(comparison: PerfComparison): string {
 
 - Baseline: \`${baseline.runId}\` (${baseline.scenario})
 - Candidate: \`${candidate.runId}\` (${candidate.scenario})
+- Evidence: **${evidenceStatus}**
 
 | Delta | Result |
 | --- | ---: |
@@ -759,24 +1363,36 @@ ${checks}
 
 async function readSummary(
   filePath: string,
-  warmupSeconds: number
+  warmupSeconds: number,
+  analysisWindow: AnalysisWindow
 ): Promise<PerfSummary> {
   const contents = await fs.readFile(filePath, 'utf8');
-  return summarizeCapture(parsePerfLog(contents), warmupSeconds);
+  return summarizeCapture(
+    parsePerfLog(contents),
+    warmupSeconds,
+    analysisWindow
+  );
 }
 
 async function writeAnalysis(
   candidatePath: string,
   baselinePath: string | undefined,
-  warmupSeconds: number
+  warmupSeconds: number,
+  analysisWindow: AnalysisWindow,
+  requireConclusive: boolean
 ): Promise<void> {
-  const candidate = await readSummary(candidatePath, warmupSeconds);
+  const candidate = await readSummary(
+    candidatePath,
+    warmupSeconds,
+    analysisWindow
+  );
   const outputBase = candidatePath.replace(/\.[^.]+$/, '');
   const summaryPath = `${outputBase}.summary.json`;
   const markdownPath = `${outputBase}.summary.md`;
+  let baseline: PerfSummary | undefined;
 
   if (baselinePath) {
-    const baseline = await readSummary(baselinePath, warmupSeconds);
+    baseline = await readSummary(baselinePath, warmupSeconds, analysisWindow);
     const comparison = compareSummaries(baseline, candidate);
     await Promise.all([
       fs.writeFile(summaryPath, JSON.stringify(comparison, null, 2), 'utf8'),
@@ -790,19 +1406,40 @@ async function writeAnalysis(
   }
 
   process.stdout.write(`${markdownPath}\n`);
+  if (
+    requireConclusive &&
+    (!candidate.evidence.conclusive ||
+      (baseline !== undefined && !baseline.evidence.conclusive))
+  ) {
+    const reasons = [
+      ...candidate.evidence.inconclusiveReasons.map(
+        (reason) => `candidate: ${reason}`
+      ),
+      ...(baseline?.evidence.inconclusiveReasons ?? []).map(
+        (reason) => `baseline: ${reason}`
+      ),
+    ];
+    throw new Error(
+      `Performance evidence is inconclusive: ${reasons.join('; ')}`
+    );
+  }
 }
 
-function parseCliArgs(args: string[]): {
+export function parseCliArgs(args: string[]): {
   candidatePath: string;
   baselinePath?: string;
   warmupSeconds: number;
+  analysisWindow: AnalysisWindow;
+  requireConclusive: boolean;
 } {
   const positional = args.filter((arg) => !arg.startsWith('--'));
   const baselineIndex = args.indexOf('--baseline');
   const warmupIndex = args.indexOf('--warmup-seconds');
+  const startIndex = args.indexOf('--analysis-start-seconds');
+  const endIndex = args.indexOf('--analysis-end-seconds');
   if (!positional[0]) {
     throw new Error(
-      'Usage: npm run perf:analyze -- <candidate.log> [--baseline <baseline.log>] [--warmup-seconds 30]'
+      'Usage: npm run perf:analyze -- <candidate.log> [--baseline <baseline.log>] [--warmup-seconds 30] [--analysis-start-seconds 60] [--analysis-end-seconds 420] [--allow-inconclusive]'
     );
   }
 
@@ -816,6 +1453,17 @@ function parseCliArgs(args: string[]): {
       warmupIndex >= 0 && Number.isFinite(Number(args[warmupIndex + 1]))
         ? Number(args[warmupIndex + 1])
         : 30,
+    analysisWindow: {
+      startSeconds:
+        startIndex >= 0 && Number.isFinite(Number(args[startIndex + 1]))
+          ? Number(args[startIndex + 1])
+          : undefined,
+      endSeconds:
+        endIndex >= 0 && Number.isFinite(Number(args[endIndex + 1]))
+          ? Number(args[endIndex + 1])
+          : undefined,
+    },
+    requireConclusive: !args.includes('--allow-inconclusive'),
   };
 }
 
@@ -828,6 +1476,8 @@ if (isCli) {
   await writeAnalysis(
     options.candidatePath,
     options.baselinePath,
-    options.warmupSeconds
+    options.warmupSeconds,
+    options.analysisWindow,
+    options.requireConclusive
   );
 }

--- a/tools/perf/run.ts
+++ b/tools/perf/run.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { execFileSync } from 'node:child_process';
 import { createWriteStream, promises as fs } from 'node:fs';
 import path from 'node:path';
+import { readWidgetInputRequirements } from './widgetInputMetadata';
 
 const PERF_REPLAY_READY_LOG_MARKER = '[PerfRun] Ready for replay publisher';
 const REPLAY_STARTUP_TIMEOUT_MS = 30_000;
@@ -19,7 +20,18 @@ interface RunOptions {
   runId: string;
   telemetryDelivery: 'on' | 'off';
   telemetryPayload: 'allowlisted' | 'raw';
+  channelDelivery: 'on' | 'off';
+  visibilityPhases: string;
   replayInput: string;
+  metadata: {
+    target: RunTarget;
+    simulatorMode: 'live' | 'replay';
+    fieldCount?: number;
+    classCount?: number;
+    displayGeometry?: string;
+    fpsCap?: number;
+    syncMode?: string;
+  };
 }
 
 function argumentValue(args: string[], name: string): string | undefined {
@@ -29,6 +41,14 @@ function argumentValue(args: string[], name: string): string | undefined {
 
 function safeName(value: string): string {
   return value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '');
+}
+
+function optionalFiniteNumber(
+  args: string[],
+  name: string
+): number | undefined {
+  const value = Number(argumentValue(args, name));
+  return Number.isFinite(value) && value >= 0 ? value : undefined;
 }
 
 function parseArgs(args: string[]): RunOptions {
@@ -48,7 +68,21 @@ function parseArgs(args: string[]): RunOptions {
   );
   const interval = Number(argumentValue(args, '--interval-ms') ?? 5000);
   const duration = Number(argumentValue(args, '--duration-seconds') ?? 0);
+  const visibilityPhases = argumentValue(args, '--visibility-phases') ?? '';
+  const phaseDuration = visibilityPhases
+    .split(',')
+    .map((entry) => entry.trim().match(/^(?:visible|hidden):(\d+)$/)?.[1])
+    .map(Number)
+    .filter((value) => Number.isFinite(value) && value >= 10)
+    .reduce((sum, value) => sum + value, 0);
+  const durationSeconds =
+    Number.isFinite(duration) && duration >= 10
+      ? duration
+      : phaseDuration >= 10
+        ? phaseDuration
+        : 0;
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const replayInput = argumentValue(args, '--replay-input') ?? '';
 
   return {
     scenario,
@@ -56,7 +90,7 @@ function parseArgs(args: string[]): RunOptions {
     target,
     widgets,
     intervalMs: Number.isFinite(interval) && interval >= 1000 ? interval : 5000,
-    durationSeconds: Number.isFinite(duration) && duration >= 10 ? duration : 0,
+    durationSeconds,
     runId: safeName(
       argumentValue(args, '--run-id') ?? `${timestamp}-${scenario}`
     ),
@@ -66,11 +100,24 @@ function parseArgs(args: string[]): RunOptions {
       argumentValue(args, '--telemetry-payload') === 'raw'
         ? 'raw'
         : 'allowlisted',
-    replayInput: argumentValue(args, '--replay-input') ?? '',
+    channelDelivery:
+      argumentValue(args, '--channel-delivery') === 'off' ? 'off' : 'on',
+    visibilityPhases,
+    replayInput,
+    metadata: {
+      target,
+      simulatorMode: replayInput ? 'replay' : 'live',
+      fieldCount: optionalFiniteNumber(args, '--field-count'),
+      classCount: optionalFiniteNumber(args, '--class-count'),
+      displayGeometry: argumentValue(args, '--display-geometry'),
+      fpsCap: optionalFiniteNumber(args, '--fps-cap'),
+      syncMode: argumentValue(args, '--sync-mode'),
+    },
   };
 }
 
 const options = parseArgs(process.argv.slice(2));
+const widgetInputRequirements = await readWidgetInputRequirements();
 const outputDirectory = path.resolve('perf-results');
 await fs.mkdir(outputDirectory, { recursive: true });
 const logPath = path.join(outputDirectory, `${options.runId}.log`);
@@ -127,6 +174,10 @@ process.stdout.write(
     `Target: ${options.target}`,
     `Telemetry delivery: ${options.telemetryDelivery}`,
     `Telemetry payload: ${options.telemetryPayload}`,
+    `Channel delivery: ${options.channelDelivery}`,
+    options.visibilityPhases
+      ? `Visibility phases: ${options.visibilityPhases}`
+      : '',
     replayInputPath ? `Replay: ${replayInputPath}` : '',
     options.widgets ? `Widgets: ${options.widgets}` : '',
     options.durationSeconds > 0
@@ -157,6 +208,19 @@ const child = spawn(childCommand, childArguments, {
     PERF_LOG_PATH: logPath,
     PERF_TELEMETRY_DELIVERY: options.telemetryDelivery,
     PERF_TELEMETRY_PAYLOAD: options.telemetryPayload,
+    PERF_CHANNEL_DELIVERY: options.channelDelivery,
+    PERF_VISIBILITY_PHASES: options.visibilityPhases,
+    PERF_SCENARIO_METADATA: JSON.stringify({
+      ...options.metadata,
+      requestedWidgetTypes: options.widgets
+        .split(',')
+        .map((widget) => widget.trim())
+        .filter(Boolean),
+      channelDelivery: options.channelDelivery,
+      telemetryDelivery: options.telemetryDelivery,
+      telemetryPayload: options.telemetryPayload,
+      widgetInputRequirements,
+    }),
     IRDASHIES_IRSDK_REPLAY: replayInputPath
       ? '1'
       : process.env.IRDASHIES_IRSDK_REPLAY,

--- a/tools/perf/widgetInputMetadata.spec.ts
+++ b/tools/perf/widgetInputMetadata.spec.ts
@@ -1,0 +1,25 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { readWidgetInputRequirements } from './widgetInputMetadata';
+
+describe('widget input metadata', () => {
+  it('reads channel requirements from widget runtime definitions', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'irdashies-perf-'));
+    const widgetDirectory = path.join(
+      root,
+      'src/frontend/components/TestWidget'
+    );
+    await mkdir(widgetDirectory, { recursive: true });
+    await writeFile(
+      path.join(widgetDirectory, 'widgetRuntimeDefinition.ts'),
+      "export default { id: 'test', channels: ['one.snapshot', 'two.snapshot'] };",
+      'utf8'
+    );
+
+    await expect(readWidgetInputRequirements(root)).resolves.toEqual({
+      test: ['one.snapshot', 'two.snapshot'],
+    });
+  });
+});

--- a/tools/perf/widgetInputMetadata.ts
+++ b/tools/perf/widgetInputMetadata.ts
@@ -1,0 +1,38 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+export type WidgetInputRequirements = Readonly<
+  Record<string, readonly string[]>
+>;
+
+export async function readWidgetInputRequirements(
+  repositoryRoot = process.cwd()
+): Promise<WidgetInputRequirements> {
+  const componentsDirectory = path.join(
+    repositoryRoot,
+    'src/frontend/components'
+  );
+  const entries = await fs.readdir(componentsDirectory, {
+    withFileTypes: true,
+  });
+  const requirements: Record<string, string[]> = {};
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const definitionPath = path.join(
+      componentsDirectory,
+      entry.name,
+      'widgetRuntimeDefinition.ts'
+    );
+    const source = await fs.readFile(definitionPath, 'utf8').catch(() => '');
+    if (!source) continue;
+    const id = source.match(/\bid:\s*'([^']+)'/)?.[1];
+    if (!id) continue;
+    const channelBlock = source.match(/\bchannels:\s*\[([\s\S]*?)\]/)?.[1];
+    requirements[id] = channelBlock
+      ? [...channelBlock.matchAll(/'([^']+)'/g)].map((match) => match[1])
+      : [];
+  }
+
+  return requirements;
+}


### PR DESCRIPTION
## Description

Makes the packaged channel benchmark evidence-aware so performance conclusions fail closed when duration, memory, or widget-input coverage is insufficient.

- adds channel-delivery on/off isolation independently of raw Telemetry Inspector delivery
- records per-channel processor execution, publication, and delivery counts/rates
- extracts each widget's declared channel inputs and reports coverage/change rates
- adds structured visibility phase scheduling and markers
- records reproducible scenario metadata and supports fixed analysis windows
- promotes private-memory slope to the primary memory gate
- marks captures inconclusive when measured duration is under five minutes, private bytes are incomplete, widget metadata is missing, or declared inputs are unexercised
- updates benchmark commands, evidence requirements, and analyzer/config tests

This is the Phase 4.1 benchmark-v2 tooling lane, stacked on the Wave 1 channel-contract corrections in PR #672.

Validation:

- `npm run lint -- --quiet`
- Full Vitest suite: 1,235 passed, 1 skipped
- focused benchmark/config/ChannelBus suite: 25 passed
- `npm run test:replay:curated` — 36,000 frames, 70 session revisions, 14 probes
- `git diff --check`

No packaged Windows or live iRacing benchmark was captured in this PR; this PR makes those later captures trustworthy.

## Screenshots

### Before

Not applicable — benchmark tooling and structured logs.

### After

Not applicable — no frontend visual changes.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

### Architecture pre-PR checklist

- [x] N1 — metadata reads are async and tooling-only
- [x] N2/N3 — no frontend layering changes
- [x] N4 — no new IPC handlers
- [x] R4.6 — channel delivery remains per-window and visibility-aware
- [x] R11.1 — structured markers use the project logger
- [x] R13 — hot-path counts are aggregated and benchmarked
- [x] Relevant phase: Phase 4.1 benchmark evidence gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Performance runs now support configurable channel delivery and timed visible/hidden display phases.
  - Benchmark reports include channel activity, widget input coverage, scenario details, and capture origins.
  - Performance tools can automatically detect widget input requirements and selected dashboard widgets.

- **Bug Fixes**
  - Incomplete private-memory data is no longer treated as valid benchmark evidence.
  - Insufficient or inconsistent benchmark results are clearly marked inconclusive.

- **Documentation**
  - Updated benchmark guidance with expanded metrics, validation rules, and analysis requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->