### PR TITLE
fix: stabilize car number column width

### DIFF
--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.stories.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.stories.tsx
@@ -61,6 +61,32 @@ export const Primary: Story = {
   },
 };
 
+export const CarNumberWidthNormal: Story = {
+  name: 'Car Number Width - Normal',
+  args: {
+    ...Primary.args,
+    carNumber: '1',
+  },
+};
+
+export const CarNumberWidthCompact: Story = {
+  name: 'Car Number Width - Compact',
+  args: {
+    ...Primary.args,
+    carNumber: '1',
+    compactMode: 'compact',
+  },
+};
+
+export const CarNumberWidthUltraCompact: Story = {
+  name: 'Car Number Width - Ultra Compact',
+  args: {
+    ...Primary.args,
+    carNumber: '1',
+    compactMode: 'ultra',
+  },
+};
+
 export const HasFastestLap: Story = {
   args: {
     ...Primary.args,

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -88,7 +88,7 @@ interface DriverRowInfoProps {
 // Helper function to provide dummy data for hidden rows
 const getDummyData = () => ({
   position: 1,
-  carNumber: '1',
+  carNumber: '333',
   name: 'Driver Name',
   teamName: 'Team Name',
   delta: 0,

--- a/src/frontend/components/Standings/components/DriverInfoRow/cells/CarNumberCell.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/cells/CarNumberCell.tsx
@@ -30,7 +30,7 @@ export const CarNumberCell = memo(
         data-column="carNumber"
         className={`w-auto ${colorClass} ${borderClass} text-white text-right ${pxClass} whitespace-nowrap`}
       >
-        {`#${carNumber}`}
+        <span className="inline-block min-w-[4ch]">{`#${carNumber}`}</span>
       </td>
     );
   }


### PR DESCRIPTION
## Description

Stabilizes the car-number column width shared by the Standings and Relative widgets.

The column previously sized itself from the currently rendered car number, so moving between values such as `#1` and `#333` could shift adjacent columns. The rendered number now reserves enough inline width for the `#` prefix plus a three-character car number, and Relative's hidden sizing rows use a representative three-character value.

User impact: Standings and Relative layouts remain stable as different drivers enter the rendered rows.

Architecture review phase: N/A — this is a localized widget presentation fix and does not change the target topology. It remains within the pure-consumer widget boundary described by R7.

Validation:
- Added dedicated DriverInfoRow stories for normal, compact, and ultra-compact modes
- Rendered all three stories and confirmed each retains a computed `4ch` minimum width (`27.84px` with the Storybook font settings)
- Confirmed normal/compact retain padding and ultra-compact removes padding without reducing the reserved number width
- ESLint passed for all changed files
- Pre-commit Prettier and ESLint hooks passed
- `git diff --check` passed

## Screenshots

### Before

Car-number width could contract for short values such as `#1`, then expand when a three-character number rendered.

### After

The car-number content reserves width for values through `#333` in normal, compact, and ultra-compact modes, preventing adjacent columns from shifting.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
