### PR TITLE
fix: side-by-side builds break themselves by updating to the official app

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,22 @@ const safeErrorDetails = (error: unknown) => {
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) app.quit();
 
-updateElectronApp();
+// Only the official build auto-updates.
+//
+// Side-by-side betas are built with a different app identity (name and
+// productName become irdashies-beta) so they install alongside the real app.
+// The update feed only ever publishes the official app, so a beta that checks
+// it is offered a release built for a *different* application, downloads it in
+// the background, and Squirrel applies it on the next launch — after which the
+// beta no longer starts. The version number is not the problem and bumping it
+// would not help; the identity mismatch is.
+if (app.getName() === 'irdashies') {
+  updateElectronApp();
+} else {
+  log.info(
+    `[update] Auto-update disabled for non-official build "${app.getName()}"`
+  );
+}
 
 const overlayManager = new OverlayManager();
 const analytics = new Analytics();


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

`updateElectronApp()` runs unconditionally, so **any build that is not the official app still checks the official update feed** — a fork, a rename, or a side-by-side test build.

The failure this causes is not a bad update prompt, it is a build that stops working. A side-by-side build sets a different `name` and `productName` so Squirrel installs it in its own directory and Electron gives it its own `userData`. It then checks the feed that only ever publishes `irdashies`, is offered a release built for a *different application*, downloads it in the background, and Squirrel applies it on the next launch. The build starts once, then fails to start again.

Gating on `app.getName()` leaves the official build exactly as it is and makes every other identity inert.

Worth stating because it is the intuitive fix and it does not work: **raising the version number would not help.** The feed is not offering an older version, it is offering a different application. Version ordering never enters into it.

The `else` branch logs once at startup so it is obvious from a log file which mode a build is in:

```
[update] Auto-update disabled for non-official build "irdashies-beta"
```

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

No visual change — this is startup behaviour in the main process.

### Before
<!-- Screenshot or description of the current behaviour -->

A build named anything other than `irdashies` checks the official feed, silently downloads a release for a different application, and fails to launch after Squirrel applies it.

### After
<!-- Screenshot or description of the new behaviour -->

Only `irdashies` checks the feed. Other identities log one line and skip the check.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

## Validation

Found on a real install, not in theory: a side-by-side test build died on its second launch, having quietly updated itself to the official app in the background.

- **Packaged build.** Confirmed the guard is in the shipped `app.asar`, not just in source, and that the packaged identity it runs under is the non-official one — so the check genuinely does not fire.
- **Official identity.** Verified `name` and `productName` are both `irdashies` in the committed `package.json`, so `app.getName()` returns `irdashies` and the official build keeps updating. This is the part that would be silently harmful to get wrong, and it is why the check is on the exact string rather than a prefix or a pattern.
- Installed on a sim rig and launched repeatedly. Previously the second launch failed; it no longer does, and the log line above appears at startup.
- `npm test` — 1912 tests across 196 files, all passing.
- `npm run lint` — clean.

No unit test added: the branch is on `app.getName()` at module scope, before `app.whenReady()`, and asserting it would mean mocking Electron's app identity to prove that a one-line conditional calls a third-party function. The meaningful verification was against the packaged artefact, which a unit test cannot reach.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic updates now run only in the official app build.
  * Beta and other non-official builds no longer check for updates and display an informational message instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->