### PR TITLE
fix: rebuild native addon for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,24 +156,11 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - name: Cache node_modules and native builds
-        uses: actions/cache@v5
-        id: cache-deps
-        with:
-          path: |
-            node_modules
-            .vite
-            **/node_modules
-            **/*.node
-            **/build/Release
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/binding.gyp', '**/node_modules/**/*.node') }}
-          restore-keys: |
-            ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-
-            ${{ runner.os }}-node-
-
       - name: Install dependencies
-        if: steps.cache-deps.outputs.cache-hit != 'true'
         run: npm ci
+
+      - name: Build native iRacing addon
+        run: npm run irsdk:build
 
       # --- Signed release ----------------------------------------------------
       # Pushes release only when the version changes. Manual runs release only
@@ -191,6 +178,39 @@ jobs:
         run: npx electron-forge package
         env:
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+
+      - name: Verify packaged native iRacing addon
+        shell: pwsh
+        run: |
+          $asarPath = 'out/irdashies-win32-x64/resources/app.asar'
+          $builtAddon = 'build/Release/irsdk_node.node'
+          $extractDirectory = Join-Path $env:RUNNER_TEMP 'irdashies-asar-verification'
+
+          if (-not (Test-Path -LiteralPath $asarPath -PathType Leaf)) {
+            throw "Packaged ASAR not found: $asarPath"
+          }
+          if (-not (Test-Path -LiteralPath $builtAddon -PathType Leaf)) {
+            throw "Built native addon not found: $builtAddon"
+          }
+
+          npx asar extract $asarPath $extractDirectory
+          if ($LASTEXITCODE -ne 0) {
+            throw 'Failed to extract the packaged ASAR.'
+          }
+
+          $packagedAddon = Join-Path `
+            $extractDirectory `
+            '.vite/build/Release/irsdk_node.node'
+          if (-not (Test-Path -LiteralPath $packagedAddon -PathType Leaf)) {
+            throw "Packaged native addon not found: $packagedAddon"
+          }
+
+          $builtHash = (Get-FileHash -LiteralPath $builtAddon -Algorithm SHA256).Hash
+          $packagedHash = `
+            (Get-FileHash -LiteralPath $packagedAddon -Algorithm SHA256).Hash
+          if ($builtHash -ne $packagedHash) {
+            throw "Packaged native addon does not match the freshly built addon. Built: $builtHash; packaged: $packagedHash"
+          }
 
       - name: Archive packaged Windows application
         shell: pwsh


### PR DESCRIPTION
## Description

Rebuild the iRacing native addon unconditionally before packaging a Windows release, and verify that the addon copied into `app.asar` is byte-for-byte identical to the fresh build.

The v1.0.0 release packaged an `irsdk_node.node` built on 2026-08-04, before the replay seek integer-overload fix landed on 2026-08-16. The release cache restored native build outputs without including native source files in its cache key, and the release job skipped both `npm ci` and `node-gyp rebuild` on a cache hit.

This change:

- removes the release job's `node_modules`, `.vite`, `.node`, and `build/Release` cache;
- runs `npm ci` for every release;
- runs `npm run irsdk:build` immediately before Forge packaging; and
- extracts the packaged ASAR and compares the packaged addon's SHA-256 with the freshly built addon before signing.

Tested with `npm run lint`, Prettier validation, YAML parsing, `git diff --check`, and a local check that the installed ASAR CLI supports the extraction command used by CI. The Windows-only release job itself will be exercised by the release workflow rather than iRacing.

Architecture review reference: this is release reproducibility hardening for the native boundary. It supports the native-code safety goals, but is not part of a numbered phase in `docs/ARCHITECTURE_REVIEW.md`.

## Screenshots

### Before

No visual change. A release could reuse a stale cached native addon and package it without checking its provenance.

### After

No visual change. The release job rebuilds the native addon and fails before signing if the packaged binary differs from that fresh build.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release packaging reliability by ensuring required native components are freshly built and included in distributed applications.
  - Added automated verification to detect missing or mismatched native components before release.

- **Chores**
  - Updated the release process to provide more consistent, trustworthy application builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->