### PR TITLE
fix: tidy settings section spacing

### DIFF
--- a/src/frontend/components/Settings/components/SessionBarItemsList.tsx
+++ b/src/frontend/components/Settings/components/SessionBarItemsList.tsx
@@ -43,7 +43,7 @@ export const SessionBarItemsList = ({
   });
 
   return (
-    <div className="space-y-3 pl-4">
+    <div className="space-y-3">
       {displayItems.map((item) => {
         const { dragHandleProps, itemProps } = getItemProps(item);
         const itemConfig = getItemConfig(item.id);

--- a/src/frontend/components/Settings/components/SettingSection.tsx
+++ b/src/frontend/components/Settings/components/SettingSection.tsx
@@ -5,8 +5,8 @@ interface SettingsSectionProps {
 
 export function SettingsSection({ title, children }: SettingsSectionProps) {
   return (
-    <section className="space-y-4 px-4">
-      <h3 className="text-lg font-medium text-slate-200">{title}</h3>
+    <section className={title ? 'space-y-4 px-4 pt-4 first:pt-0' : 'space-y-4'}>
+      {title && <h3 className="text-lg font-medium text-slate-200">{title}</h3>}
       <div className="space-y-4">{children}</div>
     </section>
   );


### PR DESCRIPTION
## Description

Tidies the shared settings layout by removing compounded padding from titleless nested sections and the extra left padding on session bar reorder rows.

The previous layout applied section padding at every nesting level, which pushed drag handles and nested controls progressively farther right. Titled sections now retain their normal padding and vertical separation, while titleless sections act as layout-neutral groups. Empty heading elements are no longer rendered.

Architecture phase: not applicable; this is a presentation-only fix within the existing settings components and does not change application layering or data flow.

Validated with `npm run lint` and `npm run build-storybook`.

## Screenshots

### Before

Session bar drag handles and nested input settings were over-indented. Adjacent titled sections also lacked consistent separation.

### After

Drag handles and nested controls align with their parent settings, while titled sections retain consistent spacing.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)