### PR TITLE
fix: count all manufacturers in standings

### DIFF
--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -10,6 +10,7 @@ import {
   useStandingsSettings,
   useHighlightColor,
   useDriverTagMap,
+  useManufacturerCounts,
 } from './hooks';
 import {
   useGeneralSettings,
@@ -26,7 +27,6 @@ import {
 } from '@irdashies/context';
 import { useIsSingleMake } from './hooks/useIsSingleMake';
 import { computeStintLap } from './components/DriverInfoRow/cells/lapCountUtils';
-import { CAR_ID_TO_CAR_MANUFACTURER } from './components/CarManufacturer/carManufacturerMapping';
 
 export const Standings = () => {
   const settings = useStandingsSettings();
@@ -41,6 +41,9 @@ export const Standings = () => {
   const p2pDisplayStates = useP2PDisplayStates();
 
   const standings = useDriverStandings(settings);
+  const manufacturerCountsByClass = useManufacturerCounts(
+    !!settings?.classHeaderStyle?.manufacturerStats?.enabled
+  );
   const classStats = useCarClassStats();
   const { tagMap, hasAnyTag } = useDriverTagMap(settings?.driverTag?.enabled);
   const numCarClasses = useWeekendInfoNumCarClasses();
@@ -123,34 +126,7 @@ export const Standings = () => {
                   ? (classColorHex ?? highlightHex)
                   : highlightHex;
 
-            const mfrMap = new Map<string, { carId: number; count: number }>();
-            for (const s of classStandings) {
-              if (s.carId === undefined) continue;
-              const mfr =
-                CAR_ID_TO_CAR_MANUFACTURER[s.carId]?.manufacturer ?? 'unknown';
-              const existing = mfrMap.get(mfr);
-              if (existing) {
-                existing.count += 1;
-              } else {
-                mfrMap.set(mfr, { carId: s.carId, count: 1 });
-              }
-            }
-            const manufacturerCounts = Array.from(mfrMap.values()).sort(
-              (a, b) => b.count - a.count
-            );
-            const playerCarId = classStandings.find((s) => s.isPlayer)?.carId;
-            const playerMfr =
-              playerCarId !== undefined
-                ? (CAR_ID_TO_CAR_MANUFACTURER[playerCarId]?.manufacturer ??
-                  'unknown')
-                : undefined;
-            const playerManufacturerEntry = playerMfr
-              ? manufacturerCounts.find(
-                  (m) =>
-                    (CAR_ID_TO_CAR_MANUFACTURER[m.carId]?.manufacturer ??
-                      'unknown') === playerMfr
-                )
-              : undefined;
+            const manufacturerStats = manufacturerCountsByClass[classId];
 
             return classStandings.length > 0 ? (
               <Fragment key={classId}>
@@ -167,8 +143,8 @@ export const Standings = () => {
                   colSpan={100}
                   classHeaderStyle={settings?.classHeaderStyle}
                   compactMode={generalSettings?.compactMode}
-                  manufacturerCounts={manufacturerCounts}
-                  playerManufacturerEntry={playerManufacturerEntry}
+                  manufacturerCounts={manufacturerStats?.counts}
+                  playerManufacturerEntry={manufacturerStats?.playerEntry}
                 />
                 {classStandings.map((result, driverIndex) => {
                   const prev = classStandings[driverIndex - 1];

--- a/src/frontend/components/Standings/hooks/index.ts
+++ b/src/frontend/components/Standings/hooks/index.ts
@@ -14,3 +14,4 @@ export * from './useSessionBestLapTime';
 export * from './useSessionLapCount';
 export * from './useTrackMapSettings';
 export * from './useDriverTagMap';
+export * from './useManufacturerCounts';

--- a/src/frontend/components/Standings/hooks/useManufacturerCounts.spec.ts
+++ b/src/frontend/components/Standings/hooks/useManufacturerCounts.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { calculateManufacturerCounts } from './useManufacturerCounts';
+
+const driver = (
+  carIdx: number,
+  carId: number,
+  carClassId = 1,
+  overrides: Partial<{
+    CarIsPaceCar: number;
+    IsSpectator: number;
+  }> = {}
+) => ({
+  CarIdx: carIdx,
+  CarID: carId,
+  CarClassID: carClassId,
+  CarIsPaceCar: 0,
+  IsSpectator: 0,
+  ...overrides,
+});
+
+describe('calculateManufacturerCounts', () => {
+  it('counts the complete class roster independently of visible standings', () => {
+    const result = calculateManufacturerCounts(
+      [
+        driver(0, 56),
+        driver(1, 56),
+        driver(2, 56),
+        driver(3, 67),
+        driver(4, 67),
+        driver(5, 55),
+      ],
+      5
+    );
+
+    expect(result['1'].counts.map(({ count }) => count)).toEqual([3, 2, 1]);
+    expect(result['1'].playerEntry).toEqual({ carId: 55, count: 1 });
+  });
+
+  it('groups counts per class and excludes non-competitors', () => {
+    const result = calculateManufacturerCounts(
+      [
+        driver(0, 56, 1),
+        driver(1, 67, 2),
+        driver(2, 56, 1, { CarIsPaceCar: 1 }),
+        driver(3, 67, 2, { IsSpectator: 1 }),
+      ],
+      0
+    );
+
+    expect(result['1'].counts).toEqual([{ carId: 56, count: 1 }]);
+    expect(result['1'].playerEntry).toEqual({ carId: 56, count: 1 });
+    expect(result['2'].counts).toEqual([{ carId: 67, count: 1 }]);
+  });
+});

--- a/src/frontend/components/Standings/hooks/useManufacturerCounts.ts
+++ b/src/frontend/components/Standings/hooks/useManufacturerCounts.ts
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+import { useFocusCarIdx, useSessionDrivers } from '@irdashies/context';
+import type { Driver } from '@irdashies/types';
+import { CAR_ID_TO_CAR_MANUFACTURER } from '../components/CarManufacturer/carManufacturerMapping';
+
+export interface ManufacturerCount {
+  carId: number;
+  count: number;
+}
+
+export interface ClassManufacturerCounts {
+  counts: ManufacturerCount[];
+  playerEntry?: ManufacturerCount;
+}
+
+type ManufacturerDriver = Pick<
+  Driver,
+  'CarIdx' | 'CarClassID' | 'CarID' | 'CarIsPaceCar' | 'IsSpectator'
+>;
+
+export const calculateManufacturerCounts = (
+  drivers: ManufacturerDriver[] | undefined,
+  playerCarIdx: number | undefined
+): Record<string, ClassManufacturerCounts> => {
+  const countsByClass = new Map<string, Map<string, ManufacturerCount>>();
+  const playerManufacturerByClass = new Map<string, string>();
+
+  for (const driver of drivers ?? []) {
+    if (driver.CarIsPaceCar || driver.IsSpectator || driver.CarID == null) {
+      continue;
+    }
+
+    const classId = String(driver.CarClassID);
+    const manufacturer =
+      CAR_ID_TO_CAR_MANUFACTURER[driver.CarID]?.manufacturer ?? 'unknown';
+    let classCounts = countsByClass.get(classId);
+    if (!classCounts) {
+      classCounts = new Map();
+      countsByClass.set(classId, classCounts);
+    }
+
+    const existing = classCounts.get(manufacturer);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      classCounts.set(manufacturer, { carId: driver.CarID, count: 1 });
+    }
+
+    if (driver.CarIdx === playerCarIdx) {
+      playerManufacturerByClass.set(classId, manufacturer);
+    }
+  }
+
+  return Object.fromEntries(
+    Array.from(countsByClass, ([classId, classCounts]) => {
+      const counts = Array.from(classCounts.values()).sort(
+        (a, b) => b.count - a.count
+      );
+      const playerManufacturer = playerManufacturerByClass.get(classId);
+      const playerEntry = playerManufacturer
+        ? classCounts.get(playerManufacturer)
+        : undefined;
+
+      return [classId, { counts, playerEntry }];
+    })
+  );
+};
+
+export const useManufacturerCounts = (enabled: boolean) => {
+  const drivers = useSessionDrivers();
+  const playerCarIdx = useFocusCarIdx();
+
+  return useMemo(
+    () => (enabled ? calculateManufacturerCounts(drivers, playerCarIdx) : {}),
+    [drivers, enabled, playerCarIdx]
+  );
+};


### PR DESCRIPTION
## Description

Fixes standings class-header manufacturer totals so they are calculated from the complete session driver roster rather than the sliced set of rows currently visible around the player.

Previously, manufacturers entered and left the counted set as the standings window followed the player. This made totals incorrect and caused both counts and ordering to jump during a session. The new scoped hook groups all competitors by class and manufacturer, excludes pace cars and spectators, and preserves the player-manufacturer override used by capped headers. It skips the calculation when manufacturer statistics are disabled.

Added unit coverage for complete-roster totals, per-class grouping, player-manufacturer selection, and non-competitor filtering.

Architecture review: this remains a pure Standings consumer calculation over the existing session snapshot, consistent with the Phase 3 renderer/channel topology; it adds no store, bridge, IPC, or telemetry subscription path.

## Screenshots

### Before

Manufacturer totals reflected only the visible standings rows and changed as the displayed driver window moved.

### After

Manufacturer totals reflect every competitor in each class and remain stable as the displayed driver window moves.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
