### PR TITLE
fix: keep pit stop timer running across team race driver changes

### DIFF
--- a/src/frontend/context/PitLapStore/PitLapStore.spec.tsx
+++ b/src/frontend/context/PitLapStore/PitLapStore.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { usePitLapStore, usePitStopDuration } from './PitLapStore';
-import { SessionState } from '@irdashies/types';
+import { SessionState, TrackLocation } from '@irdashies/types';
 
 describe('PitLapStore', () => {
   beforeEach(() => {
@@ -484,6 +484,156 @@ describe('PitLapStore', () => {
 
       const { result } = renderHook(() => usePitStopDuration());
       expect(result.current[0]).toBe(25);
+    });
+  });
+
+  describe('team race driver swaps', () => {
+    const SESSION = 123;
+    const CAR = 1;
+
+    interface Frame {
+      t: number;
+      onPitRoad: boolean;
+      surface: number;
+      lap: number;
+    }
+
+    // Feeds a stop frame by frame for a single car and returns its measured
+    // duration. Car 0 is an inert on-track filler so the arrays are realistic.
+    const playStop = (frames: Frame[]) => {
+      usePitLapStore.setState({ sessionUniqId: SESSION });
+
+      for (const frame of frames) {
+        usePitLapStore
+          .getState()
+          .updatePitLaps(
+            [false, frame.onPitRoad],
+            [0, frame.lap],
+            SESSION,
+            frame.t,
+            [TrackLocation.OnTrack, frame.surface],
+            SessionState.Racing
+          );
+      }
+
+      const { pitEntryTime, pitExitTime } = usePitLapStore.getState();
+      return {
+        entry: pitEntryTime[CAR] ?? null,
+        exit: pitExitTime[CAR] ?? null,
+      };
+    };
+
+    // A 124s stop on lap 10, with the driver change at t=140..142. iRacing drops
+    // the car out of the world while the new driver takes over, which reads as
+    // CarIdxOnPitRoad true -> false -> true.
+    const swapStop = (lapInStall: number): Frame[] => [
+      { t: 100, onPitRoad: false, surface: TrackLocation.OnTrack, lap: 10 },
+      {
+        t: 101,
+        onPitRoad: true,
+        surface: TrackLocation.ApproachingPits,
+        lap: 10,
+      },
+      {
+        t: 105,
+        onPitRoad: true,
+        surface: TrackLocation.InPitStall,
+        lap: lapInStall,
+      },
+      { t: 140, onPitRoad: false, surface: TrackLocation.NotInWorld, lap: -1 },
+      {
+        t: 142,
+        onPitRoad: true,
+        surface: TrackLocation.InPitStall,
+        lap: lapInStall,
+      },
+      {
+        t: 220,
+        onPitRoad: true,
+        surface: TrackLocation.ApproachingPits,
+        lap: lapInStall,
+      },
+      {
+        t: 225,
+        onPitRoad: false,
+        surface: TrackLocation.OnTrack,
+        lap: lapInStall,
+      },
+    ];
+
+    it('times the whole stop across a driver change', () => {
+      const { entry, exit } = playStop(swapStop(10));
+
+      expect(entry).toBe(101);
+      expect(exit).toBe(225);
+      expect((exit ?? 0) - (entry ?? 0)).toBe(124);
+    });
+
+    it('times the whole stop when the lap ticks over during the stop', () => {
+      // Pit lane spans the start/finish line, so the car's lap number changes
+      // between crossing the pit entry line and reaching its stall. This used to
+      // let the driver change re-arm the entry, reporting 83s instead of 124s.
+      const { entry, exit } = playStop(swapStop(11));
+
+      expect(entry).toBe(101);
+      expect(exit).toBe(225);
+      expect((exit ?? 0) - (entry ?? 0)).toBe(124);
+    });
+
+    it('does not close the stop while the car is out of the world', () => {
+      const frames = swapStop(10);
+      const upToSwap = frames.slice(0, 4); // through the NotInWorld frame
+
+      const { entry, exit } = playStop(upToSwap);
+
+      expect(entry).toBe(101);
+      expect(exit).toBeNull();
+    });
+
+    it('reports an ongoing duration that keeps counting through the swap', () => {
+      playStop(swapStop(10).slice(0, 5)); // through the new driver taking over
+      usePitLapStore.setState({ sessionTime: 150 });
+
+      const { result } = renderHook(() => usePitStopDuration());
+
+      // 150 - 101, not 150 - 142.
+      expect(result.current[CAR]).toBe(49);
+    });
+
+    it('still records a normal stop with no driver change', () => {
+      const { entry, exit } = playStop([
+        { t: 100, onPitRoad: false, surface: TrackLocation.OnTrack, lap: 10 },
+        {
+          t: 101,
+          onPitRoad: true,
+          surface: TrackLocation.ApproachingPits,
+          lap: 10,
+        },
+        { t: 105, onPitRoad: true, surface: TrackLocation.InPitStall, lap: 10 },
+        { t: 130, onPitRoad: false, surface: TrackLocation.OnTrack, lap: 10 },
+      ]);
+
+      expect(entry).toBe(101);
+      expect(exit).toBe(130);
+    });
+
+    it('starts a fresh stop on a later lap after the swap stop closed', () => {
+      playStop(swapStop(10));
+
+      usePitLapStore
+        .getState()
+        .updatePitLaps(
+          [false, true],
+          [0, 25],
+          SESSION,
+          800,
+          [TrackLocation.OnTrack, TrackLocation.ApproachingPits],
+          SessionState.Racing
+        );
+
+      const state = usePitLapStore.getState();
+      expect(state.pitEntryTime[CAR]).toBe(800);
+      expect(state.pitExitTime[CAR]).toBeNull();
     });
   });
 });

--- a/src/frontend/context/PitLapStore/PitLapStore.tsx
+++ b/src/frontend/context/PitLapStore/PitLapStore.tsx
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { useStoreWithEqualityFn } from 'zustand/traditional';
 import { arrayCompare } from '../TelemetryStore/telemetryCompare';
-import { SessionState } from '@irdashies/types';
+import { SessionState, TrackLocation } from '@irdashies/types';
 
 interface PitLapState {
   sessionUniqId: number;
@@ -97,6 +97,16 @@ export const usePitLapStore = create<PitLapState>((set, get) => ({
       const trackSurface = carIdxTrackSurface[idx] ?? -1;
       const currentLap = carIdxLap[idx] ?? -1;
       const lastEntryLap = entryLap[idx] ?? -1;
+
+      // A car that is not in the world reports CarIdxOnPitRoad false regardless
+      // of where it actually is. During a team-race driver change the car drops
+      // out of the world in its own stall, so the raw signal reads
+      // true -> false -> true across the swap. Acting on that would close the
+      // stop and re-arm a fresh entry at the moment the new driver takes over,
+      // restarting the clock mid-stop and reporting only the post-swap portion.
+      // Skipping these frames entirely leaves prevOnPitRoad untouched, so the
+      // swap is invisible to the entry/exit edge detection below.
+      if (trackSurface <= TrackLocation.NotInWorld) return;
 
       // Record the lap on which we first observed each car. Used to tell whether
       // we've watched a car since its session start — if so, its first-stint lap


### PR DESCRIPTION
Reported here: https://discord.com/channels/1339669873386586152/1528183010443132969

## Description

Pit stop times in team races come out short and inconsistent when a driver change happens during the stop. The clock restarts the moment the incoming driver takes over, so the reported time only covers the portion after the swap. This was reported from a league enduro where a full service read ~1:40 against an actual stop of ~2:20.

**Cause.** `PitLapStore` arms the pit entry timestamp on the rising edge of `CarIdxOnPitRoad`. A car that is not in the world reports `CarIdxOnPitRoad` as `false` regardless of where it physically is, and during a driver change iRacing drops the car out of the world while it sits in its own stall. The raw signal therefore reads `true -> false -> true` across the swap, handing the edge detection a pit entry at the moment the new driver takes over.

The existing lap guard (`currentLap !== lastEntryLap`) absorbed this only while the car's lap number had not changed since the recorded entry. It changes whenever the pit lane spans the start/finish line: the car crosses S/F between the pit entry line and its stall, `entryLap` no longer matches, and the swap re-arms the entry.

That is why the symptom looks erratic — same code, same swap, but the result depends on where a track's stalls sit relative to the line.

**Fix.** Skip frames where the car is not in the world, so `prevOnPitRoad` carries across the gap and the swap never produces an edge at all. Frames for a car nobody can see carry no pit information worth acting on. This also covers cars that flicker out more than once during a single stop, which does happen.

Exits were never affected: the exit branch requires `trackSurface > 1`, which a not-in-world car (`-1`) never satisfies.

## Screenshots

No visual change — the same pit time field, with the correct value in it.

### Before

A stop with a driver change reports only the time after the swap. Replaying one real stop through the store: entry recorded at the driver change instead of the pit entry, and a 79-second stop displayed as **63s**.

### After

The same stop reports **79s**. Stops without a driver change are unchanged.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [x] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

## How this was tested

Not yet driven in a live iRacing session — a driver change needs a second driver, so the iRacing box above is left unchecked. Instead it was verified against recorded telemetry from a real race.

**Where the data came from.** A ~6 hour endurance team race at Portimao, recorded from the SDK for the whole field rather than a single car, so every team's stops are present: roughly 707,000 frames at 30 Hz, each carrying the full `CarIdx*` arrays. This is a different event from the one in the original report — it was used because it contains a large number of driver changes, which also means the behaviour below is not specific to the track or series that was first reported.

**What was measured.** Every car index was scanned across the whole race for the shape a driver change makes — `CarIdxOnPitRoad` going `true -> false -> true` without the car ever reaching the racing surface in between, meaning it never actually left the pits. For each one, the pit entry that opened the stop was recorded alongside the track surface seen while the car was missing and whether the lap number changed between entry and return.

Results across the full race:

- **240 vanish/return events across 34 different cars.** Every one reported not-in-world while the car was missing, for 0.4-2.8 seconds, while it sat in its stall. That confirms the mechanism above rather than assuming it.
- **185 of those 240 (77%)** had the car's lap number change during the stop — the condition that defeats the old lap guard and lets the swap re-arm the entry. The other 23% were correct only because the lap happened not to tick over.
- Not one entry was recorded on the racing surface, so the adjacent theory that a car can cross the pit entry line while still reading `OnTrack` found no support here and is not addressed by this PR.

One caveat on that 240: it counts vanish/return events, not distinct stops. A single stop sometimes flickers the car out more than once (one example did so twice, 0.37s and 0.6s apart), so the number of affected stops is somewhat lower. The 77/23 split is per event.

**Frame-level check.** One complete stop was then replayed through the store frame by frame from the recording. Entry at lap 89; the lap ticks to 90 four seconds later while the car is still on pit road; the swap lands at the stall. Before the fix the entry was recorded at the swap and the stop measured **63s** against a true **79s**; after the fix, 79s.

The committed tests are hand-written from that observed signature rather than derived from the recording, so they stand alone and ship no captured data: a swap with and without the lap ticking over, the ongoing (still-counting) duration during a swap, a normal stop with no driver change, and a genuine second stop later in the race. The lap-tick case fails on `main` and passes with this change.

The recording and the analysis tooling aren't included here — happy to share more detail or re-run a query against it if that would help review.
