### PR TITLE
fix: overlays sit empty when opened during a running session

### DIFF
--- a/src/app/bridge/iracingSdk/iracingSdkBridge.spec.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.spec.ts
@@ -77,9 +77,11 @@ describe('publishIRacingSDKEvents session polling', () => {
     publishMessageToOverlay: vi.fn(),
   });
 
-  it('publishes the running state as soon as telemetry arrives', async () => {
+  it('publishes the running state as soon as the SDK produces data', async () => {
     // sessionStatusOK still reads false when the bridge seeds it, which is what
-    // left overlays believing the sim was down until the 5s poll caught up.
+    // left overlays believing the sim was down until the 5s poll caught up. A
+    // successful waitForData is the proof the sim is up, matching the existing
+    // wasRunning / lifecycle enter trigger; getTelemetry may still be null.
     mockSdkState.sessionStatusOK = false;
     const overlayManager = createOverlayManager();
 

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.spec.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.spec.ts
@@ -77,6 +77,28 @@ describe('publishIRacingSDKEvents session polling', () => {
     publishMessageToOverlay: vi.fn(),
   });
 
+  it('publishes the running state as soon as telemetry arrives', async () => {
+    // sessionStatusOK still reads false when the bridge seeds it, which is what
+    // left overlays believing the sim was down until the 5s poll caught up.
+    mockSdkState.sessionStatusOK = false;
+    const overlayManager = createOverlayManager();
+
+    const bridge = await publishIRacingSDKEvents(overlayManager as never);
+
+    // Well inside the 5s poll interval.
+    await vi.advanceTimersByTimeAsync(100);
+
+    const runningStateCalls = overlayManager.publishMessage.mock.calls.filter(
+      ([channel]) => channel === 'runningState'
+    );
+    expect(runningStateCalls).toEqual([
+      ['runningState', false],
+      ['runningState', true],
+    ]);
+
+    bridge.stop();
+  });
+
   it('polls immediately and every 500 ms using monotonic time', async () => {
     const overlayManager = createOverlayManager();
 

--- a/src/app/bridge/iracingSdk/iracingSdkBridge.ts
+++ b/src/app/bridge/iracingSdk/iracingSdkBridge.ts
@@ -207,8 +207,10 @@ export async function publishIRacingSDKEvents(
   overlayManager.publishMessage('runningState', initialRunningState);
   runningStateCallbacks.forEach((callback) => callback(initialRunningState));
 
-  const runningStateInterval = setInterval(() => {
-    const isSimRunning = sdk.sessionStatusOK;
+  // Publishes a change once, whoever notices it first. The telemetry loop
+  // calls this the moment it has data, so overlays are not left believing the
+  // sim is down until the poll below next runs.
+  const publishRunningState = (isSimRunning: boolean) => {
     if (isSimRunning === lastRunningState) {
       return;
     }
@@ -219,6 +221,10 @@ export async function publishIRacingSDKEvents(
     );
     overlayManager.publishMessage('runningState', isSimRunning);
     runningStateCallbacks.forEach((callback) => callback(isSimRunning));
+  };
+
+  const runningStateInterval = setInterval(() => {
+    publishRunningState(sdk.sessionStatusOK);
   }, 5000);
 
   // Start the telemetry loop in the background
@@ -250,6 +256,11 @@ export async function publishIRacingSDKEvents(
         if (!wasRunning) {
           logger.info(`[iracingSdkBridge] ${sourceName} is running`);
           wasRunning = true;
+          // sessionStatusOK can still read false when the bridge seeds it, so
+          // the arrival of real data is the earliest reliable proof the sim is
+          // up. Without this the overlays wait out the 5s poll before showing
+          // anything.
+          publishRunningState(true);
           lifecycle?._onEnter({ replay: isTapeReplay });
         }
         perfMetrics.markStart('processTelemetry');

--- a/src/app/logger.ts
+++ b/src/app/logger.ts
@@ -5,7 +5,18 @@ logger.initialize();
 
 // File: info and above (persisted to disk)
 // Console: debug and above (visible in dev)
-logger.transports.file.level = 'info';
+//
+// Startup instrumentation logs at debug, which the file transport drops by
+// default so ordinary runs do not bloat the log. Set IRDASHIES_LOG_LEVEL=debug
+// to capture it when diagnosing a slow or empty startup.
+const FILE_LEVELS = ['error', 'warn', 'info', 'verbose', 'debug'] as const;
+type FileLevel = (typeof FILE_LEVELS)[number];
+
+const requestedLevel = process.env.IRDASHIES_LOG_LEVEL as FileLevel | undefined;
+logger.transports.file.level =
+  requestedLevel && FILE_LEVELS.includes(requestedLevel)
+    ? requestedLevel
+    : 'info';
 logger.transports.console.level = 'debug';
 
 const perfLogPath = process.env.PERF_LOG_PATH;

--- a/src/app/processors/ProcessorHost.ts
+++ b/src/app/processors/ProcessorHost.ts
@@ -12,6 +12,9 @@ import logger from '../logger';
 
 export type ProcessorChannel = Exclude<ChannelName, 'session.lifecycle'>;
 
+/** Startup instrumentation is opt-in, so it costs nothing by default. */
+const STARTUP_DEBUG = process.env.IRDASHIES_LOG_LEVEL === 'debug';
+
 interface SnapshotShape {
   /** Log-safe summary. Never stringifies a 60-car telemetry frame. */
   description: string;
@@ -379,7 +382,9 @@ export class ProcessorHost {
     );
     if (succeeded) {
       state.lastPublishedToken = token;
-      this.logFirstPublishes(state.definition.channel, snapshot);
+      if (STARTUP_DEBUG) {
+        this.logFirstPublishes(state.definition.channel, snapshot);
+      }
     }
   }
 
@@ -403,7 +408,14 @@ export class ProcessorHost {
         `[ProcessorHost] first publish on ${channel}: ${shape.description}`
       );
     }
-    if (needsPopulated && shape.hasArrays && shape.populated) {
+    if (!needsPopulated) return;
+    // A channel with no array fields has nothing to fill, so mark it done and
+    // stop inspecting its every publish.
+    if (!shape.hasArrays) {
+      this.firstPopulatedPublishLogged.add(channel);
+      return;
+    }
+    if (shape.populated) {
       this.firstPopulatedPublishLogged.add(channel);
       logger.debug(
         `[ProcessorHost] first populated publish on ${channel}: ${shape.description}`

--- a/src/app/processors/ProcessorHost.ts
+++ b/src/app/processors/ProcessorHost.ts
@@ -8,8 +8,51 @@ import type {
 import type { ChannelBus } from '../bridge/channelBus';
 import type { SessionLifecycle } from '../sessionLifecycle';
 import type { TelemetryProcessor } from './TelemetryProcessor';
+import logger from '../logger';
 
 export type ProcessorChannel = Exclude<ChannelName, 'session.lifecycle'>;
+
+interface SnapshotShape {
+  /** Log-safe summary. Never stringifies a 60-car telemetry frame. */
+  description: string;
+  /** True once any array field carries an entry. */
+  populated: boolean;
+  /** False for channels that hold no arrays, so they are never waited on. */
+  hasArrays: boolean;
+}
+
+/**
+ * Enough of a snapshot's shape to tell a populated payload from an empty one
+ * in the log. A channel's first publish is often empty because the processor
+ * has only just been activated by a subscriber, so the first *populated*
+ * publish is the timestamp that says when data actually reached a widget.
+ */
+const inspectSnapshot = (snapshot: unknown): SnapshotShape => {
+  if (snapshot === null || snapshot === undefined) {
+    return { description: 'empty', populated: false, hasArrays: false };
+  }
+  if (Array.isArray(snapshot)) {
+    return {
+      description: `array(${snapshot.length})`,
+      populated: snapshot.length > 0,
+      hasArrays: true,
+    };
+  }
+  if (typeof snapshot !== 'object') {
+    return { description: typeof snapshot, populated: true, hasArrays: false };
+  }
+  const entries = Object.entries(snapshot as Record<string, unknown>);
+  const arrays = entries.filter(([, value]) => Array.isArray(value));
+  const longestArray = arrays.reduce(
+    (longest, [, value]) => Math.max(longest, (value as unknown[]).length),
+    0
+  );
+  return {
+    description: `keys=${entries.length} longestArray=${longestArray}`,
+    populated: longestArray > 0,
+    hasArrays: arrays.length > 0,
+  };
+};
 
 export interface ProcessorMetrics {
   markStart(label: string): void;
@@ -93,6 +136,10 @@ export class ProcessorHost {
   private readonly directDemand = new Set<ProcessorChannel>();
   private activeDemand = new Set<ProcessorChannel>();
   private readonly reportedFailures = new Set<string>();
+  /** Channels whose first publish has already been logged. Debug aid only. */
+  private readonly firstPublishLogged = new Set<ProcessorChannel>();
+  /** Channels whose first populated publish has been logged. Debug aid only. */
+  private readonly firstPopulatedPublishLogged = new Set<ProcessorChannel>();
   private readonly disconnects: (() => void)[] = [];
   private latestSession?: Session;
   private sourceReplay?: boolean;
@@ -279,6 +326,10 @@ export class ProcessorHost {
     state.processor = undefined;
     state.lastProcessedAt = undefined;
     state.lastPublishedToken = undefined;
+    // Log the first publishes again after a reconnect, so a mid-run rejoin is
+    // as traceable as the first startup.
+    this.firstPublishLogged.delete(state.definition.channel);
+    this.firstPopulatedPublishLogged.delete(state.definition.channel);
     this.bus.clearSnapshot(state.definition.channel);
   }
 
@@ -326,7 +377,38 @@ export class ProcessorHost {
       () => this.bus.publish(state.definition.channel, snapshot),
       'Publication'
     );
-    if (succeeded) state.lastPublishedToken = token;
+    if (succeeded) {
+      state.lastPublishedToken = token;
+      this.logFirstPublishes(state.definition.channel, snapshot);
+    }
+  }
+
+  /**
+   * Debug aid for diagnosing a slow or empty startup. Logs the first publish on
+   * a channel, and separately the first publish that actually carries data.
+   * Channels holding no array fields only ever log the first line.
+   */
+  private logFirstPublishes(
+    channel: ProcessorChannel,
+    snapshot: ChannelPayloads[ProcessorChannel]
+  ): void {
+    const needsFirst = !this.firstPublishLogged.has(channel);
+    const needsPopulated = !this.firstPopulatedPublishLogged.has(channel);
+    if (!needsFirst && !needsPopulated) return;
+
+    const shape = inspectSnapshot(snapshot);
+    if (needsFirst) {
+      this.firstPublishLogged.add(channel);
+      logger.debug(
+        `[ProcessorHost] first publish on ${channel}: ${shape.description}`
+      );
+    }
+    if (needsPopulated && shape.hasArrays && shape.populated) {
+      this.firstPopulatedPublishLogged.add(channel);
+      logger.debug(
+        `[ProcessorHost] first populated publish on ${channel}: ${shape.description}`
+      );
+    }
   }
 
   private isDue(

--- a/src/frontend/context/LapTimesStore/LapTimesStoreUpdater.tsx
+++ b/src/frontend/context/LapTimesStore/LapTimesStoreUpdater.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
+import logger from '@irdashies/utils/logger';
 import { useLapTimesSnapshot } from '../ChannelStore';
 import { useLapTimesStore } from './LapTimesStore';
 
@@ -10,8 +11,29 @@ import { useLapTimesStore } from './LapTimesStore';
 export const useLapTimesStoreUpdater = (enabled: boolean) => {
   const snapshot = useLapTimesSnapshot(enabled);
   const applySnapshot = useLapTimesStore((state) => state.applySnapshot);
+  // Widgets that wait on lap times look empty until the first car has a time.
+  // Log both moments once so a slow startup can be attributed.
+  const logged = useRef({ arrived: false, populated: false });
 
   useEffect(() => {
-    if (snapshot && enabled) applySnapshot(snapshot);
+    if (!snapshot || !enabled) return;
+    applySnapshot(snapshot);
+
+    const marks = logged.current;
+    if (!marks.arrived) {
+      marks.arrived = true;
+      logger.debug(
+        `[LapTimesStore] first snapshot: sessionNum=${snapshot.sessionNum} version=${snapshot.version} cars=${snapshot.lapTimes.length}`
+      );
+    }
+    if (!marks.populated) {
+      const withTimes = snapshot.lapTimes.filter((time) => time > 0).length;
+      if (withTimes > 0) {
+        marks.populated = true;
+        logger.debug(
+          `[LapTimesStore] first populated snapshot: ${withTimes} cars with a lap time (version=${snapshot.version})`
+        );
+      }
+    }
   }, [applySnapshot, enabled, snapshot]);
 };

--- a/src/frontend/context/LapTimesStore/LapTimesStoreUpdater.tsx
+++ b/src/frontend/context/LapTimesStore/LapTimesStoreUpdater.tsx
@@ -27,7 +27,12 @@ export const useLapTimesStoreUpdater = (enabled: boolean) => {
       );
     }
     if (!marks.populated) {
-      const withTimes = snapshot.lapTimes.filter((time) => time > 0).length;
+      // Counted in place: this runs on every snapshot until a car sets a lap,
+      // which can be minutes of a pre-race grid.
+      let withTimes = 0;
+      for (const time of snapshot.lapTimes) {
+        if (time > 0) withTimes++;
+      }
       if (withTimes > 0) {
         marks.populated = true;
         logger.debug(


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

Opening irdashies while a session is already running left the overlays empty for several seconds.

**Fix — running state is published as soon as telemetry arrives.**

`publishIRacingSDKEvents` seeded the running state from `sdk.sessionStatusOK` immediately after `ready()`, where it still reads `false`. The only correction was a 5-second poll, so every overlay opened during a live session was told the sim was down and waited for that poll. The telemetry loop already knew better — it sets `wasRunning = true` on its first frame — so it now publishes the change there. The 5s interval stays as the fallback that catches disconnects.

Measured on a packaged build, joining a live 72-car race:

| | before | after |
|---|---|---|
| running state published | 5.08s | **0.17s** |
| overlays visible | ~5s | ~4s |
| Gantry populated | ~19s | ~4s |

**Added — debug logging for the startup path, which had none.**

- `ProcessorHost`: first publish per channel, and separately the first publish that actually carries data. A channel's first publish is usually empty because the processor has just been activated by its first subscriber, so the two timestamps separate "channel silent" from "channel publishing but empty". Both markers reset on disconnect.
- `LapTimesStoreUpdater`: first snapshot, and first snapshot where any car has a lap time.

These log at `debug`, which the file transport dropped. `logger.ts` gains an `IRDASHIES_LOG_LEVEL` env override so the instrumentation can be captured on demand; the default is unchanged at `info`.

Known remaining issue, not addressed here: the standings widget still takes ~11s to show rows after its channel delivers a populated snapshot. The new logging is what localised it, and the next step is a marker inside `useDriverStandings`.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

Overlays render empty on launch into a running session, then populate after several seconds.

### After
<!-- Screenshot or description of the new behaviour -->

Overlays populate as soon as their data arrives. No visual design changes — timing only, so screenshots would be identical.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

---

Validation:

- `npx vitest run` — 200 files, 1934 tests pass. New test in `iracingSdkBridge.spec.ts` seeds `sessionStatusOK = false`, advances 100ms, and asserts the sequence is `[false, true]`; before the fix `true` only arrived at 5000ms.
- `npx tsc --noEmit` and `npx eslint` — clean.
- Verified in a live iRacing race from a packaged build of this branch, joining mid-session with 72 cars. Timings above are from that run's log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Overlays now receive the simulator’s running-state update immediately when telemetry begins, rather than waiting for the next polling interval.

* **Improvements**
  * Added configurable file logging levels through the `IRDASHIES_LOG_LEVEL` setting.
  * Added diagnostic logging to help identify the first telemetry and lap-time data received, including after reconnects.

* **Tests**
  * Added coverage confirming running-state updates are published promptly when telemetry arrives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->