### PR TITLE
fix: honor overlay always-on-top setting

### DIFF
--- a/src/app/overlayManager.spec.ts
+++ b/src/app/overlayManager.spec.ts
@@ -1,8 +1,97 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DashboardLayout } from '@irdashies/types';
 import {
   refreshSessionDataForVisibleWindow,
   type RendererDataSubscriptions,
 } from './rendererDataVisibility';
+
+vi.stubGlobal('MAIN_WINDOW_VITE_DEV_SERVER_URL', undefined);
+vi.stubGlobal('MAIN_WINDOW_VITE_NAME', 'main_window');
+vi.stubGlobal('APP_GIT_HASH', 'test');
+if (!process.resourcesPath) {
+  Object.defineProperty(process, 'resourcesPath', { value: '/resources' });
+}
+
+const createdWindows: FakeBrowserWindow[] = [];
+
+class FakeWebContents {
+  id = 42;
+  on = vi.fn();
+  send = vi.fn();
+  setWindowOpenHandler = vi.fn();
+}
+
+class FakeBrowserWindow {
+  static getAllWindows = vi.fn(() => []);
+  webContents = new FakeWebContents();
+  shown = false;
+  show = vi.fn(() => {
+    this.shown = true;
+  });
+  showInactive = vi.fn(() => {
+    this.shown = true;
+  });
+  focus = vi.fn();
+  setAlwaysOnTop = vi.fn();
+  setBounds = vi.fn();
+  setPosition = vi.fn();
+  setSize = vi.fn();
+  setIgnoreMouseEvents = vi.fn();
+  setVisibleOnAllWorkspaces = vi.fn();
+  getBounds = vi.fn(() => ({ x: 0, y: 0, width: 1920, height: 1080 }));
+  loadFile = vi.fn();
+  loadURL = vi.fn();
+  on = vi.fn();
+  once = vi.fn();
+  isDestroyed = vi.fn(() => false);
+  isVisible = vi.fn(() => this.shown);
+
+  constructor(public options: Record<string, unknown>) {
+    createdWindows.push(this);
+  }
+}
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '0.0.0',
+    disableHardwareAcceleration: vi.fn(),
+    commandLine: { appendSwitch: vi.fn() },
+  },
+  BrowserWindow: FakeBrowserWindow,
+  Notification: vi.fn(),
+  screen: {
+    getAllDisplays: () => [
+      {
+        id: 1,
+        bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+      },
+    ],
+    getPrimaryDisplay: () => ({
+      id: 1,
+      bounds: { x: 0, y: 0, width: 1920, height: 1080 },
+    }),
+  },
+}));
+
+vi.mock('./storage/storage', () => ({ readData: vi.fn(), writeData: vi.fn() }));
+vi.mock('./storage/dashboards', () => ({ getDashboard: vi.fn() }));
+vi.mock('./storage/chromiumFlags', () => ({
+  getChromiumFlags: vi.fn(() => ({})),
+  parseCustomSwitches: vi.fn(() => []),
+}));
+vi.mock('./trackWindowMovement', () => ({
+  markCorrectedBounds: vi.fn(),
+  trackSettingsWindowMovement: vi.fn(),
+}));
+vi.mock('./perfRendererArguments', () => ({
+  createRendererPerfArguments: vi.fn(() => []),
+}));
+vi.mock('./hardenWindow', () => ({ hardenWindow: vi.fn() }));
+vi.mock('./logger', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { OverlayManager } = await import('./overlayManager');
 
 describe('overlay renderer data visibility recovery', () => {
   it('replays the latest session snapshot when a subscribed window is shown', () => {
@@ -49,4 +138,28 @@ describe('overlay renderer data visibility recovery', () => {
     ).toBe(false);
     expect(send).not.toHaveBeenCalled();
   });
+});
+
+describe('OverlayManager display windows', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createdWindows.length = 0;
+  });
+
+  it.each([true, false])(
+    'creates overlays with alwaysOnTop=%s when configured',
+    (overlayAlwaysOnTop) => {
+      const manager = new OverlayManager();
+      const dashboard = {
+        widgets: [],
+        generalSettings: { overlayAlwaysOnTop },
+      } as DashboardLayout;
+
+      manager.createOverlays(dashboard, { createSettingsWindow: false });
+
+      expect(createdWindows).toHaveLength(1);
+      expect(createdWindows[0].options.alwaysOnTop).toBe(overlayAlwaysOnTop);
+      expect(createdWindows[0].setAlwaysOnTop).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -214,7 +214,7 @@ export class OverlayManager {
       roundedCorners: false,
       hasShadow: false,
       show: false,
-      alwaysOnTop: true,
+      alwaysOnTop: this.overlayAlwaysOnTop,
       backgroundColor: '#00000000',
       icon: getIconPath(),
       webPreferences: {
@@ -272,10 +272,6 @@ export class OverlayManager {
     browserWindow.setVisibleOnAllWorkspaces(true, {
       visibleOnFullScreen: true,
     });
-
-    if (this.overlayAlwaysOnTop) {
-      browserWindow.setAlwaysOnTop(true, 'screen-saver', 1);
-    }
 
     if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
       browserWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);


### PR DESCRIPTION
## Description

Fixes display overlay windows so the existing Keep Overlays Always On Top setting is honored when each BrowserWindow is created.

When enabled, Electron now uses its default floating topmost level instead of escalating overlays to the screen-saver level above system UI. This keeps overlays above normal application windows while avoiding the unnecessarily aggressive taskbar-level z-order. When disabled, overlays are no longer created with alwaysOnTop hardcoded to true.

Relevant architecture phase: cross-cutting main-process window lifecycle fix; no target-topology phase is changed.

Tested with the complete Vitest suite and npm run lint. The native-addon tests were rerun with the local built addon available to the temporary worktree.

## Screenshots

### Before

No visual screenshot. Disabling Keep Overlays Always On Top still created native windows with alwaysOnTop enabled, and enabled overlays were raised to the screen-saver level.

### After

No visual screenshot. The BrowserWindow constructor receives the configured value and enabled overlays use the default floating topmost level.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via npm test
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run npm run lint and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Overlay windows now respect the dashboard’s “Always on top” setting instead of always staying on top.
  * Ready display overlays now appear without unnecessarily showing or focusing the window.

* **Tests**
  * Added coverage to verify ready display overlays use the appropriate inactive display behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->