### PR TITLE
fix: stabilize tests on loaded CI runners

### DIFF
--- a/site/src/utils/previewChannelRuntime.spec.ts
+++ b/site/src/utils/previewChannelRuntime.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type {
   DriverControlsSnapshot,
   IrSdkSourceBridge,
@@ -23,13 +23,12 @@ import mockSession from '../../../src/app/irsdk/node/utils/mock-data/session.jso
  * Processors return a single mutated snapshot object rather than a fresh one
  * per tick, so assertions must capture scalar values at delivery time — a
  * retained reference reflects whatever the processor holds now, not what was
- * delivered. `ChannelBus` also throttles to the channel rate, so frames need
- * real time between them to produce separate deliveries.
+ * delivered. `ChannelBus` also throttles to the channel rate, so simulated
+ * time must advance between frames to produce separate deliveries.
  */
 const DELIVERY_INTERVAL_MS = 60; // driver-controls.snapshot defaults to 25Hz
 
-const flushDeliveries = () =>
-  new Promise((resolve) => setTimeout(resolve, DELIVERY_INTERVAL_MS));
+const flushDeliveries = () => vi.advanceTimersByTimeAsync(DELIVERY_INTERVAL_MS);
 
 const setValue = (frame: Telemetry, key: string, value: number): void => {
   (frame as unknown as Record<string, { value: number[] }>)[key].value[0] =
@@ -78,6 +77,14 @@ const createFakeSource = () => {
 };
 
 describe('createPreviewChannelRuntime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('runs the real processors in-page and delivers derived snapshots', async () => {
     const fake = createFakeSource();
     const runtime = createPreviewChannelRuntime(fake.source);

--- a/tools/telemetry-replay/validator.spec.ts
+++ b/tools/telemetry-replay/validator.spec.ts
@@ -2,12 +2,13 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createSyntheticTape,
   SYNTHETIC_SECOND_FRAME_PAYLOAD_OFFSET,
 } from './fixture';
+import { TapeReader } from './tape';
 import { validateReplay, type ReplayProbe } from './validator';
 
 const temporaryDirectories: string[] = [];
@@ -63,12 +64,21 @@ describe('headless telemetry replay validator', () => {
   });
 
   it('rejects probes that request fields outside the tape schema', async () => {
-    await expect(
-      validateReplay({
-        path: await tapePath(),
-        probes: [{ ...probe, variables: ['MissingField'] }],
-      })
-    ).rejects.toThrow('Replay probe requested unknown variable: MissingField');
+    const close = vi.spyOn(TapeReader.prototype, 'close');
+
+    try {
+      await expect(
+        validateReplay({
+          path: await tapePath(),
+          probes: [{ ...probe, variables: ['MissingField'] }],
+        })
+      ).rejects.toThrow(
+        'Replay probe requested unknown variable: MissingField'
+      );
+      expect(close).toHaveBeenCalledOnce();
+    } finally {
+      close.mockRestore();
+    }
   });
 
   it('isolates each probe from fields requested by other probes', async () => {

--- a/tools/telemetry-replay/validator.ts
+++ b/tools/telemetry-replay/validator.ts
@@ -140,58 +140,58 @@ export async function validateReplay({
     sha256File(path),
     TapeReader.open(path),
   ]);
-  const { header, variables } = reader.schema;
-  const requestedNames = new Set(
-    probes.flatMap((probe) => [...probe.variables])
-  );
-  const requestedVariables = [...requestedNames].map((name) => {
-    const variable = variables.get(name);
-    if (!variable)
-      throw new Error(`Replay probe requested unknown variable: ${name}`);
-    return variable;
-  });
-  const runtimes = probes.map((probe) => ({
-    probe,
-    hash: createHash('sha256'),
-    frameCount: 0,
-    checkpoints: {} as Record<string, unknown>,
-  }));
-
-  let records = 0;
-  let frames = 0;
-  let sessionUpdates = 0;
-  let appliedSessionUpdates = 0;
-  let gaps = 0;
-  let disconnects = 0;
-  let ends = 0;
-  let pendingSession: TapeRecord | undefined;
-  let nextSessionPoll = 0n;
-  const pollTicks =
-    (header.qpcFrequency * BigInt(sessionPollMilliseconds)) / 1000n;
-  if (pollTicks <= 0n) {
-    throw new Error('Session polling interval is shorter than one tape tick');
-  }
-
-  const applyPendingSession = (atTicks: bigint): void => {
-    if (!pendingSession) return;
-    const context = contextFor(
-      { ...pendingSession, elapsedTicks: atTicks },
-      header.qpcFrequency
-    );
-    const yaml = pendingSession.payload.toString('utf8').replace(/\0+$/, '');
-    for (const runtime of runtimes) {
-      runtime.probe.onSessionInfo?.(yaml, context);
-      runtime.checkpoints[`session:${appliedSessionUpdates}`] = {
-        sourceTick: pendingSession.sourceTick,
-        elapsedSeconds: context.elapsedSeconds,
-        revision: pendingSession.value,
-      };
-    }
-    appliedSessionUpdates += 1;
-    pendingSession = undefined;
-  };
-
   try {
+    const { header, variables } = reader.schema;
+    const requestedNames = new Set(
+      probes.flatMap((probe) => [...probe.variables])
+    );
+    const requestedVariables = [...requestedNames].map((name) => {
+      const variable = variables.get(name);
+      if (!variable)
+        throw new Error(`Replay probe requested unknown variable: ${name}`);
+      return variable;
+    });
+    const runtimes = probes.map((probe) => ({
+      probe,
+      hash: createHash('sha256'),
+      frameCount: 0,
+      checkpoints: {} as Record<string, unknown>,
+    }));
+
+    let records = 0;
+    let frames = 0;
+    let sessionUpdates = 0;
+    let appliedSessionUpdates = 0;
+    let gaps = 0;
+    let disconnects = 0;
+    let ends = 0;
+    let pendingSession: TapeRecord | undefined;
+    let nextSessionPoll = 0n;
+    const pollTicks =
+      (header.qpcFrequency * BigInt(sessionPollMilliseconds)) / 1000n;
+    if (pollTicks <= 0n) {
+      throw new Error('Session polling interval is shorter than one tape tick');
+    }
+
+    const applyPendingSession = (atTicks: bigint): void => {
+      if (!pendingSession) return;
+      const context = contextFor(
+        { ...pendingSession, elapsedTicks: atTicks },
+        header.qpcFrequency
+      );
+      const yaml = pendingSession.payload.toString('utf8').replace(/\0+$/, '');
+      for (const runtime of runtimes) {
+        runtime.probe.onSessionInfo?.(yaml, context);
+        runtime.checkpoints[`session:${appliedSessionUpdates}`] = {
+          sourceTick: pendingSession.sourceTick,
+          elapsedSeconds: context.elapsedSeconds,
+          revision: pendingSession.value,
+        };
+      }
+      appliedSessionUpdates += 1;
+      pendingSession = undefined;
+    };
+
     while (true) {
       const record = await reader.readRecord();
       if (!record) break;
@@ -263,53 +263,53 @@ export async function validateReplay({
       }
     }
     applyPendingSession(nextSessionPoll);
+
+    const metadata: ReplayMetadata = {
+      sha256,
+      formatVersion: header.formatVersion,
+      sdkVersion: header.sdkVersion,
+      tickRateHz: header.tickRate,
+      variableCount: header.variableCount,
+      frameBytes: header.frameSize,
+      mappingBytes: Number(header.mappingSize),
+      recordCount: records,
+      frameCount: frames,
+      sessionUpdateCount: sessionUpdates,
+      gapCount: gaps,
+    };
+    if (BigInt(records) !== header.recordCount) {
+      throw new Error(
+        `Record count mismatch: header=${header.recordCount}, actual=${records}`
+      );
+    }
+    if (ends !== 1)
+      throw new Error(`Expected exactly one end record, found ${ends}`);
+    for (const [key, value] of Object.entries(expected ?? {})) {
+      if (metadata[key as keyof ReplayMetadata] !== value) {
+        throw new Error(
+          `Replay metadata mismatch for ${key}: expected=${String(value)}, actual=${String(
+            metadata[key as keyof ReplayMetadata]
+          )}`
+        );
+      }
+    }
+
+    return {
+      metadata,
+      disconnectCount: disconnects,
+      endCount: ends,
+      appliedSessionUpdateCount: appliedSessionUpdates,
+      probes: runtimes.map((runtime) => ({
+        name: runtime.probe.name,
+        schemaVersion: runtime.probe.schemaVersion,
+        frameCount: runtime.frameCount,
+        rollingHash: runtime.hash.digest('hex'),
+        checkpoints: runtime.checkpoints,
+      })),
+    };
   } finally {
     await reader.close();
   }
-
-  const metadata: ReplayMetadata = {
-    sha256,
-    formatVersion: header.formatVersion,
-    sdkVersion: header.sdkVersion,
-    tickRateHz: header.tickRate,
-    variableCount: header.variableCount,
-    frameBytes: header.frameSize,
-    mappingBytes: Number(header.mappingSize),
-    recordCount: records,
-    frameCount: frames,
-    sessionUpdateCount: sessionUpdates,
-    gapCount: gaps,
-  };
-  if (BigInt(records) !== header.recordCount) {
-    throw new Error(
-      `Record count mismatch: header=${header.recordCount}, actual=${records}`
-    );
-  }
-  if (ends !== 1)
-    throw new Error(`Expected exactly one end record, found ${ends}`);
-  for (const [key, value] of Object.entries(expected ?? {})) {
-    if (metadata[key as keyof ReplayMetadata] !== value) {
-      throw new Error(
-        `Replay metadata mismatch for ${key}: expected=${String(value)}, actual=${String(
-          metadata[key as keyof ReplayMetadata]
-        )}`
-      );
-    }
-  }
-
-  return {
-    metadata,
-    disconnectCount: disconnects,
-    endCount: ends,
-    appliedSessionUpdateCount: appliedSessionUpdates,
-    probes: runtimes.map((runtime) => ({
-      name: runtime.probe.name,
-      schemaVersion: runtime.probe.schemaVersion,
-      frameCount: runtime.frameCount,
-      rollingHash: runtime.hash.digest('hex'),
-      checkpoints: runtime.checkpoints,
-    })),
-  };
 }
 
 export const telemetryStateProbe: ReplayProbe<Record<string, TelemetryValue>> =

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -8,5 +8,6 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
+    testTimeout: 10_000,
   },
 });


### PR DESCRIPTION
## Description

Stabilizes Vitest execution on loaded CI runners by:

- increasing the global per-test timeout from 5 seconds to 10 seconds
- closing telemetry tape readers on every post-open failure path
- replacing real-time waits in preview channel tests with deterministic fake-time advancement
- adding regression coverage for reader cleanup

The intermittent Tachometer failure occurred alongside a worker `write failed` crash and has also appeared on unrelated branches. The Tachometer test itself completes in tens of milliseconds, so the timeout adds scheduling headroom while the resource and timer changes remove two avoidable sources of worker pressure and timing sensitivity.

The preview channel suite's measured test time dropped from approximately 622 ms to approximately 10 ms.

Architecture phase: Not applicable — these are test infrastructure and resource-cleanup changes and do not alter application topology.

Validation:
- `npm run test -- --no-coverage` — 1,345 passed, 1 skipped
- full suite with `NODE_OPTIONS=--trace-warnings` — passed without the previous unclosed `FileHandle` warning
- targeted validator and preview suites — 11 tests passed
- `npm run lint` — passed

## Screenshots

### Before

No visual change. Vitest used its default 5-second timeout, preview throttling tests waited on wall-clock time, and an invalid replay probe could leave a tape reader open.

### After

No visual change. Vitest allows 10 seconds per test, preview throttling tests use simulated time, and replay readers close on all validation paths.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

## Architecture Pre-PR Checklist

- [x] N1 — no new synchronous filesystem I/O
- [x] N2 — no new frontend → src/app/ imports
- [x] N3 — no new cross-widget imports
- [x] N4 — no new IPC handlers
- [x] R2.1/R2.2 — no telemetry hook changes
- [x] R3.1 — no new stores
- [x] R4.1 — no new bridges
- [x] R6.1 — tape-reader cleanup remains asynchronous
- [x] R7.1 — no widget changes
- [x] R8.1 — no settings changes
- [x] R10.1 — no native-code changes
- [x] R11.1 — no logging changes
- [x] R13.1 — no production high-frequency code changes
- [x] R14.1 — regression coverage added for reader cleanup
- [x] Storybook story not applicable; no visual component changes
- [x] Architecture phase and performance impact documented above
