### PR TITLE
feat: standings columns that stay aligned, resizable panes, and a driver list on the lap graph

### DIFF
--- a/src/frontend/components/Gantry/Gantry.tsx
+++ b/src/frontend/components/Gantry/Gantry.tsx
@@ -3,10 +3,14 @@ import { GantryTabBar } from './components/GantryTabBar/GantryTabBar';
 import { GantryStandings } from './components/GantryStandings/GantryStandings';
 import { GantryIncidents } from './components/GantryIncidents/GantryIncidents';
 import { LapGraphView } from './components/LapGraph/LapGraphView';
+import { SplitPane } from './components/SplitPane/SplitPane';
 import { useRaceControlBridge, useSessionDrivers } from '@irdashies/context';
 import type { LapGraphMode } from '@irdashies/domain';
 
 type GantryView = 'standings-incidents' | 'lap-graph';
+
+/** Where the standings/incidents divider sits. A UI preference, not config. */
+const SPLIT_STORAGE_KEY = 'gantryStandingsSplitPercent';
 
 const GantryInner = memo(() => {
   const [activeView, setActiveView] = useState<GantryView>(
@@ -52,14 +56,12 @@ const GantryInner = memo(() => {
         onFollowChange={setFollowedCarIdx}
       />
       {activeView === 'standings-incidents' && (
-        <div className="flex flex-1 overflow-hidden">
-          <div className="w-1/2 border-r border-slate-700/50 overflow-hidden">
-            <GantryStandings followedCarIdx={followedCarIdx} />
-          </div>
-          <div className="w-1/2 overflow-hidden">
-            <GantryIncidents />
-          </div>
-        </div>
+        <SplitPane
+          label="Standings and incidents split"
+          storageKey={SPLIT_STORAGE_KEY}
+          left={<GantryStandings followedCarIdx={followedCarIdx} />}
+          right={<GantryIncidents />}
+        />
       )}
       {activeView === 'lap-graph' && (
         <div className="flex-1 overflow-hidden">

--- a/src/frontend/components/Gantry/components/GantryStandings/GantryStandings.stories.tsx
+++ b/src/frontend/components/Gantry/components/GantryStandings/GantryStandings.stories.tsx
@@ -15,3 +15,15 @@ export const Default: StoryObj<typeof GantryStandings> = {
 export const WithFollowedDriver: StoryObj<typeof GantryStandings> = {
   args: { followedCarIdx: 2 },
 };
+
+/** The alignment case: too narrow for the columns, so the table scrolls. */
+export const Narrow: StoryObj<typeof GantryStandings> = {
+  args: { followedCarIdx: null },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] h-[480px]">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/src/frontend/components/Gantry/components/GantryStandings/GantryStandings.tsx
+++ b/src/frontend/components/Gantry/components/GantryStandings/GantryStandings.tsx
@@ -40,7 +40,7 @@ const HeaderCell = memo(
         tabIndex={0}
         className={`${className} cursor-help focus:outline-none focus:ring-1 focus:ring-sky-400`}
       >
-        {label}
+        <span className="text-[10px]">{label}</span>
       </span>
     </Tooltip>
   )
@@ -48,13 +48,22 @@ const HeaderCell = memo(
 HeaderCell.displayName = 'HeaderCell';
 
 /**
- * Widths for the numeric columns, shared by the header and the rows so the two
- * cannot drift apart. Sized in ch rather than px because the overlay theme
- * scales the font: a fixed pixel column clips the moment a user picks a larger
- * size. shrink-0 stops flex squeezing them below their content, which is what
- * made the lap times overlap.
+ * Widths for every column, shared by the header and the rows so the two cannot
+ * drift apart. Sized in ch rather than px because the overlay theme scales the
+ * font: a fixed pixel column clips the moment a user picks a larger size.
+ *
+ * Two rules keep the header over its values. shrink-0 stops a narrow window
+ * squeezing a cell but not its header. And a ch resolves against the element's
+ * own font size, so the header row must carry the same text-xs as the driver
+ * rows — the smaller label type is set on the label span inside each cell.
  */
 const COL = {
+  position: 'w-6 shrink-0 text-center',
+  carNumber: 'w-12 shrink-0 text-center border-l-2 px-1',
+  name: 'flex-1 min-w-[8ch] truncate px-1',
+  compound: 'w-5 shrink-0',
+  rating: 'w-16 shrink-0',
+  pit: 'w-5 shrink-0 text-center',
   gap: 'w-[6ch] shrink-0 px-1',
   interval: 'w-[6ch] shrink-0 px-1',
   best: 'w-[9ch] shrink-0 px-1',
@@ -63,36 +72,36 @@ const COL = {
 } as const;
 
 const StandingsHeader = memo(() => (
-  <div className="flex items-center px-1 py-0.5 text-[10px] font-bold uppercase tracking-wider text-slate-500 bg-slate-900 border-b border-slate-700/50 flex-none">
+  <div className="sticky top-0 z-20 flex items-center px-1 py-0.5 text-xs font-bold uppercase tracking-wider text-slate-500 bg-slate-900 border-b border-slate-700/50">
     <HeaderCell
       label="P"
       tip="Running order within the car class. Rows are grouped by class, leader first."
-      className="w-6 text-center"
+      className={COL.position}
     />
     <HeaderCell
       label="#"
       tip="Car number. The coloured bar to its left is the car's class."
-      className="w-12 shrink-0 text-center border-l-2 border-transparent px-1"
+      className={`${COL.carNumber} border-transparent`}
     />
     <HeaderCell
       label="Driver"
       tip="Driver name, in the format set on the Gantry options tab. Click any row to point the sim camera at that car — this only does anything in a replay or while spectating."
-      className="flex-1 truncate px-1 text-left"
+      className={`${COL.name} text-left`}
     />
     <HeaderCell
       label="T"
       tip="Tyre compound currently fitted, for cars that report one."
-      className="w-5 text-center"
+      className={`${COL.compound} text-center`}
     />
     <HeaderCell
       label="iR"
       tip="Driver's iRating at the start of the event."
-      className="w-16 text-right"
+      className={`${COL.rating} text-right`}
     />
     <HeaderCell
       label="Pit"
       tip="Shows PIT while the car is on pit road, and DNF once it has retired or been disqualified."
-      className="w-5 text-center"
+      className={COL.pit}
     />
     <HeaderCell
       label="Gap"
@@ -183,55 +192,59 @@ export const GantryStandings = memo(({ followedCarIdx }: Props) => {
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      <StandingsHeader />
-      <div className="flex-1 overflow-y-auto min-h-0">
-        {standingsByClass.map(([classId, classDrivers]) => {
-          const firstDriver = classDrivers[0];
-          const carClass = firstDriver?.carClass;
-          const classColorHex =
-            carClass?.color !== undefined
-              ? `#${carClass.color.toString(16).padStart(6, '0')}`
-              : '#94a3b8';
-          return (
-            <div key={classId}>
-              {/* Class header */}
-              <div
-                className="flex items-center gap-2 bg-slate-900 px-2 py-0.5 border-y border-slate-700/30"
-                style={{
-                  borderLeftColor: classColorHex,
-                  borderLeftWidth: 2,
-                }}
-              >
-                <Tooltip
-                  content="Car class group. Position, gap and interval are all worked out within the class, not against the whole field."
-                  placement="bottom"
+      {/* One scroller for the header and the rows. A narrow window scrolls both
+          together instead of shrinking the columns out of line. */}
+      <div className="flex-1 min-h-0 overflow-auto scroll-pt-6">
+        <div className="min-w-min">
+          <StandingsHeader />
+          {standingsByClass.map(([classId, classDrivers]) => {
+            const firstDriver = classDrivers[0];
+            const carClass = firstDriver?.carClass;
+            const classColorHex =
+              carClass?.color !== undefined
+                ? `#${carClass.color.toString(16).padStart(6, '0')}`
+                : '#94a3b8';
+            return (
+              <div key={classId}>
+                {/* Class header */}
+                <div
+                  className="flex items-center gap-2 bg-slate-900 px-2 py-0.5 border-y border-slate-700/30"
+                  style={{
+                    borderLeftColor: classColorHex,
+                    borderLeftWidth: 2,
+                  }}
                 >
-                  <span
-                    tabIndex={0}
-                    className="text-xs font-extrabold uppercase tracking-widest cursor-help focus:outline-none focus:ring-1 focus:ring-sky-400"
-                    style={{ color: classColorHex }}
+                  <Tooltip
+                    content="Car class group. Position, gap and interval are all worked out within the class, not against the whole field."
+                    placement="bottom"
                   >
-                    {carClass?.name}
-                  </span>
-                </Tooltip>
+                    <span
+                      tabIndex={0}
+                      className="text-xs font-extrabold uppercase tracking-widest cursor-help focus:outline-none focus:ring-1 focus:ring-sky-400"
+                      style={{ color: classColorHex }}
+                    >
+                      {carClass?.name}
+                    </span>
+                  </Tooltip>
+                </div>
+                {/* Driver rows */}
+                {classDrivers.map((driver, idx) => (
+                  <GantryDriverRow
+                    key={driver.carIdx}
+                    driver={driver}
+                    idx={idx}
+                    followedCarIdx={followedCarIdx}
+                    followedRef={followedRef}
+                    isMultiClass={isMultiClass}
+                    highlightColorHex={highlightColorHex}
+                    nameFormat={nameFormat}
+                    onFocusDriver={handleFocusDriver}
+                  />
+                ))}
               </div>
-              {/* Driver rows */}
-              {classDrivers.map((driver, idx) => (
-                <GantryDriverRow
-                  key={driver.carIdx}
-                  driver={driver}
-                  idx={idx}
-                  followedCarIdx={followedCarIdx}
-                  followedRef={followedRef}
-                  isMultiClass={isMultiClass}
-                  highlightColorHex={highlightColorHex}
-                  nameFormat={nameFormat}
-                  onFocusDriver={handleFocusDriver}
-                />
-              ))}
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
     </div>
   );
@@ -319,26 +332,26 @@ const GantryDriverRow = memo(
       >
         {/* P */}
         <span
-          className={`w-6 text-center font-bold ${tailwindStyles.classHeader} ${isPlayer ? 'text-amber-300' : 'text-white'}`}
+          className={`${COL.position} font-bold ${tailwindStyles.classHeader} ${isPlayer ? 'text-amber-300' : 'text-white'}`}
         >
           {driver.classPosition ?? driver.position}
         </span>
         {/* # */}
         <span
-          className={`w-12 shrink-0 text-center tabular-nums ${tailwindStyles.driverIcon} border-l-2 px-1 text-white`}
+          className={`${COL.carNumber} tabular-nums ${tailwindStyles.driverIcon} text-white`}
         >
           #{driver.driver.carNum}
         </span>
         {/* Driver Name */}
-        <span className="flex-1 truncate px-1">{displayName}</span>
+        <span className={COL.name}>{displayName}</span>
         {/* Tyre */}
-        <span className="w-5 flex items-center justify-center">
+        <span className={`${COL.compound} flex items-center justify-center`}>
           {driver.tireCompound !== undefined && driver.carId !== undefined && (
             <Compound tireCompound={driver.tireCompound} />
           )}
         </span>
         {/* iR */}
-        <span className="w-16 flex items-center justify-end">
+        <span className={`${COL.rating} flex items-center justify-end`}>
           <DriverRatingBadge
             license={driver.driver.license}
             rating={driver.driver.rating}
@@ -346,7 +359,7 @@ const GantryDriverRow = memo(
           />
         </span>
         {/* Pit */}
-        <span className="w-5 text-center text-xs">
+        <span className={`${COL.pit} text-xs`}>
           {pitLabel && (
             <span
               className={

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.spec.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.spec.tsx
@@ -195,7 +195,7 @@ describe('LapGraphCanvas', () => {
     await waitFor(() => expect(contextFor('lap-graph-brush').strokes).toBe(60));
   });
 
-  it('keeps axes and legend in the DOM rather than the canvas', async () => {
+  it('keeps the caption and controls in the DOM rather than the canvas', async () => {
     renderChart();
 
     await waitFor(() =>
@@ -203,8 +203,6 @@ describe('LapGraphCanvas', () => {
         screen.getByText('seconds vs reference pace, higher is better')
       ).toBeInTheDocument()
     );
-    // 60 cars, less two pins and the player.
-    expect(screen.getByText('57 other cars')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /follow live/i })
     ).toBeInTheDocument();

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.tsx
@@ -10,7 +10,7 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   type RefObject,
 } from 'react';
-import { Play, PushPin } from '@phosphor-icons/react';
+import { Play } from '@phosphor-icons/react';
 import { useElementSize } from '@irdashies/context';
 import {
   formatAxisValue,
@@ -615,14 +615,6 @@ export const LapGraphCanvas = memo(
       );
     }, [geometry.window, plotSize.width]);
 
-    const legend = useMemo(
-      () =>
-        geometry.ordered
-          .filter((prepared) => prepared.tier !== 'context')
-          .map((prepared) => prepared.source),
-      [geometry.ordered]
-    );
-
     const hasData = geometry.ordered.length > 0;
 
     return (
@@ -758,30 +750,6 @@ export const LapGraphCanvas = memo(
               }}
             />
           </div>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 pt-1 shrink-0">
-          {legend.map((entry) => (
-            <button
-              key={entry.carIdx}
-              type="button"
-              onClick={() => onTogglePin(entry.carIdx)}
-              className="flex items-center gap-1 text-slate-300 hover:text-white"
-            >
-              <span
-                className="w-1.5 h-3 rounded-xs"
-                style={{ backgroundColor: entry.color }}
-              />
-              <span className="tabular-nums">#{entry.carNumber}</span>
-              <span className="max-w-32 truncate">{entry.displayName}</span>
-              <PushPin size={11} weight="fill" className="text-slate-500" />
-            </button>
-          ))}
-          {geometry.contextCount > 0 && (
-            <span className="text-slate-500">
-              {geometry.contextCount} other cars
-            </span>
-          )}
         </div>
       </div>
     );

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.spec.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.spec.tsx
@@ -113,4 +113,19 @@ describe('LapGraphDriverList', () => {
 
     expect(onToggle).not.toHaveBeenCalled();
   });
+
+  it('does not report a player with no completed laps as shown', () => {
+    const { onToggle } = renderList({
+      drivers: drivers.map((entry) =>
+        entry.isPlayer ? { ...entry, hasLine: false } : entry
+      ),
+    });
+
+    const row = screen.getByTitle('Hamilton has no completed laps yet');
+    expect(row).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(row);
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
 });

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.spec.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.spec.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { LapGraphDriverList } from './LapGraphDriverList';
+import type { DriverListEntry } from './LapGraphDriverList';
+
+const drivers: DriverListEntry[] = [
+  {
+    carIdx: 1,
+    carNumber: '11',
+    displayName: 'Verstappen',
+    position: 1,
+    isPlayer: false,
+    hasLine: true,
+  },
+  {
+    carIdx: 2,
+    carNumber: '44',
+    displayName: 'Hamilton',
+    position: 2,
+    isPlayer: true,
+    hasLine: true,
+  },
+  {
+    carIdx: 3,
+    carNumber: '16',
+    displayName: 'Leclerc',
+    position: 3,
+    isPlayer: false,
+    hasLine: false,
+  },
+];
+
+const renderList = (
+  props?: Partial<Parameters<typeof LapGraphDriverList>[0]>
+) => {
+  const onToggle = vi.fn();
+  const onHover = vi.fn();
+  render(
+    <LapGraphDriverList
+      drivers={drivers}
+      classColor="#22c55e"
+      shownCarIdxs={[1]}
+      focusedCarIdx={null}
+      onToggle={onToggle}
+      onHover={onHover}
+      {...props}
+    />
+  );
+  return { onToggle, onHover };
+};
+
+describe('LapGraphDriverList', () => {
+  it('lists the class in running order', () => {
+    renderList();
+
+    const names = screen
+      .getAllByRole('button')
+      .map((button) => button.textContent);
+
+    expect(names).toEqual(['1#11Verstappen', '2#44Hamilton', '3#16Leclerc']);
+  });
+
+  it('marks pinned cars and the player as shown', () => {
+    renderList();
+
+    expect(screen.getByTitle(/Hide Verstappen/)).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    // The player's line is always drawn, pinned or not.
+    expect(screen.getByTitle(/always drawn/)).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(screen.getByTitle(/no completed laps yet/)).toHaveAttribute(
+      'aria-pressed',
+      'false'
+    );
+  });
+
+  it('toggles a car on click and reports hover both ways', () => {
+    const { onToggle, onHover } = renderList();
+
+    const row = screen.getByTitle(/Hide Verstappen/);
+    fireEvent.pointerEnter(row);
+    fireEvent.click(row);
+
+    expect(onHover).toHaveBeenCalledWith(1);
+    expect(onToggle).toHaveBeenCalledWith(1);
+
+    fireEvent.pointerLeave(row);
+
+    expect(onHover).toHaveBeenLastCalledWith(null);
+  });
+
+  it('does not toggle a car with no laps yet, but still reports hover', () => {
+    const { onToggle, onHover } = renderList();
+
+    // aria-disabled rather than disabled, so the row keeps firing pointer
+    // events and cannot strand the highlight on the previous car.
+    const row = screen.getByTitle(/no completed laps yet/);
+    fireEvent.pointerEnter(row);
+    fireEvent.click(row);
+
+    expect(onHover).toHaveBeenCalledWith(3);
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('does not toggle the player, whose line is always drawn', () => {
+    const { onToggle } = renderList();
+
+    fireEvent.click(screen.getByTitle(/always drawn/));
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.stories.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.stories.tsx
@@ -28,7 +28,10 @@ const roster: DriverListEntry[] = SURNAMES.map((displayName, index) => ({
   hasLine: index < SURNAMES.length - 2,
 }));
 
-const Harness = ({ drivers }: { drivers: DriverListEntry[] }) => {
+interface HarnessProps {
+  drivers: DriverListEntry[];
+}
+const Harness = ({ drivers }: HarnessProps) => {
   const [shown, setShown] = useState<readonly number[]>([0, 1]);
   const [hovered, setHovered] = useState<number | null>(null);
   return (

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.stories.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { LapGraphDriverList } from './LapGraphDriverList';
+import type { DriverListEntry } from './LapGraphDriverList';
+
+const SURNAMES = [
+  'Verstappen',
+  'Hamilton',
+  'Leclerc',
+  'Norris',
+  'Russell',
+  'Alonso',
+  'Sainz',
+  'Piastri',
+  'Gasly',
+  'Ocon',
+  'Hulkenberg',
+  'Tsunoda',
+];
+
+const roster: DriverListEntry[] = SURNAMES.map((displayName, index) => ({
+  carIdx: index,
+  carNumber: String(index + 1),
+  displayName,
+  position: index + 1,
+  isPlayer: index === 3,
+  // The last two are still on their opening lap.
+  hasLine: index < SURNAMES.length - 2,
+}));
+
+const Harness = ({ drivers }: { drivers: DriverListEntry[] }) => {
+  const [shown, setShown] = useState<readonly number[]>([0, 1]);
+  const [hovered, setHovered] = useState<number | null>(null);
+  return (
+    <div className="h-screen flex bg-slate-900 text-xs p-3">
+      <div className="flex-1 flex items-center justify-center text-slate-600">
+        Chart goes here
+      </div>
+      <LapGraphDriverList
+        drivers={drivers}
+        classColor="#22c55e"
+        shownCarIdxs={shown}
+        focusedCarIdx={hovered}
+        onToggle={(carIdx) =>
+          setShown((current) =>
+            current.includes(carIdx)
+              ? current.filter((idx) => idx !== carIdx)
+              : [...current, carIdx]
+          )
+        }
+        onHover={setHovered}
+      />
+    </div>
+  );
+};
+
+const meta: Meta<typeof LapGraphDriverList> = {
+  component: LapGraphDriverList,
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+type Story = StoryObj<typeof LapGraphDriverList>;
+
+export const Field: Story = {
+  render: () => <Harness drivers={roster} />,
+};
+
+export const WaitingForTheGrid: Story = {
+  render: () => <Harness drivers={[]} />,
+};

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.tsx
@@ -1,0 +1,128 @@
+import { memo } from 'react';
+import { brightenColor } from './useLapGraphSeries';
+
+export interface DriverListEntry {
+  carIdx: number;
+  carNumber: string;
+  /** Already formatted for display. Do not reformat. */
+  displayName: string;
+  /** Class position right now, or undefined before the grid forms. */
+  position: number | undefined;
+  isPlayer: boolean;
+  /** False until the car has completed a lap the chart can draw. */
+  hasLine: boolean;
+}
+
+export interface LapGraphDriverListProps {
+  /** Drivers in the selected class, leader first. */
+  drivers: readonly DriverListEntry[];
+  /** Class colour, shared by every line in the chart. */
+  classColor: string;
+  /** Cars currently drawn at full strength. */
+  shownCarIdxs: readonly number[];
+  /** The one line drawn brightest, from the Follow control or list hover. */
+  focusedCarIdx: number | null;
+  onToggle: (carIdx: number) => void;
+  onHover: (carIdx: number | null) => void;
+}
+
+/**
+ * The class roster down the side of the chart, in running order. Clicking a
+ * name draws that car's line; hovering one lifts it above the field.
+ */
+export const LapGraphDriverList = memo(
+  ({
+    drivers,
+    classColor,
+    shownCarIdxs,
+    focusedCarIdx,
+    onToggle,
+    onHover,
+  }: LapGraphDriverListProps) => {
+    const shown = new Set(shownCarIdxs);
+
+    return (
+      <div className="w-[24ch] max-w-[40%] shrink-0 flex flex-col min-h-0 border-l border-slate-700/50 pl-2">
+        <div className="shrink-0 pb-1 text-slate-500 font-bold uppercase tracking-wider">
+          Drivers
+        </div>
+        <div
+          className="flex-1 min-h-0 overflow-y-auto"
+          onPointerLeave={() => onHover(null)}
+        >
+          {drivers.length === 0 && (
+            <div className="text-slate-600">Waiting for the grid.</div>
+          )}
+          {drivers.map((entry) => {
+            const isShown = entry.isPlayer || shown.has(entry.carIdx);
+            const isFocused = entry.carIdx === focusedCarIdx;
+            // The player's line is always drawn, so toggling it would change
+            // nothing on screen while latching the auto-pin set off.
+            const canToggle = entry.hasLine && !entry.isPlayer;
+            return (
+              <button
+                key={entry.carIdx}
+                type="button"
+                aria-pressed={isShown}
+                // aria-disabled, not disabled: Chromium swallows pointer events
+                // on a disabled control, which would strand the hover highlight
+                // on whichever car the pointer crossed last.
+                aria-disabled={!canToggle}
+                onClick={() => {
+                  if (canToggle) onToggle(entry.carIdx);
+                }}
+                onPointerEnter={() => onHover(entry.carIdx)}
+                onPointerLeave={() => onHover(null)}
+                onFocus={() => onHover(entry.carIdx)}
+                onBlur={() => onHover(null)}
+                title={
+                  entry.isPlayer
+                    ? 'Your own line is always drawn'
+                    : entry.hasLine
+                      ? `${isShown ? 'Hide' : 'Show'} ${entry.displayName}`
+                      : `${entry.displayName} has no completed laps yet`
+                }
+                className={[
+                  'flex items-center gap-1.5 w-full px-1 py-0.5 rounded-sm text-left',
+                  'focus:outline-none focus:ring-1 focus:ring-sky-400',
+                  !entry.hasLine
+                    ? 'text-slate-600'
+                    : isFocused
+                      ? 'bg-sky-500/20 text-white'
+                      : isShown
+                        ? 'text-slate-200 hover:bg-slate-700/40'
+                        : 'text-slate-500 hover:bg-slate-800/70',
+                  entry.isPlayer ? 'text-amber-300' : '',
+                  canToggle ? 'cursor-pointer' : 'cursor-default',
+                ]
+                  .filter(Boolean)
+                  .join(' ')}
+              >
+                <span className="w-5 shrink-0 text-right tabular-nums text-slate-500">
+                  {entry.position ?? '-'}
+                </span>
+                <span
+                  className="w-1.5 h-3 shrink-0 rounded-xs border border-slate-600"
+                  style={{
+                    backgroundColor: isShown
+                      ? isFocused
+                        ? brightenColor(classColor)
+                        : classColor
+                      : 'transparent',
+                  }}
+                />
+                <span className="w-[4ch] shrink-0 tabular-nums">
+                  #{entry.carNumber}
+                </span>
+                <span className="flex-1 min-w-0 truncate">
+                  {entry.displayName}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+);
+LapGraphDriverList.displayName = 'LapGraphDriverList';

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphDriverList.tsx
@@ -46,15 +46,13 @@ export const LapGraphDriverList = memo(
         <div className="shrink-0 pb-1 text-slate-500 font-bold uppercase tracking-wider">
           Drivers
         </div>
-        <div
-          className="flex-1 min-h-0 overflow-y-auto"
-          onPointerLeave={() => onHover(null)}
-        >
+        <div className="flex-1 min-h-0 overflow-y-auto">
           {drivers.length === 0 && (
             <div className="text-slate-600">Waiting for the grid.</div>
           )}
           {drivers.map((entry) => {
-            const isShown = entry.isPlayer || shown.has(entry.carIdx);
+            const isShown =
+              entry.hasLine && (entry.isPlayer || shown.has(entry.carIdx));
             const isFocused = entry.carIdx === focusedCarIdx;
             // The player's line is always drawn, so toggling it would change
             // nothing on screen while latching the auto-pin set off.
@@ -76,11 +74,11 @@ export const LapGraphDriverList = memo(
                 onFocus={() => onHover(entry.carIdx)}
                 onBlur={() => onHover(null)}
                 title={
-                  entry.isPlayer
-                    ? 'Your own line is always drawn'
-                    : entry.hasLine
-                      ? `${isShown ? 'Hide' : 'Show'} ${entry.displayName}`
-                      : `${entry.displayName} has no completed laps yet`
+                  !entry.hasLine
+                    ? `${entry.displayName} has no completed laps yet`
+                    : entry.isPlayer
+                      ? 'Your own line is always drawn'
+                      : `${isShown ? 'Hide' : 'Show'} ${entry.displayName}`
                 }
                 className={[
                   'flex items-center gap-1.5 w-full px-1 py-0.5 rounded-sm text-left',

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphView.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphView.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { useDriverStandings } from '@irdashies/domain/standings/useDriverStandings';
 import {
   classReferenceLap,
@@ -23,6 +23,8 @@ import {
 } from '../../../shared/DriverName/DriverName';
 import { LapGraphCanvas } from './LapGraphCanvas';
 import type { LapGraphSeries } from './LapGraphCanvas';
+import { LapGraphDriverList } from './LapGraphDriverList';
+import type { DriverListEntry } from './LapGraphDriverList';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { useGantrySettings } from '../../hooks/useGantrySettings';
 import { autoPinCarIdxs } from './lapGraphAutoPin';
@@ -99,6 +101,14 @@ const buildMembers = (
 const membersSignature = (members: readonly ClassMember[]): string =>
   members
     .map((m) => `${m.carIdx}|${m.carNumber}|${m.displayName}|${m.isPlayer}`)
+    .join(',');
+
+/** Live class positions, as a primitive the side list can memoise on. */
+const positionsSignature = (
+  drivers: ReturnType<typeof useDriverStandings>[number][1]
+): string =>
+  drivers
+    .map((d) => `${d.carIdx}:${d.classPosition ?? d.position ?? ''}`)
     .join(',');
 
 const axisCaptionFor = (
@@ -215,6 +225,11 @@ export const LapGraphView = memo(
 
     const pinnedCarIdxs = chosenPins ?? autoPins;
 
+    // Hovering a name in the side list lifts that line above the field. It
+    // outranks the Follow control for as long as the pointer is on the row.
+    const [hoveredCarIdx, setHoveredCarIdx] = useState<number | null>(null);
+    const focusedCarIdx = hoveredCarIdx ?? followedCarIdx;
+
     const togglePin = useCallback(
       (carIdx: number) => {
         const base = chosenPins ?? autoPins;
@@ -313,6 +328,41 @@ export const LapGraphView = memo(
       () => axisCaptionFor(mode, built.reference),
       [mode, built.reference]
     );
+
+    // Positions move on every standings tick. They are read here rather than
+    // carried on `members`, so a place swap re-sorts the side list without
+    // rebuilding a series for every car in the class.
+    const positionsKey = useMemo(
+      () => positionsSignature(activeClass?.drivers ?? []),
+      [activeClass]
+    );
+
+    /** The whole class in running order, lapped or not, drawn or not. */
+    const roster = useMemo<DriverListEntry[]>(() => {
+      const drawn = new Set(built.series.map((entry) => entry.carIdx));
+      const positions = new Map<number, number | undefined>(
+        (activeClass?.drivers ?? []).map((driver) => [
+          driver.carIdx,
+          driver.classPosition ?? driver.position,
+        ])
+      );
+      return members
+        .map((member) => ({
+          carIdx: member.carIdx,
+          carNumber: member.carNumber,
+          displayName: member.displayName,
+          isPlayer: member.isPlayer,
+          position: positions.get(member.carIdx),
+          hasLine: drawn.has(member.carIdx),
+        }))
+        .sort(
+          (a, b) =>
+            (a.position ?? Number.MAX_SAFE_INTEGER) -
+            (b.position ?? Number.MAX_SAFE_INTEGER)
+        );
+      // Deliberately keyed on the positions signature, not the list identity.
+      // eslint-disable-next-line @eslint-react/exhaustive-deps
+    }, [members, built.series, positionsKey]);
 
     const emptyMessage = useMemo(() => {
       if (sessionType && sessionType !== 'Race') {
@@ -413,22 +463,32 @@ export const LapGraphView = memo(
           </div>
         </div>
 
-        <div className="flex-1 min-h-0 p-3">
-          {built.series.length === 0 ? (
-            <div className="flex items-center justify-center h-full text-slate-600 text-sm text-center px-4">
-              {emptyMessage}
-            </div>
-          ) : (
-            <LapGraphCanvas
-              series={built.series}
-              mode={mode}
-              axisCaption={axisCaption}
-              pinnedCarIdxs={pinnedCarIdxs}
-              focusedCarIdx={followedCarIdx}
-              onTogglePin={togglePin}
-              defaultLapWindow={lapGraphSettings?.lapWindow}
-            />
-          )}
+        <div className="flex-1 min-h-0 flex gap-2 p-3 text-xs">
+          <div className="flex-1 min-w-0">
+            {built.series.length === 0 ? (
+              <div className="flex items-center justify-center h-full text-slate-600 text-sm text-center px-4">
+                {emptyMessage}
+              </div>
+            ) : (
+              <LapGraphCanvas
+                series={built.series}
+                mode={mode}
+                axisCaption={axisCaption}
+                pinnedCarIdxs={pinnedCarIdxs}
+                focusedCarIdx={focusedCarIdx}
+                onTogglePin={togglePin}
+                defaultLapWindow={lapGraphSettings?.lapWindow}
+              />
+            )}
+          </div>
+          <LapGraphDriverList
+            drivers={roster}
+            classColor={classColor}
+            shownCarIdxs={pinnedCarIdxs}
+            focusedCarIdx={focusedCarIdx}
+            onToggle={togglePin}
+            onHover={setHoveredCarIdx}
+          />
         </div>
       </div>
     );

--- a/src/frontend/components/Gantry/components/LapGraph/useLapGraphSeries.ts
+++ b/src/frontend/components/Gantry/components/LapGraph/useLapGraphSeries.ts
@@ -59,7 +59,7 @@ export interface LapGraphGeometry {
   byCarIdx: ReadonlyMap<number, LapGraphSeries>;
   /** Points actually stroked, after windowing and decimation. */
   drawnPointCount: number;
-  /** Cars drawn at context strength, for the legend's plain count. */
+  /** Cars drawn at context strength, i.e. the faint background field. */
   contextCount: number;
 }
 

--- a/src/frontend/components/Gantry/components/SplitPane/SplitPane.spec.tsx
+++ b/src/frontend/components/Gantry/components/SplitPane/SplitPane.spec.tsx
@@ -134,6 +134,26 @@ describe('SplitPane', () => {
     expect(divider()).toHaveAttribute('aria-valuenow', '50');
   });
 
+  it('ignores a second pointer during an active drag', () => {
+    renderSplit();
+
+    const handle = divider();
+    fireEvent.pointerDown(handle, { pointerId: 1, button: 0, isPrimary: true });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 700, buttons: 1 });
+
+    // A second finger on the divider must not steer it...
+    fireEvent.pointerMove(handle, { pointerId: 2, clientX: 200, buttons: 1 });
+    expect(divider()).toHaveAttribute('aria-valuenow', '70');
+
+    // ...nor end the first pointer's drag.
+    fireEvent.pointerUp(handle, { pointerId: 2 });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 400, buttons: 1 });
+    expect(divider()).toHaveAttribute('aria-valuenow', '40');
+
+    fireEvent.pointerUp(handle, { pointerId: 1 });
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('40');
+  });
+
   it('stops dragging when the pointer capture is lost', () => {
     renderSplit();
 

--- a/src/frontend/components/Gantry/components/SplitPane/SplitPane.spec.tsx
+++ b/src/frontend/components/Gantry/components/SplitPane/SplitPane.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SplitPane } from './SplitPane';
 
@@ -146,5 +146,27 @@ describe('SplitPane', () => {
     fireEvent.pointerMove(handle, { pointerId: 1, clientX: 200, buttons: 0 });
 
     expect(divider()).toHaveAttribute('aria-valuenow', '70');
+  });
+
+  it('persists the latest ratio when the final move and release land in the same batch', () => {
+    renderSplit();
+
+    const handle = divider();
+    fireEvent.pointerDown(handle, { pointerId: 1, button: 0, isPrimary: true });
+
+    // Nesting inside one act() defers the re-render from pointermove until
+    // after pointerup has also run, so pointerup sees stale React state if
+    // it isn't reading the ratio from a ref.
+    act(() => {
+      fireEvent.pointerMove(handle, {
+        pointerId: 1,
+        clientX: 700,
+        buttons: 1,
+      });
+      fireEvent.pointerUp(handle, { pointerId: 1 });
+    });
+
+    expect(divider()).toHaveAttribute('aria-valuenow', '70');
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('70');
   });
 });

--- a/src/frontend/components/Gantry/components/SplitPane/SplitPane.spec.tsx
+++ b/src/frontend/components/Gantry/components/SplitPane/SplitPane.spec.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SplitPane } from './SplitPane';
+
+const CONTAINER_WIDTH = 1000;
+const STORAGE_KEY = 'testSplitPercent';
+
+const renderSplit = (props?: Partial<Parameters<typeof SplitPane>[0]>) =>
+  render(
+    <SplitPane
+      label="Test split"
+      storageKey={STORAGE_KEY}
+      left={<div>left pane</div>}
+      right={<div>right pane</div>}
+      {...props}
+    />
+  );
+
+const divider = () => screen.getByRole('separator');
+
+/** Left pane sits immediately before the divider. */
+const leftPane = () => screen.getByText('left pane').parentElement;
+
+const drag = (toClientX: number) => {
+  const handle = divider();
+  fireEvent.pointerDown(handle, { pointerId: 1, button: 0, isPrimary: true });
+  fireEvent.pointerMove(handle, {
+    pointerId: 1,
+    clientX: toClientX,
+    buttons: 1,
+  });
+  fireEvent.pointerUp(handle, { pointerId: 1 });
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    right: CONTAINER_WIDTH,
+    bottom: 500,
+    width: CONTAINER_WIDTH,
+    height: 500,
+    toJSON: () => ({}),
+  } as DOMRect);
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn(() => true);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('SplitPane', () => {
+  it('opens at an even split', () => {
+    renderSplit();
+
+    expect(divider()).toHaveAttribute('aria-valuenow', '50');
+    expect(leftPane()).toHaveStyle({ flexBasis: '50%' });
+  });
+
+  it('resizes to where the pointer is dragged', () => {
+    renderSplit();
+
+    drag(700);
+
+    expect(divider()).toHaveAttribute('aria-valuenow', '70');
+    expect(leftPane()).toHaveStyle({ flexBasis: '70%' });
+  });
+
+  it('clamps a drag past either end to the minimum pane width', () => {
+    renderSplit({ minPercent: 15 });
+
+    drag(20);
+    expect(divider()).toHaveAttribute('aria-valuenow', '15');
+
+    drag(990);
+    expect(divider()).toHaveAttribute('aria-valuenow', '85');
+  });
+
+  it('remembers the ratio and reads it back', () => {
+    const { unmount } = renderSplit();
+
+    drag(300);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('30');
+
+    unmount();
+    renderSplit();
+
+    expect(divider()).toHaveAttribute('aria-valuenow', '30');
+  });
+
+  it('ignores a stored ratio that is not a number', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-a-number');
+
+    renderSplit();
+
+    expect(divider()).toHaveAttribute('aria-valuenow', '50');
+  });
+
+  it('nudges with the arrow keys and resets with Home', () => {
+    renderSplit();
+
+    fireEvent.keyDown(divider(), { key: 'ArrowRight' });
+    expect(divider()).toHaveAttribute('aria-valuenow', '52');
+
+    fireEvent.keyDown(divider(), { key: 'ArrowLeft' });
+    fireEvent.keyDown(divider(), { key: 'ArrowLeft' });
+    expect(divider()).toHaveAttribute('aria-valuenow', '48');
+
+    fireEvent.keyDown(divider(), { key: 'Home' });
+    expect(divider()).toHaveAttribute('aria-valuenow', '50');
+  });
+
+  it('resets on a double click', () => {
+    renderSplit({ defaultPercent: 60 });
+
+    drag(300);
+    fireEvent.doubleClick(divider());
+
+    expect(divider()).toHaveAttribute('aria-valuenow', '60');
+  });
+
+  it('does not drag on a non-primary button', () => {
+    renderSplit();
+
+    const handle = divider();
+    fireEvent.pointerDown(handle, { pointerId: 1, button: 2, isPrimary: true });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 800, buttons: 2 });
+
+    expect(divider()).toHaveAttribute('aria-valuenow', '50');
+  });
+
+  it('stops dragging when the pointer capture is lost', () => {
+    renderSplit();
+
+    const handle = divider();
+    fireEvent.pointerDown(handle, { pointerId: 1, button: 0, isPrimary: true });
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 700, buttons: 1 });
+    fireEvent.lostPointerCapture(handle, { pointerId: 1 });
+
+    // A stray move with no button held must not keep resizing.
+    fireEvent.pointerMove(handle, { pointerId: 1, clientX: 200, buttons: 0 });
+
+    expect(divider()).toHaveAttribute('aria-valuenow', '70');
+  });
+});

--- a/src/frontend/components/Gantry/components/SplitPane/SplitPane.stories.tsx
+++ b/src/frontend/components/Gantry/components/SplitPane/SplitPane.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { SplitPane } from './SplitPane';
+
+const Panel = ({ title, tone }: { title: string; tone: string }) => (
+  <div className={`h-full p-3 text-white text-sm ${tone}`}>
+    <div className="font-bold uppercase tracking-wider text-xs text-slate-400">
+      {title}
+    </div>
+    <p className="pt-2">Drag the divider. Double-click it to reset.</p>
+  </div>
+);
+
+const meta: Meta<typeof SplitPane> = {
+  component: SplitPane,
+  parameters: { layout: 'fullscreen' },
+  decorators: [
+    (Story) => (
+      <div className="w-full h-screen flex bg-slate-900">
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+type Story = StoryObj<typeof SplitPane>;
+
+export const Even: Story = {
+  args: {
+    label: 'Example split',
+    left: <Panel title="Left" tone="bg-slate-800/60" />,
+    right: <Panel title="Right" tone="bg-slate-900/60" />,
+  },
+};
+
+export const LeftHeavy: Story = {
+  args: {
+    ...Even.args,
+    defaultPercent: 70,
+  },
+};

--- a/src/frontend/components/Gantry/components/SplitPane/SplitPane.stories.tsx
+++ b/src/frontend/components/Gantry/components/SplitPane/SplitPane.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SplitPane } from './SplitPane';
 
-const Panel = ({ title, tone }: { title: string; tone: string }) => (
+interface PanelProps {
+  title: string;
+  tone: string;
+}
+const Panel = ({ title, tone }: PanelProps) => (
   <div className={`h-full p-3 text-white text-sm ${tone}`}>
     <div className="font-bold uppercase tracking-wider text-xs text-slate-400">
       {title}

--- a/src/frontend/components/Gantry/components/SplitPane/SplitPane.tsx
+++ b/src/frontend/components/Gantry/components/SplitPane/SplitPane.tsx
@@ -52,6 +52,9 @@ export const SplitPane = memo(
       clampPercent(readStored(storageKey) ?? defaultPercent, minPercent)
     );
     const draggingRef = useRef(false);
+    // Tracks the latest ratio outside of React state so pointerup can persist
+    // it even if the last pointermove's setState hasn't committed yet.
+    const percentRef = useRef(percent);
 
     const remember = useCallback(
       (value: number) => {
@@ -82,12 +85,12 @@ export const SplitPane = memo(
         }
         const rect = element.getBoundingClientRect();
         if (rect.width <= 0) return;
-        setPercent(
-          clampPercent(
-            ((event.clientX - rect.left) / rect.width) * 100,
-            minPercent
-          )
+        const next = clampPercent(
+          ((event.clientX - rect.left) / rect.width) * 100,
+          minPercent
         );
+        percentRef.current = next;
+        setPercent(next);
       },
       [minPercent]
     );
@@ -99,15 +102,16 @@ export const SplitPane = memo(
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
           event.currentTarget.releasePointerCapture(event.pointerId);
         }
-        remember(percent);
+        remember(percentRef.current);
       },
-      [percent, remember]
+      [remember]
     );
 
     const nudge = useCallback(
       (delta: number) => {
         setPercent((current) => {
           const next = clampPercent(current + delta, minPercent);
+          percentRef.current = next;
           remember(next);
           return next;
         });
@@ -125,8 +129,10 @@ export const SplitPane = memo(
           nudge(KEY_STEP_PERCENT);
         } else if (event.key === 'Home') {
           event.preventDefault();
-          setPercent(clampPercent(defaultPercent, minPercent));
-          remember(clampPercent(defaultPercent, minPercent));
+          const reset = clampPercent(defaultPercent, minPercent);
+          percentRef.current = reset;
+          setPercent(reset);
+          remember(reset);
         }
       },
       [nudge, defaultPercent, minPercent, remember]
@@ -134,12 +140,13 @@ export const SplitPane = memo(
 
     const handleDoubleClick = useCallback(() => {
       const reset = clampPercent(defaultPercent, minPercent);
+      percentRef.current = reset;
       setPercent(reset);
       remember(reset);
     }, [defaultPercent, minPercent, remember]);
 
     return (
-      <div ref={containerRef} className="flex flex-1 overflow-hidden">
+      <div ref={containerRef} className="relative flex flex-1 overflow-hidden">
         <div
           className="overflow-hidden shrink-0 grow-0"
           style={{ flexBasis: `${percent}%` }}
@@ -162,7 +169,10 @@ export const SplitPane = memo(
           onKeyDown={handleKeyDown}
           onDoubleClick={handleDoubleClick}
           title="Drag to resize. Double-click to reset."
-          className="w-1.5 shrink-0 cursor-col-resize touch-none select-none bg-slate-700/50 hover:bg-sky-500/70 focus:outline-none focus:bg-sky-500/70"
+          // Taken out of flex flow so the panes split exactly percent /
+          // (100 - percent) of the container, not of container-minus-divider.
+          className="absolute top-0 bottom-0 w-1.5 -translate-x-1/2 z-10 cursor-col-resize touch-none select-none bg-slate-700/50 hover:bg-sky-500/70 focus:outline-none focus:bg-sky-500/70"
+          style={{ left: `${percent}%` }}
         />
         <div className="flex-1 min-w-0 overflow-hidden">{right}</div>
       </div>

--- a/src/frontend/components/Gantry/components/SplitPane/SplitPane.tsx
+++ b/src/frontend/components/Gantry/components/SplitPane/SplitPane.tsx
@@ -1,0 +1,172 @@
+import {
+  memo,
+  useCallback,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from 'react';
+
+export interface SplitPaneProps {
+  left: ReactNode;
+  right: ReactNode;
+  /** Accessible name for the divider, e.g. "Standings and incidents split". */
+  label: string;
+  /** localStorage key the ratio is remembered under. Omit to forget it. */
+  storageKey?: string;
+  /** Percentage of the width the left pane starts at. */
+  defaultPercent?: number;
+  /** Narrowest either pane is allowed to get, as a percentage. */
+  minPercent?: number;
+}
+
+const KEY_STEP_PERCENT = 2;
+
+const clampPercent = (value: number, min: number): number =>
+  Math.min(100 - min, Math.max(min, value));
+
+const readStored = (key: string | undefined): number | null => {
+  if (!key) return null;
+  const raw = localStorage.getItem(key);
+  if (raw === null) return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/**
+ * Two panes with a divider the user can drag. The ratio is a UI preference, so
+ * it lives in localStorage rather than the dashboard config.
+ */
+export const SplitPane = memo(
+  ({
+    left,
+    right,
+    label,
+    storageKey,
+    defaultPercent = 50,
+    minPercent = 15,
+  }: SplitPaneProps) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const [percent, setPercent] = useState(() =>
+      clampPercent(readStored(storageKey) ?? defaultPercent, minPercent)
+    );
+    const draggingRef = useRef(false);
+
+    const remember = useCallback(
+      (value: number) => {
+        if (storageKey) localStorage.setItem(storageKey, String(value));
+      },
+      [storageKey]
+    );
+
+    const handlePointerDown = useCallback(
+      (event: ReactPointerEvent<HTMLDivElement>) => {
+        // Only the primary button drags. A right-press that ends in a context
+        // menu never delivers pointerup, which would latch the drag on.
+        if (event.button !== 0 || !event.isPrimary) return;
+        event.currentTarget.focus();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        draggingRef.current = true;
+      },
+      []
+    );
+
+    const handlePointerMove = useCallback(
+      (event: ReactPointerEvent<HTMLDivElement>) => {
+        const element = containerRef.current;
+        if (!draggingRef.current || !element) return;
+        if (event.buttons === 0) {
+          draggingRef.current = false;
+          return;
+        }
+        const rect = element.getBoundingClientRect();
+        if (rect.width <= 0) return;
+        setPercent(
+          clampPercent(
+            ((event.clientX - rect.left) / rect.width) * 100,
+            minPercent
+          )
+        );
+      },
+      [minPercent]
+    );
+
+    const handlePointerUp = useCallback(
+      (event: ReactPointerEvent<HTMLDivElement>) => {
+        if (!draggingRef.current) return;
+        draggingRef.current = false;
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+        remember(percent);
+      },
+      [percent, remember]
+    );
+
+    const nudge = useCallback(
+      (delta: number) => {
+        setPercent((current) => {
+          const next = clampPercent(current + delta, minPercent);
+          remember(next);
+          return next;
+        });
+      },
+      [minPercent, remember]
+    );
+
+    const handleKeyDown = useCallback(
+      (event: ReactKeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          nudge(-KEY_STEP_PERCENT);
+        } else if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          nudge(KEY_STEP_PERCENT);
+        } else if (event.key === 'Home') {
+          event.preventDefault();
+          setPercent(clampPercent(defaultPercent, minPercent));
+          remember(clampPercent(defaultPercent, minPercent));
+        }
+      },
+      [nudge, defaultPercent, minPercent, remember]
+    );
+
+    const handleDoubleClick = useCallback(() => {
+      const reset = clampPercent(defaultPercent, minPercent);
+      setPercent(reset);
+      remember(reset);
+    }, [defaultPercent, minPercent, remember]);
+
+    return (
+      <div ref={containerRef} className="flex flex-1 overflow-hidden">
+        <div
+          className="overflow-hidden shrink-0 grow-0"
+          style={{ flexBasis: `${percent}%` }}
+        >
+          {left}
+        </div>
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={label}
+          aria-valuenow={Math.round(percent)}
+          aria-valuemin={minPercent}
+          aria-valuemax={100 - minPercent}
+          tabIndex={0}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
+          onLostPointerCapture={handlePointerUp}
+          onKeyDown={handleKeyDown}
+          onDoubleClick={handleDoubleClick}
+          title="Drag to resize. Double-click to reset."
+          className="w-1.5 shrink-0 cursor-col-resize touch-none select-none bg-slate-700/50 hover:bg-sky-500/70 focus:outline-none focus:bg-sky-500/70"
+        />
+        <div className="flex-1 min-w-0 overflow-hidden">{right}</div>
+      </div>
+    );
+  }
+);
+SplitPane.displayName = 'SplitPane';

--- a/src/frontend/components/Gantry/components/SplitPane/SplitPane.tsx
+++ b/src/frontend/components/Gantry/components/SplitPane/SplitPane.tsx
@@ -52,9 +52,17 @@ export const SplitPane = memo(
       clampPercent(readStored(storageKey) ?? defaultPercent, minPercent)
     );
     const draggingRef = useRef(false);
+    // Only the pointer that started the drag may move or end it. A second
+    // finger landing on the divider would otherwise steer it or drop it.
+    const pointerIdRef = useRef<number | null>(null);
     // Tracks the latest ratio outside of React state so pointerup can persist
     // it even if the last pointermove's setState hasn't committed yet.
     const percentRef = useRef(percent);
+
+    const endDrag = useCallback(() => {
+      draggingRef.current = false;
+      pointerIdRef.current = null;
+    }, []);
 
     const remember = useCallback(
       (value: number) => {
@@ -71,6 +79,7 @@ export const SplitPane = memo(
         event.currentTarget.focus();
         event.currentTarget.setPointerCapture(event.pointerId);
         draggingRef.current = true;
+        pointerIdRef.current = event.pointerId;
       },
       []
     );
@@ -78,9 +87,15 @@ export const SplitPane = memo(
     const handlePointerMove = useCallback(
       (event: ReactPointerEvent<HTMLDivElement>) => {
         const element = containerRef.current;
-        if (!draggingRef.current || !element) return;
+        if (
+          !draggingRef.current ||
+          pointerIdRef.current !== event.pointerId ||
+          !element
+        ) {
+          return;
+        }
         if (event.buttons === 0) {
-          draggingRef.current = false;
+          endDrag();
           return;
         }
         const rect = element.getBoundingClientRect();
@@ -92,19 +107,21 @@ export const SplitPane = memo(
         percentRef.current = next;
         setPercent(next);
       },
-      [minPercent]
+      [minPercent, endDrag]
     );
 
     const handlePointerUp = useCallback(
       (event: ReactPointerEvent<HTMLDivElement>) => {
-        if (!draggingRef.current) return;
-        draggingRef.current = false;
+        if (!draggingRef.current || pointerIdRef.current !== event.pointerId) {
+          return;
+        }
+        endDrag();
         if (event.currentTarget.hasPointerCapture(event.pointerId)) {
           event.currentTarget.releasePointerCapture(event.pointerId);
         }
         remember(percentRef.current);
       },
-      [remember]
+      [remember, endDrag]
     );
 
     const nudge = useCallback(


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

Three Gantry changes.

**1. Standings columns no longer drift from their headers.**

`ch` is font-relative and resolves against each element's *own* font size. The header row was `text-[10px]` while the driver rows are `text-xs` (12px), so identical `w-[6ch]` classes produced different widths — around 50px of cumulative drift, absorbed entirely by the flexing Driver column. The result was headers sitting well to the right of the values they label.

The header row now carries the same `text-xs` as the driver rows, so every `ch` resolves identically; the smaller label type moved to a span inside each cell. Alongside that:

- One `COL` map defines every column, used by both the header and the rows, so the two cannot be edited apart.
- Every fixed column is `shrink-0`. A narrow window can no longer squeeze a cell but not its header.
- Header and rows share one scroll container with a sticky header, so below the minimum width the table scrolls sideways as a single piece. `scroll-pt-6` keeps the followed row from landing behind the sticky header.

**2. The Standings/Incidents divider can be dragged.**

New `SplitPane` component. Double-click resets to an even split, arrow keys nudge and Home resets, and it is exposed as a `separator` role. Neither pane can go below 15%. The ratio is a UI preference so it lives in `localStorage`, matching how the settings tabs remember their active tab, rather than in the dashboard config.

**3. The lap graph lists drivers vertically instead of as a horizontal legend.**

New `LapGraphDriverList` replaces the wrapped legend under the chart. It shows only the selected class, sorted by live class position, leader first. Clicking a name draws that car's line at full strength; clicking again hides it. Hovering a name lifts that line above the field. Cars with no completed lap are greyed and inert.

Two performance details worth flagging for review:

- Class positions are deliberately kept out of the `members` signature. Putting them there would have rebuilt all 60 series on every standings tick (5 Hz) instead of on lap crossings. The side list reads positions separately and sorts on them.
- The list is capped at `max-w-[40%]` so a narrow window cannot squeeze the plot to zero width, where `prepareCanvas` bails out and the chart silently draws nothing.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

Standings: on a narrow window the `T`, `iR`, `Pit` and `Gap` headers sit roughly 50px right of their values, the drift shrinking column by column to zero at the last delta column. Lap graph: pinned drivers appear as a horizontal wrapped legend beneath the chart, showing only the pinned set plus an "N other cars" count.

### After
<!-- Screenshot or description of the new behaviour -->
<img width="1414" height="794" alt="image" src="https://github.com/user-attachments/assets/833099d8-eb4d-4534-8663-354517c9610e" />
<img width="1409" height="798" alt="image" src="https://github.com/user-attachments/assets/0d99761c-b4f1-4ebc-90f7-a5bfe2b2435c" />
<img width="817" height="794" alt="image" src="https://github.com/user-attachments/assets/1184c9a0-2d9d-43bb-8e5e-a86c112ea36e" />
<img width="1198" height="840" alt="image" src="https://github.com/user-attachments/assets/af4d98f9-81ef-4f3e-b902-e9842c6c1dd7" />

Standings: headers stay over their values at every width; below the minimum width the whole table scrolls horizontally with the header. Standings/Incidents: a draggable divider between the two panes. Lap graph: the selected class listed down the right-hand side in running order, click to show a line, hover to highlight it.

Storybook stories are included for all three (`GantryStandings > Narrow`, `SplitPane`, `LapGraphDriverList`).

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

---

Validation performed:

- `npx vitest run` — 193 files, 1851 tests pass. New: `SplitPane.spec.tsx` (10 tests covering drag maths, clamping, persistence, and two drag-latch cases), `LapGraphDriverList.spec.tsx` (6 tests). `LapGraphCanvas.spec.tsx` updated for the removed legend.
- `npx tsc --noEmit` and `npx eslint src/frontend/components/Gantry --max-warnings=0` — both clean.
- Visual results confirmed by the author in the running app.
- Not verified in a live iRacing session, which is why that box is unchecked. Worth a look at a multi-class race with live positions enabled to confirm the lap graph still rebuilds on lap crossings rather than per tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a resizable standings and incidents layout with draggable, keyboard-adjustable panels and a remembered divider position.
  * Added a driver list beside the lap graph, allowing users to focus, show, or hide driver lines while keeping the player visible.
  * Improved standings table scrolling and column alignment on narrow screens.
  * Removed the lap graph legend; car pinning remains available through plot interactions.
* **Bug Fixes**
  * Prevented standings columns from compressing or drifting in constrained layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->