### PR TITLE
fix: prevent shutdown persistence from blocking quit

### DIFF
--- a/src/app/shutdownCoordinator.spec.ts
+++ b/src/app/shutdownCoordinator.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBeforeQuitHandler } from './shutdownCoordinator';
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function createHarness(shutdown: () => Promise<void>, timeoutMs = 5_000) {
+  const prepareToQuit = vi.fn();
+  const quit = vi.fn();
+  const reportFailure = vi.fn();
+  const preventDefault = vi.fn();
+  const handler = createBeforeQuitHandler({
+    prepareToQuit,
+    shutdown,
+    quit,
+    reportFailure,
+    timeoutMs,
+  });
+
+  return {
+    handler,
+    event: { preventDefault },
+    prepareToQuit,
+    quit,
+    reportFailure,
+    preventDefault,
+  };
+}
+
+describe('createBeforeQuitHandler', () => {
+  it('waits for shutdown and lets the follow-up quit proceed', async () => {
+    let finishShutdown: (() => void) | undefined;
+    const shutdown = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishShutdown = resolve;
+        })
+    );
+    const harness = createHarness(shutdown);
+
+    harness.handler(harness.event);
+
+    expect(harness.preventDefault).toHaveBeenCalledOnce();
+    expect(shutdown).toHaveBeenCalledOnce();
+    expect(harness.quit).not.toHaveBeenCalled();
+
+    finishShutdown?.();
+    await flushPromises();
+
+    expect(harness.quit).toHaveBeenCalledOnce();
+    harness.preventDefault.mockClear();
+    harness.handler(harness.event);
+    expect(harness.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('runs shutdown only once when quit is requested repeatedly', () => {
+    const shutdown = vi.fn(() => new Promise<void>(() => undefined));
+    const harness = createHarness(shutdown);
+
+    harness.handler(harness.event);
+    harness.handler(harness.event);
+
+    expect(shutdown).toHaveBeenCalledOnce();
+    expect(harness.preventDefault).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports a shutdown failure and continues quitting', async () => {
+    const error = new Error('flush failed');
+    const harness = createHarness(() => Promise.reject(error));
+
+    harness.handler(harness.event);
+    await flushPromises();
+
+    expect(harness.reportFailure).toHaveBeenCalledWith(error);
+    expect(harness.quit).toHaveBeenCalledOnce();
+  });
+
+  it('continues quitting when shutdown exceeds its deadline', async () => {
+    vi.useFakeTimers();
+    const harness = createHarness(
+      () => new Promise<void>(() => undefined),
+      100
+    );
+
+    harness.handler(harness.event);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(harness.reportFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Shutdown timed out' })
+    );
+    expect(harness.quit).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+});

--- a/src/app/shutdownCoordinator.ts
+++ b/src/app/shutdownCoordinator.ts
@@ -1,0 +1,52 @@
+export interface BeforeQuitEvent {
+  preventDefault(): void;
+}
+
+interface ShutdownCoordinatorOptions {
+  prepareToQuit(): void;
+  shutdown(): Promise<void>;
+  quit(): void;
+  reportFailure(error: unknown): void;
+  timeoutMs: number;
+}
+
+type ShutdownState = 'idle' | 'running' | 'complete';
+
+/**
+ * Creates an Electron before-quit handler that waits for asynchronous cleanup
+ * exactly once, then allows the follow-up quit event to proceed.
+ */
+export function createBeforeQuitHandler({
+  prepareToQuit,
+  shutdown,
+  quit,
+  reportFailure,
+  timeoutMs,
+}: ShutdownCoordinatorOptions): (event: BeforeQuitEvent) => void {
+  let state: ShutdownState = 'idle';
+
+  return (event) => {
+    prepareToQuit();
+    if (state === 'complete') return;
+
+    event.preventDefault();
+    if (state === 'running') return;
+    state = 'running';
+
+    let timeout: ReturnType<typeof setTimeout>;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(
+        () => reject(new Error('Shutdown timed out')),
+        timeoutMs
+      );
+    });
+
+    void Promise.race([shutdown(), deadline])
+      .catch(reportFailure)
+      .finally(() => {
+        clearTimeout(timeout);
+        state = 'complete';
+        quit();
+      });
+  };
+}

--- a/src/app/storage/referenceLaps.spec.ts
+++ b/src/app/storage/referenceLaps.spec.ts
@@ -218,18 +218,20 @@ describe('referenceLaps storage', () => {
   });
 
   describe('flushReferenceLapsOnShutdown', () => {
-    it('writes any pending data synchronously', () => {
+    it('writes pending data through the asynchronous queue', async () => {
       saveReferenceLap(1, 2, 3, makeLap(60));
-      flushReferenceLapsOnShutdown();
+      await flushReferenceLapsOnShutdown();
 
-      expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
-      const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(mockWriteFile).toHaveBeenCalledTimes(1);
+      const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string);
       expect(written['1_2_3'].finishTime).toBe(60);
     });
 
-    it('is a no-op when no save has happened (cache never loaded)', () => {
-      flushReferenceLapsOnShutdown();
+    it('is a no-op when no save has happened (cache never loaded)', async () => {
+      await flushReferenceLapsOnShutdown();
       expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(mockWriteFile).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/storage/referenceLaps.ts
+++ b/src/app/storage/referenceLaps.ts
@@ -27,7 +27,7 @@ let cache: Map<string, ReferenceLap> | null = null;
 /**
  * Pending async write state. When a save is in flight or scheduled, additional
  * saves update the cache (and reset the debounce timer) without scheduling a
- * second write. On app shutdown, a sync flush picks up anything still pending.
+ * second write. On app shutdown, the pending queue is drained before exit.
  */
 let writeTimer: NodeJS.Timeout | null = null;
 let writeInFlight: Promise<void> | null = null;
@@ -133,22 +133,15 @@ const flushAsync = async (): Promise<void> => {
   }
 };
 
-/**
- * Synchronous flush for app shutdown — ensures any pending debounced write
- * makes it to disk before the process exits.
- */
-const flushSync = (): void => {
-  if (!cache) return;
+/** Drain the debounced/in-flight write queue without blocking the event loop. */
+const flushPendingWrites = async (): Promise<void> => {
   if (writeTimer) {
     clearTimeout(writeTimer);
     writeTimer = null;
+    enqueueFlush();
   }
-  try {
-    const obj = Object.fromEntries(cache);
-    const jsonString = JSON.stringify(obj, replacer, 2);
-    fs.writeFileSync(filePath, jsonString);
-  } catch (error) {
-    logger.error('Failed to flush reference lap data on shutdown:', error);
+  while (writeInFlight) {
+    await writeInFlight;
   }
 };
 
@@ -226,13 +219,10 @@ export const saveReferenceLap = (
 };
 
 /**
- * Flush any pending write synchronously. Called on app shutdown to avoid
- * losing the last save if the user closes the app within WRITE_DEBOUNCE_MS
- * of setting a fast lap.
+ * Flush any pending write asynchronously. The before-quit coordinator awaits
+ * this promise, so the last save is retained without blocking its deadline.
  */
-export const flushReferenceLapsOnShutdown = (): void => {
-  flushSync();
-};
+export const flushReferenceLapsOnShutdown = flushPendingWrites;
 
 /**
  * Testing helper: await any in-flight write. Not exported in production
@@ -240,14 +230,7 @@ export const flushReferenceLapsOnShutdown = (): void => {
  * debounced write completing.
  */
 export const __awaitPendingWrite = async (): Promise<void> => {
-  if (writeTimer) {
-    clearTimeout(writeTimer);
-    writeTimer = null;
-    enqueueFlush();
-  }
-  while (writeInFlight) {
-    await writeInFlight;
-  }
+  await flushPendingWrites();
 };
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -409,12 +409,10 @@ const handleBeforeQuit = createBeforeQuitHandler({
     incidentRuntime?.dispose();
     disposeLapHistoryRuntime?.();
     channelBus.dispose();
-    // Synchronous flush so any pending debounced reference-lap write completes
-    // before the process exits.
-    flushReferenceLapsOnShutdown();
-    // Incident and lap-history writes are debounced, so anything still pending
-    // would be lost.
+    // Storage writes are debounced, so drain all pending queues within the
+    // coordinator deadline before the process exits.
     await Promise.all([
+      flushReferenceLapsOnShutdown(),
       flushIncidentsOnShutdown(),
       flushLapHistoryOnShutdown(),
     ]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,6 +66,7 @@ import { ChannelBus, setupChannelBridge } from './app/bridge/channelBridge';
 import { connectSessionLifecycleChannel } from './app/bridge/sessionLifecycleChannel';
 import { setupRendererDataSubscriptions } from './app/bridge/rendererDataSubscriptions';
 import { PerfHeapProfiler } from './app/perfHeapProfiler';
+import { createBeforeQuitHandler } from './app/shutdownCoordinator';
 
 const safeErrorDetails = (error: unknown) => {
   const code =
@@ -397,40 +398,30 @@ app.on('quit', () => {
   analytics.shutdown();
 });
 
-type ShutdownFlushState = 'idle' | 'flushing' | 'complete';
-let shutdownFlushState: ShutdownFlushState = 'idle';
+const SHUTDOWN_FLUSH_TIMEOUT_MS = 5_000;
 
-app.on('before-quit', (event) => {
-  overlayManager.markQuitting();
-  // app.quit() below emits before-quit again. Once the async flush has
-  // completed, let that second event proceed without preventing it.
-  if (shutdownFlushState === 'complete') return;
-
-  // Electron does not await promises returned by before-quit handlers, so
-  // postpone shutdown while incident persistence finishes.
-  event.preventDefault();
-  if (shutdownFlushState === 'flushing') return;
-  shutdownFlushState = 'flushing';
-  keybindingManager?.stopGamepad();
-  disconnectLifecycleChannel?.();
-  disposeRendererDataSubscriptions?.();
-  incidentRuntime?.dispose();
-  disposeLapHistoryRuntime?.();
-  channelBus.dispose();
-  // Synchronous flush so any pending debounced reference-lap write completes
-  // before the process exits.
-  flushReferenceLapsOnShutdown();
-  // Incident and lap-history writes are debounced, so anything still pending
-  // would be lost.
-  void Promise.all([
-    flushIncidentsOnShutdown().catch((err) =>
-      log.error('[RaceControl] Shutdown flush failed:', err)
-    ),
-    flushLapHistoryOnShutdown().catch((err) =>
-      log.error('[LapHistory] Shutdown flush failed:', err)
-    ),
-  ]).finally(() => {
-    shutdownFlushState = 'complete';
-    app.quit();
-  });
+const handleBeforeQuit = createBeforeQuitHandler({
+  prepareToQuit: () => overlayManager.markQuitting(),
+  shutdown: async () => {
+    keybindingManager?.stopGamepad();
+    disconnectLifecycleChannel?.();
+    disposeRendererDataSubscriptions?.();
+    incidentRuntime?.dispose();
+    disposeLapHistoryRuntime?.();
+    channelBus.dispose();
+    // Synchronous flush so any pending debounced reference-lap write completes
+    // before the process exits.
+    flushReferenceLapsOnShutdown();
+    // Incident and lap-history writes are debounced, so anything still pending
+    // would be lost.
+    await Promise.all([
+      flushIncidentsOnShutdown(),
+      flushLapHistoryOnShutdown(),
+    ]);
+  },
+  quit: () => app.quit(),
+  reportFailure: (err) => log.error('[Shutdown] Cleanup failed:', err),
+  timeoutMs: SHUTDOWN_FLUSH_TIMEOUT_MS,
 });
+
+app.on('before-quit', handleBeforeQuit);


### PR DESCRIPTION
## Description

Fixes a regression where choosing Quit from the system tray could leave Electron running indefinitely after the `before-quit` handler had already torn down IPC subscriptions.

Extracts the asynchronous quit barrier into a small shutdown coordinator. Cleanup runs once, repeated quit requests remain guarded, failures are reported, and a five-second deadline prevents stalled incident or lap-history persistence from blocking application exit forever.

Architecture review phase: Phase 0.5 (L1 asynchronous storage and shutdown persistence).

Validation:
- `npm run test -- --no-coverage` — 189 files passed, 1 skipped; 1,827 tests passed, 1 skipped
- `npm run lint`

## Screenshots

### Before
Tray Quit could leave the Electron process alive with renderer IPC handlers already removed.

### After
Tray Quit waits for pending persistence, then exits; failed or stalled cleanup can no longer strand the process.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application shutdown handling while cleanup is in progress.
  - Prevented duplicate shutdown operations during repeated quit requests.
  - Ensured the application can exit when cleanup fails or exceeds the five-second limit.
  - Improved reliability of saving reference lap data during shutdown by completing pending asynchronous writes.

- **Reliability**
  - Added shutdown failure reporting while allowing the application to quit safely.
  - Improved consistency when multiple quit requests occur during application cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->