### PR TITLE
chore: PRs follow repository publishing conventions

### DIFF
--- a/.claude/skills/publish-pr/SKILL.md
+++ b/.claude/skills/publish-pr/SKILL.md
@@ -13,10 +13,11 @@ Publish the current work as a GitHub pull request, ready for review by default.
 2. Inspect the worktree, current branch, diff, commits, and remote. Never commit directly to `main`.
 3. Determine the intentional PR scope. Preserve unrelated user changes. Run checks appropriate to the changed files and report any checks that cannot be run.
 4. Create or use a correctly named feature branch, commit the intended changes with the repository's commit convention, and push the branch when needed.
-5. Derive the PR title from recent PR history and the rules below.
-6. Build the PR body from `.github/pull_request_template.md` without deleting or renaming its sections. Fill in every applicable section and check only items actually completed. For screenshots, provide the requested before/after evidence or clearly state when screenshots are not applicable.
-7. Create the PR as published and ready for review unless the user explicitly asks for a draft. Treat silence about publication state as a request for a published PR.
-8. Verify the created PR has the requested publication state and return its title and URL. If the user did not request a draft and tooling unexpectedly creates one, immediately mark it ready for review and verify again.
+5. Check whether the current branch already has an open or draft PR. Reuse and update it instead of creating a duplicate.
+6. Derive the PR title from recent PR history and the rules below.
+7. Copy `.github/pull_request_template.md` verbatim for the PR body. Preserve every heading, HTML comment, checklist entry, and their order. Fill in applicable placeholders and check only items actually completed. For screenshots, provide the requested before/after evidence or clearly state when screenshots are not applicable.
+8. Update the existing PR or create a new one as published and ready for review unless the user explicitly asks for a draft. Treat silence about publication state as a request for a published PR. If an existing PR is a draft and the user requests publication, mark it ready for review.
+9. Verify the PR has the requested publication state and return its title and URL. If the user did not request a draft and tooling unexpectedly leaves one, immediately mark it ready for review and verify again.
 
 ## Title Rules
 
@@ -46,7 +47,7 @@ Keep the title concise, concrete, and understandable without reading the diff. P
 
 ## PR Body Rules
 
-- Start from the current repository template rather than recreating it from memory.
+- Copy the current repository template verbatim rather than recreating it from memory. Preserve all headings, HTML comments, checklist entries, and their order.
 - Explain the problem, its effect, and how the PR resolves it in the Description.
 - Include exact validation performed and distinguish automated, Storybook, manual, and real-environment testing.
 - Do not check a checklist item based on intention or inference.
@@ -55,4 +56,4 @@ Keep the title concise, concrete, and understandable without reading the diff. P
 
 ## Publication Guardrail
 
-Published means ready for review, not merely pushed to a remote. Unless the user explicitly requests a draft, confirm the PR's draft flag is false before completing the task. When the user explicitly requests a draft, create and verify a draft PR instead.
+Published means ready for review, not merely pushed to a remote. Unless the user explicitly requests a draft, confirm the PR's draft flag is false before completing the task. When the user explicitly requests a draft, create or retain and verify a draft PR instead. Never create a duplicate PR when the branch already has one.

--- a/.claude/skills/publish-pr/SKILL.md
+++ b/.claude/skills/publish-pr/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: publish-pr
+description: Publish GitHub pull requests for this repository. Use this skill whenever the user asks to create, open, raise, or publish a PR. Follow the repository's pull request template exactly, default to a published/ready-for-review PR unless the user explicitly requests a draft, and write a conventional-commit-style title that describes the user-visible problem solved or outcome achieved.
+---
+
+# Publish a Pull Request
+
+Publish the current work as a GitHub pull request, ready for review by default.
+
+## Workflow
+
+1. Read `AGENTS.md`, `.github/pull_request_template.md`, and relevant contribution guidance.
+2. Inspect the worktree, current branch, diff, commits, and remote. Never commit directly to `main`.
+3. Determine the intentional PR scope. Preserve unrelated user changes. Run checks appropriate to the changed files and report any checks that cannot be run.
+4. Create or use a correctly named feature branch, commit the intended changes with the repository's commit convention, and push the branch when needed.
+5. Derive the PR title from recent PR history and the rules below.
+6. Build the PR body from `.github/pull_request_template.md` without deleting or renaming its sections. Fill in every applicable section and check only items actually completed. For screenshots, provide the requested before/after evidence or clearly state when screenshots are not applicable.
+7. Create the PR as published and ready for review unless the user explicitly asks for a draft. Treat silence about publication state as a request for a published PR.
+8. Verify the created PR has the requested publication state and return its title and URL. If the user did not request a draft and tooling unexpectedly creates one, immediately mark it ready for review and verify again.
+
+## Title Rules
+
+Use the conventional prefix and casing style found in recent PR history:
+
+```text
+<type>: <problem solved or outcome achieved>
+```
+
+Choose the type that matches the work, such as `feat`, `fix`, `perf`, `refactor`, `docs`, `test`, `build`, `ci`, or `chore`.
+
+Describe the problem that is now solved or the capability the user now has. Do not merely name the implementation action, internal symbol, file, bridge, or refactor.
+
+Good:
+
+```text
+fix: site missing session bridge causing it to not load
+```
+
+Avoid:
+
+```text
+fix: initialize browser session bridge
+```
+
+Keep the title concise, concrete, and understandable without reading the diff. Prefer the repository's established wording when history provides a close precedent, but apply the problem/outcome rule even if an older title was implementation-focused.
+
+## PR Body Rules
+
+- Start from the current repository template rather than recreating it from memory.
+- Explain the problem, its effect, and how the PR resolves it in the Description.
+- Include exact validation performed and distinguish automated, Storybook, manual, and real-environment testing.
+- Do not check a checklist item based on intention or inference.
+- Do not claim iRacing or other live-environment testing unless it was actually performed.
+- Preserve Before and After screenshot headings.
+
+## Publication Guardrail
+
+Published means ready for review, not merely pushed to a remote. Unless the user explicitly requests a draft, confirm the PR's draft flag is false before completing the task. When the user explicitly requests a draft, create and verify a draft PR instead.


### PR DESCRIPTION
## Description

Adds a repository-scoped PR publishing skill so requests to create a PR consistently follow the project template, use problem- or outcome-focused titles, and publish ready for review unless a draft is explicitly requested.

Validated with the skill validator and git diff checks. No iRacing testing was required for this repository tooling change.

## Screenshots

### Before

Not applicable — no visual changes.

### After

Not applicable — no visual changes.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for publishing pull requests, including branch creation, title conventions, description requirements, validation checks, testing details, screenshots, and draft-state verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->