### PR TITLE
perf: adopt channel snapshot selectors

### DIFF
--- a/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
@@ -5,7 +5,8 @@ import { BlindSpotMonitorSimpleIndicator } from './components/BlindSpotMonitorSi
 import {
   useDashboard,
   useSessionVisibility,
-  useTrackStateSnapshot,
+  trackStateSelectors,
+  useTrackStateSelector,
 } from '@irdashies/context';
 import { CarLeftRight } from '@irdashies/types';
 
@@ -136,7 +137,8 @@ export const BlindSpotMonitor = () => {
   const state = useBlindSpotMonitor();
   const settings = useBlindSpotMonitorSettings();
   const { isDemoMode } = useDashboard();
-  const isOnTrack = useTrackStateSnapshot()?.isOnTrack ?? false;
+  const isOnTrack =
+    useTrackStateSelector(trackStateSelectors.isOnTrack) ?? false;
 
   const sessionVisible = useSessionVisibility(settings?.sessionVisibility);
   const activeState = isDemoMode ? DEMO_STATE_SIMPLE : state;

--- a/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState, useEffect } from 'react';
+import type { TrackStateSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
 import {
-  useTrackStateSnapshot,
+  useTrackStateSelector,
   useDriverCarIdx,
   useTrackLength,
 } from '@irdashies/context';
@@ -17,15 +19,35 @@ interface BlindSpotMonitorState {
 }
 
 const EMPTY_POSITIONS: readonly number[] = [];
+const EMPTY_BLIND_SPOT_TELEMETRY: readonly [
+  CarLeftRight,
+  readonly number[],
+  boolean,
+] = [CarLeftRight.Off, EMPTY_POSITIONS, false];
+
+const selectBlindSpotTelemetry = (snapshot: TrackStateSnapshot) =>
+  [
+    snapshot.carLeftRight as CarLeftRight,
+    snapshot.carIdxLapDistPct,
+    snapshot.isOnTrack,
+  ] as const;
+
+const blindSpotTelemetryEqual = (
+  previous: ReturnType<typeof selectBlindSpotTelemetry>,
+  next: ReturnType<typeof selectBlindSpotTelemetry>
+) =>
+  previous[0] === next[0] &&
+  shallow(previous[1], next[1]) &&
+  previous[2] === next[2];
 
 export const useBlindSpotMonitor = (): BlindSpotMonitorState => {
-  const trackState = useTrackStateSnapshot();
-  const carLeftRight = trackState?.carLeftRight ?? CarLeftRight.Off;
-  const lapDistPcts = trackState?.carIdxLapDistPct ?? EMPTY_POSITIONS;
+  const [carLeftRight, lapDistPcts, isOnTrack] =
+    useTrackStateSelector(selectBlindSpotTelemetry, {
+      equality: blindSpotTelemetryEqual,
+    }) ?? EMPTY_BLIND_SPOT_TELEMETRY;
   const driverCarIdx = useDriverCarIdx() ?? 0;
   const trackLength = useTrackLength();
   const settings = useBlindSpotMonitorSettings();
-  const isOnTrack = trackState?.isOnTrack ?? false;
 
   const [leftCarIdx, setLeftCarIdx] = useState<number | null>(null);
   const [rightCarIdx, setRightCarIdx] = useState<number | null>(null);

--- a/src/frontend/components/CornerNameOverlay/hooks/useCurrentSection.ts
+++ b/src/frontend/components/CornerNameOverlay/hooks/useCurrentSection.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
-import { useTrackStateSnapshot } from '@irdashies/context';
-import type { LovelyTrackSection } from '@irdashies/types';
+import { useTrackStateSelector } from '@irdashies/context';
+import type { LovelyTrackSection, TrackStateSnapshot } from '@irdashies/types';
 import { useLovelyTrackData } from './useLovelyTrackData';
 
 interface CurrentSectionResult {
@@ -8,6 +8,9 @@ interface CurrentSectionResult {
   progress: number; // 0-1 within the current section
   lapDistPct: number; // normalized [0,1), 0 when telemetry isn't ready
 }
+
+const selectRoundedLapDistPct = (snapshot: TrackStateSnapshot) =>
+  Math.round(snapshot.lapDistPct * 1000) / 1000;
 
 /**
  * Determines the current track section from LapDistPct. Returns the matched
@@ -18,9 +21,7 @@ interface CurrentSectionResult {
 export const useCurrentSection = (): CurrentSectionResult => {
   const { sections } = useLovelyTrackData();
   // 3dp ≈ 5m on a 5km track — matches SectorDelta precision
-  const lapDistPct = useTrackStateSnapshot()?.lapDistPct;
-  const rawLapDistPct =
-    lapDistPct === undefined ? undefined : Math.round(lapDistPct * 1000) / 1000;
+  const rawLapDistPct = useTrackStateSelector(selectRoundedLapDistPct);
 
   return useMemo(() => {
     if (sections.length === 0 || rawLapDistPct == null) {

--- a/src/frontend/components/Flag/Flag.tsx
+++ b/src/frontend/components/Flag/Flag.tsx
@@ -1,21 +1,26 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import {
-  useTrackStateSnapshot,
+  useTrackStateSelector,
   useSessionVisibility,
 } from '@irdashies/context';
-import type { GeneralSettingsType } from '@irdashies/types';
+import type { GeneralSettingsType, TrackStateSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
 import { useFlagSettings } from './hooks/useFlagSettings';
 import { useBlinkState } from './hooks/useBlinkState';
 import { getLedColor } from './hooks/getLedColor';
 import { getTextColorClass } from './hooks/getTextColorClass';
 import { getFlag } from '@irdashies/utils/getFlag';
 
+const EMPTY_FLAG_STATE: readonly [number, boolean] = [0, false];
+const selectFlagState = (snapshot: TrackStateSnapshot) =>
+  [snapshot.sessionFlags, snapshot.isOnTrack] as const;
+
 export const Flag = () => {
   const settings = useFlagSettings();
 
-  const trackState = useTrackStateSnapshot();
-  const sessionFlags = trackState?.sessionFlags ?? 0;
-  const isPlayerOnTrack = trackState?.isOnTrack ?? false;
+  const [sessionFlags, isPlayerOnTrack] =
+    useTrackStateSelector(selectFlagState, { equality: shallow }) ??
+    EMPTY_FLAG_STATE;
   const isVisibleInSession = useSessionVisibility(settings.sessionVisibility);
 
   const blinkOn = useBlinkState(settings.animate, settings.blinkPeriod);

--- a/src/frontend/components/GarageCover/GarageCover.tsx
+++ b/src/frontend/components/GarageCover/GarageCover.tsx
@@ -2,13 +2,23 @@ import { useState, useEffect } from 'react';
 import { useGarageCoverSettings } from './hooks/useGarageCoverSettings';
 import { useGarageCoverImage } from './hooks/useGarageCoverImage';
 import logoSvg from '../../assets/icons/logo.svg';
-import { useTrackStateSnapshot } from '@irdashies/context';
+import type { TrackStateSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
+import { useTrackStateSelector } from '@irdashies/context';
+
+const EMPTY_GARAGE_STATE: readonly [boolean, boolean, boolean] = [
+  false,
+  false,
+  false,
+];
+
+const selectGarageState = (snapshot: TrackStateSnapshot) =>
+  [snapshot.isInGarage, snapshot.isGarageVisible, snapshot.isOnTrack] as const;
 
 export const GarageCover = () => {
-  const trackState = useTrackStateSnapshot();
-  const isInGarageDirect = trackState?.isInGarage ?? false;
-  const isGarageVisible = trackState?.isGarageVisible ?? false;
-  const isOnTrack = trackState?.isOnTrack ?? false;
+  const [isInGarageDirect, isGarageVisible, isOnTrack] =
+    useTrackStateSelector(selectGarageState, { equality: shallow }) ??
+    EMPTY_GARAGE_STATE;
 
   // Combining both garage-specific flags ensures the fastest possible
   // detection of the garage screen without false positives from other

--- a/src/frontend/components/PitlaneHelper/PitlaneHelper.spec.tsx
+++ b/src/frontend/components/PitlaneHelper/PitlaneHelper.spec.tsx
@@ -5,18 +5,21 @@ import * as context from '@irdashies/context';
 
 // Mock all the context hooks
 vi.mock('@irdashies/context', () => ({
-  useTrackStateSnapshot: vi.fn(),
+  useTrackStateSelector: vi.fn(),
   useDriverControlsSnapshot: vi.fn(),
   useDashboard: vi.fn(),
   useSessionVisibility: vi.fn(),
 }));
 
 const mockSnapshots = (read: (key: string) => unknown) => {
-  vi.mocked(context.useTrackStateSnapshot).mockReturnValue({
+  const trackState = {
     playerTrackSurface: read('PlayerTrackSurface'),
     onPitRoad: read('OnPitRoad'),
     displayUnits: read('DisplayUnits'),
-  } as never);
+  };
+  vi.mocked(context.useTrackStateSelector).mockImplementation(
+    (selector) => selector(trackState as never) as never
+  );
   vi.mocked(context.useDriverControlsSnapshot).mockReturnValue({
     throttle: read('Throttle'),
     clutch: read('Clutch'),

--- a/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
+++ b/src/frontend/components/PitlaneHelper/PitlaneHelper.tsx
@@ -5,7 +5,7 @@ import { usePitlaneVisibility } from './hooks/usePitlaneVisibility';
 import { usePitLimiterWarning } from './hooks/usePitLimiterWarning';
 import { usePitlaneTraffic } from './hooks/usePitlaneTraffic';
 import {
-  useTrackStateSnapshot,
+  useTrackStateSelector,
   useDashboard,
   useSessionVisibility,
 } from '@irdashies/context';
@@ -16,10 +16,27 @@ import {
   PitLimiterWarningResult,
   PitlaneTrafficResult,
 } from './demoData';
-import type { PitlaneHelperWidgetSettings } from '@irdashies/types';
+import type {
+  PitlaneHelperWidgetSettings,
+  TrackStateSnapshot,
+} from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
 import { PitCountdownBar } from './components/PitCountdownBar';
 import { PitExitInputs } from './components/PitExitInputs';
 import { PitSpeedBar } from './components/PitSpeedBar';
+
+const EMPTY_PIT_STATE: readonly [number, boolean, number | undefined] = [
+  3,
+  false,
+  undefined,
+];
+
+const selectPitState = (snapshot: TrackStateSnapshot) =>
+  [
+    snapshot.playerTrackSurface,
+    snapshot.onPitRoad,
+    snapshot.displayUnits,
+  ] as const;
 
 // Calculate color for countdown bars based on distance
 const getCountdownColor = (distance: number, maxDistance: number): string => {
@@ -35,10 +52,9 @@ export const PitlaneHelper = () => {
 
   const isSessionVisible = useSessionVisibility(config?.sessionVisibility);
 
-  const trackState = useTrackStateSnapshot();
-  const surface = trackState?.playerTrackSurface ?? 3;
-  const onPitRoadTelemetry = trackState?.onPitRoad ?? false;
-  const displayUnits = trackState?.displayUnits;
+  const [surface, onPitRoadTelemetry, displayUnits] =
+    useTrackStateSelector(selectPitState, { equality: shallow }) ??
+    EMPTY_PIT_STATE;
 
   // Core data hooks - must be called in same order every render
   const speed = usePitSpeed();

--- a/src/frontend/components/PitlaneHelper/hooks/usePitLimiterWarning.spec.tsx
+++ b/src/frontend/components/PitlaneHelper/hooks/usePitLimiterWarning.spec.tsx
@@ -5,7 +5,7 @@ import { EngineWarnings } from '@irdashies/types';
 import { usePitLimiterWarning } from './usePitLimiterWarning';
 
 vi.mock('@irdashies/context', () => ({
-  useTrackStateSnapshot: vi.fn(),
+  useTrackStateSelector: vi.fn(),
   useSessionStore: vi.fn(),
 }));
 
@@ -17,13 +17,16 @@ const trackState = (
     engineWarnings: number;
   }> = {}
 ) => {
-  vi.mocked(context.useTrackStateSnapshot).mockReturnValue({
+  const snapshot = {
     onPitRoad: false,
     pitSpeedLimiterToggle: false,
     pitstopActive: false,
     engineWarnings: 0,
     ...values,
-  } as never);
+  };
+  vi.mocked(context.useTrackStateSelector).mockImplementation(
+    (selector) => selector(snapshot as never) as never
+  );
 };
 
 const sessionStore = { session: { WeekendInfo: { TeamRacing: 0 } } };
@@ -40,7 +43,7 @@ describe('usePitLimiterWarning', () => {
 
   it('reads the typed track-state snapshot', () => {
     renderHook(() => usePitLimiterWarning(true));
-    expect(context.useTrackStateSnapshot).toHaveBeenCalledOnce();
+    expect(context.useTrackStateSelector).toHaveBeenCalledOnce();
   });
 
   it('warns when entering pit road without a limiter', () => {
@@ -67,9 +70,7 @@ describe('usePitLimiterWarning', () => {
 
   it('warns when a manual toggle follows auto-limiter detection', () => {
     trackState({ onPitRoad: false });
-    const { result, rerender } = renderHook(() =>
-      usePitLimiterWarning(true)
-    );
+    const { result, rerender } = renderHook(() => usePitLimiterWarning(true));
 
     trackState({
       onPitRoad: true,
@@ -90,9 +91,7 @@ describe('usePitLimiterWarning', () => {
   it('warns a team after pitstop completion without a limiter', () => {
     sessionStore.session.WeekendInfo.TeamRacing = 1;
     trackState({ pitstopActive: true });
-    const { result, rerender } = renderHook(() =>
-      usePitLimiterWarning(true)
-    );
+    const { result, rerender } = renderHook(() => usePitLimiterWarning(true));
 
     trackState({ pitstopActive: false });
     rerender();
@@ -118,9 +117,7 @@ describe('usePitLimiterWarning', () => {
   it('clears the team warning when the limiter is activated', () => {
     sessionStore.session.WeekendInfo.TeamRacing = 1;
     trackState({ pitstopActive: true });
-    const { result, rerender } = renderHook(() =>
-      usePitLimiterWarning(true)
-    );
+    const { result, rerender } = renderHook(() => usePitLimiterWarning(true));
     trackState({ pitstopActive: false });
     rerender();
 

--- a/src/frontend/components/PitlaneHelper/hooks/usePitLimiterWarning.tsx
+++ b/src/frontend/components/PitlaneHelper/hooks/usePitLimiterWarning.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
-import { useTrackStateSnapshot, useSessionStore } from '@irdashies/context';
-import { EngineWarnings } from '@irdashies/types';
+import { useTrackStateSelector, useSessionStore } from '@irdashies/context';
+import { EngineWarnings, type TrackStateSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
 
 export interface PitLimiterWarningResult {
   showWarning: boolean;
@@ -8,15 +9,28 @@ export interface PitLimiterWarningResult {
   warningText: string;
 }
 
+const EMPTY_LIMITER_STATE: readonly [boolean, boolean, boolean, number] = [
+  false,
+  false,
+  false,
+  0,
+];
+
+const selectLimiterState = (snapshot: TrackStateSnapshot) =>
+  [
+    snapshot.onPitRoad,
+    snapshot.pitSpeedLimiterToggle,
+    snapshot.pitstopActive,
+    snapshot.engineWarnings,
+  ] as const;
+
 export const usePitLimiterWarning = (
   enabled: boolean
 ): PitLimiterWarningResult => {
   const session = useSessionStore((state) => state.session);
-  const trackState = useTrackStateSnapshot();
-  const onPitRoad = trackState?.onPitRoad ?? false;
-  const limiterActive = trackState?.pitSpeedLimiterToggle ?? false;
-  const pitstopActive = trackState?.pitstopActive ?? false;
-  const engineWarnings = trackState?.engineWarnings ?? 0;
+  const [onPitRoad, limiterActive, pitstopActive, engineWarnings] =
+    useTrackStateSelector(selectLimiterState, { equality: shallow }) ??
+    EMPTY_LIMITER_STATE;
   const isTeamRacing = (session?.WeekendInfo?.TeamRacing ?? 0) === 1;
 
   // Check if pit speed limiter is actively engaged (manual OR auto)

--- a/src/frontend/components/PitlaneHelper/hooks/usePitSpeed.tsx
+++ b/src/frontend/components/PitlaneHelper/hooks/usePitSpeed.tsx
@@ -1,5 +1,9 @@
 import { useMemo } from 'react';
-import { useTrackStateSnapshot, useSessionStore } from '@irdashies/context';
+import {
+  trackStateSelectors,
+  useTrackStateSelector,
+  useSessionStore,
+} from '@irdashies/context';
 import {
   kphFromSpeed,
   speedFromKph,
@@ -21,7 +25,7 @@ export interface PitSpeedResult {
 
 export const usePitSpeed = (): PitSpeedResult => {
   const session = useSessionStore((state) => state.session);
-  const speed = useTrackStateSnapshot()?.speed ?? 0;
+  const speed = useTrackStateSelector(trackStateSelectors.speed) ?? 0;
 
   return useMemo(() => {
     // Parse pit speed limit (format: "60.00 kph" or "35.00 mph")

--- a/src/frontend/components/PitlaneHelper/hooks/usePitboxPosition.tsx
+++ b/src/frontend/components/PitlaneHelper/hooks/usePitboxPosition.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
+import { shallow } from 'zustand/shallow';
 import {
-  useTrackStateSnapshot,
+  trackStateSelectors,
+  useTrackStateSelector,
   useSessionStore,
   useFocusCarIdx,
   useTrackLength,
@@ -24,7 +26,10 @@ export const usePitboxPosition = (
 ): PitboxPositionResult => {
   const session = useSessionStore((state) => state.session);
   const focusCarIdx = useFocusCarIdx();
-  const carIdxLapDistPct = useTrackStateSnapshot()?.carIdxLapDistPct;
+  const carIdxLapDistPct = useTrackStateSelector(
+    trackStateSelectors.carIdxLapDistPct,
+    { equality: shallow }
+  );
   const trackLength = useTrackLength() ?? 0;
   const { pitEntryPct, pitExitPct } = usePitLaneStore();
 

--- a/src/frontend/components/PitlaneHelper/hooks/usePitlaneTraffic.tsx
+++ b/src/frontend/components/PitlaneHelper/hooks/usePitlaneTraffic.tsx
@@ -1,8 +1,7 @@
 import { useMemo } from 'react';
-import {
-  useTrackStateSnapshot,
-  useFocusCarIdx,
-} from '@irdashies/context';
+import type { TrackStateSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
+import { useTrackStateSelector, useFocusCarIdx } from '@irdashies/context';
 
 export interface PitlaneTrafficResult {
   carsAhead: number;
@@ -10,15 +9,28 @@ export interface PitlaneTrafficResult {
   totalCars: number;
 }
 
+const EMPTY_TRAFFIC: readonly [readonly boolean[], readonly number[]] = [
+  [],
+  [],
+];
+
+const selectTraffic = (snapshot: TrackStateSnapshot) =>
+  [snapshot.carIdxOnPitRoad, snapshot.carIdxLapDistPct] as const;
+
+const trafficEqual = (
+  previous: ReturnType<typeof selectTraffic>,
+  next: ReturnType<typeof selectTraffic>
+) => shallow(previous[0], next[0]) && shallow(previous[1], next[1]);
+
 export const usePitlaneTraffic = (enabled: boolean): PitlaneTrafficResult => {
   const focusCarIdx = useFocusCarIdx();
-  const trackState = useTrackStateSnapshot();
-  const carIdxOnPitRoadRaw = trackState?.carIdxOnPitRoad;
-  const carIdxLapDistPctRaw = trackState?.carIdxLapDistPct;
+  const [carIdxOnPitRoadRaw, carIdxLapDistPctRaw] =
+    useTrackStateSelector(selectTraffic, { equality: trafficEqual }) ??
+    EMPTY_TRAFFIC;
 
   return useMemo(() => {
-    const carIdxOnPitRoad = carIdxOnPitRoadRaw ?? [];
-    const carIdxLapDistPct = carIdxLapDistPctRaw ?? [];
+    const carIdxOnPitRoad = carIdxOnPitRoadRaw;
+    const carIdxLapDistPct = carIdxLapDistPctRaw;
 
     if (!enabled || focusCarIdx === undefined) {
       return { carsAhead: 0, carsBehind: 0, totalCars: 0 };

--- a/src/frontend/components/PitlaneHelper/hooks/usePitlaneVisibility.tsx
+++ b/src/frontend/components/PitlaneHelper/hooks/usePitlaneVisibility.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
+import type { TrackStateSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
 import {
-  useTrackStateSnapshot,
+  useTrackStateSelector,
   useFocusCarIdx,
   useTrackLength,
   useSessionStore,
@@ -8,15 +10,38 @@ import {
 } from '@irdashies/context';
 import { usePitlaneHelperSettings } from './usePitlaneHelperSettings';
 
+const EMPTY_VISIBILITY_STATE: readonly [
+  boolean,
+  number,
+  readonly number[],
+  readonly boolean[],
+] = [false, 3, [], []];
+
+const selectVisibilityState = (snapshot: TrackStateSnapshot) =>
+  [
+    snapshot.isOnTrack,
+    snapshot.playerTrackSurface,
+    snapshot.carIdxLapDistPct,
+    snapshot.carIdxOnPitRoad,
+  ] as const;
+
+const visibilityStateEqual = (
+  previous: ReturnType<typeof selectVisibilityState>,
+  next: ReturnType<typeof selectVisibilityState>
+) =>
+  previous[0] === next[0] &&
+  previous[1] === next[1] &&
+  shallow(previous[2], next[2]) &&
+  shallow(previous[3], next[3]);
+
 export const usePitlaneVisibility = (): boolean => {
   const config = usePitlaneHelperSettings();
   const session = useSessionStore((state) => state.session);
-  const trackState = useTrackStateSnapshot();
-  const isOnTrack = trackState?.isOnTrack ?? false;
-  const surface = trackState?.playerTrackSurface ?? 3;
+  const [isOnTrack, surface, carIdxLapDistPct, carIdxOnPitRoad] =
+    useTrackStateSelector(selectVisibilityState, {
+      equality: visibilityStateEqual,
+    }) ?? EMPTY_VISIBILITY_STATE;
   const focusCarIdx = useFocusCarIdx();
-  const carIdxLapDistPct = trackState?.carIdxLapDistPct;
-  const carIdxOnPitRoad = trackState?.carIdxOnPitRoad;
   const trackLength = useTrackLength() ?? 0;
   const pitExitPct = usePitLaneStore((state) => state.pitExitPct);
 

--- a/src/frontend/components/SectorDelta/SectorDelta.tsx
+++ b/src/frontend/components/SectorDelta/SectorDelta.tsx
@@ -1,9 +1,11 @@
 import { useEffect } from 'react';
 import { GhostIcon, WarningIcon } from '@phosphor-icons/react';
-import { useSectorDeltas, useSectorTimingStore } from '@irdashies/context';
 import {
+  trackStateSelectors,
+  useSectorDeltas,
+  useSectorTimingStore,
   useSessionVisibility,
-  useTrackStateSnapshot,
+  useTrackStateSelector,
 } from '@irdashies/context';
 import { useReferenceLapSectorTimes } from '@irdashies/context';
 import type { SectorDeltaConfig } from '@irdashies/types';
@@ -92,7 +94,7 @@ export const SectorDelta = ({
     previousSessionBestSectorTimes,
     currentSectorIdx,
   } = useSectorDeltas();
-  const isOnTrack = useTrackStateSnapshot()?.isOnTrack;
+  const isOnTrack = useTrackStateSelector(trackStateSelectors.isOnTrack);
   const { refSectorTimes, hasReferenceLap } = useReferenceLapSectorTimes();
 
   const useGhost = ghostComparison === 'prefer-ghost' && hasReferenceLap;

--- a/src/frontend/components/SectorDelta/components/SectorProgressIndicator.tsx
+++ b/src/frontend/components/SectorDelta/components/SectorProgressIndicator.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useRef } from 'react';
-import { useTrackStateSnapshot } from '@irdashies/context';
+import { trackStateSelectors, useTrackStateSelector } from '@irdashies/context';
 
 /**
  * Track-progress overlay for the active card. Subscribes to LapDistPct
@@ -21,7 +21,7 @@ export const SectorProgressIndicator = ({
   const fillRef = useRef<HTMLDivElement>(null);
   const topBarRef = useRef<HTMLDivElement>(null);
   const bottomBarRef = useRef<HTMLDivElement>(null);
-  const lapDistPct = useTrackStateSnapshot()?.lapDistPct ?? 0;
+  const lapDistPct = useTrackStateSelector(trackStateSelectors.lapDistPct) ?? 0;
 
   useLayoutEffect(() => {
     const apply = () => {

--- a/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
+++ b/src/frontend/components/SectorDelta/hooks/useCarouselWindow.ts
@@ -1,5 +1,5 @@
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { useTrackStateSnapshot } from '@irdashies/context';
+import { trackStateSelectors, useTrackStateSelector } from '@irdashies/context';
 
 const GAP = 4; // gap-1 = 4px
 
@@ -37,7 +37,7 @@ export function useCarouselWindow(
   alwaysScroll: boolean | null | undefined = false
 ) {
   const effectiveAlwaysScroll = alwaysScroll ?? false;
-  const lapDistPct = useTrackStateSnapshot()?.lapDistPct ?? 0;
+  const lapDistPct = useTrackStateSelector(trackStateSelectors.lapDistPct) ?? 0;
   const isWindowed =
     effectiveAlwaysScroll ||
     (maxSectorsShown != null && totalSectors > maxSectorsShown);

--- a/src/frontend/components/Weather/Weather.tsx
+++ b/src/frontend/components/Weather/Weather.tsx
@@ -1,7 +1,9 @@
 import {
   useDashboard,
-  useSessionBarSnapshot,
-  useTrackStateSnapshot,
+  sessionBarSelectors,
+  trackStateSelectors,
+  useSessionBarSelector,
+  useTrackStateSelector,
   useSessionVisibility,
   useThrottledWeather,
 } from '@irdashies/context';
@@ -30,8 +32,8 @@ type WeatherColumnId =
 export const Weather = () => {
   const { isDemoMode } = useDashboard();
   const settings = useWeatherSettings();
-  const displayUnits = useSessionBarSnapshot()?.displayUnits;
-  const isOnTrack = useTrackStateSnapshot()?.isOnTrack;
+  const displayUnits = useSessionBarSelector(sessionBarSelectors.displayUnits);
+  const isOnTrack = useTrackStateSelector(trackStateSelectors.isOnTrack);
   const isSessionVisible = useSessionVisibility(settings?.sessionVisibility);
 
   // Determine actual unit to use: auto uses iRacing's DisplayUnits setting

--- a/src/frontend/components/Weather/hooks/useTrackTemperature.tsx
+++ b/src/frontend/components/Weather/hooks/useTrackTemperature.tsx
@@ -1,18 +1,28 @@
 import { useMemo } from 'react';
-import { useSessionBarSnapshot } from '@irdashies/context';
+import type { SessionBarSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
+import { useSessionBarSelector } from '@irdashies/context';
 
 interface UseTrackTemperatureOptions {
   airTempUnit?: 'Metric' | 'Imperial';
   trackTempUnit?: 'Metric' | 'Imperial';
 }
 
+const EMPTY_TEMPERATURES: readonly [number | undefined, number | undefined] = [
+  undefined,
+  undefined,
+];
+
+const selectTemperatures = (snapshot: SessionBarSnapshot) =>
+  [snapshot.trackTemp, snapshot.airTemp] as const;
+
 export const useTrackTemperature = (
   options: UseTrackTemperatureOptions = {}
 ) => {
   const { airTempUnit = 'Metric', trackTempUnit = 'Metric' } = options;
-  const snapshot = useSessionBarSnapshot();
-  const trackTempVal = snapshot?.trackTemp;
-  const airTempVal = snapshot?.airTemp;
+  const [trackTempVal, airTempVal] =
+    useSessionBarSelector(selectTemperatures, { equality: shallow }) ??
+    EMPTY_TEMPERATURES;
 
   const trackTemp = useMemo(() => {
     if (trackTempVal === undefined) return '';

--- a/src/frontend/components/Wind/Wind.tsx
+++ b/src/frontend/components/Wind/Wind.tsx
@@ -2,8 +2,10 @@ import { memo } from 'react';
 import {
   useDashboard,
   useSessionVisibility,
-  useSessionBarSnapshot,
-  useTrackStateSnapshot,
+  sessionBarSelectors,
+  trackStateSelectors,
+  useSessionBarSelector,
+  useTrackStateSelector,
   useThrottledWeather,
 } from '@irdashies/context';
 import { useWindSettings } from './hooks/useWindSettings';
@@ -13,8 +15,8 @@ import { useWindDemoData } from '../../domain/weather/useWindDemoData';
 export const Wind = memo(() => {
   const { isDemoMode } = useDashboard();
   const settings = useWindSettings();
-  const displayUnits = useSessionBarSnapshot()?.displayUnits;
-  const isOnTrack = useTrackStateSnapshot()?.isOnTrack;
+  const displayUnits = useSessionBarSelector(sessionBarSelectors.displayUnits);
+  const isOnTrack = useTrackStateSelector(trackStateSelectors.isOnTrack);
   const isSessionVisible = useSessionVisibility(settings?.sessionVisibility);
 
   const unitSetting = settings?.units ?? 'auto';

--- a/src/frontend/context/BattleGapStore/BattleGapStoreUpdater.tsx
+++ b/src/frontend/context/BattleGapStore/BattleGapStoreUpdater.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef } from 'react';
+import { shallow } from 'zustand/shallow';
 import { useBattleGapStore } from './BattleGapStore';
 import { useFocusCarIdx } from '../shared/useFocusCarIdx';
-import { useStandingsSnapshot } from '../ChannelStore';
+import { standingsSelectors, useStandingsSelector } from '../ChannelStore';
 
 interface BattleGapStoreUpdaterProps {
   /** Live gap to the car immediately ahead of the player (negative = ahead) */
@@ -19,7 +20,9 @@ export const useBattleGapStoreUpdater = ({
   liveGapBehind,
 }: BattleGapStoreUpdaterProps) => {
   const focusCarIdx = useFocusCarIdx();
-  const carIdxLap = useStandingsSnapshot()?.carIdxLap;
+  const carIdxLap = useStandingsSelector(standingsSelectors.carIdxLap, {
+    equality: shallow,
+  });
   const snapshot = useBattleGapStore((s) => s.snapshot);
   const reset = useBattleGapStore((s) => s.reset);
 

--- a/src/frontend/context/CarSpeedStore/TopSpeedStoreUpdater.tsx
+++ b/src/frontend/context/CarSpeedStore/TopSpeedStoreUpdater.tsx
@@ -1,6 +1,18 @@
 import { useEffect } from 'react';
-import { useSessionBarSnapshot } from '../ChannelStore';
+import type { SessionBarSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
+import { useSessionBarSelector } from '../ChannelStore';
 import { useTopSpeedStore } from './TopSpeedStore';
+
+const EMPTY_TOP_SPEEDS: readonly [number | null, number | null, number | null] =
+  [null, null, null];
+
+const selectTopSpeeds = (snapshot: SessionBarSnapshot) =>
+  [
+    snapshot.lastLapTopSpeed,
+    snapshot.sessionBestTopSpeed,
+    snapshot.sessionNum,
+  ] as const;
 
 /**
  * Hook that feeds live Speed + Lap telemetry into the TopSpeedStore.
@@ -8,11 +20,12 @@ import { useTopSpeedStore } from './TopSpeedStore';
  * Multiple callers are safe — updates are idempotent.
  */
 export const useTopSpeedStoreUpdater = (enabled: boolean) => {
-  const snapshot = useSessionBarSnapshot();
-  const hasSnapshot = snapshot !== undefined;
-  const lastLapTopSpeed = snapshot?.lastLapTopSpeed ?? null;
-  const sessionBestTopSpeed = snapshot?.sessionBestTopSpeed ?? null;
-  const sessionNum = snapshot?.sessionNum ?? null;
+  const selected = useSessionBarSelector(selectTopSpeeds, {
+    equality: shallow,
+  });
+  const hasSnapshot = selected !== undefined;
+  const [lastLapTopSpeed, sessionBestTopSpeed, sessionNum] =
+    selected ?? EMPTY_TOP_SPEEDS;
 
   useEffect(() => {
     if (!enabled || !hasSnapshot) return;

--- a/src/frontend/context/ChannelStore/channelSelectors.spec.tsx
+++ b/src/frontend/context/ChannelStore/channelSelectors.spec.tsx
@@ -1,0 +1,145 @@
+import { act, renderHook } from '@testing-library/react';
+import { shallow } from 'zustand/shallow';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ChannelBridge,
+  ChannelName,
+  ChannelPayloads,
+  SessionBarSnapshot,
+  StandingsSnapshot,
+  TrackStateSnapshot,
+} from '@irdashies/types';
+import {
+  sessionBarSelectors,
+  useSessionBarSelector,
+} from './useSessionBarSnapshot';
+import {
+  standingsSelectors,
+  useStandingsSelector,
+} from './useStandingsSnapshot';
+import {
+  trackStateSelectors,
+  useTrackStateSelector,
+} from './useTrackStateSnapshot';
+
+const createBridge = <K extends ChannelName>() => {
+  let publish: ((payload: ChannelPayloads[K]) => void) | undefined;
+  const subscribe = vi.fn(
+    (_channel: K, callback: (payload: ChannelPayloads[K]) => void) => {
+      publish = callback;
+      return vi.fn();
+    }
+  );
+
+  return {
+    bridge: { subscribe } as unknown as ChannelBridge,
+    publish: (snapshot: ChannelPayloads[K]) => publish?.(snapshot),
+  };
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('channel-specific selectors', () => {
+  it('does not rerender a track-state consumer for unrelated fields', () => {
+    let now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const source = createBridge<'track-state.snapshot'>();
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useTrackStateSelector(trackStateSelectors.isOnTrack, {
+        bridge: source.bridge,
+      });
+    });
+
+    act(() =>
+      source.publish({
+        isOnTrack: true,
+        sessionTime: 1,
+        version: 1,
+      } as TrackStateSnapshot)
+    );
+    expect(result.current).toBe(true);
+    const rendersAfterInitialSnapshot = renders;
+
+    now = 40;
+    act(() =>
+      source.publish({
+        isOnTrack: true,
+        sessionTime: 2,
+        version: 2,
+      } as TrackStateSnapshot)
+    );
+
+    expect(renders).toBe(rendersAfterInitialSnapshot);
+  });
+
+  it('does not rerender a session-bar consumer for unrelated fields', () => {
+    let now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const source = createBridge<'session-bar.snapshot'>();
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useSessionBarSelector(sessionBarSelectors.displayUnits, {
+        bridge: source.bridge,
+      });
+    });
+
+    act(() =>
+      source.publish({
+        displayUnits: 1,
+        trackTemp: 25,
+        version: 1,
+      } as SessionBarSnapshot)
+    );
+    expect(result.current).toBe(1);
+    const rendersAfterInitialSnapshot = renders;
+
+    now = 200;
+    act(() =>
+      source.publish({
+        displayUnits: 1,
+        trackTemp: 26,
+        version: 2,
+      } as SessionBarSnapshot)
+    );
+
+    expect(renders).toBe(rendersAfterInitialSnapshot);
+  });
+
+  it('uses custom equality for selected standings arrays', () => {
+    let now = 0;
+    vi.spyOn(performance, 'now').mockImplementation(() => now);
+    const source = createBridge<'standings.snapshot'>();
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useStandingsSelector(standingsSelectors.carIdxLap, {
+        bridge: source.bridge,
+        equality: shallow,
+      });
+    });
+
+    act(() =>
+      source.publish({
+        carIdxLap: [3, 4],
+        sessionTime: 1,
+        version: 1,
+      } as StandingsSnapshot)
+    );
+    expect(result.current).toEqual([3, 4]);
+    const rendersAfterInitialSnapshot = renders;
+
+    now = 200;
+    act(() =>
+      source.publish({
+        carIdxLap: [3, 4],
+        sessionTime: 2,
+        version: 2,
+      } as StandingsSnapshot)
+    );
+
+    expect(renders).toBe(rendersAfterInitialSnapshot);
+  });
+});

--- a/src/frontend/context/ChannelStore/useSessionBarSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useSessionBarSnapshot.ts
@@ -1,3 +1,21 @@
-import { useChannelSnapshot } from './useChannelSnapshot';
+import type { SessionBarSnapshot } from '@irdashies/types';
+import {
+  useChannelSelector,
+  useChannelSnapshot,
+  type ChannelSelectorOptions,
+} from './useChannelSnapshot';
+
+export const sessionBarSelectors = {
+  airTemp: (snapshot: SessionBarSnapshot) => snapshot.airTemp,
+  displayUnits: (snapshot: SessionBarSnapshot) => snapshot.displayUnits,
+  sessionNum: (snapshot: SessionBarSnapshot) => snapshot.sessionNum,
+  trackTemp: (snapshot: SessionBarSnapshot) => snapshot.trackTemp,
+} as const;
+
+export const useSessionBarSelector = <Selected>(
+  selector: (snapshot: SessionBarSnapshot) => Selected,
+  options: ChannelSelectorOptions<Selected> = {}
+) => useChannelSelector('session-bar.snapshot', selector, options);
+
 export const useSessionBarSnapshot = () =>
   useChannelSnapshot('session-bar.snapshot');

--- a/src/frontend/context/ChannelStore/useStandingsSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useStandingsSnapshot.ts
@@ -1,4 +1,18 @@
-import { useChannelSnapshot } from './useChannelSnapshot';
+import type { StandingsSnapshot } from '@irdashies/types';
+import {
+  useChannelSelector,
+  useChannelSnapshot,
+  type ChannelSelectorOptions,
+} from './useChannelSnapshot';
+
+export const standingsSelectors = {
+  carIdxLap: (snapshot: StandingsSnapshot) => snapshot.carIdxLap,
+} as const;
+
+export const useStandingsSelector = <Selected>(
+  selector: (snapshot: StandingsSnapshot) => Selected,
+  options: ChannelSelectorOptions<Selected> = {}
+) => useChannelSelector('standings.snapshot', selector, options);
 
 export const useStandingsSnapshot = (enabled = true) =>
   useChannelSnapshot('standings.snapshot', undefined, undefined, enabled);

--- a/src/frontend/context/ChannelStore/useTrackStateSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useTrackStateSnapshot.ts
@@ -1,7 +1,28 @@
-import type { ChannelBridge } from '@irdashies/types';
-import { useChannelSnapshot } from './useChannelSnapshot';
+import type { ChannelBridge, TrackStateSnapshot } from '@irdashies/types';
+import {
+  useChannelSelector,
+  useChannelSnapshot,
+  type ChannelSelectorOptions,
+} from './useChannelSnapshot';
 
-export const useTrackStateSnapshot = (
-  enabled = true,
-  bridge?: ChannelBridge
-) => useChannelSnapshot('track-state.snapshot', undefined, bridge, enabled);
+export const trackStateSelectors = {
+  carIdxLapDistPct: (snapshot: TrackStateSnapshot) => snapshot.carIdxLapDistPct,
+  carIdxOnPitRoad: (snapshot: TrackStateSnapshot) => snapshot.carIdxOnPitRoad,
+  carIdxTrackSurface: (snapshot: TrackStateSnapshot) =>
+    snapshot.carIdxTrackSurface,
+  displayUnits: (snapshot: TrackStateSnapshot) => snapshot.displayUnits,
+  focusCarIdx: (snapshot: TrackStateSnapshot) => snapshot.focusCarIdx,
+  isOnTrack: (snapshot: TrackStateSnapshot) => snapshot.isOnTrack,
+  lapDistPct: (snapshot: TrackStateSnapshot) => snapshot.lapDistPct,
+  sessionFlags: (snapshot: TrackStateSnapshot) => snapshot.sessionFlags,
+  sessionNum: (snapshot: TrackStateSnapshot) => snapshot.sessionNum,
+  speed: (snapshot: TrackStateSnapshot) => snapshot.speed,
+} as const;
+
+export const useTrackStateSelector = <Selected>(
+  selector: (snapshot: TrackStateSnapshot) => Selected,
+  options: ChannelSelectorOptions<Selected> = {}
+) => useChannelSelector('track-state.snapshot', selector, options);
+
+export const useTrackStateSnapshot = (enabled = true, bridge?: ChannelBridge) =>
+  useChannelSnapshot('track-state.snapshot', undefined, bridge, enabled);

--- a/src/frontend/context/PitLaneStore/usePitLaneDetection.tsx
+++ b/src/frontend/context/PitLaneStore/usePitLaneDetection.tsx
@@ -1,8 +1,31 @@
 import { useEffect, useRef } from 'react';
+import type { TrackStateSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
 import { usePitLaneStore, detectPitTransitions } from './PitLaneStore';
-import { useTrackStateSnapshot } from '../ChannelStore';
+import { useTrackStateSelector } from '../ChannelStore';
 import { useSessionStore } from '../SessionStore/SessionStore';
 import type { PitLaneBridge } from '@irdashies/types';
+
+const EMPTY_PIT_LANE_TELEMETRY: readonly [
+  readonly boolean[],
+  readonly number[],
+  readonly number[],
+] = [[], [], []];
+
+const selectPitLaneTelemetry = (snapshot: TrackStateSnapshot) =>
+  [
+    snapshot.carIdxOnPitRoad,
+    snapshot.carIdxTrackSurface,
+    snapshot.carIdxLapDistPct,
+  ] as const;
+
+const pitLaneTelemetryEqual = (
+  previous: ReturnType<typeof selectPitLaneTelemetry>,
+  next: ReturnType<typeof selectPitLaneTelemetry>
+) =>
+  shallow(previous[0], next[0]) &&
+  shallow(previous[1], next[1]) &&
+  shallow(previous[2], next[2]);
 
 /**
  * Hook that monitors telemetry and detects pit entry/exit positions.
@@ -14,10 +37,10 @@ export const usePitLaneDetection = (
   const trackId = useSessionStore(
     (state) => state.session?.WeekendInfo?.TrackID?.toString() ?? null
   );
-  const trackState = useTrackStateSnapshot();
-  const carIdxOnPitRoad = trackState?.carIdxOnPitRoad;
-  const carIdxTrackSurface = trackState?.carIdxTrackSurface;
-  const carIdxLapDistPct = trackState?.carIdxLapDistPct;
+  const [carIdxOnPitRoad, carIdxTrackSurface, carIdxLapDistPct] =
+    useTrackStateSelector(selectPitLaneTelemetry, {
+      equality: pitLaneTelemetryEqual,
+    }) ?? EMPTY_PIT_LANE_TELEMETRY;
 
   const { currentTrackId, pitEntryPct, pitExitPct, setCurrentTrack, reset } =
     usePitLaneStore();
@@ -69,9 +92,9 @@ export const usePitLaneDetection = (
   // Detect pit entry/exit transitions
   useEffect(() => {
     if (
-      !carIdxOnPitRoad ||
-      !carIdxTrackSurface ||
-      !carIdxLapDistPct ||
+      carIdxOnPitRoad.length === 0 ||
+      carIdxTrackSurface.length === 0 ||
+      carIdxLapDistPct.length === 0 ||
       !trackId
     ) {
       return;

--- a/src/frontend/context/PitLapStore/PitLapStoreUpdater.tsx
+++ b/src/frontend/context/PitLapStore/PitLapStoreUpdater.tsx
@@ -1,20 +1,39 @@
 import { useEffect } from 'react';
-import { useStandingsSnapshot } from '../ChannelStore';
+import type { StandingsSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
+import { useStandingsSelector } from '../ChannelStore';
 import { usePitLapStore } from './PitLapStore';
 
+const selectPitLapTelemetry = (snapshot: StandingsSnapshot) =>
+  [
+    snapshot.carIdxOnPitRoad,
+    snapshot.carIdxLap,
+    snapshot.sessionUniqueId,
+    Math.floor(snapshot.sessionTime),
+    snapshot.carIdxTrackSurface,
+    snapshot.sessionState,
+  ] as const;
+
+const pitLapTelemetryEqual = (
+  previous: ReturnType<typeof selectPitLapTelemetry>,
+  next: ReturnType<typeof selectPitLapTelemetry>
+) =>
+  shallow(previous[0], next[0]) &&
+  shallow(previous[1], next[1]) &&
+  previous[2] === next[2] &&
+  previous[3] === next[3] &&
+  shallow(previous[4], next[4]) &&
+  previous[5] === next[5];
+
 export const usePitLapStoreUpdater = (enabled: boolean) => {
-  const snapshot = useStandingsSnapshot(enabled);
+  const telemetry = useStandingsSelector(selectPitLapTelemetry, {
+    enabled,
+    equality: pitLapTelemetryEqual,
+  });
   const updatePitLapTimes = usePitLapStore((state) => state.updatePitLaps);
 
   useEffect(() => {
-    if (!enabled || !snapshot) return;
-    updatePitLapTimes(
-      snapshot.carIdxOnPitRoad,
-      snapshot.carIdxLap,
-      snapshot.sessionUniqueId,
-      Math.floor(snapshot.sessionTime),
-      snapshot.carIdxTrackSurface,
-      snapshot.sessionState
-    );
-  }, [enabled, snapshot, updatePitLapTimes]);
+    if (!enabled || !telemetry) return;
+    updatePitLapTimes(...telemetry);
+  }, [enabled, telemetry, updatePitLapTimes]);
 };

--- a/src/frontend/context/PushToPassStore/PushToPassStoreUpdater.tsx
+++ b/src/frontend/context/PushToPassStore/PushToPassStoreUpdater.tsx
@@ -1,10 +1,32 @@
 import { useEffect, useMemo } from 'react';
+import type { StandingsSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
 import { useDriverCarIdx, useSessionStore } from '../SessionStore/SessionStore';
-import { useStandingsSnapshot } from '../ChannelStore';
+import { useStandingsSelector } from '../ChannelStore';
 import { usePushToPassStore } from './PushToPassStore';
 
+const selectPushToPassTelemetry = (snapshot: StandingsSnapshot) =>
+  [
+    snapshot.carIdxP2PStatus,
+    snapshot.carIdxP2PCount,
+    Math.floor(snapshot.sessionTime),
+    snapshot.sessionUniqueId,
+  ] as const;
+
+const pushToPassTelemetryEqual = (
+  previous: ReturnType<typeof selectPushToPassTelemetry>,
+  next: ReturnType<typeof selectPushToPassTelemetry>
+) =>
+  shallow(previous[0], next[0]) &&
+  shallow(previous[1], next[1]) &&
+  previous[2] === next[2] &&
+  previous[3] === next[3];
+
 export const usePushToPassStoreUpdater = (enabled: boolean) => {
-  const snapshot = useStandingsSnapshot(enabled);
+  const telemetry = useStandingsSelector(selectPushToPassTelemetry, {
+    enabled,
+    equality: pushToPassTelemetryEqual,
+  });
   const sessionDrivers = useSessionStore((s) => s.session?.DriverInfo?.Drivers);
   const playerCarIdx = useDriverCarIdx();
   const update = usePushToPassStore((s) => s.update);
@@ -16,14 +38,14 @@ export const usePushToPassStoreUpdater = (enabled: boolean) => {
   }, [sessionDrivers]);
 
   useEffect(() => {
-    if (!enabled || !snapshot) return;
+    if (!enabled || !telemetry) return;
     update(
-      snapshot.carIdxP2PStatus,
-      snapshot.carIdxP2PCount,
+      telemetry[0],
+      telemetry[1],
       carIdxToCarId,
-      Math.floor(snapshot.sessionTime),
-      snapshot.sessionUniqueId,
+      telemetry[2],
+      telemetry[3],
       playerCarIdx
     );
-  }, [enabled, snapshot, carIdxToCarId, playerCarIdx, update]);
+  }, [enabled, telemetry, carIdxToCarId, playerCarIdx, update]);
 };

--- a/src/frontend/context/TrackTemperatureStore/TrackTemperatureStoreUpdater.spec.tsx
+++ b/src/frontend/context/TrackTemperatureStore/TrackTemperatureStoreUpdater.spec.tsx
@@ -2,10 +2,10 @@ import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useTrackTemperatureStoreUpdater } from './TrackTemperatureStoreUpdater';
 import { useTrackTemperatureStore } from './TrackTemperatureStore';
-import { useSessionBarSnapshot } from '../ChannelStore';
+import { useSessionBarSelector } from '../ChannelStore';
 
 vi.mock('../ChannelStore', () => {
-  return { useSessionBarSnapshot: vi.fn() };
+  return { useSessionBarSelector: vi.fn() };
 });
 
 describe('useTrackTemperatureStoreUpdater', () => {
@@ -14,10 +14,7 @@ describe('useTrackTemperatureStoreUpdater', () => {
       trackTempC: undefined,
       airTempC: undefined,
     });
-    vi.mocked(useSessionBarSnapshot).mockReturnValue({
-      trackTemp: 28,
-      airTemp: 22,
-    } as ReturnType<typeof useSessionBarSnapshot>);
+    vi.mocked(useSessionBarSelector).mockReturnValue([28, 22]);
   });
 
   it('writes raw Celsius values into the store when enabled', () => {

--- a/src/frontend/context/TrackTemperatureStore/TrackTemperatureStoreUpdater.tsx
+++ b/src/frontend/context/TrackTemperatureStore/TrackTemperatureStoreUpdater.tsx
@@ -1,15 +1,27 @@
 import { useEffect } from 'react';
-import { useSessionBarSnapshot } from '../ChannelStore';
+import type { SessionBarSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
+import { useSessionBarSelector } from '../ChannelStore';
 import { useTrackTemperatureStore } from './TrackTemperatureStore';
 
+const EMPTY_TEMPERATURES: readonly [number | undefined, number | undefined] = [
+  undefined,
+  undefined,
+];
+
+const selectTemperatures = (snapshot: SessionBarSnapshot) =>
+  [snapshot.trackTemp, snapshot.airTemp] as const;
+
 export const useTrackTemperatureStoreUpdater = (enabled: boolean) => {
-  const snapshot = useSessionBarSnapshot();
+  const [trackTemp, airTemp] =
+    useSessionBarSelector(selectTemperatures, { equality: shallow }) ??
+    EMPTY_TEMPERATURES;
   const update = useTrackTemperatureStore((s) => s.update);
 
   useEffect(() => {
     if (!enabled) return;
-    update(snapshot?.trackTemp, snapshot?.airTemp);
-  }, [enabled, snapshot?.trackTemp, snapshot?.airTemp, update]);
+    update(trackTemp, airTemp);
+  }, [enabled, trackTemp, airTemp, update]);
 };
 
 /**

--- a/src/frontend/context/shared/useCarIdxOffTrack.tsx
+++ b/src/frontend/context/shared/useCarIdxOffTrack.tsx
@@ -1,10 +1,13 @@
 import { useMemo } from 'react';
-import { useTrackStateSnapshot } from '../ChannelStore';
+import { shallow } from 'zustand/shallow';
+import { trackStateSelectors, useTrackStateSelector } from '../ChannelStore';
 
 const EMPTY_TRACK_SURFACES: readonly number[] = [];
 export const useCarIdxOffTrack = (): boolean[] => {
   const trackSurface =
-    useTrackStateSnapshot()?.carIdxTrackSurface ?? EMPTY_TRACK_SURFACES;
+    useTrackStateSelector(trackStateSelectors.carIdxTrackSurface, {
+      equality: shallow,
+    }) ?? EMPTY_TRACK_SURFACES;
   return useMemo(
     () => trackSurface.map((surface) => surface === 0),
     [trackSurface]

--- a/src/frontend/context/shared/useCurrentSessionType.spec.tsx
+++ b/src/frontend/context/shared/useCurrentSessionType.spec.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useCurrentSessionType } from './useCurrentSessionType';
 import { useSessionType } from '@irdashies/context';
-import { useTrackStateSnapshot } from '../ChannelStore';
+import { useTrackStateSelector } from '../ChannelStore';
 
 // Mock the context hooks
 vi.mock('@irdashies/context', () => ({
@@ -10,7 +10,8 @@ vi.mock('@irdashies/context', () => ({
 }));
 
 vi.mock('../ChannelStore', () => ({
-  useTrackStateSnapshot: vi.fn(),
+  trackStateSelectors: { sessionNum: vi.fn() },
+  useTrackStateSelector: vi.fn(),
 }));
 
 describe('useCurrentSession', () => {
@@ -19,28 +20,26 @@ describe('useCurrentSession', () => {
   });
 
   it('should return the session type when session number is available', () => {
-    vi.mocked(useTrackStateSnapshot).mockReturnValue({
-      sessionNum: 1,
-    } as never);
+    vi.mocked(useTrackStateSelector).mockReturnValue(1);
     // Mock the session type
     vi.mocked(useSessionType).mockReturnValue('Race');
 
     const { result } = renderHook(() => useCurrentSessionType());
 
     expect(result.current).toBe('Race');
-    expect(useTrackStateSnapshot).toHaveBeenCalledOnce();
+    expect(useTrackStateSelector).toHaveBeenCalledOnce();
     expect(useSessionType).toHaveBeenCalledWith(1);
   });
 
   it('should return undefined when session number is not available', () => {
-    vi.mocked(useTrackStateSnapshot).mockReturnValue(undefined);
+    vi.mocked(useTrackStateSelector).mockReturnValue(undefined);
     // Mock the session type
     vi.mocked(useSessionType).mockReturnValue(undefined);
 
     const { result } = renderHook(() => useCurrentSessionType());
 
     expect(result.current).toBeUndefined();
-    expect(useTrackStateSnapshot).toHaveBeenCalledOnce();
+    expect(useTrackStateSelector).toHaveBeenCalledOnce();
     expect(useSessionType).toHaveBeenCalledWith(undefined);
   });
 });

--- a/src/frontend/context/shared/useCurrentSessionType.tsx
+++ b/src/frontend/context/shared/useCurrentSessionType.tsx
@@ -1,13 +1,15 @@
 import { useSessionType } from '@irdashies/context';
-import { useTrackStateSnapshot } from '../ChannelStore';
+import { trackStateSelectors, useTrackStateSelector } from '../ChannelStore';
 
-type SessionType = 'Race' | 'Lone Qualify' | 'Open Qualify' | 'Practice' | 'Offline Testing';
+type SessionType =
+  'Race' | 'Lone Qualify' | 'Open Qualify' | 'Practice' | 'Offline Testing';
 
 /**
  * @returns The current session type. Undefined if sessionNum is unknown.
  */
 export const useCurrentSessionType = (): SessionType | undefined => {
-  const sessionNum = useTrackStateSnapshot()?.sessionNum ?? undefined;
+  const sessionNum =
+    useTrackStateSelector(trackStateSelectors.sessionNum) ?? undefined;
   const sessionType = useSessionType(sessionNum);
 
   return sessionType as SessionType | undefined;

--- a/src/frontend/context/shared/useDrivingState.spec.ts
+++ b/src/frontend/context/shared/useDrivingState.spec.ts
@@ -9,15 +9,17 @@ vi.mock('../TelemetryStore/TelemetryStore', () => ({
 }));
 
 vi.mock('../ChannelStore', () => ({
-  useTrackStateSnapshot: vi.fn(() => ({
-    isOnTrack: useTelemetryValue('IsOnTrack'),
-    playerCarInPitStall: useTelemetryValue('PlayerCarInPitStall'),
-    focusCarIdx: 0,
-    carIdxOnPitRoad: [useTelemetryValue('CarIdxOnPitRoad')],
-    isInGarage: useTelemetryValue('IsInGarage'),
-    isGarageVisible: useTelemetryValue('IsGarageVisible'),
-    isReplayPlaying: useTelemetryValue('IsReplayPlaying'),
-  })),
+  useTrackStateSelector: vi.fn((selector) =>
+    selector({
+      isOnTrack: useTelemetryValue('IsOnTrack'),
+      playerCarInPitStall: useTelemetryValue('PlayerCarInPitStall'),
+      focusCarIdx: 0,
+      carIdxOnPitRoad: [useTelemetryValue('CarIdxOnPitRoad')],
+      isInGarage: useTelemetryValue('IsInGarage'),
+      isGarageVisible: useTelemetryValue('IsGarageVisible'),
+      isReplayPlaying: useTelemetryValue('IsReplayPlaying'),
+    })
+  ),
 }));
 
 describe('useDrivingState', () => {

--- a/src/frontend/context/shared/useDrivingState.ts
+++ b/src/frontend/context/shared/useDrivingState.ts
@@ -1,18 +1,19 @@
-import { useTrackStateSnapshot } from '../ChannelStore';
+import type { TrackStateSnapshot } from '@irdashies/types';
+import { useTrackStateSelector } from '../ChannelStore';
+
+const selectIsDriving = (snapshot: TrackStateSnapshot): boolean => {
+  const focusCarIdx = snapshot.focusCarIdx ?? -1;
+  const onPitRoad = snapshot.carIdxOnPitRoad[focusCarIdx] ?? false;
+  const isInGarage = snapshot.isInGarage || snapshot.isGarageVisible;
+  return (
+    (snapshot.isOnTrack || snapshot.playerCarInPitStall || onPitRoad) &&
+    !isInGarage &&
+    !snapshot.isReplayPlaying
+  );
+};
 
 export const useDrivingState = () => {
-  const snapshot = useTrackStateSnapshot();
-  const isOnTrack = snapshot?.isOnTrack ?? false;
-  const inPitStall = snapshot?.playerCarInPitStall ?? false;
-  const focusCarIdx = snapshot?.focusCarIdx ?? -1;
-  const onPitRoad = snapshot?.carIdxOnPitRoad[focusCarIdx] ?? false;
-  const isInGarageDirect = snapshot?.isInGarage ?? false;
-  const isGarageVisible = snapshot?.isGarageVisible ?? false;
-  const isInGarage = isInGarageDirect || isGarageVisible;
-  const isReplayPlaying = snapshot?.isReplayPlaying ?? false;
-
-  const isDriving =
-    (isOnTrack || inPitStall || onPitRoad) && !isInGarage && !isReplayPlaying;
+  const isDriving = useTrackStateSelector(selectIsDriving) ?? false;
 
   return {
     isDriving,

--- a/src/frontend/context/shared/useFocusCarIdx.ts
+++ b/src/frontend/context/shared/useFocusCarIdx.ts
@@ -1,5 +1,5 @@
 import { useDriverCarIdx } from '../SessionStore/SessionStore';
-import { useTrackStateSnapshot } from '../ChannelStore';
+import { trackStateSelectors, useTrackStateSelector } from '../ChannelStore';
 
 /**
  * Hook to get the car index that should be the "focus" for relative displays.
@@ -17,7 +17,7 @@ import { useTrackStateSnapshot } from '../ChannelStore';
  */
 export const useFocusCarIdx = (): number | undefined => {
   const driverCarIdx = useDriverCarIdx();
-  const camCarIdx = useTrackStateSnapshot()?.focusCarIdx;
+  const camCarIdx = useTrackStateSelector(trackStateSelectors.focusCarIdx);
 
   // If we have a valid camera target, always use that
   // This works in all scenarios: racing, spectating, replays, spotting

--- a/src/frontend/context/shared/useThrottledWeather.tsx
+++ b/src/frontend/context/shared/useThrottledWeather.tsx
@@ -1,4 +1,6 @@
-import { useSessionBarSnapshot } from '../ChannelStore';
+import type { SessionBarSnapshot } from '@irdashies/types';
+import { shallow } from 'zustand/shallow';
+import { useSessionBarSelector } from '../ChannelStore';
 
 export interface WeatherData {
   trackMoisture: number | undefined;
@@ -8,6 +10,25 @@ export interface WeatherData {
   humidity: number | undefined;
   precipitation: number | undefined;
 }
+
+const EMPTY_WEATHER: readonly [
+  number | undefined,
+  number | undefined,
+  number | undefined,
+  number | undefined,
+  number | undefined,
+  number | undefined,
+] = [undefined, undefined, undefined, undefined, undefined, undefined];
+
+const selectWeather = (snapshot: SessionBarSnapshot) =>
+  [
+    snapshot.trackWetness,
+    snapshot.windYaw,
+    snapshot.windDirection,
+    snapshot.windVelocity,
+    snapshot.relativeHumidity,
+    snapshot.precipitation,
+  ] as const;
 
 /**
  * Subscribes to weather telemetry data but only updates React state
@@ -19,14 +40,16 @@ export interface WeatherData {
  * reflects the player's own car heading.
  */
 export const useThrottledWeather = (): WeatherData => {
-  const data = useSessionBarSnapshot();
+  const data =
+    useSessionBarSelector(selectWeather, { equality: shallow }) ??
+    EMPTY_WEATHER;
 
   return {
-    trackMoisture: data?.trackWetness,
-    windYaw: data?.windYaw,
-    windDirection: data?.windDirection,
-    windVelocity: data?.windVelocity,
-    humidity: data?.relativeHumidity,
-    precipitation: data?.precipitation,
+    trackMoisture: data[0],
+    windYaw: data[1],
+    windDirection: data[2],
+    windVelocity: data[3],
+    humidity: data[4],
+    precipitation: data[5],
   };
 };


### PR DESCRIPTION
## Description

Adopts the shared channel selector API across the broadest Track State, Session Bar, and Standings consumers without changing channel payloads or visual behavior.

- adds stable field and tuple selectors with custom array equality
- migrates pit, warning, track, weather, driving-state, standings, and store-updater consumers away from whole-snapshot subscriptions
- adds channel-specific render regressions proving unrelated field changes do not rerender consumers
- reduces broad snapshot consumers from 67 to 37 (estimated 45% fanout reduction)
  - Track State: 31 → 10
  - Session Bar: 29 → 23
  - Standings: 7 → 4

This PR is stacked on the shared selector store in PR #676.

Validation:

- `npm run lint -- --quiet`
- Full Vitest suite before final base rebase: 1,243 passed, 1 skipped
- Post-rebase focused affected-consumer suite: 75 passed
- `git diff --check`

No live iRacing session or React DevTools profile was captured yet; packaged profiling remains the integration evidence gate.

## Screenshots

### Before

Not applicable — subscription granularity change only.

### After

Not applicable — no visual changes.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

### Architecture pre-PR checklist

- [x] N2/N3 — layering and widget boundaries preserved
- [x] R4.4 — consumers remain on typed named channels
- [x] R7.1/R7.2 — widgets use narrow selectors and primitive/tuple state
- [x] R13.2 — fanout reduction has deterministic render coverage
- [x] R14.2 — selector behavior is covered by component/hook tests
- [x] Relevant phase: Phase 4.1 selector adoption
