### PR TITLE
fix: restore fuel projection accuracy

### DIFF
--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -121,6 +121,8 @@ describe('FuelProjectionProcessor', () => {
 
     expect(processor.snapshot()).toMatchObject({
       calculatedTotalRaceLaps: 19.1,
+      estimatedLapsRemaining: 18.9,
+      hasValidRaceEstimate: true,
       isFixedLapRace: false,
     });
 
@@ -165,10 +167,44 @@ describe('FuelProjectionProcessor', () => {
       CarIdxBestLapTime: { value: [100, 100] },
     } as unknown as Telemetry);
 
-    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(17.1);
+    expect(processor.snapshot()).toMatchObject({
+      calculatedTotalRaceLaps: 16.1,
+      estimatedLapsRemaining: 9.2,
+      hasValidRaceEstimate: true,
+    });
   });
 
-  it('resets completed laps when the session number changes', () => {
+  it('rejects transient timed-race lap times', () => {
+    const processor = new FuelProjectionProcessor();
+    processor.init({
+      DriverInfo: {
+        DriverCarIdx: 0,
+        Drivers: [{ CarIdx: 0, CarClassEstLapTime: 1 }],
+      },
+      SessionInfo: {
+        Sessions: [
+          { SessionNum: 0, SessionType: 'Race', SessionLaps: 'unlimited' },
+        ],
+      },
+    } as unknown as Session);
+
+    processor.onFrame({
+      SessionNum: { value: [0] },
+      SessionTimeRemain: { value: [1500] },
+      CarIdxLap: { value: [1] },
+      CarIdxLapDistPct: { value: [0] },
+      CarIdxPosition: { value: [1] },
+      CarIdxBestLapTime: { value: [1] },
+    } as unknown as Telemetry);
+
+    expect(processor.snapshot()).toMatchObject({
+      calculatedTotalRaceLaps: 0,
+      estimatedLapsRemaining: 0,
+      hasValidRaceEstimate: false,
+    });
+  });
+
+  it('preserves completed laps while resetting crossing state on session change', () => {
     const processor = new FuelProjectionProcessor();
     processor.onFrame(
       frame({
@@ -192,8 +228,23 @@ describe('FuelProjectionProcessor', () => {
 
     processor.onLifecycle({ type: 'sessionNumChange' });
 
-    expect(processor.snapshot().completedLaps).toEqual([]);
+    expect(processor.snapshot().completedLaps).toHaveLength(1);
     expect(processor.snapshot().engine.lastLap).toBe(0);
+
+    processor.onFrame(
+      frame({
+        FuelLevel: 30,
+        Lap: 1,
+        LapDistPct: 0.01,
+        SessionFlags: 4,
+        SessionNum: 1,
+        SessionTime: 100,
+      })
+    );
+
+    expect(processor.snapshot().completedLaps).toHaveLength(1);
+    expect(processor.snapshot().projectedLapUsage).toBeGreaterThan(2);
+    expect(processor.snapshot().projectedLapUsage).toBeLessThan(2.2);
   });
 
   it('does not aggregate replay frames and resumes from clean state live', () => {

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -186,6 +186,8 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       sessionNum,
       sessionLaps: sessionInfo?.SessionLaps ?? 0,
       calculatedTotalRaceLaps: raceProjection.totalRaceLaps,
+      estimatedLapsRemaining: raceProjection.lapsRemaining,
+      hasValidRaceEstimate: raceProjection.hasValidEstimate,
       isFixedLapRace: raceProjection.isFixedLapRace,
       sessionType: sessionInfo?.SessionType,
       isOnTrack: booleanValue(frame, 'IsOnTrack'),
@@ -211,7 +213,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       return;
     }
     if (event.type === 'sessionNumChange') {
-      this.reset();
+      this.reset({ preserveCompletedLaps: true });
       return;
     }
     this.reset();
@@ -242,10 +244,14 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     }
   }
 
-  private reset(): void {
+  private reset(
+    { preserveCompletedLaps }: { preserveCompletedLaps: boolean } = {
+      preserveCompletedLaps: false,
+    }
+  ): void {
     this.engine.reset();
     this.lastCommands = [];
-    this.laps.length = 0;
+    if (!preserveCompletedLaps) this.laps.length = 0;
     this.latest = this.emptySnapshot();
   }
 
@@ -267,6 +273,8 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       sessionNum: 0,
       sessionLaps: 0,
       calculatedTotalRaceLaps: 0,
+      estimatedLapsRemaining: 0,
+      hasValidRaceEstimate: false,
       isFixedLapRace: false,
       isOnTrack: false,
       completedLaps: this.laps,
@@ -278,10 +286,21 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     frame: Telemetry,
     sessionType?: string,
     sessionLaps?: string
-  ): { totalRaceLaps: number; isFixedLapRace: boolean } {
+  ): {
+    totalRaceLaps: number;
+    lapsRemaining: number;
+    hasValidEstimate: boolean;
+    isFixedLapRace: boolean;
+  } {
     const timeRemaining = value(frame, 'SessionTimeRemain');
     const isFixedLapRace = !(timeRemaining > 0 && timeRemaining !== 604800);
-    if (sessionType !== 'Race') return { totalRaceLaps: 0, isFixedLapRace };
+    const emptyProjection = {
+      totalRaceLaps: 0,
+      lapsRemaining: 0,
+      hasValidEstimate: false,
+      isFixedLapRace,
+    };
+    if (sessionType !== 'Race') return emptyProjection;
 
     const driverCarIdx = this.session?.DriverInfo?.DriverCarIdx ?? 0;
     const cameraCarIdx = value(frame, 'CamCarIdx', -1);
@@ -309,7 +328,12 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     const configuredLaps = Number.parseInt(sessionLaps ?? '0', 10) || 0;
 
     if (value(frame, 'SessionState') >= 5) {
-      return { totalRaceLaps: playerLap, isFixedLapRace };
+      return {
+        totalRaceLaps: playerLap,
+        lapsRemaining: 0,
+        hasValidEstimate: true,
+        isFixedLapRace,
+      };
     }
     if (isFixedLapRace) {
       let totalRaceLaps = configuredLaps;
@@ -321,11 +345,9 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
           leaderLap + leaderDistance - (playerLap + playerDistance);
         if (distanceBehind > 0) totalRaceLaps -= Math.floor(distanceBehind);
       }
-      return { totalRaceLaps, isFixedLapRace };
+      return { ...emptyProjection, totalRaceLaps };
     }
-    if (averageLapTime <= 0) {
-      return { totalRaceLaps: 0, isFixedLapRace };
-    }
+    if (averageLapTime < 10) return emptyProjection;
 
     const leaderLap = carLaps[leaderCarIdx] ?? playerLap;
     const leaderDistance = lapDistances[leaderCarIdx] ?? 0;
@@ -335,12 +357,18 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       playerLap === 0
         ? value(frame, 'SessionTimeTotal') / averageLapTime
         : timeRemaining / averageLapTime + (leaderLap - 1) + leaderDistance;
-    const distanceBehind =
-      leaderLap + leaderDistance - (playerLap + playerDistance);
-    totalRaceLaps -= Math.max(0, Math.floor(distanceBehind));
+    const lapsBehind =
+      leaderLap > playerLap + 1 ? Math.floor(leaderLap - playerLap) : 0;
+    totalRaceLaps -= lapsBehind;
     if (configuredLaps > 0 && totalRaceLaps > configuredLaps) {
       totalRaceLaps = configuredLaps;
     }
-    return { totalRaceLaps, isFixedLapRace };
+    const playerProgress = Math.max(0, playerLap - 1) + playerDistance;
+    return {
+      totalRaceLaps,
+      lapsRemaining: Math.max(0, Math.ceil(totalRaceLaps) - playerProgress),
+      hasValidEstimate: true,
+      isFixedLapRace,
+    };
   }
 }

--- a/src/app/webserver/componentRenderer.spec.ts
+++ b/src/app/webserver/componentRenderer.spec.ts
@@ -47,6 +47,8 @@ const projection: FuelProjectionSnapshot = {
   sessionNum: 0,
   sessionLaps: 12,
   calculatedTotalRaceLaps: 12,
+  estimatedLapsRemaining: 0,
+  hasValidRaceEstimate: false,
   isFixedLapRace: true,
   sessionType: 'Race',
   isOnTrack: true,

--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -159,6 +159,7 @@ export default {
   title: 'widgets/FuelCalculator',
   args: baselineArgs,
   decorators: [
+    TelemetryDecorator(),
     ChannelSnapshotDecorator({ 'fuel.projection': previewProjection }),
     (Story, context) => (
       <OverlayFrame
@@ -185,7 +186,6 @@ export const Primary: Story = {
         <Story />
       </MockFuelDataProvider>
     ),
-    TelemetryDecorator(),
   ],
   args: { ...baselineArgs, previewData: previewFuelData },
 };

--- a/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
+++ b/src/frontend/components/FuelCalculator/FuelCalculator.stories.tsx
@@ -135,6 +135,8 @@ const previewProjection = {
   sessionNum: 0,
   sessionLaps: previewFuelData.totalLaps,
   calculatedTotalRaceLaps: previewFuelData.totalLaps,
+  estimatedLapsRemaining: 0,
+  hasValidRaceEstimate: false,
   isFixedLapRace: true,
   sessionType: 'Race',
   isOnTrack: true,

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
@@ -137,6 +137,39 @@ describe('useFuelCalculation channel parity', () => {
     expect(result.current?.lapsRemaining).not.toBeCloseTo(12.2);
   });
 
+  it('accepts a validated zero-lap timed-race estimate', async () => {
+    window.channelBridge = {
+      subscribe: <K extends ChannelName>(
+        _channel: K,
+        callback: (payload: ChannelPayloads[K]) => void
+      ) => {
+        callback({
+          ...projection,
+          currentLap: 8,
+          lapDistPct: 0.8,
+          sessionLaps: 'unlimited',
+          sessionLapsRemain: 32767,
+          calculatedTotalRaceLaps: 8,
+          estimatedLapsRemaining: 0,
+          hasValidRaceEstimate: true,
+          isFixedLapRace: false,
+        } as ChannelPayloads[K]);
+        return () => undefined;
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useFuelCalculation(defaultFuelCalculatorSettings.safetyMargin, {
+        ...defaultFuelCalculatorSettings,
+        enableStorage: false,
+        enableLogging: false,
+      })
+    );
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current?.lapsRemaining).toBe(0);
+  });
+
   it('does not load or save live history for recorded replay', async () => {
     const getHistoricalLaps = vi.fn(async () => []);
     const saveLap = vi.fn(async () => undefined);

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
@@ -28,6 +28,8 @@ const projection: FuelProjectionSnapshot = {
   sessionNum: 0,
   sessionLaps: 16,
   calculatedTotalRaceLaps: 16,
+  estimatedLapsRemaining: 0,
+  hasValidRaceEstimate: false,
   isFixedLapRace: true,
   sessionType: 'Race',
   isOnTrack: true,
@@ -99,6 +101,40 @@ describe('useFuelCalculation channel parity', () => {
     expect(result.current?.lastLapUsage).toBeCloseTo(3.6420249938964844);
     expect(result.current?.avgLaps).toBeCloseTo(3.6037120819091797);
     expect(result.current?.currentLap).toBe(3);
+  });
+
+  it('uses the validated timed-race remaining distance without reconstructing it', async () => {
+    window.channelBridge = {
+      subscribe: <K extends ChannelName>(
+        _channel: K,
+        callback: (payload: ChannelPayloads[K]) => void
+      ) => {
+        callback({
+          ...projection,
+          currentLap: 8,
+          lapDistPct: 0.8,
+          sessionLaps: 'unlimited',
+          sessionLapsRemain: 32767,
+          calculatedTotalRaceLaps: 20.1,
+          estimatedLapsRemaining: 9.2,
+          hasValidRaceEstimate: true,
+          isFixedLapRace: false,
+        } as ChannelPayloads[K]);
+        return () => undefined;
+      },
+    };
+
+    const { result } = renderHook(() =>
+      useFuelCalculation(defaultFuelCalculatorSettings.safetyMargin, {
+        ...defaultFuelCalculatorSettings,
+        enableStorage: false,
+        enableLogging: false,
+      })
+    );
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(result.current?.lapsRemaining).toBe(9.2);
+    expect(result.current?.lapsRemaining).not.toBeCloseTo(12.2);
   });
 
   it('does not load or save live history for recorded replay', async () => {

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -605,11 +605,7 @@ export function useFuelCalculation(
       }
     } else if (sessionLapsRemain === TIMED_RACE_LAPS_REMAINING) {
       // Use centralized useTotalRaceLaps hook for timed race calculations
-      if (
-        hasValidRaceEstimate &&
-        calculatedTotalRaceLaps > 0 &&
-        estimatedLapsRemaining > 0
-      ) {
+      if (hasValidRaceEstimate && calculatedTotalRaceLaps > 0) {
         // Use the hook's result directly
         totalLaps = Math.ceil(calculatedTotalRaceLaps);
         lapsRemaining = estimatedLapsRemaining;

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -57,6 +57,8 @@ export function useFuelCalculation(
   const isOnTrack = projection?.isOnTrack;
   const isFixedLapRace = projection?.isFixedLapRace ?? false;
   const calculatedTotalRaceLaps = projection?.calculatedTotalRaceLaps ?? 0;
+  const estimatedLapsRemaining = projection?.estimatedLapsRemaining ?? 0;
+  const hasValidRaceEstimate = projection?.hasValidRaceEstimate ?? false;
   const isRace = projection?.sessionType === 'Race';
   const fuelTankCapacityFromSession = projection?.fuelTankCapacity;
   const trackId = projection?.trackId;
@@ -603,10 +605,14 @@ export function useFuelCalculation(
       }
     } else if (sessionLapsRemain === TIMED_RACE_LAPS_REMAINING) {
       // Use centralized useTotalRaceLaps hook for timed race calculations
-      if (calculatedTotalRaceLaps > 0) {
+      if (
+        hasValidRaceEstimate &&
+        calculatedTotalRaceLaps > 0 &&
+        estimatedLapsRemaining > 0
+      ) {
         // Use the hook's result directly
         totalLaps = Math.ceil(calculatedTotalRaceLaps);
-        lapsRemaining = Math.max(0, totalLaps - (lap - 1) - (lapDistPct || 0));
+        lapsRemaining = estimatedLapsRemaining;
 
         // Add safety buffer for refuel calculations
         const TIME_PADDING_REFUEL = 45.0;
@@ -1019,6 +1025,8 @@ export function useFuelCalculation(
     fuelTankCapacityFromSession,
     lapDistPct,
     calculatedTotalRaceLaps,
+    estimatedLapsRemaining,
+    hasValidRaceEstimate,
     lapHistorySize,
     projection,
   ]);

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -322,6 +322,8 @@ export interface FuelProjectionSnapshot {
   sessionNum: number;
   sessionLaps: number | string;
   calculatedTotalRaceLaps: number;
+  estimatedLapsRemaining: number;
+  hasValidRaceEstimate: boolean;
   isFixedLapRace: boolean;
   sessionType?: string;
   isOnTrack: boolean;


### PR DESCRIPTION
## Description

Restores fuel calculator behavior that regressed during the Phase 3 fuel channel migration:

- preserves completed fuel laps across practice, qualifying, and race session-number transitions while resetting volatile crossing/refuel state
- publishes a validated timed-race remaining-distance estimate on the typed fuel.projection channel
- uses that estimate directly instead of reconstructing it from a rounded total lap count
- accounts for whole laps lost to the leader and rejects transient lap times below 10 seconds

Architecture review phase: Phase 3 — Channel-based bridge.

Validation:

- 28 focused fuel, processor, renderer, and runtime-boundary tests passed
- npm run lint passed
- git diff --check passed
- curated telemetry replay was run; it reported an existing relative-gaps-state golden mismatch unrelated to fuel, so that golden was not updated

Not tested in a live iRacing session.

## Screenshots

### Before

No visual layout change. Fuel estimates could discard qualifying/practice consumption at a session transition and overestimate timed-race distance for lapped cars.

### After

No visual layout change. Fuel history remains available across session transitions and timed-race fuel requirements use the validated player-relative remaining distance.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added estimated laps remaining for timed races.
  - Added an indicator showing whether the race estimate is valid.
  - Updated fuel calculations to use validated lap estimates directly, including zero-lap estimates.

- **Bug Fixes**
  - Improved accuracy for fractional lap distances and laps-behind calculations.
  - Invalid or transient lap times no longer produce misleading estimates.
  - Completed laps are preserved when changing sessions while projection tracking resets correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->