### PR TITLE
fix: Relative, Battle and FasterCarsFromBehind stories render empty or wrong data

### DIFF
--- a/.storybook/captureChannelDecorator.tsx
+++ b/.storybook/captureChannelDecorator.tsx
@@ -1,0 +1,83 @@
+import type { Decorator } from '@storybook/react-vite';
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
+import type {
+  ChannelBridge,
+  ChannelName,
+  ChannelPayloads,
+} from '@irdashies/types';
+import { buildCaptureSnapshots } from './captureSnapshots';
+
+/**
+ * Serves channel data generated from the same capture the story loads.
+ *
+ * Unlike ChannelSnapshotDecorator, which takes snapshots already in hand, this
+ * one resolves them asynchronously because a capture is a dynamic import.
+ * Channels are push based, so a subscriber simply receives its payload when the
+ * capture has finished loading.
+ */
+const bridgeFor = (path?: string): ChannelBridge => {
+  const snapshots = buildCaptureSnapshots(path);
+  return {
+    subscribe: <K extends ChannelName>(
+      channel: K,
+      callback: (payload: ChannelPayloads[K]) => void
+    ) => {
+      let subscribed = true;
+      void snapshots.then((resolved) => {
+        if (!subscribed) return;
+        const snapshot = resolved[channel];
+        if (snapshot !== undefined) callback(snapshot as ChannelPayloads[K]);
+      });
+      return () => {
+        subscribed = false;
+      };
+    },
+  };
+};
+
+/**
+ * Component form, for a story whose capture is chosen at runtime. A decorator
+ * is built once, so it cannot follow a path held in React state.
+ */
+export const CaptureChannels = ({
+  path,
+  children,
+}: {
+  path?: string;
+  children: ReactNode;
+}) => {
+  const previousBridge = useRef(window.channelBridge);
+  window.channelBridge = useMemo(() => bridgeFor(path), [path]);
+  useEffect(
+    () => () => {
+      if (previousBridge.current === undefined) {
+        Reflect.deleteProperty(window, 'channelBridge');
+      } else {
+        window.channelBridge = previousBridge.current;
+      }
+    },
+    []
+  );
+  return <>{children}</>;
+};
+
+export const CaptureChannelDecorator = (path?: string): Decorator => {
+  const bridge = bridgeFor(path);
+
+  const DecoratorComponent: Decorator = (Story) => {
+    const previousBridge = useRef(window.channelBridge);
+    window.channelBridge = bridge;
+    useEffect(
+      () => () => {
+        if (previousBridge.current === undefined) {
+          Reflect.deleteProperty(window, 'channelBridge');
+        } else {
+          window.channelBridge = previousBridge.current;
+        }
+      },
+      []
+    );
+    return <Story />;
+  };
+  return DecoratorComponent;
+};

--- a/.storybook/captureSnapshots.ts
+++ b/.storybook/captureSnapshots.ts
@@ -1,0 +1,104 @@
+import type {
+  ChannelName,
+  ChannelPayloads,
+  Session,
+  Telemetry,
+} from '@irdashies/types';
+import { StandingsProcessor } from '../src/app/processors/StandingsProcessor';
+import { RelativeGapProcessor } from '../src/app/processors/RelativeGapProcessor';
+import { SessionBarProcessor } from '../src/app/processors/SessionBarProcessor';
+import { TrackStateProcessor } from '../src/app/processors/TrackStateProcessor';
+import { LapTimesProcessor } from '../src/app/processors/LapTimesProcessor';
+import defaultSession from '../src/app/irsdk/node/utils/mock-data/session.json';
+import defaultTelemetry from '../src/app/irsdk/node/utils/mock-data/telemetry.json';
+
+/**
+ * Channel snapshots generated from whichever capture a story loads.
+ *
+ * Stories drive two things from the same capture: the session, through
+ * SessionProvider, and the channels, through window.channelBridge. Pinning the
+ * channels to one capture while a story loads another makes the two disagree —
+ * and a disagreement about which car is the player is enough to blank the
+ * Relative widget entirely, because it centres its window on the channel's
+ * focus car but finds the player row by a flag set from the session's.
+ *
+ * Generating both from the same source removes the whole class of problem.
+ */
+
+const first = <T>(value: T | T[]): T =>
+  Array.isArray(value) ? value[0] : value;
+
+/** No recorded reference laps in a fixture, so gaps use the class estimate. */
+const noReferenceLaps = {
+  snapshot: () => ({
+    bestLaps: [],
+    persistedLaps: [],
+    sessionNum: null,
+    version: 0,
+  }),
+};
+
+const loadCapture = async (path?: string) => {
+  if (!path) {
+    return {
+      session: defaultSession as unknown as Session,
+      telemetry: defaultTelemetry as unknown as Telemetry,
+    };
+  }
+  const telemetry = (await import(/* @vite-ignore */ `${path}/telemetry.json`))
+    .default;
+  const session = (await import(/* @vite-ignore */ `${path}/session.json`))
+    .default;
+  return {
+    session: first(session) as Session,
+    telemetry: first(telemetry) as Telemetry,
+  };
+};
+
+export type CaptureSnapshots = Partial<
+  Record<ChannelName, ChannelPayloads[ChannelName]>
+>;
+
+const cache = new Map<string, Promise<CaptureSnapshots>>();
+
+/**
+ * @param path A `/test-data/<id>` capture, or undefined for the default mock.
+ */
+export const buildCaptureSnapshots = (
+  path?: string
+): Promise<CaptureSnapshots> => {
+  const key = path ?? '__default__';
+  const existing = cache.get(key);
+  if (existing) return existing;
+
+  const built = loadCapture(path).then(({ session, telemetry }) => {
+    const standings = new StandingsProcessor();
+    const relativeGaps = new RelativeGapProcessor(noReferenceLaps);
+    const sessionBar = new SessionBarProcessor();
+    const trackState = new TrackStateProcessor();
+    const lapTimes = new LapTimesProcessor();
+
+    const processors = [
+      standings,
+      relativeGaps,
+      sessionBar,
+      trackState,
+      lapTimes,
+    ];
+    for (const processor of processors) {
+      processor.init?.(session);
+      processor.onFrame(telemetry);
+    }
+
+    return {
+      'standings.snapshot': standings.snapshot(),
+      'relative-gaps.snapshot': relativeGaps.snapshot(),
+      'session-bar.snapshot': sessionBar.snapshot(),
+      'track-state.snapshot': trackState.snapshot(),
+      'lap-times.snapshot': lapTimes.snapshot(),
+    } as CaptureSnapshots;
+  });
+
+  cache.set(key, built);
+  return built;
+};

--- a/.storybook/index.ts
+++ b/.storybook/index.ts
@@ -1,5 +1,7 @@
 export * from './telemetryDecorator';
 export * from './channelSnapshotDecorator';
+export * from './captureChannelDecorator';
+export * from './captureSnapshots';
 export * from './standingsSnapshot';
 export * from './trackStateSnapshot';
 export * from './sessionBarSnapshot';

--- a/src/frontend/components/Battle/Battle.stories.tsx
+++ b/src/frontend/components/Battle/Battle.stories.tsx
@@ -1,22 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { Battle } from './Battle';
 import {
-  ChannelSnapshotDecorator,
+  CaptureChannelDecorator,
   TelemetryDecorator,
-  trackStateStorySnapshot,
-  standingsStorySnapshot,
 } from '@irdashies/storybook';
-import type { RelativeGapsSnapshot } from '@irdashies/types';
-
-const relativeGapsStorySnapshot = {
-  focusCarIdx: 30,
-  relativePcts: Array.from({ length: 64 }, (_, carIdx) =>
-    Math.max(-0.49, Math.min(0.49, (carIdx - 30) * 0.012))
-  ),
-  deltas: Array.from({ length: 64 }, (_, carIdx) => (carIdx - 30) * 1.2),
-  sessionNum: 0,
-  version: 1,
-} satisfies RelativeGapsSnapshot;
 
 export default {
   component: Battle,
@@ -29,15 +16,6 @@ export const Primary: Story = {
   render: () => <Battle />,
   decorators: [
     TelemetryDecorator('/test-data/1747384033336'),
-    ChannelSnapshotDecorator({
-      'car-speeds.snapshot': {
-        carSpeeds: [],
-        sessionNum: 0,
-        version: 1,
-      },
-      'relative-gaps.snapshot': relativeGapsStorySnapshot,
-      'standings.snapshot': standingsStorySnapshot,
-      'track-state.snapshot': trackStateStorySnapshot,
-    }),
+    CaptureChannelDecorator('/test-data/1747384033336'),
   ],
 };

--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.stories.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.stories.tsx
@@ -4,22 +4,9 @@ import {
   FasterCarsFromBehindDisplay,
 } from './FasterCarsFromBehind';
 import {
-  ChannelSnapshotDecorator,
-  trackStateStorySnapshot,
-  standingsStorySnapshot,
+  CaptureChannelDecorator,
   TelemetryDecorator,
 } from '@irdashies/storybook';
-import type { RelativeGapsSnapshot } from '@irdashies/types';
-
-const relativeGapsStorySnapshot = {
-  focusCarIdx: 30,
-  relativePcts: Array.from({ length: 64 }, (_, carIdx) =>
-    Math.max(-0.49, Math.min(0.49, (carIdx - 30) * 0.012))
-  ),
-  deltas: Array.from({ length: 64 }, (_, carIdx) => (carIdx - 30) * 1.2),
-  sessionNum: 0,
-  version: 1,
-} satisfies RelativeGapsSnapshot;
 
 // Mock the settings hook for stories
 const mockSettings = {
@@ -72,11 +59,7 @@ export const Primary: Story = {
   render: () => <FasterCarsFromBehind />,
   decorators: [
     TelemetryDecorator('/test-data/1747384033336'),
-    ChannelSnapshotDecorator({
-      'relative-gaps.snapshot': relativeGapsStorySnapshot,
-      'standings.snapshot': standingsStorySnapshot,
-      'track-state.snapshot': trackStateStorySnapshot,
-    }),
+    CaptureChannelDecorator('/test-data/1747384033336'),
   ],
 };
 

--- a/src/frontend/components/Standings/Relative.stories.tsx
+++ b/src/frontend/components/Standings/Relative.stories.tsx
@@ -4,10 +4,8 @@ import {
   TelemetryDecorator,
   DynamicTelemetrySelector,
   TelemetryDecoratorWithConfig,
-  ChannelSnapshotDecorator,
-  standingsStorySnapshot,
-  sessionBarStorySnapshot,
-  trackStateStorySnapshot,
+  CaptureChannelDecorator,
+  CaptureChannels,
 } from '@irdashies/storybook';
 import {
   DashboardProvider,
@@ -20,11 +18,7 @@ import {
 } from '@irdashies/context';
 import { mockDashboardBridge } from '@irdashies/storybook';
 import { generateMockDataFromPath } from '../../../app/bridge/iracingSdk/mock-data/generateMockData';
-import type {
-  DashboardBridge,
-  RelativeGapsSnapshot,
-  RelativeWidgetSettings,
-} from '@irdashies/types';
+import type { DashboardBridge, RelativeWidgetSettings } from '@irdashies/types';
 import { getWidgetDefaultConfig } from '@irdashies/types';
 import { useState, useMemo } from 'react';
 import { DriverInfoRow } from './components/DriverInfoRow/DriverInfoRow';
@@ -36,16 +30,6 @@ import {
   useHighlightColor,
 } from './hooks';
 import type { ResolvedDriverTag } from './hooks/useDriverTagMap';
-
-const relativeGapsStorySnapshot = {
-  focusCarIdx: 30,
-  relativePcts: Array.from({ length: 64 }, (_, carIdx) =>
-    Math.max(-0.49, Math.min(0.49, (carIdx - 30) * 0.012))
-  ),
-  deltas: Array.from({ length: 64 }, (_, carIdx) => (carIdx - 30) * 1.2),
-  sessionNum: 0,
-  version: 1,
-} satisfies RelativeGapsSnapshot;
 
 // Create a custom decorator that combines TelemetryDecoratorWithConfig with generalSettings override
 function TelemetryDecoratorWithConfigAndGeneralSettings(
@@ -345,20 +329,9 @@ const RelativeWithoutHeaderFooter = () => {
 export default {
   component: Relative,
   title: 'widgets/Relative',
-  decorators: [
-    ChannelSnapshotDecorator({
-      'lap-times.snapshot': {
-        lapTimes: [],
-        lapTimeHistory: [],
-        sessionNum: null,
-        version: 0,
-      },
-      'relative-gaps.snapshot': relativeGapsStorySnapshot,
-      'standings.snapshot': standingsStorySnapshot,
-      'track-state.snapshot': trackStateStorySnapshot,
-      'session-bar.snapshot': sessionBarStorySnapshot,
-    }),
-  ],
+  // Channels come from the same capture the story loads. The default mock
+  // here; stories that pin a capture override this with their own.
+  decorators: [CaptureChannelDecorator()],
   parameters: {
     controls: {
       exclude: ['telemetryPath'],
@@ -389,8 +362,10 @@ export const Primary: Story = {
 export const DynamicTelemetry: Story = {
   decorators: [
     (Story, context) => {
+      // 1747384273173 was the previous default and no longer exists in
+      // test-data, which left this story with no session at all.
       const [selectedPath, setSelectedPath] = useState(
-        '/test-data/1747384273173'
+        '/test-data/1747384033336'
       );
 
       return (
@@ -399,12 +374,14 @@ export const DynamicTelemetry: Story = {
             onPathChange={setSelectedPath}
             initialPath={selectedPath}
           />
-          {TelemetryDecoratorWithConfig(selectedPath, {
-            relative: {
-              headerBar: { enabled: true },
-              footerBar: { enabled: true },
-            },
-          })(Story, context)}
+          <CaptureChannels path={selectedPath}>
+            {TelemetryDecoratorWithConfig(selectedPath, {
+              relative: {
+                headerBar: { enabled: true },
+                footerBar: { enabled: true },
+              },
+            })(Story, context)}
+          </CaptureChannels>
         </>
       );
     },
@@ -413,6 +390,7 @@ export const DynamicTelemetry: Story = {
 
 export const MultiClassPCCWithClio: Story = {
   decorators: [
+    CaptureChannelDecorator('/test-data/1731637331038'),
     TelemetryDecoratorWithConfig('/test-data/1731637331038', {
       relative: {
         headerBar: { enabled: true },
@@ -424,6 +402,7 @@ export const MultiClassPCCWithClio: Story = {
 
 export const SupercarsRace: Story = {
   decorators: [
+    CaptureChannelDecorator('/test-data/1732274253573'),
     TelemetryDecoratorWithConfig('/test-data/1732274253573', {
       relative: {
         headerBar: { enabled: true },
@@ -435,6 +414,7 @@ export const SupercarsRace: Story = {
 
 export const AdvancedMX5: Story = {
   decorators: [
+    CaptureChannelDecorator('/test-data/1732260478001'),
     TelemetryDecoratorWithConfig('/test-data/1732260478001', {
       relative: {
         headerBar: { enabled: true },
@@ -446,6 +426,7 @@ export const AdvancedMX5: Story = {
 
 export const GT3Practice: Story = {
   decorators: [
+    CaptureChannelDecorator('/test-data/1732355190142'),
     TelemetryDecoratorWithConfig('/test-data/1732355190142', {
       relative: {
         headerBar: { enabled: true },
@@ -457,6 +438,7 @@ export const GT3Practice: Story = {
 
 export const PCCPacing: Story = {
   decorators: [
+    CaptureChannelDecorator('/test-data/1735296198162'),
     TelemetryDecoratorWithConfig('/test-data/1735296198162', {
       relative: {
         headerBar: { enabled: true },
@@ -468,6 +450,7 @@ export const PCCPacing: Story = {
 
 export const MultiClass: Story = {
   decorators: [
+    CaptureChannelDecorator('/test-data/1747384033336'),
     TelemetryDecoratorWithConfig('/test-data/1747384033336', {
       relative: {
         headerBar: { enabled: true },
@@ -479,6 +462,7 @@ export const MultiClass: Story = {
 
 export const WithFlairs: Story = {
   decorators: [
+    CaptureChannelDecorator('/test-data/1752616787255'),
     TelemetryDecoratorWithConfig('/test-data/1752616787255', {
       relative: {
         headerBar: { enabled: true },
@@ -539,6 +523,7 @@ export const WithLapDeltasEnabled: Story = {
 
 export const SuzukaGT3EnduranceRace: Story = {
   decorators: [
+    CaptureChannelDecorator('/test-data/1763227688917'),
     TelemetryDecoratorWithConfig('/test-data/1763227688917', {
       relative: {
         headerBar: { enabled: true },
@@ -550,6 +535,7 @@ export const SuzukaGT3EnduranceRace: Story = {
 
 export const TeamSession: Story = {
   decorators: [
+    CaptureChannelDecorator('/test-data/1763227688917'),
     TelemetryDecoratorWithConfig('/test-data/1763227688917', {
       relative: {
         headerBar: { enabled: true },


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

Every `widgets/Relative` story rendered its title bar, header and footer with **no driver rows**. `widgets/Standings` rendered a full field from the same mock data, so it looked specific to Relative.

The widget was fine. The fixtures disagreed with the session.

A story drives two things from a capture: the **session**, through `SessionProvider`, and the **channels**, through `window.channelBridge`. The channels were pinned to one hand-written set shared by every story, in which `relative-gaps.snapshot` named `focusCarIdx: 30`. The mock session's actual player is car 4.

That matters because the two are read by different code:

- `useDriverRelatives` centres its window on the **channel snapshot's** focus car — car 30.
- `isPlayer` is set from the **session's** focus car — car 4.
- `Relative.tsx` finds the player row by that `isPlayer` flag.

So the window was built around car 30, the player flag sat on car 4 which was never in that window, `playerIndex` came back `-1`, and the widget fell through to rendering seven invisible placeholder rows. Invisible, so the table looked empty rather than obviously broken.

**The fix** generates channel snapshots from whichever capture a story loads, so the session and the channels cannot disagree. Stories pinned to a `/test-data` capture get snapshots built from that capture; the rest get the default mock. A component form covers the one story that chooses its capture from React state, since a decorator is constructed once and cannot follow it.

This also repoints that story's default at an existing capture. It referenced `/test-data/1747384273173`, which is no longer in the repo, so its dynamic import failed and it had no session at all — a separate pre-existing break that only surfaced once the channel side was fixed.

**The same fault was then found in two more widgets.** `Battle.stories.tsx` and `FasterCarsFromBehind.stories.tsx` each declared their own copy-pasted `relativeGapsStorySnapshot`, and were worse off than Relative because they mixed **three** inconsistent sources in one story:

| Source | Says the player is |
| --- | --- |
| Session, from `TelemetryDecorator('/test-data/1747384033336')` | car **0** |
| `standings.snapshot`, from `standingsStorySnapshot` (built from the *default mock* capture) | car **4** |
| `relative-gaps.snapshot`, hand-written | car **30** |

`FasterCarsFromBehind` rendered nothing at all: `useCarBehind` identifies the player as the driver whose `delta === 0`, and with the sources disagreeing no such driver existed. `Battle` rendered, but wrongly — the car ahead sat in a *lower* position than the player, the car-behind row was blank, and every gap, delta, stint and lap-time column was an em-dash.

Both now take `CaptureChannelDecorator`, the same fix. Their `Display` and `MultipleDrivers` stories are pure prop-driven and were never affected.

Not addressed here, but the same shape: `TrackMap.stories.tsx` and `FlatTrackMap.stories.tsx` apply `standingsStorySnapshot` at **meta** level, so default-mock standings reach every story in those files while each loads its own capture. They draw to `<canvas>`, so I could not confirm a visible fault by inspecting the DOM and am flagging rather than claiming it.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

Storybook only — no change to the application. Measured in the browser as the number of rendered widget rows that are placeholders (`invisible`) rather than real drivers.

### Before
<!-- Screenshot or description of the current behaviour -->

`widgets-relative--primary`: 7 of 7 widget rows invisible placeholders, table appears empty. Every other Relative story the same.

`widgets-fastercarsfrombehind--primary`: renders nothing.

`widgets-battle--primary`: three rows, positions inverted and all data missing.

```
14 | #21 | Jeff Rubin   | — | — | — | —     <- ahead, yet a higher position number
13 | #64 | Tarik Alani  | — | — | — | —     <- player
   |     |              | — | — | — | —     <- car behind: no entry at all
```

### After
<!-- Screenshot or description of the new behaviour -->

`widgets-relative--primary`: 0 invisible, 7 real driver rows centred on the player. Checked story by story:

```
primary 10/10   multi-class 10/10          gt-3-practice 10/10
with-flairs 10/10                          multi-class-pcc-with-clio 10/10
suzuka-gt-3-endurance-race 10/10           team-session 10/10
no-header-footer 10/10                     compact-mode 10/10
with-flag-contour 10/10                    dynamic-telemetry 10/10
advanced-mx-5 9/10   pcc-pacing 7/10       supercars-race 6/10
```

The three that are not full render a partial window, which is correct — those captures have fewer cars near the player than the buffer asks for. Counts include three rows from Storybook's own docs table.

`widgets-fastercarsfrombehind--primary`: `Jimmy Van Veen  -0.2`.

`widgets-battle--primary`: correct order, real lap times and live gaps.

```
18 | #32 | Derek Edgerton | 1:46.4 | 0.38s
19 | #64 | Tarik Alani    | 1:43.9 | —       <- player
20 | #33 | John West      | 1:46.5 | 1.14s
```

The speed column stays em-dashed in Battle: speed is derived from frame-to-frame movement, and a capture snapshot is a single frame. That matches the previous fixture, which supplied an empty `car-speeds` snapshot for the same reason.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

Not tested in iRacing: this changes Storybook fixtures only, with no runtime code touched, so there is nothing to observe in a live session.

No unit tests added: the failure is a rendering outcome of fixture wiring, and asserting it in jsdom would restate the fixture rather than catch the bug. Every reasoning step I tried in jsdom reported "works" while the browser rendered empty, which is exactly why this was verified in a real browser instead.

## Validation

- `npm test` — 1824 tests across 189 files, all passing.
- `npm run lint` — clean (`tsc --noEmit` and `eslint --max-warnings 0`).
- `npm run build-storybook` — succeeds.
- **Browser**, per story, counting placeholder rows in the DOM before and after. This was the only method that reproduced the fault: hooks, channel delivery and session data all tested fine in isolation, and console instrumentation on the live page is what showed the window and the player flag pointing at different cars.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic capture-based data for Storybook previews.
  * Added support for loading default or selected test-session captures.
  * Added reusable tools for displaying standings, telemetry, lap times, track state, and session data.
* **Improvements**
  * Updated component examples to use dynamic captures instead of fixed snapshots.
  * Added capture-backed examples covering multiple racing scenarios and telemetry configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
