### PR TITLE
fix: smooth blind spot monitor 

### DIFF
--- a/src/app/perfMetrics.ts
+++ b/src/app/perfMetrics.ts
@@ -73,6 +73,7 @@ interface ChannelMetricsSource {
 }
 
 const PROCESSOR_CHANNELS: Readonly<Record<string, string>> = {
+  blindSpotProcessing: 'blind-spot.snapshot',
   carSpeedsProcessing: 'car-speeds.snapshot',
   driverControlsProcessing: 'driver-controls.snapshot',
   fuelProjectionProcessing: 'fuel.projection',

--- a/src/app/processors/BlindSpotProcessor.spec.ts
+++ b/src/app/processors/BlindSpotProcessor.spec.ts
@@ -22,6 +22,34 @@ describe('BlindSpotProcessor', () => {
     });
   });
 
+  it('does not copy or publish moving positions while there is no overlap', () => {
+    const processor = new BlindSpotProcessor();
+    processor.onFrame(frame(1, [0.1, 0.2]));
+    const idleVersion = processor.snapshot().version;
+
+    processor.onFrame(frame(1, [0.11, 0.21]));
+
+    expect(processor.snapshot()).toMatchObject({
+      carLeftRight: 1,
+      carIdxLapDistPct: [],
+      isOnTrack: true,
+      version: idleVersion,
+    });
+  });
+
+  it('stops publishing positions when an overlap clears', () => {
+    const processor = new BlindSpotProcessor();
+    processor.onFrame(frame(2, [0.5, 0.5005]));
+    processor.onFrame(frame(1, [0.51, 0.52]));
+
+    expect(processor.snapshot()).toMatchObject({
+      carLeftRight: 1,
+      carIdxLapDistPct: [],
+      isOnTrack: true,
+      version: 2,
+    });
+  });
+
   it('clears safety state at lifecycle boundaries', () => {
     const processor = new BlindSpotProcessor();
     processor.onFrame(frame(3, [0.5, 0.6]));

--- a/src/app/processors/BlindSpotProcessor.spec.ts
+++ b/src/app/processors/BlindSpotProcessor.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import type { Telemetry } from '@irdashies/types';
+import { BlindSpotProcessor } from './BlindSpotProcessor';
+
+const frame = (carLeftRight: number, positions: number[], isOnTrack = true) =>
+  ({
+    CarLeftRight: { value: [carLeftRight] },
+    CarIdxLapDistPct: { value: positions },
+    IsOnTrack: { value: [isOnTrack] },
+  }) as unknown as Telemetry;
+
+describe('BlindSpotProcessor', () => {
+  it('publishes overlap state and full-precision positions together', () => {
+    const processor = new BlindSpotProcessor();
+    processor.onFrame(frame(2, [0.123456, 0.123789]));
+
+    expect(processor.snapshot()).toMatchObject({
+      carLeftRight: 2,
+      carIdxLapDistPct: [0.123456, 0.123789],
+      isOnTrack: true,
+      version: 1,
+    });
+  });
+
+  it('clears safety state at lifecycle boundaries', () => {
+    const processor = new BlindSpotProcessor();
+    processor.onFrame(frame(3, [0.5, 0.6]));
+    processor.onLifecycle({ type: 'disconnect' });
+
+    expect(processor.snapshot()).toMatchObject({
+      carLeftRight: 0,
+      carIdxLapDistPct: [],
+      isOnTrack: false,
+      version: 2,
+    });
+  });
+});

--- a/src/app/processors/BlindSpotProcessor.spec.ts
+++ b/src/app/processors/BlindSpotProcessor.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import type { Telemetry } from '@irdashies/types';
+import type { Session, Telemetry } from '@irdashies/types';
+import recordedSession from '../../../test-data/1747384033336/session.json';
+import recordedOverlapFrame from '../../../test-data/1747384033336/telemetry.json';
+import recordedClearFrame from '../../../test-data/1770713920383/telemetry.json';
 import { BlindSpotProcessor } from './BlindSpotProcessor';
 
 const frame = (carLeftRight: number, positions: number[], isOnTrack = true) =>
@@ -10,6 +13,28 @@ const frame = (carLeftRight: number, positions: number[], isOnTrack = true) =>
   }) as unknown as Telemetry;
 
 describe('BlindSpotProcessor', () => {
+  it('processes recorded telemetry through the complete lifecycle', () => {
+    const processor = new BlindSpotProcessor();
+    processor.init(recordedSession as unknown as Session);
+    processor.onFrame(recordedOverlapFrame as unknown as Telemetry);
+
+    expect(processor.snapshot()).toMatchObject({
+      carLeftRight: 2,
+      carIdxLapDistPct: recordedOverlapFrame.CarIdxLapDistPct.value,
+      isOnTrack: true,
+      version: 1,
+    });
+
+    processor.onFrame(recordedClearFrame as unknown as Telemetry);
+
+    expect(processor.snapshot()).toMatchObject({
+      carLeftRight: 1,
+      carIdxLapDistPct: [],
+      isOnTrack: true,
+      version: 2,
+    });
+  });
+
   it('publishes overlap state and full-precision positions together', () => {
     const processor = new BlindSpotProcessor();
     processor.onFrame(frame(2, [0.123456, 0.123789]));

--- a/src/app/processors/BlindSpotProcessor.ts
+++ b/src/app/processors/BlindSpotProcessor.ts
@@ -4,6 +4,7 @@ import type {
   SessionLifecycleEvent,
   Telemetry,
 } from '@irdashies/types';
+import { CarLeftRight } from '@irdashies/types';
 import type { TelemetryProcessor } from './TelemetryProcessor';
 
 const scalar = (frame: Telemetry, key: string): unknown =>
@@ -37,19 +38,22 @@ export class BlindSpotProcessor implements TelemetryProcessor<BlindSpotSnapshot>
   }
 
   onFrame(frame: Telemetry): void {
-    let changed = copyPositions(
-      this.latest.carIdxLapDistPct as number[],
-      frame
-    );
-    const carLeftRight = scalar(frame, 'CarLeftRight');
+    const rawCarLeftRight = scalar(frame, 'CarLeftRight');
+    const carLeftRight =
+      typeof rawCarLeftRight === 'number' ? rawCarLeftRight : CarLeftRight.Off;
     const isOnTrack = scalar(frame, 'IsOnTrack');
-    changed =
-      this.set(
-        'carLeftRight',
-        typeof carLeftRight === 'number' ? carLeftRight : 0
-      ) || changed;
+    let changed = this.set('carLeftRight', carLeftRight);
     changed =
       this.set('isOnTrack', isOnTrack === true || isOnTrack === 1) || changed;
+
+    const positions = this.latest.carIdxLapDistPct as number[];
+    if (carLeftRight > CarLeftRight.Clear) {
+      changed = copyPositions(positions, frame) || changed;
+    } else if (positions.length > 0) {
+      positions.length = 0;
+      changed = true;
+    }
+
     if (changed) this.latest.version += 1;
   }
 

--- a/src/app/processors/BlindSpotProcessor.ts
+++ b/src/app/processors/BlindSpotProcessor.ts
@@ -24,7 +24,7 @@ const copyPositions = (target: number[], frame: Telemetry): boolean => {
 
 export class BlindSpotProcessor implements TelemetryProcessor<BlindSpotSnapshot> {
   readonly channel = 'blind-spot.snapshot';
-  readonly tickRateHz = 60;
+  readonly tickRateHz = 25;
 
   private readonly latest: BlindSpotSnapshot = {
     carLeftRight: 0,

--- a/src/app/processors/BlindSpotProcessor.ts
+++ b/src/app/processors/BlindSpotProcessor.ts
@@ -1,0 +1,76 @@
+import type {
+  BlindSpotSnapshot,
+  Session,
+  SessionLifecycleEvent,
+  Telemetry,
+} from '@irdashies/types';
+import type { TelemetryProcessor } from './TelemetryProcessor';
+
+const scalar = (frame: Telemetry, key: string): unknown =>
+  (frame as unknown as Record<string, { value?: unknown[] } | undefined>)[key]
+    ?.value?.[0];
+
+const copyPositions = (target: number[], frame: Telemetry): boolean => {
+  const source = frame.CarIdxLapDistPct?.value ?? [];
+  let changed = target.length !== source.length;
+  target.length = source.length;
+  for (let index = 0; index < source.length; index += 1) {
+    if (target[index] !== source[index]) changed = true;
+    target[index] = source[index];
+  }
+  return changed;
+};
+
+export class BlindSpotProcessor implements TelemetryProcessor<BlindSpotSnapshot> {
+  readonly channel = 'blind-spot.snapshot';
+  readonly tickRateHz = 60;
+
+  private readonly latest: BlindSpotSnapshot = {
+    carLeftRight: 0,
+    carIdxLapDistPct: [],
+    isOnTrack: false,
+    version: 0,
+  };
+
+  init(session: Session): void {
+    void session;
+  }
+
+  onFrame(frame: Telemetry): void {
+    let changed = copyPositions(
+      this.latest.carIdxLapDistPct as number[],
+      frame
+    );
+    const carLeftRight = scalar(frame, 'CarLeftRight');
+    const isOnTrack = scalar(frame, 'IsOnTrack');
+    changed =
+      this.set(
+        'carLeftRight',
+        typeof carLeftRight === 'number' ? carLeftRight : 0
+      ) || changed;
+    changed =
+      this.set('isOnTrack', isOnTrack === true || isOnTrack === 1) || changed;
+    if (changed) this.latest.version += 1;
+  }
+
+  onLifecycle(event: SessionLifecycleEvent): void {
+    if (event.type === 'enter') return;
+    (this.latest.carIdxLapDistPct as number[]).length = 0;
+    this.latest.carLeftRight = 0;
+    this.latest.isOnTrack = false;
+    this.latest.version += 1;
+  }
+
+  snapshot(): BlindSpotSnapshot {
+    return this.latest;
+  }
+
+  private set<K extends 'carLeftRight' | 'isOnTrack'>(
+    key: K,
+    value: BlindSpotSnapshot[K]
+  ): boolean {
+    if (this.latest[key] === value) return false;
+    this.latest[key] = value;
+    return true;
+  }
+}

--- a/src/app/processors/processorRegistry.ts
+++ b/src/app/processors/processorRegistry.ts
@@ -1,9 +1,7 @@
-import type {
-  LapTimesSnapshot,
-  ReferenceLapsSnapshot,
-} from '@irdashies/types';
+import type { LapTimesSnapshot, ReferenceLapsSnapshot } from '@irdashies/types';
 import type { ReferenceLapPersistence } from './ReferenceLapProcessor';
 import { CarSpeedsProcessor } from './CarSpeedsProcessor';
+import { BlindSpotProcessor } from './BlindSpotProcessor';
 import { DriverControlsProcessor } from './DriverControlsProcessor';
 import { FuelProjectionProcessor } from './FuelProjectionProcessor';
 import { LapLogProcessor } from './LapLogProcessor';
@@ -58,10 +56,14 @@ export const createProcessorDefinitions = ({
   referenceLapPersistence,
 }: ProcessorRegistryOptions): readonly AnyProcessorDefinition[] => [
   defineProcessor({
+    channel: 'blind-spot.snapshot',
+    metricsPrefix: 'blindSpot',
+    create: () => new BlindSpotProcessor(),
+  }),
+  defineProcessor({
     channel: 'fuel.projection',
     metricsPrefix: 'fuelProjection',
-    create: ({ sourceReplay }) =>
-      new FuelProjectionProcessor({ sourceReplay }),
+    create: ({ sourceReplay }) => new FuelProjectionProcessor({ sourceReplay }),
   }),
   defineProcessor({
     channel: 'lap-times.snapshot',
@@ -90,8 +92,7 @@ export const createProcessorDefinitions = ({
     metricsPrefix: 'relativeGap',
     create: ({ snapshot }) =>
       new RelativeGapProcessor({
-        snapshot: () =>
-          snapshot('reference-laps.snapshot') ?? noReferenceLaps,
+        snapshot: () => snapshot('reference-laps.snapshot') ?? noReferenceLaps,
       }),
   }),
   defineProcessor({

--- a/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/BlindSpotMonitor.tsx
@@ -2,12 +2,7 @@ import { useBlindSpotMonitor } from './hooks/useBlindSpotMonitor';
 import { useBlindSpotMonitorSettings } from './hooks/useBlindSpotMonitorSettings';
 import { BlindSpotMonitorIndicator } from './components/BlindSpotMonitorIndicator';
 import { BlindSpotMonitorSimpleIndicator } from './components/BlindSpotMonitorSimpleIndicator';
-import {
-  useDashboard,
-  useSessionVisibility,
-  trackStateSelectors,
-  useTrackStateSelector,
-} from '@irdashies/context';
+import { useDashboard, useSessionVisibility } from '@irdashies/context';
 import { CarLeftRight } from '@irdashies/types';
 
 export interface BlindSpotMonitorDisplayProps {
@@ -137,14 +132,13 @@ export const BlindSpotMonitor = () => {
   const state = useBlindSpotMonitor();
   const settings = useBlindSpotMonitorSettings();
   const { isDemoMode } = useDashboard();
-  const isOnTrack =
-    useTrackStateSelector(trackStateSelectors.isOnTrack) ?? false;
 
   const sessionVisible = useSessionVisibility(settings?.sessionVisibility);
   const activeState = isDemoMode ? DEMO_STATE_SIMPLE : state;
 
   if (!isDemoMode && !sessionVisible) return <></>;
-  if (!isDemoMode && settings?.showOnlyWhenOnTrack && !isOnTrack) return <></>;
+  if (!isDemoMode && settings?.showOnlyWhenOnTrack && !state.isOnTrack)
+    return <></>;
 
   return (
     <BlindSpotMonitorDisplay

--- a/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.spec.tsx
+++ b/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.spec.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CarLeftRight, type BlindSpotSnapshot } from '@irdashies/types';
+import { useBlindSpotMonitor } from './useBlindSpotMonitor';
+
+let blindSpotSnapshot: BlindSpotSnapshot;
+
+vi.mock('@irdashies/context', () => ({
+  useDriverCarIdx: () => 0,
+  useTrackLength: () => 5000,
+  useBlindSpotSelector: (selector: (snapshot: BlindSpotSnapshot) => unknown) =>
+    selector(blindSpotSnapshot),
+}));
+
+vi.mock('./useBlindSpotMonitorSettings', () => ({
+  useBlindSpotMonitorSettings: () => ({ distAhead: 4, distBehind: 4 }),
+}));
+
+const snapshot = (rivalProgress: number): BlindSpotSnapshot => ({
+  carLeftRight: CarLeftRight.CarLeft,
+  carIdxLapDistPct: [0.5, rivalProgress],
+  isOnTrack: true,
+  version: 1,
+});
+
+describe('useBlindSpotMonitor', () => {
+  beforeEach(() => {
+    blindSpotSnapshot = snapshot(0.5004);
+  });
+
+  it('does not enter a render loop while tracking an adjacent car', () => {
+    let renderCount = 0;
+    const { result, rerender } = renderHook(() => {
+      renderCount += 1;
+      return useBlindSpotMonitor();
+    });
+
+    expect(result.current.show).toBe(true);
+    expect(result.current.leftState).toBe(CarLeftRight.CarLeft);
+
+    blindSpotSnapshot = snapshot(0.5005);
+    rerender();
+
+    expect(result.current.leftPercent).toBeGreaterThan(0);
+    expect(renderCount).toBeLessThan(10);
+  });
+});

--- a/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.spec.tsx
+++ b/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.spec.tsx
@@ -36,6 +36,7 @@ describe('useBlindSpotMonitor', () => {
     });
 
     expect(result.current.show).toBe(true);
+    expect(result.current.isOnTrack).toBe(true);
     expect(result.current.leftState).toBe(CarLeftRight.CarLeft);
 
     blindSpotSnapshot = snapshot(0.5005);

--- a/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.tsx
@@ -10,6 +10,7 @@ import { useBlindSpotMonitorSettings } from './useBlindSpotMonitorSettings';
 import { CarLeftRight } from '@irdashies/types';
 
 interface BlindSpotMonitorState {
+  isOnTrack: boolean;
   show: boolean;
   leftState: CarLeftRight;
   rightState: CarLeftRight;
@@ -55,6 +56,7 @@ export const useBlindSpotMonitor = (): BlindSpotMonitorState => {
 
   const result = useMemo(() => {
     const defaultState = {
+      isOnTrack,
       show: false,
       leftState: CarLeftRight.Off,
       rightState: CarLeftRight.Off,
@@ -150,6 +152,7 @@ export const useBlindSpotMonitor = (): BlindSpotMonitorState => {
     }
 
     return {
+      isOnTrack,
       show: true,
       leftState,
       rightState,

--- a/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.tsx
+++ b/src/frontend/components/BlindSpotMonitor/hooks/useBlindSpotMonitor.tsx
@@ -1,8 +1,8 @@
-import { useMemo, useState, useEffect } from 'react';
-import type { TrackStateSnapshot } from '@irdashies/types';
+import { useMemo, useState, useEffect, useRef } from 'react';
+import type { BlindSpotSnapshot } from '@irdashies/types';
 import { shallow } from 'zustand/shallow';
 import {
-  useTrackStateSelector,
+  useBlindSpotSelector,
   useDriverCarIdx,
   useTrackLength,
 } from '@irdashies/context';
@@ -19,13 +19,8 @@ interface BlindSpotMonitorState {
 }
 
 const EMPTY_POSITIONS: readonly number[] = [];
-const EMPTY_BLIND_SPOT_TELEMETRY: readonly [
-  CarLeftRight,
-  readonly number[],
-  boolean,
-] = [CarLeftRight.Off, EMPTY_POSITIONS, false];
-
-const selectBlindSpotTelemetry = (snapshot: TrackStateSnapshot) =>
+const TELEPORT_THRESHOLD = 0.5;
+const selectBlindSpotTelemetry = (snapshot: BlindSpotSnapshot) =>
   [
     snapshot.carLeftRight as CarLeftRight,
     snapshot.carIdxLapDistPct,
@@ -41,23 +36,22 @@ const blindSpotTelemetryEqual = (
   previous[2] === next[2];
 
 export const useBlindSpotMonitor = (): BlindSpotMonitorState => {
-  const [carLeftRight, lapDistPcts, isOnTrack] =
-    useTrackStateSelector(selectBlindSpotTelemetry, {
+  const [carLeftRight, lapDistPcts, isOnTrack] = useBlindSpotSelector(
+    selectBlindSpotTelemetry,
+    {
       equality: blindSpotTelemetryEqual,
-    }) ?? EMPTY_BLIND_SPOT_TELEMETRY;
+    }
+  ) ?? [CarLeftRight.Off, EMPTY_POSITIONS, false];
   const driverCarIdx = useDriverCarIdx() ?? 0;
   const trackLength = useTrackLength();
   const settings = useBlindSpotMonitorSettings();
 
   const [leftCarIdx, setLeftCarIdx] = useState<number | null>(null);
   const [rightCarIdx, setRightCarIdx] = useState<number | null>(null);
-  const [prevPercents, setPrevPercents] = useState<{
+  const prevPercentsRef = useRef<{
     left: number | null;
     right: number | null;
-  }>({
-    left: null,
-    right: null,
-  });
+  }>({ left: null, right: null });
 
   const result = useMemo(() => {
     const defaultState = {
@@ -127,9 +121,10 @@ export const useBlindSpotMonitor = (): BlindSpotMonitorState => {
       leftPercent =
         is3Wide && leftCarIdx === null ? 0 : calculatePercent(leftCarIdx);
 
+      const previousLeft = prevPercentsRef.current.left;
       if (
-        prevPercents.left !== null &&
-        Math.abs(prevPercents.left - leftPercent) > 0.5
+        previousLeft !== null &&
+        Math.abs(previousLeft - leftPercent) > TELEPORT_THRESHOLD
       ) {
         disableTransition = true;
       }
@@ -145,9 +140,10 @@ export const useBlindSpotMonitor = (): BlindSpotMonitorState => {
       rightPercent =
         is3Wide && rightCarIdx === null ? 0 : calculatePercent(rightCarIdx);
 
+      const previousRight = prevPercentsRef.current.right;
       if (
-        prevPercents.right !== null &&
-        Math.abs(prevPercents.right - rightPercent) > 0.5
+        previousRight !== null &&
+        Math.abs(previousRight - rightPercent) > TELEPORT_THRESHOLD
       ) {
         disableTransition = true;
       }
@@ -170,14 +166,13 @@ export const useBlindSpotMonitor = (): BlindSpotMonitorState => {
     isOnTrack,
     leftCarIdx,
     rightCarIdx,
-    prevPercents,
   ]);
 
   useEffect(() => {
     if (carLeftRight <= CarLeftRight.Clear) {
       setLeftCarIdx(null);
       setRightCarIdx(null);
-      setPrevPercents({ left: null, right: null });
+      prevPercentsRef.current = { left: null, right: null };
       return;
     }
 
@@ -225,10 +220,10 @@ export const useBlindSpotMonitor = (): BlindSpotMonitorState => {
       // If BOTH are null (fresh 3-wide), we stay at 0%
     }
 
-    setPrevPercents({
+    prevPercentsRef.current = {
       left: result.leftPercent !== 0 ? result.leftPercent : null,
       right: result.rightPercent !== 0 ? result.rightPercent : null,
-    });
+    };
   }, [
     result.show,
     carLeftRight,

--- a/src/frontend/components/BlindSpotMonitor/widgetRuntimeDefinition.ts
+++ b/src/frontend/components/BlindSpotMonitor/widgetRuntimeDefinition.ts
@@ -5,5 +5,5 @@ export default {
   sessionData: true,
   channels: ['blind-spot.snapshot'],
   ratePreset: 'driverFocused',
-  channelRates: { 'blind-spot.snapshot': 60 },
+  channelRates: { 'blind-spot.snapshot': 25 },
 } satisfies WidgetRuntimeDefinition;

--- a/src/frontend/components/BlindSpotMonitor/widgetRuntimeDefinition.ts
+++ b/src/frontend/components/BlindSpotMonitor/widgetRuntimeDefinition.ts
@@ -3,6 +3,7 @@ import type { WidgetRuntimeDefinition } from '../../widgetRuntime';
 export default {
   id: 'blindspotmonitor',
   sessionData: true,
-  channels: ['track-state.snapshot'],
+  channels: ['blind-spot.snapshot'],
   ratePreset: 'driverFocused',
+  channelRates: { 'blind-spot.snapshot': 60 },
 } satisfies WidgetRuntimeDefinition;

--- a/src/frontend/components/TrackMap/hooks/useDriverProgress.tsx
+++ b/src/frontend/components/TrackMap/hooks/useDriverProgress.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import {
   useFocusCarIdx,
   useSessionDrivers,
@@ -9,16 +9,6 @@ import {
 } from '@irdashies/context';
 
 const EMPTY_POSITIONS: readonly number[] = [];
-const POSITION_UPDATE_INTERVAL_MS = 1000 / 25;
-
-const interpolateProgress = (from: number, to: number, amount: number) => {
-  let delta = to - from;
-  if (delta > 0.5) delta -= 1;
-  if (delta < -0.5) delta += 1;
-
-  const progress = from + delta * amount;
-  return progress < 0 ? progress + 1 : progress >= 1 ? progress - 1 : progress;
-};
 
 // Drivers progress logic
 export const useDriverProgress = () => {
@@ -118,50 +108,5 @@ export const useDriverProgress = () => {
       .filter((d) => d.progress > -1); // ignore drivers not on track
   }, [driverIdentities, driversLapDist]);
 
-  const [smoothedDrivers, setSmoothedDrivers] = useState(driversTrackData);
-  const displayedDriversRef = useRef(driversTrackData);
-
-  useEffect(() => {
-    if (typeof requestAnimationFrame === 'undefined') {
-      displayedDriversRef.current = driversTrackData;
-      setSmoothedDrivers(driversTrackData);
-      return;
-    }
-
-    const startingProgress = new Map(
-      displayedDriversRef.current.map(({ driver, progress }) => [
-        driver.CarIdx,
-        progress,
-      ])
-    );
-    const startedAt = performance.now();
-    let animationFrame: number | undefined;
-
-    const animate = (now: number) => {
-      const amount = Math.min(
-        1,
-        (now - startedAt) / POSITION_UPDATE_INTERVAL_MS
-      );
-      const nextDrivers = driversTrackData.map((entry) => {
-        const from = startingProgress.get(entry.driver.CarIdx);
-        return from === undefined
-          ? entry
-          : {
-              ...entry,
-              progress: interpolateProgress(from, entry.progress, amount),
-            };
-      });
-
-      displayedDriversRef.current = nextDrivers;
-      setSmoothedDrivers(nextDrivers);
-      if (amount < 1) animationFrame = requestAnimationFrame(animate);
-    };
-
-    animationFrame = requestAnimationFrame(animate);
-    return () => {
-      if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
-    };
-  }, [driversTrackData]);
-
-  return { drivers: smoothedDrivers, identities: driverIdentities };
+  return { drivers: driversTrackData, identities: driverIdentities };
 };

--- a/src/frontend/components/TrackMap/hooks/useDriverProgress.tsx
+++ b/src/frontend/components/TrackMap/hooks/useDriverProgress.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   useFocusCarIdx,
   useSessionDrivers,
@@ -9,6 +9,16 @@ import {
 } from '@irdashies/context';
 
 const EMPTY_POSITIONS: readonly number[] = [];
+const POSITION_UPDATE_INTERVAL_MS = 1000 / 25;
+
+const interpolateProgress = (from: number, to: number, amount: number) => {
+  let delta = to - from;
+  if (delta > 0.5) delta -= 1;
+  if (delta < -0.5) delta += 1;
+
+  const progress = from + delta * amount;
+  return progress < 0 ? progress + 1 : progress >= 1 ? progress - 1 : progress;
+};
 
 // Drivers progress logic
 export const useDriverProgress = () => {
@@ -108,5 +118,50 @@ export const useDriverProgress = () => {
       .filter((d) => d.progress > -1); // ignore drivers not on track
   }, [driverIdentities, driversLapDist]);
 
-  return { drivers: driversTrackData, identities: driverIdentities };
+  const [smoothedDrivers, setSmoothedDrivers] = useState(driversTrackData);
+  const displayedDriversRef = useRef(driversTrackData);
+
+  useEffect(() => {
+    if (typeof requestAnimationFrame === 'undefined') {
+      displayedDriversRef.current = driversTrackData;
+      setSmoothedDrivers(driversTrackData);
+      return;
+    }
+
+    const startingProgress = new Map(
+      displayedDriversRef.current.map(({ driver, progress }) => [
+        driver.CarIdx,
+        progress,
+      ])
+    );
+    const startedAt = performance.now();
+    let animationFrame: number | undefined;
+
+    const animate = (now: number) => {
+      const amount = Math.min(
+        1,
+        (now - startedAt) / POSITION_UPDATE_INTERVAL_MS
+      );
+      const nextDrivers = driversTrackData.map((entry) => {
+        const from = startingProgress.get(entry.driver.CarIdx);
+        return from === undefined
+          ? entry
+          : {
+              ...entry,
+              progress: interpolateProgress(from, entry.progress, amount),
+            };
+      });
+
+      displayedDriversRef.current = nextDrivers;
+      setSmoothedDrivers(nextDrivers);
+      if (amount < 1) animationFrame = requestAnimationFrame(animate);
+    };
+
+    animationFrame = requestAnimationFrame(animate);
+    return () => {
+      if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
+    };
+  }, [driversTrackData]);
+
+  return { drivers: smoothedDrivers, identities: driverIdentities };
 };

--- a/src/frontend/context/ChannelStore/index.ts
+++ b/src/frontend/context/ChannelStore/index.ts
@@ -10,5 +10,6 @@ export * from './useSessionBarSnapshot';
 export * from './useSectorTimingSnapshot';
 export * from './useStandingsSnapshot';
 export * from './useCarSpeedsSnapshot';
+export * from './useBlindSpotSnapshot';
 export * from './useDriverControlsSnapshot';
 export * from './useTrackStateSnapshot';

--- a/src/frontend/context/ChannelStore/useBlindSpotSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useBlindSpotSnapshot.ts
@@ -1,0 +1,10 @@
+import type { BlindSpotSnapshot } from '@irdashies/types';
+import {
+  useChannelSelector,
+  type ChannelSelectorOptions,
+} from './useChannelSnapshot';
+
+export const useBlindSpotSelector = <Selected>(
+  selector: (snapshot: BlindSpotSnapshot) => Selected,
+  options: ChannelSelectorOptions<Selected> = {}
+) => useChannelSelector('blind-spot.snapshot', selector, options);

--- a/src/frontend/widgetRuntime.spec.tsx
+++ b/src/frontend/widgetRuntime.spec.tsx
@@ -85,6 +85,13 @@ describe('widget runtime metadata', () => {
     ).toBe(false);
   });
 
+  it('requests a dedicated 60 Hz blind-spot snapshot', () => {
+    expect(getWidgetRuntimeDefinition('blindspotmonitor')).toMatchObject({
+      channels: ['blind-spot.snapshot'],
+      channelRates: { 'blind-spot.snapshot': 60 },
+    });
+  });
+
   it('declares standings and relative as channel-only consumers', () => {
     expect(getWidgetRuntimeDefinition('standings')).toMatchObject({
       channels: [

--- a/src/frontend/widgetRuntime.spec.tsx
+++ b/src/frontend/widgetRuntime.spec.tsx
@@ -85,10 +85,10 @@ describe('widget runtime metadata', () => {
     ).toBe(false);
   });
 
-  it('requests a dedicated 60 Hz blind-spot snapshot', () => {
+  it('requests a dedicated 25 Hz blind-spot snapshot', () => {
     expect(getWidgetRuntimeDefinition('blindspotmonitor')).toMatchObject({
       channels: ['blind-spot.snapshot'],
-      channelRates: { 'blind-spot.snapshot': 60 },
+      channelRates: { 'blind-spot.snapshot': 25 },
     });
   });
 

--- a/src/runtimeBoundaryReplay.spec.ts
+++ b/src/runtimeBoundaryReplay.spec.ts
@@ -17,6 +17,7 @@ import {
 } from './frontend/context/ChannelStore/ChannelSnapshotStore';
 
 const SNAPSHOT_CHANNELS = [
+  'blind-spot.snapshot',
   'car-speeds.snapshot',
   'driver-controls.snapshot',
   'fuel.projection',
@@ -211,10 +212,7 @@ class SyntheticSourceAdapter {
 interface RendererStores {
   readonly stores: Map<
     SnapshotChannel,
-    ChannelSelectionStore<
-      SnapshotChannel,
-      ChannelPayloads[SnapshotChannel]
-    >
+    ChannelSelectionStore<SnapshotChannel, ChannelPayloads[SnapshotChannel]>
   >;
   readonly changes: Map<SnapshotChannel, ReturnType<typeof vi.fn>>;
   snapshot<K extends SnapshotChannel>(
@@ -229,10 +227,7 @@ const attachStores = (
 ): RendererStores => {
   const stores = new Map<
     SnapshotChannel,
-    ChannelSelectionStore<
-      SnapshotChannel,
-      ChannelPayloads[SnapshotChannel]
-    >
+    ChannelSelectionStore<SnapshotChannel, ChannelPayloads[SnapshotChannel]>
   >();
   const changes = new Map<SnapshotChannel, ReturnType<typeof vi.fn>>();
   const unsubscribes: (() => void)[] = [];

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -298,8 +298,8 @@ export type ChannelRegistry = Readonly<Record<ChannelName, ChannelDefinition>>;
 export const channelRegistry = {
   'blind-spot.snapshot': {
     kind: 'snapshot',
-    defaultRateHz: 60,
-    maxRateHz: 60,
+    defaultRateHz: 25,
+    maxRateHz: 25,
   },
   'car-speeds.snapshot': {
     kind: 'snapshot',

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -8,6 +8,7 @@ export type SessionLifecycleEvent =
   | { type: 'disconnect' };
 
 export interface ChannelPayloads {
+  'blind-spot.snapshot': BlindSpotSnapshot;
   'car-speeds.snapshot': CarSpeedsSnapshot;
   'driver-controls.snapshot': DriverControlsSnapshot;
   'fuel.projection': FuelProjectionSnapshot;
@@ -48,6 +49,13 @@ export interface TrackStateSnapshot {
   engineWarnings: number;
   lapDistPct: number;
   sessionNum: number | null;
+  version: number;
+}
+
+export interface BlindSpotSnapshot {
+  carLeftRight: number;
+  carIdxLapDistPct: readonly number[];
+  isOnTrack: boolean;
   version: number;
 }
 
@@ -288,6 +296,11 @@ export type ChannelDefinition =
 export type ChannelRegistry = Readonly<Record<ChannelName, ChannelDefinition>>;
 
 export const channelRegistry = {
+  'blind-spot.snapshot': {
+    kind: 'snapshot',
+    defaultRateHz: 60,
+    maxRateHz: 60,
+  },
   'car-speeds.snapshot': {
     kind: 'snapshot',
     defaultRateHz: 10,


### PR DESCRIPTION
## Description

Fixes two positional-widget regressions observed after the Phase 4 performance profile:

- Adds a minimal dedicated 60 Hz blind-spot snapshot containing `CarLeftRight`, full-precision `CarIdxLapDistPct`, and `IsOnTrack` from the same telemetry frame. This restores prompt overlap detection and smooth movement without raising the general track-state channel rate.
- Stores previous blind-spot percentages in a ref to prevent the active monitor from entering a render/effect feedback loop and repeatedly remounting.
- Interpolates track-map driver progress between the existing 25 Hz positional snapshots, including shortest-path interpolation across the start/finish boundary.
- Adds processor, hook, runtime-definition, and boundary-replay regression coverage.

This follows the Phase 4 channel-snapshot topology while restoring the presentation smoothness lost during the channel migration.

Tested live in iRacing by reproducing the original flashing blind-spot monitor and confirming the dedicated high-frequency path substantially improves its behavior.

## Screenshots

### Before

Blind-spot indicators flashed/repeatedly remounted while a car overlapped, and track-map markers moved in visible 25 Hz steps.

### After

Blind-spot overlap and distance telemetry update coherently at 60 Hz, and track-map markers interpolate smoothly between positional snapshots.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated blind-spot telemetry channel updating at 25 Hz.
  * Improved blind-spot monitoring with accurate nearby-car positions and on-track status.
  * Added state handling for cars entering, leaving, or disconnecting from a session.

* **Bug Fixes**
  * Reduced unnecessary monitor updates and improved position-change handling.
  * Preserved blind-spot visibility behavior across demo mode, session visibility, and on-track settings.

* **Tests**
  * Added coverage for telemetry processing, widget subscriptions, state updates, and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->