### PR TITLE
fix: show overlays without taking focus

### DIFF
--- a/src/app/overlayManager.spec.ts
+++ b/src/app/overlayManager.spec.ts
@@ -1,8 +1,97 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DashboardLayout } from '@irdashies/types';
 import {
   refreshSessionDataForVisibleWindow,
   type RendererDataSubscriptions,
 } from './rendererDataVisibility';
+
+vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', undefined);
+vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window');
+vi.stubGlobal('APP_GIT_HASH', 'test');
+if (!process.resourcesPath) {
+  Object.defineProperty(process, 'resourcesPath', { value: '/resources' });
+}
+
+const createdWindows: FakeBrowserWindow[] = [];
+
+class FakeWebContents {
+  id = 42;
+  on = vi.fn();
+  send = vi.fn();
+  setWindowOpenHandler = vi.fn();
+}
+
+class FakeBrowserWindow {
+  static getAllWindows = vi.fn(() => []);
+  webContents = new FakeWebContents();
+  shown = false;
+  show = vi.fn(() => {
+    this.shown = true;
+  });
+  showInactive = vi.fn(() => {
+    this.shown = true;
+  });
+  focus = vi.fn();
+  setAlwaysOnTop = vi.fn();
+  setBounds = vi.fn();
+  setPosition = vi.fn();
+  setSize = vi.fn();
+  setIgnoreMouseEvents = vi.fn();
+  setVisibleOnAllWorkspaces = vi.fn();
+  getBounds = vi.fn(() => ({ x: 0, y: 0, width: 1920, height: 1080 }));
+  loadFile = vi.fn();
+  loadURL = vi.fn();
+  on = vi.fn();
+  once = vi.fn();
+  isDestroyed = vi.fn(() => false);
+  isVisible = vi.fn(() => this.shown);
+
+  constructor(public options: Record<string, unknown>) {
+    createdWindows.push(this);
+  }
+}
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '0.0.0',
+    disableHardwareAcceleration: vi.fn(),
+    commandLine: { appendSwitch: vi.fn() },
+  },
+  BrowserWindow: FakeBrowserWindow,
+  Notification: vi.fn(),
+  screen: {
+    getAllDisplays: () => [
+      {
+        id: 1,
+        bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+      },
+    ],
+    getPrimaryDisplay: () => ({
+      id: 1,
+      bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+    }),
+  },
+}));
+
+vi.mock('./storage/storage', () => ({ readData: vi.fn(), writeData: vi.fn() }));
+vi.mock('./storage/dashboards', () => ({ getDashboard: vi.fn() }));
+vi.mock('./storage/chromiumFlags', () => ({
+  getChromiumFlags: vi.fn(() => ({})),
+  parseCustomSwitches: vi.fn(() => []),
+}));
+vi.mock('./trackWindowMovement', () => ({
+  markCorrectedBounds: vi.fn(),
+  trackSettingsWindowMovement: vi.fn(),
+}));
+vi.mock('./perfRendererArguments', () => ({
+  createRendererPerfArguments: vi.fn(() => []),
+}));
+vi.mock('./hardenWindow', () => ({ hardenWindow: vi.fn() }));
+vi.mock('./logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { OverlayManager } = await import('./overlayManager');
 
 describe('overlay renderer data visibility recovery', () => {
   it('replays the latest session snapshot when a subscribed window is shown', () => {
@@ -48,5 +137,29 @@ describe('overlay renderer data visibility recovery', () => {
       refreshSessionDataForVisibleWindow(win, subscriptions, { value: 1 })
     ).toBe(false);
     expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe('OverlayManager display windows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createdWindows.length = 0;
+  });
+
+  it('shows a ready display overlay without activating it', () => {
+    const manager = new OverlayManager();
+    manager.createOverlays({ widgets: [] } as DashboardLayout, {
+      createSettingsWindow: false,
+    });
+    const displayWindow = createdWindows[0];
+    const readyHandler = displayWindow.once.mock.calls.find(
+      ([event]) => event === 'ready-to-show'
+    )?.[1] as () => void;
+
+    readyHandler();
+
+    expect(displayWindow.showInactive).toHaveBeenCalledOnce();
+    expect(displayWindow.show).not.toHaveBeenCalled();
+    expect(displayWindow.focus).not.toHaveBeenCalled();
   });
 });

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -355,7 +355,7 @@ export class OverlayManager {
 
       browserWindow.setPosition(expectedBounds.x, expectedBounds.y);
       browserWindow.setSize(expectedBounds.width, expectedBounds.height);
-      browserWindow.show();
+      browserWindow.showInactive();
 
       const actualBounds = browserWindow.getBounds();
       const offset = {


### PR DESCRIPTION
## Description

Shows display overlay windows without activating them when their renderer is ready.

Electron BrowserWindow.show gives focus to the window, which can take input away from iRacing during overlay startup. BrowserWindow.showInactive makes the overlay visible without changing the active application.

The existing renderer-only Hide / Show UI behavior is intentionally unchanged so hidden overlays continue receiving telemetry and preserve processor history.

Relevant architecture phase: cross-cutting main-process window lifecycle fix; no target-topology phase is changed.

Tested with the focused Vitest spec and npm run lint, including TypeScript typechecking.

## Screenshots

### Before

No visual screenshot. A display overlay used BrowserWindow.show during startup, which activates the overlay window.

### After

No visual screenshot. A display overlay uses BrowserWindow.showInactive and becomes visible without taking focus.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via npm test
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run npm run lint and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Display overlays now appear without taking focus away from the active application.

* **Tests**
  * Added coverage to verify overlays are shown without activation or focus changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->