### PR TITLE
feat: estimate iRating changes in practice

### DIFF
--- a/src/frontend/components/Settings/sections/StandingsSettings.tsx
+++ b/src/frontend/components/Settings/sections/StandingsSettings.tsx
@@ -59,7 +59,12 @@ const sortableSettings: SortableSetting[] = [
   },
   { id: 'driverTag', label: 'Driver Tag', configKey: 'driverTag' },
   { id: 'badge', label: 'Driver Badge', configKey: 'badge' },
-  { id: 'iratingChange', label: 'iRating Change', configKey: 'iratingChange' },
+  {
+    id: 'iratingChange',
+    label: 'iRating Change',
+    configKey: 'iratingChange',
+    hasSubSetting: true,
+  },
   {
     id: 'positionChange',
     label: 'Position Change',
@@ -144,6 +149,28 @@ const DisplaySettingsList = ({
             }}
             sortableProps={sortableProps}
           >
+            {setting.hasSubSetting &&
+              setting.configKey === 'iratingChange' &&
+              settings.config.iratingChange.enabled && (
+                <div className="flex items-center justify-between gap-3 pl-8 mt-2 indent-8">
+                  <span className="text-sm text-slate-300">
+                    Estimate During Practice
+                  </span>
+                  <ToggleSwitch
+                    enabled={
+                      settings.config.iratingChange.estimateInPractice ?? false
+                    }
+                    onToggle={(enabled) =>
+                      handleConfigChange({
+                        iratingChange: {
+                          ...settings.config.iratingChange,
+                          estimateInPractice: enabled,
+                        },
+                      })
+                    }
+                  />
+                </div>
+              )}
             {setting.hasSubSetting &&
               setting.configKey === 'lapTimeDeltas' &&
               settings.config.lapTimeDeltas.enabled && (
@@ -287,8 +314,7 @@ const DisplaySettingsList = ({
                         [setting.configKey]: {
                           ...cv,
                           pitLapDisplayMode: e.target.value as
-                            | 'lastPitLap'
-                            | 'lapsSinceLastPit',
+                            'lastPitLap' | 'lapsSinceLastPit',
                         },
                       });
                     }}
@@ -1092,24 +1118,26 @@ export const StandingsSettings = () => {
                             manufacturerStats: {
                               enabled: newValue,
                               cap:
-                                settings.config.classHeaderStyle?.manufacturerStats
-                                  ?.cap ?? 5,
+                                settings.config.classHeaderStyle
+                                  ?.manufacturerStats?.cap ?? 5,
                               showPlayerManufacturer:
-                                settings.config.classHeaderStyle?.manufacturerStats
-                                  ?.showPlayerManufacturer ?? false,
+                                settings.config.classHeaderStyle
+                                  ?.manufacturerStats?.showPlayerManufacturer ??
+                                false,
                             },
                           },
                         })
                       }
                     />
                     {(settings.config.classHeaderStyle?.manufacturerStats
-                      ?.enabled ?? false) && (
+                      ?.enabled ??
+                      false) && (
                       <>
                         <SettingSelectRow
                           title="Max manufacturers to show"
                           value={
-                            settings.config.classHeaderStyle?.manufacturerStats
-                              ?.cap?.toString() ?? 'all'
+                            settings.config.classHeaderStyle?.manufacturerStats?.cap?.toString() ??
+                            'all'
                           }
                           options={[
                             ...Array.from({ length: 10 }, (_, i) => ({

--- a/src/frontend/components/Settings/types.ts
+++ b/src/frontend/components/Settings/types.ts
@@ -15,7 +15,7 @@ export interface SessionVisibilitySettings {
 
 export interface StandingsWidgetSettings extends BaseWidgetSettings {
   config: {
-    iratingChange: { enabled: boolean };
+    iratingChange: { enabled: boolean; estimateInPractice?: boolean };
     positionChange: { enabled: boolean };
     badge: {
       enabled: boolean;

--- a/src/frontend/components/Standings/hooks/useDriverStandings.spec.ts
+++ b/src/frontend/components/Standings/hooks/useDriverStandings.spec.ts
@@ -1,5 +1,40 @@
 import { describe, it, expect } from 'vitest';
-import { calculateLapDeltas } from './useDriverStandings';
+import {
+  calculateLapDeltas,
+  shouldCalculateIRatingChange,
+} from './useDriverStandings';
+
+describe('shouldCalculateIRatingChange', () => {
+  it('calculates changes for official race weekends', () => {
+    expect(shouldCalculateIRatingChange('Race', true, 'Race', false)).toBe(
+      true
+    );
+  });
+
+  it('calculates hypothetical changes in practice when enabled', () => {
+    expect(
+      shouldCalculateIRatingChange('Practice', false, 'Practice', true)
+    ).toBe(true);
+  });
+
+  it('does not calculate hypothetical changes in practice by default', () => {
+    expect(
+      shouldCalculateIRatingChange('Practice', false, 'Practice', false)
+    ).toBe(false);
+  });
+
+  it('does not calculate hypothetical changes during offline testing', () => {
+    expect(shouldCalculateIRatingChange('Test', false, 'Practice', true)).toBe(
+      false
+    );
+  });
+
+  it('does not extend estimates to qualifying sessions', () => {
+    expect(
+      shouldCalculateIRatingChange('Practice', false, 'Open Qualify', true)
+    ).toBe(false);
+  });
+});
 
 describe('calculateLapDeltas', () => {
   it('should return undefined when disabled', () => {

--- a/src/frontend/components/Standings/hooks/useDriverStandings.tsx
+++ b/src/frontend/components/Standings/hooks/useDriverStandings.tsx
@@ -33,6 +33,17 @@ const EMPTY_NUMBERS: number[] = [];
 const EMPTY_BOOLEANS: boolean[] = [];
 const EMPTY_TRACK_LOCATIONS: TrackLocation[] = [];
 
+export const shouldCalculateIRatingChange = (
+  eventType: string | undefined,
+  isOfficial: boolean,
+  sessionType: string | undefined,
+  estimateInPractice: boolean
+) =>
+  (eventType === 'Race' && isOfficial) ||
+  (eventType === 'Practice' &&
+    sessionType === 'Practice' &&
+    estimateInPractice);
+
 export const useDriverStandings = (
   settings?: StandingsWidgetSettings['config']
 ) => {
@@ -173,11 +184,16 @@ export const useDriverStandings = (
         ? augmentStandingsWithPositionChange(groupedByClass, qualifyingResults)
         : groupedByClass;
 
-    // Calculate iRating changes for official race weekends
-    const iratingAugmentedGroupedByClass =
-      eventType === 'Race' && isOfficial
-        ? augmentStandingsWithIRating(positionChangeAugmentedGroupedByClass)
-        : positionChangeAugmentedGroupedByClass;
+    // Official race weekends retain the existing behavior. Practice estimates
+    // are opt-in because they are hypothetical and do not affect iRating.
+    const iratingAugmentedGroupedByClass = shouldCalculateIRatingChange(
+      eventType,
+      isOfficial,
+      sessionType,
+      settings?.iratingChange?.estimateInPractice ?? false
+    )
+      ? augmentStandingsWithIRating(positionChangeAugmentedGroupedByClass)
+      : positionChangeAugmentedGroupedByClass;
 
     // Calculate gap to class leader when enabled OR when interval is enabled (interval needs gap data)
     const gapAugmentedGroupedByClass =
@@ -226,6 +242,7 @@ export const useDriverStandings = (
     useLivePositionStandings,
     isOfficial,
     eventType,
+    settings?.iratingChange?.estimateInPractice,
     gapEnabled,
     intervalEnabled,
     carIdxLap,

--- a/src/types/defaultDashboard.spec.ts
+++ b/src/types/defaultDashboard.spec.ts
@@ -182,6 +182,7 @@ describe('getWidgetDefaultConfig', () => {
     expect(config).toBeDefined();
     expect(config.background).toBeDefined();
     expect(config.displayOrder).toBeDefined();
+    expect(config.iratingChange.estimateInPractice).toBe(false);
   });
 
   it('returns the fuel config', () => {

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -19,6 +19,7 @@ export const defaultDashboard: {
         useLivePosition: false,
         iratingChange: {
           enabled: true,
+          estimateInPractice: false,
         },
         positionChange: {
           enabled: false,

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -147,7 +147,7 @@ export type RelativeBadgeFormat =
 // ===========================
 
 export interface StandingsConfig {
-  iratingChange: { enabled: boolean };
+  iratingChange: { enabled: boolean; estimateInPractice?: boolean };
   positionChange: { enabled: boolean };
   badge: { enabled: boolean; badgeFormat: StandingsBadgeFormat };
   delta: { enabled: boolean };


### PR DESCRIPTION
## Description

Adds an opt-in standings setting to show hypothetical iRating changes during online practice sessions. The existing iRating calculation is reused and remains unchanged for official race weekends.

The new **Estimate During Practice** toggle is nested under the existing **iRating Change** display option and defaults to off, preserving current behavior for new and saved dashboards. Offline testing and qualifying sessions are excluded.

This is consistent with the Phase 2 settings direction in `docs/ARCHITECTURE_REVIEW.md`: the new field is additive and is supplied through the existing default-config deep merge, so no breaking settings migration is required.

Validation:

- `npm run test -- --no-coverage src/frontend/components/Standings/hooks/useDriverStandings.spec.ts src/types/defaultDashboard.spec.ts` (46 tests passed)
- `npm run lint -- --no-fix`
- `git diff --check`

## Screenshots

### Before

The iRating Change display option has no practice-session estimate control, and standalone online practice sessions do not show hypothetical changes.

### After

The iRating Change display option includes an **Estimate During Practice** toggle. When enabled, online practice standings display hypothetical iRating changes using the current running order.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

## Architecture Pre-PR Checklist

- [x] N1 — no new synchronous filesystem access
- [x] N2 — no frontend imports from `src/app`
- [x] N3 — no new cross-widget imports
- [x] N4 — no new IPC handlers
- [x] R2.1/R2.2 — no new telemetry subscriptions
- [x] R3.1 — no new stores
- [x] R4.1 — no new bridges
- [x] R6.1 — no new storage code
- [x] R7.1 — existing widget extended; no registration changes
- [x] R8.1 — additive optional setting with a default; no breaking migration required
- [x] R10.1 — no native-code changes
- [x] R11.1 — no logging changes
- [x] R13.1 — no new high-frequency subscription path
- [x] R14.1 — decision logic has focused unit coverage
- [ ] Storybook visual verification completed
- [ ] iRacing online-session verification completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Estimate During Practice” option for iRating changes in standings.
  * Practice-session iRating estimates are now configurable and disabled by default.
  * iRating changes continue to apply automatically in eligible official sessions.

* **Bug Fixes**
  * Improved handling of standings configuration when optional settings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->