### PR TITLE
fix: prevent fuel average label collapse

### DIFF
--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -188,6 +188,29 @@ export const Primary: Story = {
   args: { ...baselineArgs, previewData: previewFuelData },
 };
 
+/** Guards the widest consumption label at a font size that exceeded the old fixed column. */
+export const Avg10AtLargerFontSize: Story = {
+  decorators: [
+    (Story) => (
+      <MockFuelDataProvider>
+        <Story />
+      </MockFuelDataProvider>
+    ),
+    TelemetryDecorator(),
+  ],
+  args: {
+    ...baselineArgs,
+    avgLapsCount: 10,
+    widgetStyles: {
+      fuelGrid: {
+        labelFontSize: 14,
+        valueFontSize: 15,
+      },
+    },
+    previewData: previewFuelData,
+  },
+};
+
 /** Fuel required at the next stop fits within the car's usable tank capacity. */
 export const RefuelFitsTank: Story = {
   decorators: [

--- a/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
+++ b/src/frontend/components/FuelCalculator/widgets/FuelCalculatorConsumptionGrid.tsx
@@ -342,7 +342,7 @@ export const FuelCalculatorConsumptionGrid: React.FC<
   return (
     <div
       style={containerStyle}
-      className={`grid w-full grid-cols-[2.75rem_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.15fr)] select-none overflow-hidden ${gridPadding} ${rowGap}`}
+      className={`grid w-full grid-cols-[max-content_minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.15fr)] select-none overflow-hidden ${gridPadding} ${rowGap}`}
     >
       <div
         className="col-span-4 flex items-center justify-between pb-1 text-slate-500 font-semibold tracking-wide uppercase"


### PR DESCRIPTION
## Description

Fixes the Fuel Calculator consumption grid so the `AVG 10` label does not wrap and collapse its row at larger configured font sizes.

The label track was fixed at `2.75rem`, which was narrower than `AVG 10` once label text and cell padding were rendered at larger sizes. The track now uses intrinsic content sizing while the three numeric tracks remain flexible.

Adds an `Avg10AtLargerFontSize` Storybook regression story using the standard 300px overlay width and a font size that exceeded the previous fixed track.

Architecture review: this remains isolated to the Fuel Calculator widget and follows the widget isolation direction described in Phase 2 of `docs/ARCHITECTURE_REVIEW.md`; it introduces no data-flow, store, telemetry, or IPC changes.

Validation:

- `npm run lint`
- `npm run build-storybook`
- Visual inspection of `widgets/FuelCalculator / Avg10 At Larger Font Size` at 300px width

## Screenshots

### Before

At larger label font sizes, the fixed-width first column forced `AVG 10` to wrap and increased the row height.

### After

The label column sizes to its widest content, keeping `AVG 10` on one line while the grid remains aligned at the standard 300px overlay width. Validated with the new Storybook regression story.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
