### PR TITLE
fix: promote reference laps in CarClassID 0 sessions

### DIFF
--- a/src/app/processors/ReferenceLapProcessor.spec.ts
+++ b/src/app/processors/ReferenceLapProcessor.spec.ts
@@ -24,6 +24,19 @@ const frame = (
     SessionNum: { value: [sessionNum] },
   }) as unknown as Telemetry;
 
+/** Drives a full clean lap for car 0 through the given frame factory. */
+const runCleanLap = (
+  processor: ReferenceLapProcessor,
+  makeFrame: (lapDistPct: number, sessionTime: number) => Telemetry
+) => {
+  processor.onFrame(makeFrame(0.001, 0));
+  processor.onFrame(makeFrame(0.001, 0.01));
+  for (let point = 1; point < 100; point += 1) {
+    processor.onFrame(makeFrame((point + 0.1) / 100, point * 0.6));
+  }
+  processor.onFrame(makeFrame(0.001, 60));
+};
+
 describe('ReferenceLapProcessor', () => {
   it('promotes and persists a complete clean lap', () => {
     const save = vi.fn();
@@ -42,6 +55,40 @@ describe('ReferenceLapProcessor', () => {
     expect(snapshot.bestLaps[0][1].finishTime).toBe(60);
     expect(snapshot.bestLaps[0][1].tangents.every(Number.isFinite)).toBe(true);
     expect(save).toHaveBeenCalledOnce();
+  });
+
+  it('promotes CarClassID 0 laps in memory but never persists them', () => {
+    // iRacing reports CarClassID 0 in test sessions. Class-0 laps from
+    // different cars would all collide on one seriesId_trackId_0 disk key, so
+    // persistence is skipped — but the session best still has to be usable.
+    const classlessSession = session();
+    classlessSession.DriverInfo.Drivers[0].CarClassID = 0;
+    const save = vi.fn();
+    const processor = new ReferenceLapProcessor({ load: () => null, save });
+    processor.init(classlessSession);
+    runCleanLap(processor, (pct, time) => frame(pct, time));
+
+    expect(processor.snapshot().bestLaps).toHaveLength(1);
+    expect(processor.snapshot().persistedLaps).toEqual([]);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('records offline-session laps in memory without persisting them', () => {
+    // Offline sessions — AI races, test sessions, hosted practice — report
+    // SeriesID 0. That is a real session, not missing data, so laps must still
+    // be collected; only the disk key (seriesId_trackId_classId) is meaningless
+    // there, so persistence is what gets skipped.
+    const offlineSession = session();
+    offlineSession.WeekendInfo.SeriesID = 0;
+    const save = vi.fn();
+    const load = vi.fn(() => null);
+    const processor = new ReferenceLapProcessor({ load, save });
+    processor.init(offlineSession);
+    runCleanLap(processor, (pct, time) => frame(pct, time));
+
+    expect(processor.snapshot().bestLaps).toHaveLength(1);
+    expect(save).not.toHaveBeenCalled();
+    expect(load).not.toHaveBeenCalled();
   });
 
   it('rejects a lap that enters pit road', () => {

--- a/src/app/processors/ReferenceLapProcessor.spec.ts
+++ b/src/app/processors/ReferenceLapProcessor.spec.ts
@@ -64,13 +64,17 @@ describe('ReferenceLapProcessor', () => {
     const classlessSession = session();
     classlessSession.DriverInfo.Drivers[0].CarClassID = 0;
     const save = vi.fn();
-    const processor = new ReferenceLapProcessor({ load: () => null, save });
+    const load = vi.fn(() => null);
+    const processor = new ReferenceLapProcessor({ load, save });
     processor.init(classlessSession);
     runCleanLap(processor, (pct, time) => frame(pct, time));
 
     expect(processor.snapshot().bestLaps).toHaveLength(1);
     expect(processor.snapshot().persistedLaps).toEqual([]);
     expect(save).not.toHaveBeenCalled();
+    // The class is also the disk read key, so a class-0 session must not go
+    // looking for a persisted lap either.
+    expect(load).not.toHaveBeenCalled();
   });
 
   it('records offline-session laps in memory without persisting them', () => {

--- a/src/app/processors/ReferenceLapProcessor.ts
+++ b/src/app/processors/ReferenceLapProcessor.ts
@@ -252,15 +252,14 @@ export class ReferenceLapProcessor implements TelemetryProcessor<ReferenceLapsSn
 
   private promote(driver: Driver, lap: ReferenceLap): void {
     const lapTime = lap.finishTime - lap.startTime;
-    if (
-      !lap.isCleanLap ||
-      lap.pointPos.includes(-1) ||
-      lapTime <= 0 ||
-      driver.CarClassID <= 0
-    ) {
-      return;
-    }
-    const persisted = this.persistedLaps.get(driver.CarClassID);
+    // Deliberately not gated on CarClassID: bestLaps is keyed by CarIdx and
+    // nothing on this path needs a class. iRacing reports CarClassID 0 in test
+    // sessions, which is a real session rather than missing data — gating
+    // promotion on it silently disabled every bestLaps consumer there. The
+    // class is still required for *persistence*, which is keyed by it.
+    if (!lap.isCleanLap || lap.pointPos.includes(-1) || lapTime <= 0) return;
+    const classId = driver.CarClassID;
+    const persisted = classId > 0 ? this.persistedLaps.get(classId) : undefined;
     const persistedTime = persisted
       ? persisted.finishTime - persisted.startTime
       : null;
@@ -270,15 +269,13 @@ export class ReferenceLapProcessor implements TelemetryProcessor<ReferenceLapsSn
     if (bestTime && lapTime >= bestTime) return;
     precomputeTangents(lap);
     this.bestLaps.set(driver.CarIdx, lap);
-    if (!persistedTime || lapTime < persistedTime) {
-      this.persistedLaps.set(driver.CarClassID, lap);
+    // classId > 0 guards persistence only. The disk key is
+    // seriesId_trackId_classId, so class-0 laps from different cars in offline
+    // test sessions would all collide on one key and overwrite each other.
+    if (classId > 0 && (!persistedTime || lapTime < persistedTime)) {
+      this.persistedLaps.set(classId, lap);
       if (this.persistenceEnabled && this.seriesId > 0) {
-        this.persistence.save(
-          this.seriesId,
-          this.trackId,
-          driver.CarClassID,
-          lap
-        );
+        this.persistence.save(this.seriesId, this.trackId, classId, lap);
       }
     }
     this.publish();


### PR DESCRIPTION
## Description

iRacing reports `CarClassID 0` in offline test sessions. Lap promotion in `ReferenceLapProcessor` was gated on `driver.CarClassID <= 0`, so in those sessions every lap was discarded however clean and complete it was, and `bestLaps` stayed empty for the entire session.

That silently disabled every `bestLaps` consumer there. `getReferenceLap` falls back to `persistedLaps.get(classId)`, which in a class-0 session is also empty, so consumers receive `EMPTY_REFERENCE_LAP`:

- **SectorDelta's ghost is fully dead** — `useLiveSectorDelta` bails on `refLap.finishTime < 0`, so no delta is ever shown in an offline test session.
- **Standings live-position gaps degrade** — `createStandings` uses the reference lap to estimate gaps when `useLivePosition` is enabled, and silently loses that input.

This is not a new-widget problem; it predates the Delta Speed work that surfaced it.

The gate was in the wrong place. `bestLaps` is keyed by `CarIdx` and the promotion path never uses the class at all — only *persistence* does. So promotion is now ungated, and `classId > 0` guards the disk write alone: the persistence key is `seriesId_trackId_classId`, so class-0 laps from different cars would otherwise all collide on `0_<trackId>_0` and overwrite each other.

**Deliberate consequence:** in an offline test session the reference lap is now held in memory only and is gone on restart. That is the correct trade — a usable session best beats a corrupt shared disk key.

This is the twin of the `SeriesID 0` fix in 06d8eb1 — the same mistake of reading a legitimate offline id of `0` as missing data. The new tests pin both cases down.

Found on a Windows sim rig against live iRacing: four clean laps, all buckets visited, `promoted=false` every time.

## Screenshots

No visual change — this is main-process lap collection. The observable difference is that `bestLaps` is non-empty in an offline test session, which restores SectorDelta's ghost there.

### Before
In an offline test session (AI race, test session, hosted practice), no reference lap is ever promoted. SectorDelta shows no ghost comparison for the whole session, and Standings live-position gaps lose their reference input.

### After
Reference laps promote normally, so SectorDelta's ghost and the Standings gap estimate both work there. Nothing is written to disk in these sessions.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clean laps are now retained for sessions without a car class or series identifier.
  * Classless laps continue to work in memory while safely skipping unavailable persistence and lookup operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->