### PR TITLE
fix: improve timed multiclass fuel estimates

### DIFF
--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -219,6 +219,38 @@ describe('FuelProjectionProcessor', () => {
     });
   });
 
+  it('uses player distance when no overall leader position is available', () => {
+    const processor = new FuelProjectionProcessor();
+    processor.init({
+      DriverInfo: {
+        DriverCarIdx: 1,
+        Drivers: [{ CarIdx: 1, CarClassID: 1, CarClassEstLapTime: 100 }],
+      },
+      SessionInfo: {
+        Sessions: [
+          { SessionNum: 0, SessionType: 'Race', SessionLaps: 'unlimited' },
+        ],
+      },
+    } as unknown as Session);
+
+    processor.onFrame({
+      SessionNum: { value: [0] },
+      SessionState: { value: [4] },
+      SessionTimeRemain: { value: [810] },
+      CamCarIdx: { value: [1] },
+      CarIdxLap: { value: [0, 8] },
+      CarIdxLapDistPct: { value: [0, 0.8] },
+      CarIdxPosition: { value: [0, 2] },
+      CarIdxBestLapTime: { value: [0, 100] },
+    } as unknown as Telemetry);
+
+    expect(processor.snapshot()).toMatchObject({
+      calculatedTotalRaceLaps: 16,
+      estimatedLapsRemaining: 8.2,
+      hasValidRaceEstimate: true,
+    });
+  });
+
   it('rejects transient timed-race lap times', () => {
     const processor = new FuelProjectionProcessor();
     processor.init({

--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -120,7 +120,7 @@ describe('FuelProjectionProcessor', () => {
     processor.onFrame(timedRaceFrame);
 
     expect(processor.snapshot()).toMatchObject({
-      calculatedTotalRaceLaps: 19.1,
+      calculatedTotalRaceLaps: 20,
       estimatedLapsRemaining: 18.9,
       hasValidRaceEstimate: true,
       isFixedLapRace: false,
@@ -130,13 +130,13 @@ describe('FuelProjectionProcessor', () => {
       ...timedRaceFrame,
       CarIdxLastLapTime: { value: [100] },
     } as unknown as Telemetry);
-    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(19.1);
+    expect(processor.snapshot().calculatedTotalRaceLaps).toBe(20);
 
     processor.onFrame({
       ...timedRaceFrame,
       CarIdxLastLapTime: { value: [110] },
     } as unknown as Telemetry);
-    expect(processor.snapshot().calculatedTotalRaceLaps).toBeCloseTo(19.1);
+    expect(processor.snapshot().calculatedTotalRaceLaps).toBe(20);
   });
 
   it('uses fractional distance when correcting a timed race for lapping', () => {
@@ -168,8 +168,43 @@ describe('FuelProjectionProcessor', () => {
     } as unknown as Telemetry);
 
     expect(processor.snapshot()).toMatchObject({
-      calculatedTotalRaceLaps: 16.1,
-      estimatedLapsRemaining: 9.2,
+      calculatedTotalRaceLaps: 18,
+      estimatedLapsRemaining: 10.2,
+      hasValidRaceEstimate: true,
+    });
+  });
+
+  it('uses player-class pace for remaining distance in multiclass races', () => {
+    const processor = new FuelProjectionProcessor();
+    processor.init({
+      DriverInfo: {
+        DriverCarIdx: 1,
+        Drivers: [
+          { CarIdx: 0, CarClassEstLapTime: 60 },
+          { CarIdx: 1, CarClassEstLapTime: 90 },
+        ],
+      },
+      SessionInfo: {
+        Sessions: [
+          { SessionNum: 0, SessionType: 'Race', SessionLaps: 'unlimited' },
+        ],
+      },
+    } as unknown as Session);
+
+    processor.onFrame({
+      SessionNum: { value: [0] },
+      SessionState: { value: [4] },
+      SessionTimeRemain: { value: [900] },
+      CamCarIdx: { value: [1] },
+      CarIdxLap: { value: [10, 8] },
+      CarIdxLapDistPct: { value: [0.1, 0.8] },
+      CarIdxPosition: { value: [1, 10] },
+      CarIdxBestLapTime: { value: [60, 90] },
+    } as unknown as Telemetry);
+
+    expect(processor.snapshot()).toMatchObject({
+      calculatedTotalRaceLaps: 19,
+      estimatedLapsRemaining: 11.2,
       hasValidRaceEstimate: true,
     });
   });

--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -92,7 +92,7 @@ describe('FuelProjectionProcessor', () => {
     processor.init({
       DriverInfo: {
         DriverCarIdx: 0,
-        Drivers: [{ CarIdx: 0, CarClassEstLapTime: 90 }],
+        Drivers: [{ CarIdx: 0, CarClassID: 1, CarClassEstLapTime: 90 }],
       },
       SessionInfo: {
         Sessions: [
@@ -114,6 +114,7 @@ describe('FuelProjectionProcessor', () => {
       CarIdxLap: { value: [2] },
       CarIdxLapDistPct: { value: [0.1] },
       CarIdxPosition: { value: [1] },
+      CarIdxClassPosition: { value: [1] },
       CarIdxLastLapTime: { value: [1] },
       CarIdxBestLapTime: { value: [1] },
     } as unknown as Telemetry;
@@ -130,13 +131,19 @@ describe('FuelProjectionProcessor', () => {
       ...timedRaceFrame,
       CarIdxLastLapTime: { value: [100] },
     } as unknown as Telemetry);
-    expect(processor.snapshot().calculatedTotalRaceLaps).toBe(20);
+    expect(processor.snapshot()).toMatchObject({
+      calculatedTotalRaceLaps: 18,
+      estimatedLapsRemaining: 16.9,
+    });
 
     processor.onFrame({
       ...timedRaceFrame,
       CarIdxLastLapTime: { value: [110] },
     } as unknown as Telemetry);
-    expect(processor.snapshot().calculatedTotalRaceLaps).toBe(20);
+    expect(processor.snapshot()).toMatchObject({
+      calculatedTotalRaceLaps: 18,
+      estimatedLapsRemaining: 16.9,
+    });
   });
 
   it('uses fractional distance when correcting a timed race for lapping', () => {
@@ -145,8 +152,8 @@ describe('FuelProjectionProcessor', () => {
       DriverInfo: {
         DriverCarIdx: 1,
         Drivers: [
-          { CarIdx: 0, CarClassEstLapTime: 100 },
-          { CarIdx: 1, CarClassEstLapTime: 100 },
+          { CarIdx: 0, CarClassID: 1, CarClassEstLapTime: 100 },
+          { CarIdx: 1, CarClassID: 1, CarClassEstLapTime: 100 },
         ],
       },
       SessionInfo: {
@@ -164,6 +171,7 @@ describe('FuelProjectionProcessor', () => {
       CarIdxLap: { value: [10, 8] },
       CarIdxLapDistPct: { value: [0.1, 0.8] },
       CarIdxPosition: { value: [1, 10] },
+      CarIdxClassPosition: { value: [1, 2] },
       CarIdxBestLapTime: { value: [100, 100] },
     } as unknown as Telemetry);
 
@@ -180,8 +188,8 @@ describe('FuelProjectionProcessor', () => {
       DriverInfo: {
         DriverCarIdx: 1,
         Drivers: [
-          { CarIdx: 0, CarClassEstLapTime: 60 },
-          { CarIdx: 1, CarClassEstLapTime: 90 },
+          { CarIdx: 0, CarClassID: 1, CarClassEstLapTime: 55 },
+          { CarIdx: 1, CarClassID: 2, CarClassEstLapTime: 80 },
         ],
       },
       SessionInfo: {
@@ -199,7 +207,9 @@ describe('FuelProjectionProcessor', () => {
       CarIdxLap: { value: [10, 8] },
       CarIdxLapDistPct: { value: [0.1, 0.8] },
       CarIdxPosition: { value: [1, 10] },
-      CarIdxBestLapTime: { value: [60, 90] },
+      CarIdxClassPosition: { value: [1, 1] },
+      CarIdxLastLapTime: { value: [60, 90] },
+      CarIdxBestLapTime: { value: [55, 80] },
     } as unknown as Telemetry);
 
     expect(processor.snapshot()).toMatchObject({

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -12,6 +12,8 @@ import {
 import type { TelemetryProcessor } from './TelemetryProcessor';
 
 const MAX_LAP_HISTORY = 50;
+const CLASS_PACE_HISTORY = 5;
+const CLASS_PACE_OUTLIER_SECONDS = 2;
 
 export interface FuelProjectionPersistence {
   lapCompleted(lap: FuelLapData): void;
@@ -87,6 +89,8 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   private readonly persistence: FuelProjectionPersistence;
   private readonly persistLaps: boolean;
   private lastCommands: readonly FuelEngineCommand[] = [];
+  private readonly classLapTimes = new Map<number, number[]>();
+  private lastLapTimesByCarIdx: number[] = [];
   private aggregationEnabled = true;
   private session?: Session;
   private sourceReplay: boolean;
@@ -126,6 +130,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     const driverInfo = this.session?.DriverInfo;
     const maxFuel = driverInfo?.DriverCarFuelMaxLtr;
     const maxFuelPct = driverInfo?.DriverCarMaxFuelPct;
+    this.updateClassLapTimes(frame);
     const raceProjection = this.calculateRaceProjection(
       frame,
       sessionInfo?.SessionType,
@@ -251,6 +256,8 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
   ): void {
     this.engine.reset();
     this.lastCommands = [];
+    this.classLapTimes.clear();
+    this.lastLapTimesByCarIdx = [];
     if (!preserveCompletedLaps) this.laps.length = 0;
     this.latest = this.emptySnapshot();
   }
@@ -326,13 +333,15 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     )?.CarClassEstLapTime;
     const bestLapTimes = values(frame, 'CarIdxBestLapTime');
     const leaderLapTime =
-      leaderClassEstimate && leaderClassEstimate > 0
+      this.classPace(paceCarIdx) ??
+      (leaderClassEstimate && leaderClassEstimate > 0
         ? leaderClassEstimate
-        : (bestLapTimes[paceCarIdx] ?? 0);
+        : (bestLapTimes[paceCarIdx] ?? 0));
     const playerLapTime =
-      playerClassEstimate && playerClassEstimate > 0
+      this.classPace(playerCarIdx) ??
+      (playerClassEstimate && playerClassEstimate > 0
         ? playerClassEstimate
-        : (bestLapTimes[playerCarIdx] ?? 0);
+        : (bestLapTimes[playerCarIdx] ?? 0));
     const configuredLaps = Number.parseInt(sessionLaps ?? '0', 10) || 0;
 
     if (value(frame, 'SessionState') >= 5) {
@@ -380,5 +389,48 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       hasValidEstimate: true,
       isFixedLapRace,
     };
+  }
+
+  private updateClassLapTimes(frame: Telemetry): void {
+    const lapTimes = values(frame, 'CarIdxLastLapTime');
+    if (lapTimes.length === 0 || !isGreenFlag(value(frame, 'SessionFlags'))) {
+      return;
+    }
+    const classPositions = values(frame, 'CarIdxClassPosition');
+    const drivers = this.session?.DriverInfo?.Drivers;
+    lapTimes.forEach((lapTime, carIdx) => {
+      const previous = this.lastLapTimesByCarIdx[carIdx];
+      this.lastLapTimesByCarIdx[carIdx] = lapTime;
+      if (
+        lapTime < 10 ||
+        lapTime === previous ||
+        classPositions[carIdx] !== 1
+      ) {
+        return;
+      }
+      const classId = drivers?.find(
+        (driver) => driver.CarIdx === carIdx
+      )?.CarClassID;
+      if (classId === undefined) return;
+      const history = [
+        ...(this.classLapTimes.get(classId) ?? []),
+        lapTime,
+      ].slice(-CLASS_PACE_HISTORY);
+      this.classLapTimes.set(classId, history);
+    });
+  }
+
+  private classPace(carIdx: number): number | undefined {
+    const classId = this.session?.DriverInfo?.Drivers?.find(
+      (driver) => driver.CarIdx === carIdx
+    )?.CarClassID;
+    if (classId === undefined) return undefined;
+    const history = this.classLapTimes.get(classId) ?? [];
+    if (history.length === 0) return undefined;
+    const fastest = Math.min(...history);
+    const valid = history.filter(
+      (lapTime) => lapTime <= fastest + CLASS_PACE_OUTLIER_SECONDS
+    );
+    return valid.reduce((sum, lapTime) => sum + lapTime, 0) / valid.length;
   }
 }

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -316,14 +316,22 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
         break;
       }
     }
-    const projectionCarIdx = leaderCarIdx >= 0 ? leaderCarIdx : playerCarIdx;
-    const classEstimate = this.session?.DriverInfo?.Drivers?.find(
-      (driver) => driver.CarIdx === projectionCarIdx
+    const paceCarIdx = leaderCarIdx >= 0 ? leaderCarIdx : playerCarIdx;
+    const drivers = this.session?.DriverInfo?.Drivers;
+    const leaderClassEstimate = drivers?.find(
+      (driver) => driver.CarIdx === paceCarIdx
+    )?.CarClassEstLapTime;
+    const playerClassEstimate = drivers?.find(
+      (driver) => driver.CarIdx === playerCarIdx
     )?.CarClassEstLapTime;
     const bestLapTimes = values(frame, 'CarIdxBestLapTime');
-    const averageLapTime =
-      classEstimate && classEstimate > 0
-        ? classEstimate
+    const leaderLapTime =
+      leaderClassEstimate && leaderClassEstimate > 0
+        ? leaderClassEstimate
+        : (bestLapTimes[paceCarIdx] ?? 0);
+    const playerLapTime =
+      playerClassEstimate && playerClassEstimate > 0
+        ? playerClassEstimate
         : (bestLapTimes[playerCarIdx] ?? 0);
     const configuredLaps = Number.parseInt(sessionLaps ?? '0', 10) || 0;
 
@@ -347,26 +355,28 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
       }
       return { ...emptyProjection, totalRaceLaps };
     }
-    if (averageLapTime < 10) return emptyProjection;
+    if (leaderLapTime < 10 || playerLapTime < 10) return emptyProjection;
 
     const leaderLap = carLaps[leaderCarIdx] ?? playerLap;
     const leaderDistance = lapDistances[leaderCarIdx] ?? 0;
     const playerDistance =
       lapDistances[playerCarIdx] ?? value(frame, 'LapDistPct');
-    let totalRaceLaps =
-      playerLap === 0
-        ? value(frame, 'SessionTimeTotal') / averageLapTime
-        : timeRemaining / averageLapTime + (leaderLap - 1) + leaderDistance;
-    const lapsBehind =
-      leaderLap > playerLap + 1 ? Math.floor(leaderLap - playerLap) : 0;
-    totalRaceLaps -= lapsBehind;
-    if (configuredLaps > 0 && totalRaceLaps > configuredLaps) {
-      totalRaceLaps = configuredLaps;
-    }
+    const leaderProgress = Math.max(0, leaderLap - 1) + leaderDistance;
     const playerProgress = Math.max(0, playerLap - 1) + playerDistance;
+    const leaderProgressAtTimeLimit =
+      leaderProgress + timeRemaining / leaderLapTime;
+    const leaderFinishProgress = Math.ceil(leaderProgressAtTimeLimit);
+    const timeUntilLeaderFinishes =
+      (leaderFinishProgress - leaderProgress) * leaderLapTime;
+    let playerFinishProgress = Math.ceil(
+      playerProgress + timeUntilLeaderFinishes / playerLapTime
+    );
+    if (configuredLaps > 0) {
+      playerFinishProgress = Math.min(playerFinishProgress, configuredLaps);
+    }
     return {
-      totalRaceLaps,
-      lapsRemaining: Math.max(0, Math.ceil(totalRaceLaps) - playerProgress),
+      totalRaceLaps: playerFinishProgress,
+      lapsRemaining: Math.max(0, playerFinishProgress - playerProgress),
       hasValidEstimate: true,
       isFixedLapRace,
     };

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -367,7 +367,7 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
     if (leaderLapTime < 10 || playerLapTime < 10) return emptyProjection;
 
     const leaderLap = carLaps[leaderCarIdx] ?? playerLap;
-    const leaderDistance = lapDistances[leaderCarIdx] ?? 0;
+    const leaderDistance = lapDistances[paceCarIdx] ?? 0;
     const playerDistance =
       lapDistances[playerCarIdx] ?? value(frame, 'LapDistPct');
     const leaderProgress = Math.max(0, leaderLap - 1) + leaderDistance;

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
@@ -135,6 +135,10 @@ describe('useFuelCalculation channel parity', () => {
     await waitFor(() => expect(result.current).not.toBeNull());
     expect(result.current?.lapsRemaining).toBe(9.2);
     expect(result.current?.lapsRemaining).not.toBeCloseTo(12.2);
+    expect(result.current?.fuelToFinish).toBeCloseTo(
+      9.2 * (result.current?.avgLaps ?? 0) +
+        (defaultFuelCalculatorSettings.safetyMargin + 0.25) * 1.3
+    );
   });
 
   it('accepts a validated zero-lap timed-race estimate', async () => {

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -610,11 +610,7 @@ export function useFuelCalculation(
         totalLaps = Math.ceil(calculatedTotalRaceLaps);
         lapsRemaining = estimatedLapsRemaining;
 
-        // Add safety buffer for refuel calculations
-        const TIME_PADDING_REFUEL = 45.0;
-        const avgLapTimeForBuffer = avgLapTime > 0 ? avgLapTime : 90; // Default 90s if unknown
-        const bufferLaps = TIME_PADDING_REFUEL / avgLapTimeForBuffer;
-        lapsRemainingRefuel = lapsRemaining + bufferLaps;
+        lapsRemainingRefuel = lapsRemaining;
 
         if (DEBUG_LOGGING) {
           logger.info(
@@ -638,10 +634,8 @@ export function useFuelCalculation(
           const timeToFinishLap = projectionLapTime * pctRemainingInLap;
           const timeAtLine = sessionTimeRemain - timeToFinishLap;
           const TIME_PADDING_SECONDS = 0.5;
-          const TIME_PADDING_REFUEL = 45.0;
 
           let futureLaps = 0;
-          let futureLapsRefuel = 0;
 
           if (timeAtLine < -TIME_PADDING_SECONDS) {
             lapsRemaining = 1;
@@ -655,15 +649,7 @@ export function useFuelCalculation(
           }
           totalLaps = lap + futureLaps;
 
-          if (timeAtLine < -TIME_PADDING_REFUEL) {
-            lapsRemainingRefuel = 1;
-          } else {
-            futureLapsRefuel = Math.ceil(
-              (timeAtLine + TIME_PADDING_REFUEL) / projectionLapTime
-            );
-            futureLapsRefuel = Math.max(0, futureLapsRefuel);
-            lapsRemainingRefuel = 1 + futureLapsRefuel;
-          }
+          lapsRemainingRefuel = lapsRemaining;
         } else {
           const estimatedLapsFromFuel =
             trendAdjustedConsumption > 0


### PR DESCRIPTION
## Description

Fixes timed multiclass fuel estimates using the overall leaders faster class pace for the player cars remaining distance.

The fuel projection now separates the two parts of the estimate:

- overall-leader pace determines when the leader reaches the finish after the time limit
- player-class pace determines how many laps the player completes before their next finish-line crossing

This prevents slower-class cars from being assigned prototype-paced remaining laps. The processor test suite includes a synthetic 60-second prototype leader and 90-second GT player regression case, plus updated same-class lapping coverage.

Architecture review phase: Phase 3 — Channel-based bridge.

Validation:

- full test suite: 1,906 passed, 1 skipped
- npm run lint passed
- git diff --check passed

Not tested in a live iRacing session.

## Screenshots

### Before

No visual layout change. In a timed multiclass race, a slower-class player could receive a fuel estimate based on the overall leaders faster lap pace.

### After

No visual layout change. Remaining player laps are projected using player-class pace while preserving overall-leader timing for the race finish.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fuel and race-lap projections for timed races.
  * Projections now better account for class-specific pace in multiclass races.
  * Improved accuracy when overall leader data is unavailable by using the player’s race distance.
  * Added safeguards against unreliable lap-time data and outliers.
  * Corrected projected total laps and remaining laps in timed and fractional-distance scenarios.
  * Updated fuel-to-finish calculations to use validated remaining-lap estimates and configured safety margins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->