### PR TITLE
fix: keep replay overlays responsive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             **/node_modules
             **/*.node
             **/build/Release
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/binding.gyp', '**/node_modules/**/*.node') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/binding.gyp', 'src/app/irsdk/native/**/*.{c,cc,cpp,h,hpp}') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-
             ${{ runner.os }}-node-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
             **/node_modules
             **/*.node
             **/build/Release
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/binding.gyp', 'src/app/irsdk/native/**/*.{c,cc,cpp,h,hpp}') }}
+          key: ${{ runner.os }}-node-v2-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/binding.gyp', 'src/app/irsdk/native/**/*.c', 'src/app/irsdk/native/**/*.cc', 'src/app/irsdk/native/**/*.cpp', 'src/app/irsdk/native/**/*.h', 'src/app/irsdk/native/**/*.hpp') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-
             ${{ runner.os }}-node-

--- a/src/app/bridge/channelBridge.spec.ts
+++ b/src/app/bridge/channelBridge.spec.ts
@@ -62,11 +62,27 @@ describe('ChannelBus', () => {
     expect(() => bus.subscribe(target, 'snapshot', 0)).toThrow(
       'Invalid channel rate'
     );
-    expect(() => bus.subscribe(target, 'snapshot', 61)).toThrow(
-      'Invalid channel rate'
-    );
     expect(() => bus.subscribe(target, 'event', 10)).toThrow(
       'Event channels do not accept'
+    );
+  });
+
+  it('clamps requested snapshot rates to the channel maximum', () => {
+    const { bus, clock } = createBus();
+    const target = createTarget();
+    bus.subscribe(target, 'snapshot', 1_000);
+
+    bus.publish('snapshot', 1);
+    clock.advance(10);
+    bus.publish('snapshot', 2);
+    expect(target.send).toHaveBeenCalledTimes(1);
+
+    clock.advance(7);
+    expect(target.send).toHaveBeenCalledTimes(2);
+    expect(target.send).toHaveBeenLastCalledWith(
+      CHANNEL_DELIVERY,
+      'snapshot',
+      2
     );
   });
 

--- a/src/app/bridge/channelBus.ts
+++ b/src/app/bridge/channelBus.ts
@@ -278,10 +278,13 @@ export class ChannelBus {
       return 'event';
     }
     const rate = requested ?? definition.defaultRateHz;
-    if (!Number.isFinite(rate) || rate <= 0 || rate > definition.maxRateHz) {
+    if (!Number.isFinite(rate) || rate <= 0) {
       throw new Error(`Invalid channel rate: ${String(rate)}`);
     }
-    return rate;
+    // Renderer rates are desired ceilings. Enforce the authoritative channel
+    // limit here so an overly broad widget preset cannot make subscription
+    // startup fail or increase main-process delivery work.
+    return Math.min(rate, definition.maxRateHz);
   }
 
   private queueDelivery(

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.spec.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.spec.ts
@@ -4,12 +4,17 @@ import type { Session } from '@irdashies/types';
 const mockGetSessionData = vi.hoisted(() => vi.fn());
 const mockWaitForData = vi.hoisted(() => vi.fn());
 const mockStopSDK = vi.hoisted(() => vi.fn());
-const mockSdkState = vi.hoisted(() => ({ sessionVersion: 1 }));
+const mockSdkState = vi.hoisted(() => ({
+  sessionVersion: 1,
+  sessionStatusOK: true,
+}));
 
 vi.mock('../../irsdk', () => ({
   IRacingSDK: class {
     autoEnableTelemetry = false;
-    sessionStatusOK = true;
+    get sessionStatusOK() {
+      return mockSdkState.sessionStatusOK;
+    }
 
     get currDataVersion() {
       return mockSdkState.sessionVersion;
@@ -58,6 +63,7 @@ describe('publishIRacingSDKEvents session polling', () => {
     mockWaitForData.mockReturnValue(true);
     mockStopSDK.mockReset();
     mockSdkState.sessionVersion = 1;
+    mockSdkState.sessionStatusOK = true;
   });
 
   afterEach(() => {
@@ -95,12 +101,51 @@ describe('publishIRacingSDKEvents session polling', () => {
     );
     expect(mockGetSessionData).toHaveBeenCalledTimes(1);
 
+    mockSdkState.sessionStatusOK = false;
     mockWaitForData.mockReturnValueOnce(false);
     await vi.advanceTimersByTimeAsync(40);
     expect(mockGetSessionData).toHaveBeenCalledTimes(1);
 
+    mockSdkState.sessionStatusOK = true;
     await vi.advanceTimersByTimeAsync(1000);
     expect(mockGetSessionData).toHaveBeenCalledTimes(2);
+
+    bridge.stop();
+  });
+
+  it('retains session state through a connected replay pause', async () => {
+    const overlayManager = {
+      ...createOverlayManager(),
+      clearLatestSessionData: vi.fn(),
+    };
+    const lifecycle = {
+      _onEnter: vi.fn(),
+      _onTelemetry: vi.fn(),
+      _onSession: vi.fn(),
+      _onDisconnect: vi.fn(),
+    };
+    const session = { WeekendInfo: {} } as Session;
+    mockGetSessionData.mockReturnValue(session);
+
+    const bridge = await publishIRacingSDKEvents(
+      overlayManager as never,
+      lifecycle as never
+    );
+    expect(lifecycle._onEnter).toHaveBeenCalledOnce();
+
+    mockWaitForData.mockReturnValue(false);
+    await vi.advanceTimersByTimeAsync(1_200);
+
+    expect(lifecycle._onDisconnect).not.toHaveBeenCalled();
+    expect(overlayManager.clearLatestSessionData).not.toHaveBeenCalled();
+
+    const callback = vi.fn();
+    bridge.onSessionData(callback);
+    expect(callback).toHaveBeenCalledWith(session);
+
+    mockWaitForData.mockReturnValue(true);
+    await vi.advanceTimersByTimeAsync(80);
+    expect(mockGetSessionData.mock.calls.length).toBeGreaterThan(1);
 
     bridge.stop();
   });

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -231,13 +231,18 @@ export async function publishIRacingSDKEvents(
       let wasRunning = false;
 
       while (!shouldStop) {
+        const pollStartedAt = performance.now();
         const hasNewData = sdk.waitForData(WAIT_TIMEOUT);
         if (!hasNewData) {
           // A paused replay remains connected but does not advance the SDK's
           // telemetry buffer. Keep the current session and channel snapshots
           // until either playback resumes or the SDK actually disconnects.
           if (sdk.sessionStatusOK) {
-            await new Promise((resolve) => setTimeout(resolve, 1000 / 25));
+            const remainingDelay = Math.max(
+              0,
+              1000 / 25 - (performance.now() - pollStartedAt)
+            );
+            await new Promise((resolve) => setTimeout(resolve, remainingDelay));
             continue;
           }
           break;

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -230,7 +230,18 @@ export async function publishIRacingSDKEvents(
       let lastSessionPollTime = Number.NEGATIVE_INFINITY;
       let wasRunning = false;
 
-      while (!shouldStop && sdk.waitForData(WAIT_TIMEOUT)) {
+      while (!shouldStop) {
+        const hasNewData = sdk.waitForData(WAIT_TIMEOUT);
+        if (!hasNewData) {
+          // A paused replay remains connected but does not advance the SDK's
+          // telemetry buffer. Keep the current session and channel snapshots
+          // until either playback resumes or the SDK actually disconnects.
+          if (sdk.sessionStatusOK) {
+            await new Promise((resolve) => setTimeout(resolve, 1000 / 25));
+            continue;
+          }
+          break;
+        }
         if (!wasRunning) {
           logger.info(`[iracingSdkBridge] ${sourceName} is running`);
           wasRunning = true;

--- a/src/app/irsdk/native/irsdk-replay.spec.ts
+++ b/src/app/irsdk/native/irsdk-replay.spec.ts
@@ -149,7 +149,12 @@ describeOnWindows('iRacing native record/replay boundary', () => {
         // The current buffer is delivered immediately so connecting while a
         // replay is paused does not require playback to advance first.
         await sendCommand(publisher, 'next');
-        expect(sdk.waitForData(1000)).toBe(true);
+        const initialDeadline = performance.now() + 5_000;
+        let initialReady = false;
+        while (!initialReady && performance.now() < initialDeadline) {
+          initialReady = sdk.waitForData(100);
+        }
+        expect(initialReady).toBe(true);
 
         const initialTelemetry = sdk.getTelemetryData();
         expect(doubleValue(initialTelemetry.SessionTime.value)).toBeCloseTo(
@@ -159,9 +164,9 @@ describeOnWindows('iRacing native record/replay boundary', () => {
         expect(intValue(initialTelemetry.SessionTick.value)).toBe(100);
         expect(floatValue(initialTelemetry.Speed.value)).toBeCloseTo(50);
 
-        // The replay test addon uses a one-second connection timeout. Polling
+        // The replay test addon uses a two-second connection timeout. Polling
         // the same paused tick beyond that timeout must keep it connected.
-        const pauseUntil = performance.now() + 1_200;
+        const pauseUntil = performance.now() + 2_200;
         while (performance.now() < pauseUntil) {
           expect(sdk.waitForData(100)).toBe(false);
           expect(sdk.isRunning()).toBe(true);

--- a/src/app/irsdk/native/irsdk-replay.spec.ts
+++ b/src/app/irsdk/native/irsdk-replay.spec.ts
@@ -149,12 +149,8 @@ describeOnWindows('iRacing native record/replay boundary', () => {
         // The current buffer is delivered immediately so connecting while a
         // replay is paused does not require playback to advance first.
         await sendCommand(publisher, 'next');
-        const initialDeadline = performance.now() + 5_000;
-        let initialReady = false;
-        while (!initialReady && performance.now() < initialDeadline) {
-          initialReady = sdk.waitForData(100);
-        }
-        expect(initialReady).toBe(true);
+        await output.waitFor(/FRAME 1 100/, 15_000);
+        expect(sdk.waitForData(100)).toBe(true);
 
         const initialTelemetry = sdk.getTelemetryData();
         expect(doubleValue(initialTelemetry.SessionTime.value)).toBeCloseTo(
@@ -173,7 +169,8 @@ describeOnWindows('iRacing native record/replay boundary', () => {
         }
 
         await sendCommand(publisher, 'next');
-        expect(sdk.waitForData(1000)).toBe(true);
+        await output.waitFor(/FRAME 2 101/, 15_000);
+        expect(sdk.waitForData(100)).toBe(true);
 
         const telemetry = sdk.getTelemetryData();
         expect(doubleValue(telemetry.SessionTime.value)).toBeCloseTo(
@@ -199,7 +196,8 @@ describeOnWindows('iRacing native record/replay boundary', () => {
         expect(sdk.currDataVersion).toBe(1);
 
         await sendCommand(publisher, 'next');
-        expect(sdk.waitForData(1000)).toBe(true);
+        await output.waitFor(/FRAME 3 102/, 15_000);
+        expect(sdk.waitForData(100)).toBe(true);
         expect(floatValue(sdk.getTelemetryData().Speed.value)).toBeCloseTo(52);
         expect(sdk.getSessionData()).toContain('SessionNum: 0');
         expect(sdk.currDataVersion).toBe(2);

--- a/src/app/irsdk/native/irsdk-replay.spec.ts
+++ b/src/app/irsdk/native/irsdk-replay.spec.ts
@@ -146,10 +146,26 @@ describeOnWindows('iRacing native record/replay boundary', () => {
       try {
         expect(sdk.startSDK()).toBe(true);
 
-        // The official client deliberately establishes its tick baseline on
-        // the first observed buffer and reports data from the following tick.
+        // The current buffer is delivered immediately so connecting while a
+        // replay is paused does not require playback to advance first.
         await sendCommand(publisher, 'next');
-        expect(sdk.waitForData(1000)).toBe(false);
+        expect(sdk.waitForData(1000)).toBe(true);
+
+        const initialTelemetry = sdk.getTelemetryData();
+        expect(doubleValue(initialTelemetry.SessionTime.value)).toBeCloseTo(
+          10,
+          8
+        );
+        expect(intValue(initialTelemetry.SessionTick.value)).toBe(100);
+        expect(floatValue(initialTelemetry.Speed.value)).toBeCloseTo(50);
+
+        // The replay test addon uses a one-second connection timeout. Polling
+        // the same paused tick beyond that timeout must keep it connected.
+        const pauseUntil = performance.now() + 1_200;
+        while (performance.now() < pauseUntil) {
+          expect(sdk.waitForData(100)).toBe(false);
+          expect(sdk.isRunning()).toBe(true);
+        }
 
         await sendCommand(publisher, 'next');
         expect(sdk.waitForData(1000)).toBe(true);

--- a/src/app/irsdk/native/lib/irsdk_utils.cpp
+++ b/src/app/irsdk/native/lib/irsdk_utils.cpp
@@ -63,7 +63,7 @@ static int lastTickCount = INT_MAX;
 static bool isInitialized = false;
 
 #ifdef IRDASHIES_IRSDK_REPLAY_NAMES
-static const double timeout = 1.0; // Keep replay integration tests fast.
+static const double timeout = 2.0; // Keep replay integration tests fast.
 #else
 static const double timeout = 30.0; // timeout after 30 seconds with no communication
 #endif

--- a/src/app/irsdk/native/lib/irsdk_utils.cpp
+++ b/src/app/irsdk/native/lib/irsdk_utils.cpp
@@ -147,8 +147,10 @@ bool irsdk_getNewData(char *data)
 			if(pHeader->varBuf[latest].tickCount < pHeader->varBuf[i].tickCount)
 			   latest = i;	
 
-		// if newer than last recieved, than report new data
-		if(lastTickCount < pHeader->varBuf[latest].tickCount)
+		// Seed the current buffer on first connection, even when the sim is
+		// paused and will not produce a newer tick until playback resumes.
+		// Subsequent reads still require a genuinely newer tick.
+		if(lastTickCount == INT_MAX || lastTickCount < pHeader->varBuf[latest].tickCount)
 		{
 			// if asked to retrieve the data
 			if(data)

--- a/src/app/irsdk/native/lib/irsdk_utils.cpp
+++ b/src/app/irsdk/native/lib/irsdk_utils.cpp
@@ -62,7 +62,11 @@ static const irsdk_header *pHeader = NULL;
 static int lastTickCount = INT_MAX;
 static bool isInitialized = false;
 
+#ifdef IRDASHIES_IRSDK_REPLAY_NAMES
+static const double timeout = 1.0; // Keep replay integration tests fast.
+#else
 static const double timeout = 30.0; // timeout after 30 seconds with no communication
+#endif
 static time_t lastValidTime = 0;
 
 // Function Implementations
@@ -141,6 +145,11 @@ bool irsdk_getNewData(char *data)
 			lastTickCount = INT_MAX;
 			return false;
 		}
+
+		// A paused replay can keep publishing the same tick indefinitely. The
+		// connected header is still a valid heartbeat even when there is no new
+		// telemetry buffer to copy.
+		lastValidTime = time(NULL);
 
 		int latest = 0;
 		for(int i=1; i<pHeader->numBuf; i++)

--- a/src/app/processors/ProcessorHost.spec.ts
+++ b/src/app/processors/ProcessorHost.spec.ts
@@ -88,6 +88,47 @@ describe('ProcessorHost', () => {
     expect(processor.onFrame).toHaveBeenCalledTimes(3);
   });
 
+  it('processes frames when the session clock is frozen', () => {
+    const bus = new ChannelBus();
+    bus.subscribe(target(14), 'track-state.snapshot');
+    const processor = fakeProcessor('track-state.snapshot', 25, (state) => {
+      state.version += 1;
+    });
+    const host = new ProcessorHost({
+      bus,
+      metrics: metrics(),
+      frameClock: () => 10,
+      definitions: [definition('track-state.snapshot', () => processor)],
+    });
+    const frame = {} as Telemetry;
+
+    host.onFrame(frame);
+    host.onFrame(frame);
+
+    expect(processor.onFrame).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses elapsed runtime rather than slow simulation time for cadence', () => {
+    vi.useFakeTimers({ now: 0 });
+    const bus = new ChannelBus();
+    bus.subscribe(target(15), 'track-state.snapshot');
+    const processor = fakeProcessor('track-state.snapshot', 25, (state) => {
+      state.version += 1;
+    });
+    const host = new ProcessorHost({
+      bus,
+      metrics: metrics(),
+      definitions: [definition('track-state.snapshot', () => processor)],
+    });
+
+    host.onFrame({ SessionTime: { value: [10] } } as unknown as Telemetry);
+    vi.advanceTimersByTime(40);
+    host.onFrame({ SessionTime: { value: [10.01] } } as unknown as Telemetry);
+
+    expect(processor.onFrame).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
   it('checks event processors every frame and publishes only on a signal', () => {
     const bus = new ChannelBus();
     const publish = vi.spyOn(bus, 'publish');

--- a/src/app/processors/ProcessorHost.spec.ts
+++ b/src/app/processors/ProcessorHost.spec.ts
@@ -121,9 +121,15 @@ describe('ProcessorHost', () => {
       definitions: [definition('track-state.snapshot', () => processor)],
     });
 
-    host.onFrame({ SessionTime: { value: [10] } } as unknown as Telemetry);
+    host.onFrame({
+      SessionTime: { value: [10] },
+      IsReplayPlaying: { value: [true] },
+    } as unknown as Telemetry);
     vi.advanceTimersByTime(40);
-    host.onFrame({ SessionTime: { value: [10.01] } } as unknown as Telemetry);
+    host.onFrame({
+      SessionTime: { value: [10.01] },
+      IsReplayPlaying: { value: [true] },
+    } as unknown as Telemetry);
 
     expect(processor.onFrame).toHaveBeenCalledTimes(2);
     vi.useRealTimers();

--- a/src/app/processors/ProcessorHost.spec.ts
+++ b/src/app/processors/ProcessorHost.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, type Mock } from 'vitest';
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest';
 import type {
   ChannelPayloads,
   Session,
@@ -15,6 +15,10 @@ import {
 } from './ProcessorHost';
 
 const metrics = () => ({ markStart: vi.fn(), markEnd: vi.fn() });
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 const target = (id: number, isVisible: () => boolean = () => true) => ({
   id,
@@ -132,7 +136,6 @@ describe('ProcessorHost', () => {
     } as unknown as Telemetry);
 
     expect(processor.onFrame).toHaveBeenCalledTimes(2);
-    vi.useRealTimers();
   });
 
   it('checks event processors every frame and publishes only on a signal', () => {

--- a/src/app/processors/ProcessorHost.ts
+++ b/src/app/processors/ProcessorHost.ts
@@ -63,11 +63,18 @@ interface ProcessorHostOptions {
   logError?: (message: string, error: unknown) => void;
 }
 
-// Processor cadence is a presentation/runtime concern and must not scale with
-// simulation time. SessionTime freezes while paused and advances slowly in a
-// slow-motion replay, but camera and other non-driving telemetry can still
-// change and must remain responsive.
-const defaultFrameClock = (): number => performance.now() / 1000;
+const defaultFrameClock = (frame: Telemetry): number | undefined => {
+  const isReplayPlaying = frame.IsReplayPlaying?.value?.[0];
+  if (isReplayPlaying === true) {
+    // Replay presentation must remain responsive while SessionTime is paused
+    // or advancing in slow motion.
+    return performance.now() / 1000;
+  }
+  const sessionTime = frame.SessionTime?.value?.[0];
+  return typeof sessionTime === 'number' && Number.isFinite(sessionTime)
+    ? sessionTime
+    : undefined;
+};
 
 const snapshotToken = (snapshot: unknown): unknown => {
   if (typeof snapshot !== 'object' || snapshot === null) return snapshot;

--- a/src/app/processors/ProcessorHost.ts
+++ b/src/app/processors/ProcessorHost.ts
@@ -63,12 +63,11 @@ interface ProcessorHostOptions {
   logError?: (message: string, error: unknown) => void;
 }
 
-const defaultFrameClock = (frame: Telemetry): number | undefined => {
-  const value = frame.SessionTime?.value?.[0];
-  return typeof value === 'number' && Number.isFinite(value)
-    ? value
-    : undefined;
-};
+// Processor cadence is a presentation/runtime concern and must not scale with
+// simulation time. SessionTime freezes while paused and advances slowly in a
+// slow-motion replay, but camera and other non-driving telemetry can still
+// change and must remain responsive.
+const defaultFrameClock = (): number => performance.now() / 1000;
 
 const snapshotToken = (snapshot: unknown): unknown => {
   if (typeof snapshot !== 'object' || snapshot === null) return snapshot;
@@ -333,7 +332,7 @@ export class ProcessorHost {
     const interval = 1 / tickRateHz;
     if (
       previous !== undefined &&
-      frameTime >= previous &&
+      frameTime > previous &&
       frameTime - previous < interval - 1e-6
     ) {
       return false;

--- a/src/app/processors/RelativeGapProcessor.spec.ts
+++ b/src/app/processors/RelativeGapProcessor.spec.ts
@@ -53,7 +53,7 @@ const frame = ({
   }) as unknown as Telemetry;
 
 describe('RelativeGapProcessor', () => {
-  it('publishes signed relative distances and estimated-time deltas at 5 Hz', () => {
+  it('projects every frame supplied by the host', () => {
     const processor = new RelativeGapProcessor({ snapshot: emptyReferences });
     processor.init(session());
     processor.onFrame(frame());
@@ -67,9 +67,9 @@ describe('RelativeGapProcessor', () => {
     expect(processor.snapshot().relativePcts[2]).toBeCloseTo(-0.05);
     const version = processor.snapshot().version;
     processor.onFrame(frame({ sessionTime: 1.1, pcts: [0.2, 0.3, 0.1] }));
-    expect(processor.snapshot().version).toBe(version);
-    processor.onFrame(frame({ sessionTime: 1.2, pcts: [0.2, 0.3, 0.1] }));
     expect(processor.snapshot().version).toBe(version + 1);
+    processor.onFrame(frame({ sessionTime: 1.2, pcts: [0.2, 0.3, 0.1] }));
+    expect(processor.snapshot().version).toBe(version + 2);
   });
 
   it('updates immediately when the camera focus changes while time is paused', () => {

--- a/src/app/processors/RelativeGapProcessor.ts
+++ b/src/app/processors/RelativeGapProcessor.ts
@@ -10,9 +10,6 @@ import type {
 import type { TelemetryProcessor } from './TelemetryProcessor';
 
 const FALLBACK_LAP_TIME = 90;
-const UPDATE_INTERVAL_SECONDS = 0.2;
-const TIME_EPSILON = 1e-6;
-
 const lapTimeOrFallback = (value: number | undefined): number =>
   typeof value === 'number' && Number.isFinite(value) && value > 0
     ? value
@@ -83,7 +80,6 @@ export class RelativeGapProcessor implements TelemetryProcessor<RelativeGapsSnap
   private readonly relativePcts: (number | null)[] = [];
   private readonly deltas: (number | null)[] = [];
   private driverCarIdx: number | null = null;
-  private lastUpdateTime: number | null = null;
   private enabled = true;
   private latest: RelativeGapsSnapshot = this.emptySnapshot();
 
@@ -113,19 +109,6 @@ export class RelativeGapProcessor implements TelemetryProcessor<RelativeGapsSnap
       cameraCarIdx !== null && cameraCarIdx >= 0
         ? cameraCarIdx
         : this.driverCarIdx;
-    const focusChanged = focusCarIdx !== this.latest.focusCarIdx;
-    const timeWentBackwards =
-      this.lastUpdateTime !== null && sessionTime < this.lastUpdateTime;
-    if (
-      !focusChanged &&
-      !timeWentBackwards &&
-      this.lastUpdateTime !== null &&
-      sessionTime - this.lastUpdateTime < UPDATE_INTERVAL_SECONDS - TIME_EPSILON
-    ) {
-      return;
-    }
-    this.lastUpdateTime = sessionTime;
-
     const sessionNum = numericValue(frame, 'SessionNum');
     if (
       this.latest.sessionNum !== null &&
@@ -284,7 +267,6 @@ export class RelativeGapProcessor implements TelemetryProcessor<RelativeGapsSnap
 
   private reset(sessionNum: number | null): void {
     const version = this.latest.version + 1;
-    this.lastUpdateTime = null;
     this.referenceVersion = -1;
     this.bestLaps.clear();
     this.persistedLaps.clear();

--- a/src/app/processors/StandingsProcessor.spec.ts
+++ b/src/app/processors/StandingsProcessor.spec.ts
@@ -43,17 +43,16 @@ describe('StandingsProcessor', () => {
     });
   });
 
-  it('publishes no faster than five hertz unless focus changes', () => {
+  it('projects every frame supplied by the host, including focus changes', () => {
     const processor = new StandingsProcessor();
     processor.init(session);
     processor.onFrame(frame(10));
-    const first = processor.snapshot();
     processor.onFrame(frame(10.1));
-    expect(processor.snapshot()).toBe(first);
+    expect(processor.snapshot().version).toBe(2);
 
     processor.onFrame(frame(10.1, { CamCarIdx: { value: [0] } }));
     expect(processor.snapshot().focusCarIdx).toBe(0);
-    expect(processor.snapshot().version).toBe(2);
+    expect(processor.snapshot().version).toBe(3);
   });
 
   it('reuses projection buffers between accepted frames', () => {

--- a/src/app/processors/StandingsProcessor.ts
+++ b/src/app/processors/StandingsProcessor.ts
@@ -7,9 +7,6 @@ import type {
 import { SessionState, TrackLocation } from '@irdashies/types';
 import type { TelemetryProcessor } from './TelemetryProcessor';
 
-const UPDATE_INTERVAL_SECONDS = 0.2;
-const TIME_EPSILON = 1e-6;
-
 const numberValue = (frame: Telemetry, key: keyof Telemetry): number | null => {
   const value = frame[key]?.value?.[0];
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
@@ -96,18 +93,9 @@ export class StandingsProcessor implements TelemetryProcessor<StandingsSnapshot>
     const sessionNum = numberValue(frame, 'SessionNum');
     const lifecycleChanged =
       this.latest.sessionNum !== null && sessionNum !== this.latest.sessionNum;
-    const focusChanged = focusCarIdx !== this.latest.focusCarIdx;
     const timeWentBackwards =
       this.lastUpdateTime !== null && sessionTime < this.lastUpdateTime;
     if (lifecycleChanged || timeWentBackwards) this.reset(sessionNum);
-    if (
-      !focusChanged &&
-      !timeWentBackwards &&
-      this.lastUpdateTime !== null &&
-      sessionTime - this.lastUpdateTime < UPDATE_INTERVAL_SECONDS - TIME_EPSILON
-    ) {
-      return;
-    }
     this.lastUpdateTime = sessionTime;
 
     copyBooleanArray(frame, 'CarIdxOnPitRoad', this.latest.carIdxOnPitRoad);


### PR DESCRIPTION
## Description

Keeps track-map, standings, relative, and lap-time telemetry responsive during paused and slow-motion iRacing replays.

- Treats a telemetry timeout as a pause while the SDK remains connected, retaining session/channel snapshots.
- Seeds the current native telemetry buffer when connecting to an already-paused replay.
- Schedules processor cadence from elapsed runtime instead of simulation time.
- Removes duplicate simulation-time throttling from standings and relative processors.
- Adds regression coverage for pause/resume, frozen clocks, and slow simulation time.

Architecture phase: Phase 3 channel processors and main-process derived telemetry.

Validation: 19 processor/bridge test files (121 tests), targeted ESLint, TypeScript no-emit check, and native SDK rebuild.

## Screenshots

### Before

Paused or slow-motion replay could freeze or blank standings/relative data, delay camera-car focus changes, and clear session state after a frame timeout.

### After

Replay overlays retain their latest state while paused and update independently of replay playback speed.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replay pause and resume behavior while preserving session and overlay data.
  * Telemetry now resumes reliably after SDK reconnection, including the first available data frame.
  * Prevented duplicate timestamps from triggering unnecessary processing.
  * Improved frame handling when simulation time is frozen, delayed, or repeated.

* **Performance**
  * Standings and relative gap displays now process every available frame for more accurate, responsive updates.
  * Excessively high snapshot rates are safely limited to the channel maximum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->