### PR TITLE
fix: stabilize Phase 4 performance evidence

### DIFF
--- a/src/app/bridge/channelBridge.spec.ts
+++ b/src/app/bridge/channelBridge.spec.ts
@@ -179,6 +179,29 @@ describe('ChannelBus', () => {
     });
   });
 
+  it('does not seed a reactivated renderer when delivery is disabled', () => {
+    const first = createTarget(1);
+    const second = createTarget(2);
+    const bus = new ChannelBus({ registry, deliveryEnabled: false });
+    bus.subscribe(first, 'snapshot');
+    bus.subscribe(second, 'snapshot');
+
+    second.visible = false;
+    bus.rendererBecameHidden(second.id);
+    bus.publish('snapshot', { value: 1 });
+
+    second.visible = true;
+    bus.rendererBecameVisible(second.id);
+
+    expect(bus.subscriberCount('snapshot')).toBe(2);
+    expect(first.send).not.toHaveBeenCalled();
+    expect(second.send).not.toHaveBeenCalled();
+    expect(bus.metricsSnapshot()).toMatchObject({
+      channelPublications: { snapshot: 1 },
+      channelDeliveries: {},
+    });
+  });
+
   it('reschedules a pending snapshot when the requested rate changes', () => {
     const { bus, clock } = createBus();
     const target = createTarget();

--- a/src/app/bridge/channelBridge.ts
+++ b/src/app/bridge/channelBridge.ts
@@ -201,7 +201,11 @@ export class ChannelBus {
       if (subscription.lastDeliveredAt !== undefined) continue;
 
       const definition = this.definition(channel);
-      if (definition.kind === 'snapshot' && this.latestSnapshots.has(channel)) {
+      if (
+        this.deliveryEnabled &&
+        definition.kind === 'snapshot' &&
+        this.latestSnapshots.has(channel)
+      ) {
         this.deliver(channel, subscription, this.latestSnapshots.get(channel));
       }
     }

--- a/src/app/perfRunConfig.spec.ts
+++ b/src/app/perfRunConfig.spec.ts
@@ -4,6 +4,7 @@ import {
   activePerfWidgetTypes,
   createPerfDashboard,
   getPerfRunConfig,
+  parsePerfVisibilityPhases,
 } from './perfRunConfig';
 
 const dashboard: DashboardLayout = {
@@ -72,6 +73,17 @@ describe('performance run configuration', () => {
 
     expect(result.widgets.every((widget) => !widget.enabled)).toBe(true);
     expect(dashboard.widgets.every((widget) => widget.enabled)).toBe(true);
+  });
+
+  it('rejects visibility phases outside the shared duration bounds', () => {
+    expect(
+      parsePerfVisibilityPhases(
+        'visible:9,visible:10,hidden:86400,hidden:86401'
+      )
+    ).toEqual([
+      { visibility: 'visible', durationSeconds: 10 },
+      { visibility: 'hidden', durationSeconds: 86_400 },
+    ]);
   });
 
   it('isolates selected widget types', () => {

--- a/src/app/perfRunConfig.ts
+++ b/src/app/perfRunConfig.ts
@@ -30,6 +30,21 @@ const PERF_OVERLAY_MODES = new Set<PerfOverlayMode>([
   'observer',
 ]);
 
+export const parsePerfVisibilityPhases = (
+  value: string
+): PerfVisibilityPhase[] =>
+  value
+    .split(',')
+    .map((entry) => entry.trim().match(/^(visible|hidden):(\d+)$/))
+    .filter((match): match is RegExpMatchArray => match !== null)
+    .map((match) => ({
+      visibility: match[1] as PerfVisibilityPhase['visibility'],
+      durationSeconds: Number(match[2]),
+    }))
+    .filter(
+      (phase) => phase.durationSeconds >= 10 && phase.durationSeconds <= 86_400
+    );
+
 export function getPerfRunConfig(
   env: NodeJS.ProcessEnv = process.env
 ): PerfRunConfig {
@@ -49,17 +64,9 @@ export function getPerfRunConfig(
     requestedDuration <= 86_400
       ? requestedDuration
       : 0;
-  const visibilityPhases = (env.PERF_VISIBILITY_PHASES ?? '')
-    .split(',')
-    .map((entry) => entry.trim().match(/^(visible|hidden):(\d+)$/))
-    .filter((match): match is RegExpMatchArray => match !== null)
-    .map((match) => ({
-      visibility: match[1] as PerfVisibilityPhase['visibility'],
-      durationSeconds: Number(match[2]),
-    }))
-    .filter(
-      (phase) => phase.durationSeconds >= 10 && phase.durationSeconds <= 86_400
-    );
+  const visibilityPhases = parsePerfVisibilityPhases(
+    env.PERF_VISIBILITY_PHASES ?? ''
+  );
 
   return {
     enabled: env.PERF_METRICS === '1',

--- a/tools/perf/analyze.spec.ts
+++ b/tools/perf/analyze.spec.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import type {
   NumericSampleStats,
@@ -351,5 +352,39 @@ describe('performance analysis', () => {
     expect(
       parseCliArgs(['candidate.log', '--allow-inconclusive']).requireConclusive
     ).toBe(false);
+  });
+
+  it('accepts value flags before the candidate path', () => {
+    const options = parseCliArgs([
+      '--analysis-start-seconds',
+      '60',
+      '--warmup-seconds',
+      '10',
+      'candidate.log',
+      '--baseline',
+      'baseline.log',
+    ]);
+
+    expect(options.candidatePath).toBe(path.resolve('candidate.log'));
+    expect(options.baselinePath).toBe(path.resolve('baseline.log'));
+    expect(options.warmupSeconds).toBe(10);
+    expect(options.analysisWindow.startSeconds).toBe(60);
+  });
+
+  it('treats missing nested channel metrics as zero', () => {
+    const sample = mainSample(0, 100);
+    sample.channelMetrics = {
+      processorExecutions: { 'standings.snapshot': 100 },
+      publications: undefined,
+      deliveries: { 'standings.snapshot': 20 },
+    } as never;
+
+    const summary = summarizeCapture(capture([sample]), 0);
+
+    expect(summary.channels['standings.snapshot']).toMatchObject({
+      processorExecutions: 100,
+      publications: 0,
+      deliveries: 20,
+    });
   });
 });

--- a/tools/perf/analyze.spec.ts
+++ b/tools/perf/analyze.spec.ts
@@ -392,4 +392,26 @@ describe('performance analysis', () => {
       'phase channel metrics are incomplete'
     );
   });
+
+  it('rejects non-numeric channel metric values', () => {
+    const sample = mainSample(0, 100);
+    sample.channelMetrics = {
+      processorExecutions: { 'standings.snapshot': 100 },
+      publications: { 'standings.snapshot': '20' },
+      deliveries: { 'standings.snapshot': Number.NaN },
+    } as never;
+
+    const summary = summarizeCapture(capture([sample]), 0);
+
+    expect(summary.channels['standings.snapshot']).toMatchObject({
+      processorExecutions: 100,
+      publications: 0,
+      deliveries: 0,
+    });
+    expect(summary.evidence.inputCoverageAvailable).toBe(false);
+    expect(summary.evidence.conclusive).toBe(false);
+    expect(summary.phaseEvidence[0].reasons).toContain(
+      'phase channel metrics are incomplete'
+    );
+  });
 });

--- a/tools/perf/analyze.spec.ts
+++ b/tools/perf/analyze.spec.ts
@@ -386,5 +386,10 @@ describe('performance analysis', () => {
       publications: 0,
       deliveries: 20,
     });
+    expect(summary.evidence.inputCoverageAvailable).toBe(false);
+    expect(summary.evidence.conclusive).toBe(false);
+    expect(summary.phaseEvidence[0].reasons).toContain(
+      'phase channel metrics are incomplete'
+    );
   });
 });

--- a/tools/perf/analyze.ts
+++ b/tools/perf/analyze.ts
@@ -385,7 +385,12 @@ type ChannelMetricField = keyof NonNullable<
 >;
 
 const isMetricMap = (value: unknown): value is Record<string, number> =>
-  typeof value === 'object' && value !== null && !Array.isArray(value);
+  typeof value === 'object' &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.values(value).every(
+    (metric) => typeof metric === 'number' && Number.isFinite(metric)
+  );
 
 const hasCompleteChannelMetrics = (sample: MainPerfSample): boolean => {
   const metrics = sample.channelMetrics;
@@ -403,7 +408,10 @@ const channelCount = (
   channel: string
 ): number =>
   samples.reduce(
-    (sum, sample) => sum + (sample.channelMetrics?.[field]?.[channel] ?? 0),
+    (sum, sample) => {
+      const metrics = sample.channelMetrics?.[field];
+      return sum + (isMetricMap(metrics) ? (metrics[channel] ?? 0) : 0);
+    },
     0
   );
 

--- a/tools/perf/analyze.ts
+++ b/tools/perf/analyze.ts
@@ -384,6 +384,19 @@ type ChannelMetricField = keyof NonNullable<
   MainPerfSample['channelMetrics']
 >;
 
+const isMetricMap = (value: unknown): value is Record<string, number> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const hasCompleteChannelMetrics = (sample: MainPerfSample): boolean => {
+  const metrics = sample.channelMetrics;
+  return (
+    metrics !== undefined &&
+    isMetricMap(metrics.processorExecutions) &&
+    isMetricMap(metrics.publications) &&
+    isMetricMap(metrics.deliveries)
+  );
+};
+
 const channelCount = (
   samples: readonly MainPerfSample[],
   field: ChannelMetricField,
@@ -647,8 +660,7 @@ export function summarizeCapture(
     const phaseDurationSeconds = Math.max(0, (phase.end - phase.start) / 1000);
     const phaseChannels = summarizeChannels(samples, phaseDurationSeconds);
     const hasMetrics =
-      samples.length > 0 &&
-      samples.every((sample) => sample.channelMetrics !== undefined);
+      samples.length > 0 && samples.every(hasCompleteChannelMetrics);
     const visibleInputsChanged = requiredChannels.every(
       (channel) => (phaseChannels[channel]?.publications ?? 0) > 0
     );
@@ -776,7 +788,7 @@ export function summarizeCapture(
     ) &&
     phaseWindows.length > 0 &&
     phaseWindows.every((phase) => samplesForPhase(phase).length > 0) &&
-    effectiveMain.every((sample) => sample.channelMetrics !== undefined);
+    effectiveMain.every(hasCompleteChannelMetrics);
   const inputCoverageComplete =
     inputCoverageAvailable &&
     phaseEvidence.every((phase) => phase.expectedBehaviorSatisfied);

--- a/tools/perf/analyze.ts
+++ b/tools/perf/analyze.ts
@@ -390,7 +390,7 @@ const channelCount = (
   channel: string
 ): number =>
   samples.reduce(
-    (sum, sample) => sum + (sample.channelMetrics?.[field][channel] ?? 0),
+    (sum, sample) => sum + (sample.channelMetrics?.[field]?.[channel] ?? 0),
     0
   );
 
@@ -1432,7 +1432,16 @@ export function parseCliArgs(args: string[]): {
   analysisWindow: AnalysisWindow;
   requireConclusive: boolean;
 } {
-  const positional = args.filter((arg) => !arg.startsWith('--'));
+  const valueFlags = new Set([
+    '--baseline',
+    '--warmup-seconds',
+    '--analysis-start-seconds',
+    '--analysis-end-seconds',
+  ]);
+  const positional = args.filter(
+    (arg, index) =>
+      !arg.startsWith('--') && !valueFlags.has(args[index - 1] ?? '')
+  );
   const baselineIndex = args.indexOf('--baseline');
   const warmupIndex = args.indexOf('--warmup-seconds');
   const startIndex = args.indexOf('--analysis-start-seconds');

--- a/tools/perf/run.ts
+++ b/tools/perf/run.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process';
 import { createWriteStream, promises as fs } from 'node:fs';
 import path from 'node:path';
 import { readWidgetInputRequirements } from './widgetInputMetadata';
+import { parsePerfVisibilityPhases } from '../../src/app/perfRunConfig';
 
 const PERF_REPLAY_READY_LOG_MARKER = '[PerfRun] Ready for replay publisher';
 const REPLAY_STARTUP_TIMEOUT_MS = 30_000;
@@ -69,12 +70,10 @@ function parseArgs(args: string[]): RunOptions {
   const interval = Number(argumentValue(args, '--interval-ms') ?? 5000);
   const duration = Number(argumentValue(args, '--duration-seconds') ?? 0);
   const visibilityPhases = argumentValue(args, '--visibility-phases') ?? '';
-  const phaseDuration = visibilityPhases
-    .split(',')
-    .map((entry) => entry.trim().match(/^(?:visible|hidden):(\d+)$/)?.[1])
-    .map(Number)
-    .filter((value) => Number.isFinite(value) && value >= 10)
-    .reduce((sum, value) => sum + value, 0);
+  const phaseDuration = parsePerfVisibilityPhases(visibilityPhases).reduce(
+    (sum, phase) => sum + phase.durationSeconds,
+    0
+  );
   const durationSeconds =
     Number.isFinite(duration) && duration >= 10
       ? duration


### PR DESCRIPTION
## Description

Fixes four regressions found during the post-merge Phase 4.1 review:

- prevents cached channel snapshots from bypassing the channel-delivery-off benchmark isolation when a renderer becomes visible;
- makes performance analyzer positional parsing independent of flag order;
- treats missing nested channel metrics in older or partial captures as zero instead of throwing;
- shares visibility-phase parsing between the runner and application so both enforce the same 10–86,400 second bounds.

This is Phase 4.1 performance-evidence stabilization following the Phase 4 processor and channel migration. It does not change normal channel delivery behavior when delivery is enabled.

Validation:

- `npm run test -- --no-coverage` — 1,234 passed, 1 skipped
- `npm run lint`
- targeted channel bridge, analyzer, and performance configuration tests — 32 passed

Architecture checklist:

- [x] N1 — no synchronous filesystem I/O added
- [x] N2 — no frontend-to-main imports added
- [x] N3 — no cross-widget imports added
- [x] N4 — no IPC handlers added or changed
- [x] R4.1 — no bridge definition changes
- [x] R11.1 — no direct console logging added
- [x] R14.1 — regression coverage added for changed runtime/tooling behavior

## Screenshots

### Before

No visual change. Delivery-off captures could emit a cached snapshot after hide/show, and some valid analyzer CLI flag orders selected the wrong candidate path.

### After

No visual change. Delivery-off remains isolated through visibility transitions, and benchmark parsing is consistent and resilient.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cached snapshots from being replayed when delivery is disabled after a subscriber becomes visible.
  * Improved performance analysis handling for missing or malformed channel metrics.
  * Fixed command-line path parsing when analysis options are provided.

* **Improvements**
  * Added validation for visibility phases, including supported phase types and duration limits.
  * Standardized visibility-phase parsing across performance configuration and execution tools.
  * Improved handling of incomplete performance evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->