### PR TITLE
fix: hide empty country flag column

### DIFF
--- a/src/frontend/components/Standings/Relative.tsx
+++ b/src/frontend/components/Standings/Relative.tsx
@@ -34,6 +34,10 @@ export const Relative = () => {
   const buffer = settings?.buffer ?? 3;
   const { isDriving } = useDrivingState();
   const standings = useDriverRelatives({ buffer });
+  const hasAnyCountryFlag = useMemo(
+    () => standings.some((result) => (result.driver?.flairId ?? 0) > 0),
+    [standings]
+  );
   const highlightColor = useHighlightColor();
   const { tagMap, hasAnyTag } = useDriverTagMap(settings?.driverTag?.enabled);
   const numCarClasses = useWeekendInfoNumCarClasses();
@@ -136,6 +140,7 @@ export const Relative = () => {
           pitExitAfterSF={pitExitAfterSF}
           hideCarManufacturer={hideCarManufacturer}
           hasAnyDriverTag={hasAnyTag}
+          hasAnyCountryFlag={hasAnyCountryFlag}
           compactMode={generalSettings?.compactMode}
         />
       ));
@@ -193,6 +198,7 @@ export const Relative = () => {
             deltaDecimalPlaces={settings?.delta?.precision}
             hideCarManufacturer={hideCarManufacturer}
             hasAnyDriverTag={hasAnyTag}
+            hasAnyCountryFlag={hasAnyCountryFlag}
             compactMode={generalSettings?.compactMode}
           />
         );
@@ -204,6 +210,7 @@ export const Relative = () => {
           carIdx={result.carIdx}
           resolvedTag={tagMap.get(result.carIdx)}
           hasAnyDriverTag={hasAnyTag}
+          hasAnyCountryFlag={hasAnyCountryFlag}
           classColor={result.carClass.color}
           carNumber={
             (settings?.carNumber?.enabled ?? true)
@@ -285,6 +292,7 @@ export const Relative = () => {
     isTeamRacing,
     tagMap,
     hasAnyTag,
+    hasAnyCountryFlag,
     generalSettings?.compactMode,
     lapTimeDeltasEnabled,
     numLapDeltas,

--- a/src/frontend/components/Standings/Standings.tsx
+++ b/src/frontend/components/Standings/Standings.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useMemo } from 'react';
 import { DriverClassHeader } from './components/DriverClassHeader/DriverClassHeader';
 import { DriverInfoRow } from './components/DriverInfoRow/DriverInfoRow';
 import { SessionBar } from './components/SessionBar/SessionBar';
@@ -41,6 +41,13 @@ export const Standings = () => {
   const p2pDisplayStates = useP2PDisplayStates();
 
   const standings = useDriverStandings(settings);
+  const hasAnyCountryFlag = useMemo(
+    () =>
+      standings.some(([, classStandings]) =>
+        classStandings.some((result) => (result.driver?.flairId ?? 0) > 0)
+      ),
+    [standings]
+  );
   const manufacturerCountsByClass = useManufacturerCounts(
     !!settings?.classHeaderStyle?.manufacturerStats?.enabled
   );
@@ -189,6 +196,7 @@ export const Standings = () => {
                         carIdx={result.carIdx}
                         resolvedTag={tagMap.get(result.carIdx)}
                         hasAnyDriverTag={hasAnyTag}
+                        hasAnyCountryFlag={hasAnyCountryFlag}
                         classColor={result.carClass.color}
                         carNumber={
                           (settings?.carNumber?.enabled ?? true)

--- a/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
+++ b/src/frontend/components/Standings/components/DriverInfoRow/DriverInfoRow.tsx
@@ -79,6 +79,7 @@ interface DriverRowInfoProps {
   hideCarManufacturer?: boolean;
   resolvedTag?: ResolvedDriverTag;
   hasAnyDriverTag?: boolean;
+  hasAnyCountryFlag?: boolean;
   compactMode?: string;
   p2pDisplayState?: P2PDisplayState;
   currentLap?: number;
@@ -231,6 +232,7 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
     hideCarManufacturer,
     resolvedTag,
     hasAnyDriverTag,
+    hasAnyCountryFlag,
     compactMode,
     p2pDisplayState,
     currentLap,
@@ -342,7 +344,8 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
         id: 'countryFlags',
         shouldRender:
           (displayOrder ? displayOrder.includes('countryFlags') : true) &&
-          (config?.countryFlags?.enabled ?? true),
+          (config?.countryFlags?.enabled ?? true) &&
+          (hasAnyCountryFlag ?? true),
         component: (
           <CountryFlagsCell
             key="countryFlags"
@@ -696,6 +699,7 @@ export const DriverInfoRow = memo((props: DriverRowInfoProps) => {
     tagSettings,
     resolvedTag,
     hasAnyDriverTag,
+    hasAnyCountryFlag,
     hidden,
     badgeMinimal,
     statusBadgesMinimal,


### PR DESCRIPTION
## Description

Hide the country flag column in the Standings and Relative overlays when no driver in the current result set has a valid flair ID.

Previously, each row rendered the configured country flag cell independently. AI and offline sessions can omit flair IDs or report them as zero, leaving a completely empty column in the table. The overlays now calculate flag availability once for the current standings and pass that table-level state to every row. The existing Country Flags setting continues to be respected, and the column remains visible when at least one driver has a flag.

This is a localized widget-consumer change and does not alter the architecture topology. It follows the Phase 1 performance hygiene described in `docs/ARCHITECTURE_REVIEW.md` by memoizing the table-level availability calculation.

Validation:

- `npm run lint -- --no-cache`
- `npm run test -- --no-coverage --run` (1,246 passed, 1 skipped)
- Commit-time Prettier and ESLint hooks

## Screenshots

### Before

AI and offline races with no country flair data displayed an empty country flag column.

### After

The empty country flag column is omitted. Sessions with at least one available flag continue to display the column.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Country flag columns now appear in standings only when at least one displayed driver has a configured country flag.
  * Standings rows consistently handle populated, empty, and placeholder entries without unnecessary flag columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->