### PR TITLE
feat: set a layout per session type instead of reconfiguring between sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ ka-local/register-task.ps1
 ka-local/update-and-launch.ps1
 ka-local/iracing-api.ts
 docs/GANTRY_LAP_GRAPH_PLAN.md
+
+# Python bytecode from the telemetry tooling
+__pycache__/
+*.pyc

--- a/site/src/utils/previewChannelRuntime.ts
+++ b/site/src/utils/previewChannelRuntime.ts
@@ -122,6 +122,8 @@ export function createPreviewChannelRuntime(
     onDriverJoined: () => () => undefined,
     onDriverLeft: () => () => undefined,
     onSessionNumChange: () => () => undefined,
+    onSessionTypeChange: () => () => undefined,
+    onDrivingStateChange: () => () => undefined,
     onDisconnect: () => () => undefined,
     _onEnter: () => undefined,
     _onTelemetry: () => undefined,

--- a/site/src/utils/previewChannelRuntime.ts
+++ b/site/src/utils/previewChannelRuntime.ts
@@ -125,6 +125,7 @@ export function createPreviewChannelRuntime(
     onSessionTypeChange: () => () => undefined,
     onDrivingStateChange: () => () => undefined,
     onDisconnect: () => () => undefined,
+    getCurrentState: () => ({ sessionType: undefined, isDriving: undefined }),
     _onEnter: () => undefined,
     _onTelemetry: () => undefined,
     _onSession: () => undefined,

--- a/src/app/bridge/dashboard/dashboardBridge.ts
+++ b/src/app/bridge/dashboard/dashboardBridge.ts
@@ -42,9 +42,38 @@ import {
   setCycleProfiles as setCycleProfilesStorage,
   getShowProfileBanner as getShowProfileBannerStorage,
   setShowProfileBanner as setShowProfileBannerStorage,
+  getSessionProfileMap as getSessionProfileMapStorage,
+  setSessionProfileMap as setSessionProfileMapStorage,
 } from '../../storage/appSettings';
+import {
+  SESSION_PROFILE_KEYS,
+  SPOTTING_TRIGGER_KEY,
+  type ProfileTriggerKey,
+  type SessionProfileMap,
+} from '@irdashies/types';
 import { Analytics } from '../../analytics';
 import logger from '../../logger';
+
+const PROFILE_TRIGGER_KEYS: ProfileTriggerKey[] = [
+  ...SESSION_PROFILE_KEYS,
+  SPOTTING_TRIGGER_KEY,
+];
+
+/**
+ * The mapping arrives over IPC, so it is rebuilt from an allowlist of keys
+ * rather than trusted. Unknown keys and non-string profile ids are dropped;
+ * an empty string is kept as-is because that is how the UI says "no profile".
+ */
+const sanitiseSessionProfileMap = (input: unknown): SessionProfileMap => {
+  const map: SessionProfileMap = {};
+  if (!input || typeof input !== 'object') return map;
+  const source = input as Record<string, unknown>;
+  for (const key of PROFILE_TRIGGER_KEYS) {
+    const value = source[key];
+    if (typeof value === 'string') map[key] = value;
+  }
+  return map;
+};
 
 /**
  * Injects global driver tag settings into a dashboard layout before broadcasting.
@@ -385,6 +414,12 @@ export async function publishDashboardUpdates(
 
   ipcMain.handle('setCycleProfiles', (_, enabled: boolean) =>
     setCycleProfilesStorage(enabled)
+  );
+
+  ipcMain.handle('getSessionProfileMap', () => getSessionProfileMapStorage());
+
+  ipcMain.handle('setSessionProfileMap', (_, map: unknown) =>
+    setSessionProfileMapStorage(sanitiseSessionProfileMap(map))
   );
 
   ipcMain.handle('getShowProfileBanner', () => getShowProfileBannerStorage());

--- a/src/app/bridge/rendererExposeBridge.ts
+++ b/src/app/bridge/rendererExposeBridge.ts
@@ -6,6 +6,7 @@ import type {
   DashboardBridge,
   DashboardLayout,
   DashboardProfile,
+  SessionProfileMap,
   SaveDashboardOptions,
   ContainerBoundsInfo,
   FuelCalculatorBridge,
@@ -193,6 +194,12 @@ export function exposeBridge() {
     },
     setCycleProfiles: (enabled: boolean) => {
       return ipcRenderer.invoke('setCycleProfiles', enabled);
+    },
+    getSessionProfileMap: () => {
+      return ipcRenderer.invoke('getSessionProfileMap');
+    },
+    setSessionProfileMap: (map: SessionProfileMap) => {
+      return ipcRenderer.invoke('setSessionProfileMap', map);
     },
     getShowProfileBanner: () => {
       return ipcRenderer.invoke('getShowProfileBanner');

--- a/src/app/services/sessionProfileSwitcher.spec.ts
+++ b/src/app/services/sessionProfileSwitcher.spec.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockLoggerInfo = vi.hoisted(() => vi.fn());
+const mockLoggerWarn = vi.hoisted(() => vi.fn());
+const mockLoggerError = vi.hoisted(() => vi.fn());
+
+vi.mock('../logger', () => ({
+  default: {
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError,
+    debug: vi.fn(),
+  },
+}));
+
+import {
+  createSessionProfileSwitcher,
+  SPOTTING_DWELL_MS,
+} from './sessionProfileSwitcher';
+import type { SessionProfileMap } from '@irdashies/types';
+import type { SessionLifecycle } from '../sessionLifecycle';
+
+/**
+ * A stand-in lifecycle that lets a test drive the two events the switcher
+ * listens to, without needing telemetry frames.
+ */
+const makeLifecycle = () => {
+  const typeCallbacks = new Set<(sessionType: string) => void>();
+  const drivingCallbacks = new Set<(isDriving: boolean) => void>();
+  const disconnectCallbacks = new Set<() => void>();
+
+  const lifecycle = {
+    onSessionTypeChange: (cb: (sessionType: string) => void) => {
+      typeCallbacks.add(cb);
+      return () => typeCallbacks.delete(cb);
+    },
+    onDrivingStateChange: (cb: (isDriving: boolean) => void) => {
+      drivingCallbacks.add(cb);
+      return () => drivingCallbacks.delete(cb);
+    },
+    onDisconnect: (cb: () => void) => {
+      disconnectCallbacks.add(cb);
+      return () => disconnectCallbacks.delete(cb);
+    },
+  } as unknown as SessionLifecycle;
+
+  return {
+    lifecycle,
+    emitSessionType: (sessionType: string) =>
+      typeCallbacks.forEach((cb) => cb(sessionType)),
+    emitDriving: (isDriving: boolean) =>
+      drivingCallbacks.forEach((cb) => cb(isDriving)),
+    emitDisconnect: () => disconnectCallbacks.forEach((cb) => cb()),
+    subscriberCount: () =>
+      typeCallbacks.size + drivingCallbacks.size + disconnectCallbacks.size,
+  };
+};
+
+const setup = (
+  map: SessionProfileMap,
+  {
+    currentProfileId = 'default',
+    existingProfiles = ['default', 'quali', 'race', 'spotter'],
+  }: { currentProfileId?: string; existingProfiles?: string[] } = {}
+) => {
+  const harness = makeLifecycle();
+  const switchProfile = vi.fn();
+  let current = currentProfileId;
+  switchProfile.mockImplementation((profileId: string) => {
+    current = profileId;
+  });
+
+  const switcher = createSessionProfileSwitcher({
+    lifecycle: harness.lifecycle,
+    getMap: () => map,
+    getCurrentProfileId: () => current,
+    profileExists: (profileId) => existingProfiles.includes(profileId),
+    switchProfile,
+  });
+
+  return { ...harness, switcher, switchProfile };
+};
+
+describe('sessionProfileSwitcher', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockLoggerInfo.mockReset();
+    mockLoggerWarn.mockReset();
+    mockLoggerError.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('session types', () => {
+    it('switches to the profile mapped to the new session type', () => {
+      const { emitSessionType, switchProfile } = setup({ race: 'race' });
+
+      emitSessionType('Race');
+
+      expect(switchProfile).toHaveBeenCalledWith('race');
+    });
+
+    it('leaves the profile alone for a session type with no mapping', () => {
+      const { emitSessionType, switchProfile } = setup({ race: 'race' });
+
+      emitSessionType('Practice');
+
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    it('leaves the profile alone for an unrecognised session type', () => {
+      const { emitSessionType, switchProfile } = setup({
+        race: 'race',
+        practice: 'default',
+      });
+
+      emitSessionType('Team Enduro Shootout');
+
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    it('does not switch when already on the mapped profile', () => {
+      const { emitSessionType, switchProfile } = setup(
+        { race: 'race' },
+        { currentProfileId: 'race' }
+      );
+
+      emitSessionType('Race');
+
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    it('does not switch to a profile that has been deleted', () => {
+      const { emitSessionType, switchProfile } = setup(
+        { race: 'deleted-profile' },
+        { existingProfiles: ['default'] }
+      );
+
+      emitSessionType('Race');
+
+      expect(switchProfile).not.toHaveBeenCalled();
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining('no longer exists')
+      );
+    });
+
+    it('treats a time trial as its own trigger, not as practice', () => {
+      const { emitSessionType, switchProfile } = setup({
+        practice: 'default',
+        timeTrial: 'quali',
+      });
+
+      // iRacing reports a time trial as 'Lone Practice'.
+      emitSessionType('Lone Practice');
+
+      expect(switchProfile).toHaveBeenCalledWith('quali');
+    });
+
+    it('carries the previous profile into a session that has no mapping', () => {
+      // Practice is mapped, qualifying is not. The qualifying session leaves
+      // the practice profile in place rather than reverting to anything.
+      const { emitSessionType, switchProfile } = setup({ practice: 'quali' });
+
+      emitSessionType('Practice');
+      switchProfile.mockClear();
+      emitSessionType('Open Qualify');
+
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    it('switches into a mapped session even when the previous one had none', () => {
+      const { emitSessionType, switchProfile } = setup({ race: 'race' });
+
+      emitSessionType('Practice');
+      expect(switchProfile).not.toHaveBeenCalled();
+
+      emitSessionType('Race');
+
+      expect(switchProfile).toHaveBeenCalledWith('race');
+    });
+
+    it('returns to a mapped session type after an unmapped one', () => {
+      // The full round trip: an unmapped session in the middle does not
+      // prevent the next mapped one from applying.
+      const { emitSessionType, switchProfile } = setup({
+        practice: 'default',
+        race: 'race',
+      });
+
+      emitSessionType('Race');
+      emitSessionType('Lone Qualify');
+      emitSessionType('Practice');
+
+      expect(switchProfile.mock.calls).toEqual([['race'], ['default']]);
+    });
+
+    it('follows the event from qualifying into the race', () => {
+      const { emitSessionType, switchProfile } = setup({
+        openQualify: 'quali',
+        race: 'race',
+      });
+
+      emitSessionType('Open Qualify');
+      emitSessionType('Race');
+
+      expect(switchProfile.mock.calls).toEqual([['quali'], ['race']]);
+    });
+  });
+
+  describe('spotting', () => {
+    it('applies the spotting profile once the player has been out of the car', () => {
+      const { emitSessionType, emitDriving, switchProfile } = setup({
+        race: 'race',
+        spotting: 'spotter',
+      });
+      emitSessionType('Race');
+      switchProfile.mockClear();
+
+      emitDriving(false);
+      expect(switchProfile).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(SPOTTING_DWELL_MS);
+      expect(switchProfile).toHaveBeenCalledWith('spotter');
+    });
+
+    it('ignores a brief hop out of the car', () => {
+      const { emitSessionType, emitDriving, switchProfile } = setup({
+        race: 'race',
+        spotting: 'spotter',
+      });
+      emitSessionType('Race');
+      switchProfile.mockClear();
+
+      emitDriving(false);
+      vi.advanceTimersByTime(SPOTTING_DWELL_MS - 1);
+      emitDriving(true);
+      vi.advanceTimersByTime(SPOTTING_DWELL_MS);
+
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    it('hands back to the session profile as soon as the player drives', () => {
+      const { emitSessionType, emitDriving, switchProfile } = setup({
+        race: 'race',
+        spotting: 'spotter',
+      });
+      emitSessionType('Race');
+      emitDriving(false);
+      vi.advanceTimersByTime(SPOTTING_DWELL_MS);
+      switchProfile.mockClear();
+
+      emitDriving(true);
+
+      expect(switchProfile).toHaveBeenCalledWith('race');
+    });
+
+    it('outranks the session type when the session changes while spotting', () => {
+      const { emitSessionType, emitDriving, switchProfile } = setup({
+        practice: 'default',
+        race: 'race',
+        spotting: 'spotter',
+      });
+      emitDriving(false);
+      vi.advanceTimersByTime(SPOTTING_DWELL_MS);
+      switchProfile.mockClear();
+
+      emitSessionType('Race');
+
+      expect(switchProfile).not.toHaveBeenCalledWith('race');
+    });
+
+    it('falls back to the session profile when spotting is unmapped', () => {
+      const { emitSessionType, emitDriving, switchProfile } = setup({
+        race: 'race',
+      });
+      emitSessionType('Race');
+      emitDriving(false);
+      vi.advanceTimersByTime(SPOTTING_DWELL_MS);
+      switchProfile.mockClear();
+
+      emitDriving(true);
+
+      // Already on 'race' and nothing else applies, so nothing to do.
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('forgets the session after a disconnect', () => {
+      const { emitSessionType, emitDisconnect, emitDriving, switchProfile } =
+        setup({ race: 'race', spotting: 'spotter' });
+      emitSessionType('Race');
+      emitDriving(false);
+      vi.advanceTimersByTime(SPOTTING_DWELL_MS);
+      switchProfile.mockClear();
+
+      emitDisconnect();
+      emitDriving(true);
+
+      // iRacing has gone away, so there is no session type to return to. The
+      // switcher must not drag the last event's race profile into whatever
+      // the user does next.
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    it('cancels a pending dwell when disposed', () => {
+      const { emitDriving, switcher, switchProfile } = setup({
+        spotting: 'spotter',
+      });
+
+      emitDriving(false);
+      switcher.dispose();
+      vi.advanceTimersByTime(SPOTTING_DWELL_MS);
+
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    it('unsubscribes from the lifecycle when disposed', () => {
+      const { switcher, subscriberCount } = setup({ race: 'race' });
+      expect(subscriberCount()).toBe(3);
+
+      switcher.dispose();
+
+      expect(subscriberCount()).toBe(0);
+    });
+
+    it('keeps working when switching throws', () => {
+      const harness = makeLifecycle();
+      const switchProfile = vi.fn(() => {
+        throw new Error('profile store is busy');
+      });
+      createSessionProfileSwitcher({
+        lifecycle: harness.lifecycle,
+        getMap: () => ({ race: 'race' }),
+        getCurrentProfileId: () => 'default',
+        profileExists: () => true,
+        switchProfile,
+      });
+
+      expect(() => harness.emitSessionType('Race')).not.toThrow();
+      expect(mockLoggerError).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/services/sessionProfileSwitcher.spec.ts
+++ b/src/app/services/sessionProfileSwitcher.spec.ts
@@ -23,8 +23,17 @@ import type { SessionLifecycle } from '../sessionLifecycle';
 /**
  * A stand-in lifecycle that lets a test drive the two events the switcher
  * listens to, without needing telemetry frames.
+ *
+ * `initialState` is what the real lifecycle has already resolved by the time a
+ * subscriber attaches. It defaults to nothing known, which is the app starting
+ * before iRacing does.
  */
-const makeLifecycle = () => {
+const makeLifecycle = (
+  initialState: {
+    sessionType?: string;
+    isDriving?: boolean;
+  } = {}
+) => {
   const typeCallbacks = new Set<(sessionType: string) => void>();
   const drivingCallbacks = new Set<(isDriving: boolean) => void>();
   const disconnectCallbacks = new Set<() => void>();
@@ -42,6 +51,10 @@ const makeLifecycle = () => {
       disconnectCallbacks.add(cb);
       return () => disconnectCallbacks.delete(cb);
     },
+    getCurrentState: () => ({
+      sessionType: initialState.sessionType,
+      isDriving: initialState.isDriving,
+    }),
   } as unknown as SessionLifecycle;
 
   return {
@@ -61,9 +74,14 @@ const setup = (
   {
     currentProfileId = 'default',
     existingProfiles = ['default', 'quali', 'race', 'spotter'],
-  }: { currentProfileId?: string; existingProfiles?: string[] } = {}
+    initialState = {},
+  }: {
+    currentProfileId?: string;
+    existingProfiles?: string[];
+    initialState?: { sessionType?: string; isDriving?: boolean };
+  } = {}
 ) => {
-  const harness = makeLifecycle();
+  const harness = makeLifecycle(initialState);
   const switchProfile = vi.fn();
   let current = currentProfileId;
   switchProfile.mockImplementation((profileId: string) => {
@@ -341,6 +359,84 @@ describe('sessionProfileSwitcher', () => {
 
       expect(() => harness.emitSessionType('Race')).not.toThrow();
       expect(mockLoggerError).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * The lifecycle's callbacks carry transitions and are never replayed, and the
+   * SDK is already publishing by the time main.ts gets here. Everything below
+   * describes starting irDashies while iRacing is mid-session — the ordinary
+   * case of alt-tabbing out to launch the overlay.
+   */
+  describe('starting up mid-session', () => {
+    it('applies the mapped profile for the session already under way', () => {
+      const { switchProfile } = setup(
+        { race: 'race' },
+        { initialState: { sessionType: 'Race', isDriving: true } }
+      );
+
+      expect(switchProfile).toHaveBeenCalledWith('race');
+    });
+
+    it('applies the spotting profile when started out of the car', () => {
+      const { switchProfile } = setup(
+        { race: 'race', spotting: 'spotter' },
+        { initialState: { sessionType: 'Race', isDriving: false } }
+      );
+
+      // Without waiting out the dwell: it exists to ride out brief hops out of
+      // the car, and someone already out when the app launched has been out for
+      // longer than the app has existed.
+      expect(switchProfile).toHaveBeenCalledWith('spotter');
+      expect(switchProfile).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the profile alone when nothing has resolved yet', () => {
+      const { switchProfile } = setup({ race: 'race', spotting: 'spotter' });
+
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    it('leaves the profile alone when the running session is unmapped', () => {
+      const { switchProfile } = setup(
+        { race: 'race' },
+        { initialState: { sessionType: 'Practice', isDriving: true } }
+      );
+
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    it('does not fight a profile that already matches the mapping', () => {
+      const { switchProfile } = setup(
+        { race: 'race' },
+        {
+          currentProfileId: 'race',
+          initialState: { sessionType: 'Race', isDriving: true },
+        }
+      );
+
+      expect(switchProfile).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The reported symptom behind all of this: a session whose type never
+     * changes after the app attaches. Practice through to a warmup that iRacing
+     * also reports as Practice fires nothing, so an unseeded switcher held no
+     * session key at all and could only ever apply the spotting profile.
+     */
+    it('recovers from spotting into a session that never fires a change', () => {
+      const { emitDriving, switchProfile } = setup(
+        { practice: 'default', spotting: 'spotter' },
+        {
+          currentProfileId: 'spotter',
+          initialState: { sessionType: 'Practice', isDriving: false },
+        }
+      );
+      switchProfile.mockClear();
+
+      emitDriving(true);
+
+      expect(switchProfile).toHaveBeenCalledWith('default');
     });
   });
 });

--- a/src/app/services/sessionProfileSwitcher.ts
+++ b/src/app/services/sessionProfileSwitcher.ts
@@ -1,0 +1,137 @@
+import type { SessionProfileMap, ProfileTriggerKey } from '@irdashies/types';
+import { sessionProfileKeyFor, SPOTTING_TRIGGER_KEY } from '@irdashies/types';
+import type { SessionLifecycle } from '../sessionLifecycle';
+import logger from '../logger';
+
+/**
+ * How long the player must stay out of the car before the spotting profile
+ * applies. Getting out is not instantaneous or always deliberate — a tow, a
+ * quick garage visit, the moment between a swap — and switching the whole
+ * overlay layout on every blip would be worse than switching a little late.
+ * Getting back in reverts immediately; only the outbound edge waits.
+ */
+export const SPOTTING_DWELL_MS = 20_000;
+
+export interface SessionProfileSwitcherDeps {
+  lifecycle: SessionLifecycle;
+  /** Read fresh on every decision, so edits in settings take effect at once. */
+  getMap: () => SessionProfileMap;
+  getCurrentProfileId: () => string;
+  profileExists: (profileId: string) => boolean;
+  switchProfile: (profileId: string) => void;
+  dwellMs?: number;
+}
+
+export interface SessionProfileSwitcher {
+  dispose: () => void;
+}
+
+/**
+ * Switches the active profile as an event moves between session types, so a
+ * layout can be set up once per session type instead of being reconfigured
+ * between sessions.
+ *
+ * Two rules govern the whole thing:
+ *
+ * - A trigger with no profile mapped means "leave the profile alone". That is
+ *   the default for every trigger, so an untouched install never switches.
+ * - Spotting outranks the session type while it lasts. It is a state rather
+ *   than a session type, so it can occur inside any of them.
+ *
+ * A manual profile change is never fought: the switcher only acts on a
+ * transition, so whatever the user picks stands until the session type or the
+ * driving state actually changes.
+ */
+export const createSessionProfileSwitcher = (
+  deps: SessionProfileSwitcherDeps
+): SessionProfileSwitcher => {
+  const dwellMs = deps.dwellMs ?? SPOTTING_DWELL_MS;
+
+  let sessionKey: ProfileTriggerKey | undefined;
+  let spotting = false;
+  let dwellTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearDwell = () => {
+    if (dwellTimer === undefined) return;
+    clearTimeout(dwellTimer);
+    dwellTimer = undefined;
+  };
+
+  const apply = (reason: string) => {
+    const map = deps.getMap();
+    const trigger =
+      spotting && map[SPOTTING_TRIGGER_KEY] ? SPOTTING_TRIGGER_KEY : sessionKey;
+    if (!trigger) return;
+
+    const profileId = map[trigger];
+    if (!profileId) return;
+
+    if (profileId === deps.getCurrentProfileId()) return;
+
+    if (!deps.profileExists(profileId)) {
+      // The profile was deleted after being mapped. Staying put is safer than
+      // failing, and the mapping is left alone so it starts working again if
+      // the profile comes back.
+      logger.warn(
+        `[sessionProfile] ${trigger} maps to profile ${profileId}, which no longer exists`
+      );
+      return;
+    }
+
+    logger.info(
+      `[sessionProfile] ${reason}: switching to profile ${profileId} for ${trigger}`
+    );
+    try {
+      deps.switchProfile(profileId);
+    } catch (err) {
+      logger.error('[sessionProfile] Failed to switch profile:', err);
+    }
+  };
+
+  const unsubscribeType = deps.lifecycle.onSessionTypeChange((sessionType) => {
+    const key = sessionProfileKeyFor(sessionType);
+    if (!key) {
+      // An unrecognised session type gets no opinion rather than a guess, so
+      // the user keeps whatever layout they are on.
+      logger.info(
+        `[sessionProfile] No mapping vocabulary for session type "${sessionType}"`
+      );
+      sessionKey = undefined;
+      return;
+    }
+    sessionKey = key;
+    apply(`session type ${sessionType}`);
+  });
+
+  const unsubscribeDriving = deps.lifecycle.onDrivingStateChange(
+    (isDriving) => {
+      clearDwell();
+      if (isDriving) {
+        if (!spotting) return;
+        spotting = false;
+        apply('back in the car');
+        return;
+      }
+      dwellTimer = setTimeout(() => {
+        dwellTimer = undefined;
+        spotting = true;
+        apply('out of the car');
+      }, dwellMs);
+    }
+  );
+
+  const unsubscribeDisconnect = deps.lifecycle.onDisconnect(() => {
+    clearDwell();
+    sessionKey = undefined;
+    spotting = false;
+  });
+
+  return {
+    dispose: () => {
+      clearDwell();
+      unsubscribeType();
+      unsubscribeDriving();
+      unsubscribeDisconnect();
+    },
+  };
+};

--- a/src/app/services/sessionProfileSwitcher.ts
+++ b/src/app/services/sessionProfileSwitcher.ts
@@ -38,9 +38,13 @@ export interface SessionProfileSwitcher {
  * - Spotting outranks the session type while it lasts. It is a state rather
  *   than a session type, so it can occur inside any of them.
  *
- * A manual profile change is never fought: the switcher only acts on a
- * transition, so whatever the user picks stands until the session type or the
- * driving state actually changes.
+ * A manual profile change is never fought: past the initial seed the switcher
+ * only acts on a transition, so whatever the user picks stands until the
+ * session type or the driving state actually changes.
+ *
+ * The seed is the exception, and it is what makes starting the app mid-session
+ * behave like being there for the transition. It happens once, at construction,
+ * before the user has had any chance to choose a profile for this run.
  */
 export const createSessionProfileSwitcher = (
   deps: SessionProfileSwitcherDeps
@@ -88,7 +92,8 @@ export const createSessionProfileSwitcher = (
     }
   };
 
-  const unsubscribeType = deps.lifecycle.onSessionTypeChange((sessionType) => {
+  /** Returns whether the new state is worth acting on. */
+  const takeSessionType = (sessionType: string): boolean => {
     const key = sessionProfileKeyFor(sessionType);
     if (!key) {
       // An unrecognised session type gets no opinion rather than a guess, so
@@ -97,26 +102,46 @@ export const createSessionProfileSwitcher = (
         `[sessionProfile] No mapping vocabulary for session type "${sessionType}"`
       );
       sessionKey = undefined;
-      return;
+      return false;
     }
     sessionKey = key;
-    apply(`session type ${sessionType}`);
+    return true;
+  };
+
+  /** Returns whether the new state is worth acting on. */
+  const takeDrivingState = (
+    isDriving: boolean,
+    immediate: boolean
+  ): boolean => {
+    clearDwell();
+    if (isDriving) {
+      if (!spotting) return false;
+      spotting = false;
+      return true;
+    }
+    if (immediate) {
+      // Seeding, not a transition. The dwell rides out the brief hops out of
+      // the car during a session; someone already out when this attached has
+      // been out for longer than the app has been running, and making them
+      // wait would only delay the layout they configured for exactly this.
+      spotting = true;
+      return true;
+    }
+    dwellTimer = setTimeout(() => {
+      dwellTimer = undefined;
+      spotting = true;
+      apply('out of the car');
+    }, dwellMs);
+    return false;
+  };
+
+  const unsubscribeType = deps.lifecycle.onSessionTypeChange((sessionType) => {
+    if (takeSessionType(sessionType)) apply(`session type ${sessionType}`);
   });
 
   const unsubscribeDriving = deps.lifecycle.onDrivingStateChange(
     (isDriving) => {
-      clearDwell();
-      if (isDriving) {
-        if (!spotting) return;
-        spotting = false;
-        apply('back in the car');
-        return;
-      }
-      dwellTimer = setTimeout(() => {
-        dwellTimer = undefined;
-        spotting = true;
-        apply('out of the car');
-      }, dwellMs);
+      if (takeDrivingState(isDriving, false)) apply('back in the car');
     }
   );
 
@@ -125,6 +150,23 @@ export const createSessionProfileSwitcher = (
     sessionKey = undefined;
     spotting = false;
   });
+
+  // Seeded after subscribing, because the lifecycle reports transitions and
+  // never replays them. The SDK starts publishing at iRacingSDKSetup and
+  // startup awaits other work before constructing this, so launching irDashies
+  // while already sat in a session means the session type resolved before there
+  // was anything here to hear it. Without this the mapped profile stays
+  // unapplied until some later transition — and in an event whose sessions all
+  // report the same type, there may never be one.
+  const initial = deps.lifecycle.getCurrentState();
+  let seeded = false;
+  if (initial.sessionType !== undefined) {
+    seeded = takeSessionType(initial.sessionType) || seeded;
+  }
+  if (initial.isDriving !== undefined) {
+    seeded = takeDrivingState(initial.isDriving, true) || seeded;
+  }
+  if (seeded) apply('current session state');
 
   return {
     dispose: () => {

--- a/src/app/sessionLifecycle/sessionLifecycle.spec.ts
+++ b/src/app/sessionLifecycle/sessionLifecycle.spec.ts
@@ -38,6 +38,25 @@ const makeEmptySession = (): Session =>
 const makeSessionWithMissingDrivers = (): Session =>
   ({ DriverInfo: {} }) as unknown as Session;
 
+const makeSessionList = (
+  sessions: { SessionNum: number; SessionType: string }[]
+): Session =>
+  ({
+    SessionInfo: { Sessions: sessions },
+    DriverInfo: { Drivers: [{ CarIdx: 0, CarIsPaceCar: 0, IsSpectator: 0 }] },
+  }) as unknown as Session;
+
+const makeDrivingTelemetry = (
+  sessionNum: number,
+  flags: Record<string, boolean>
+): Telemetry =>
+  ({
+    SessionNum: { value: [sessionNum] },
+    ...Object.fromEntries(
+      Object.entries(flags).map(([key, value]) => [key, { value: [value] }])
+    ),
+  }) as unknown as Telemetry;
+
 describe('sessionLifecycle', () => {
   let lifecycle: ReturnType<typeof createSessionLifecycle>;
 
@@ -299,6 +318,140 @@ describe('sessionLifecycle', () => {
       lifecycle._onSession(makeSession([0]));
 
       expect(goodSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('session type', () => {
+    it('fires for the first session, because entering an event is the transition', () => {
+      const typeSpy = vi.fn();
+      lifecycle.onSessionTypeChange(typeSpy);
+
+      lifecycle._onSession(
+        makeSessionList([{ SessionNum: 0, SessionType: 'Practice' }])
+      );
+      lifecycle._onTelemetry(makeTelemetry(0));
+
+      expect(typeSpy).toHaveBeenCalledWith('Practice');
+    });
+
+    it('resolves when the session list arrives after the telemetry tick', () => {
+      const typeSpy = vi.fn();
+      lifecycle.onSessionTypeChange(typeSpy);
+
+      lifecycle._onTelemetry(makeTelemetry(2));
+      expect(typeSpy).not.toHaveBeenCalled();
+
+      lifecycle._onSession(
+        makeSessionList([{ SessionNum: 2, SessionType: 'Race' }])
+      );
+
+      expect(typeSpy).toHaveBeenCalledWith('Race');
+    });
+
+    it('does not fire when the session number changes but the type does not', () => {
+      const typeSpy = vi.fn();
+      lifecycle.onSessionTypeChange(typeSpy);
+      lifecycle._onSession(
+        makeSessionList([
+          { SessionNum: 0, SessionType: 'Practice' },
+          { SessionNum: 1, SessionType: 'Practice' },
+        ])
+      );
+
+      lifecycle._onTelemetry(makeTelemetry(0));
+      lifecycle._onTelemetry(makeTelemetry(1));
+
+      expect(typeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires as the event moves from practice to qualifying to race', () => {
+      const typeSpy = vi.fn();
+      lifecycle.onSessionTypeChange(typeSpy);
+      lifecycle._onSession(
+        makeSessionList([
+          { SessionNum: 0, SessionType: 'Practice' },
+          { SessionNum: 1, SessionType: 'Open Qualify' },
+          { SessionNum: 2, SessionType: 'Race' },
+        ])
+      );
+
+      lifecycle._onTelemetry(makeTelemetry(0));
+      lifecycle._onTelemetry(makeTelemetry(1));
+      lifecycle._onTelemetry(makeTelemetry(2));
+
+      expect(typeSpy.mock.calls).toEqual([
+        ['Practice'],
+        ['Open Qualify'],
+        ['Race'],
+      ]);
+    });
+
+    it('starts clean after a disconnect', () => {
+      const typeSpy = vi.fn();
+      lifecycle.onSessionTypeChange(typeSpy);
+      lifecycle._onSession(
+        makeSessionList([{ SessionNum: 0, SessionType: 'Race' }])
+      );
+      lifecycle._onTelemetry(makeTelemetry(0));
+      typeSpy.mockClear();
+
+      lifecycle._onDisconnect();
+      lifecycle._onSession(
+        makeSessionList([{ SessionNum: 0, SessionType: 'Race' }])
+      );
+      lifecycle._onTelemetry(makeTelemetry(0));
+
+      expect(typeSpy).toHaveBeenCalledWith('Race');
+    });
+  });
+
+  describe('driving state', () => {
+    const drivingCases: [string, Record<string, boolean>, boolean][] = [
+      ['on track', { IsOnTrack: true }, true],
+      ['stationary in the pit box', { PlayerCarInPitStall: true }, true],
+      ['rolling down pit lane', { OnPitRoad: true }, true],
+      ['in the garage', { IsOnTrack: true, IsInGarage: true }, false],
+      ['watching a replay', { IsOnTrack: true, IsReplayPlaying: true }, false],
+      ['spotting for a team-mate', { IsOnTrack: false }, false],
+    ];
+
+    it.each(drivingCases)(
+      'reports %s as driving=%o -> %s',
+      (_label, flags, expected) => {
+        const drivingSpy = vi.fn();
+        lifecycle.onDrivingStateChange(drivingSpy);
+
+        lifecycle._onTelemetry(makeDrivingTelemetry(0, flags));
+
+        if (expected) {
+          expect(drivingSpy).toHaveBeenCalledWith(true);
+        } else {
+          // False is the starting assumption, so only a true->false edge fires.
+          expect(drivingSpy).not.toHaveBeenCalledWith(true);
+        }
+      }
+    );
+
+    it('fires only on the edge, not on every tick', () => {
+      const drivingSpy = vi.fn();
+      lifecycle.onDrivingStateChange(drivingSpy);
+
+      lifecycle._onTelemetry(makeDrivingTelemetry(0, { IsOnTrack: true }));
+      lifecycle._onTelemetry(makeDrivingTelemetry(0, { IsOnTrack: true }));
+      lifecycle._onTelemetry(makeDrivingTelemetry(0, { IsOnTrack: true }));
+
+      expect(drivingSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires both ways when the player hands the car over and takes it back', () => {
+      const drivingSpy = vi.fn();
+      lifecycle.onDrivingStateChange(drivingSpy);
+
+      lifecycle._onTelemetry(makeDrivingTelemetry(0, { IsOnTrack: true }));
+      lifecycle._onTelemetry(makeDrivingTelemetry(0, { IsOnTrack: false }));
+      lifecycle._onTelemetry(makeDrivingTelemetry(0, { IsOnTrack: true }));
+
+      expect(drivingSpy.mock.calls).toEqual([[true], [false], [true]]);
     });
   });
 });

--- a/src/app/sessionLifecycle/sessionLifecycle.spec.ts
+++ b/src/app/sessionLifecycle/sessionLifecycle.spec.ts
@@ -423,12 +423,13 @@ describe('sessionLifecycle', () => {
 
         lifecycle._onTelemetry(makeDrivingTelemetry(0, flags));
 
-        if (expected) {
-          expect(drivingSpy).toHaveBeenCalledWith(true);
-        } else {
-          // False is the starting assumption, so only a true->false edge fires.
-          expect(drivingSpy).not.toHaveBeenCalledWith(true);
-        }
+        // Asserted the same way for both outcomes. The driving state starts
+        // unknown rather than false, so the first frame is an edge either way
+        // and must fire exactly once with the state it found — a "did not fire
+        // with true" assertion would also pass if nothing fired at all, and the
+        // spotting dwell timer depends on that first false arriving.
+        expect(drivingSpy).toHaveBeenCalledTimes(1);
+        expect(drivingSpy).toHaveBeenCalledWith(expected);
       }
     );
 

--- a/src/app/sessionLifecycle/sessionLifecycle.spec.ts
+++ b/src/app/sessionLifecycle/sessionLifecycle.spec.ts
@@ -39,11 +39,15 @@ const makeSessionWithMissingDrivers = (): Session =>
   ({ DriverInfo: {} }) as unknown as Session;
 
 const makeSessionList = (
-  sessions: { SessionNum: number; SessionType: string }[]
+  sessions: { SessionNum: number; SessionType: string }[],
+  subSessionId?: number
 ): Session =>
   ({
     SessionInfo: { Sessions: sessions },
     DriverInfo: { Drivers: [{ CarIdx: 0, CarIsPaceCar: 0, IsSpectator: 0 }] },
+    ...(subSessionId === undefined
+      ? {}
+      : { WeekendInfo: { SubSessionID: subSessionId } }),
   }) as unknown as Session;
 
 const makeDrivingTelemetry = (
@@ -453,6 +457,116 @@ describe('sessionLifecycle', () => {
       lifecycle._onTelemetry(makeDrivingTelemetry(0, { IsOnTrack: true }));
 
       expect(drivingSpy.mock.calls).toEqual([[true], [false], [true]]);
+    });
+  });
+
+  /**
+   * Joining a different event — open practice into the race subsession — swaps
+   * the whole session list without disconnecting the SDK, so nothing else
+   * clears the state keyed to the old one. Reported from a rig: a race event
+   * opening with a warmup, which iRacing reports as SessionType 'Practice',
+   * never announced itself after a practice session of the same type, leaving
+   * the mapped profile unapplied.
+   */
+  describe('moving between subsessions', () => {
+    it('announces a new event whose first session repeats the old type', () => {
+      const lifecycle = createSessionLifecycle();
+      const typeSpy = vi.fn();
+      lifecycle.onSessionTypeChange(typeSpy);
+
+      lifecycle._onSession(
+        makeSessionList([{ SessionNum: 0, SessionType: 'Practice' }], 1001)
+      );
+      lifecycle._onTelemetry(makeTelemetry(0));
+      expect(typeSpy).toHaveBeenCalledTimes(1);
+
+      // The race event: a warmup at session 0, reported as Practice again.
+      lifecycle._onSession(
+        makeSessionList(
+          [
+            { SessionNum: 0, SessionType: 'Practice' },
+            { SessionNum: 1, SessionType: 'Race' },
+          ],
+          2002
+        )
+      );
+      lifecycle._onTelemetry(makeTelemetry(0));
+
+      expect(typeSpy).toHaveBeenCalledTimes(2);
+      expect(typeSpy).toHaveBeenLastCalledWith('Practice');
+    });
+
+    it('does not announce a session the new event does not have yet', () => {
+      const lifecycle = createSessionLifecycle();
+      const typeSpy = vi.fn();
+      lifecycle.onSessionTypeChange(typeSpy);
+
+      lifecycle._onSession(
+        makeSessionList(
+          [
+            { SessionNum: 0, SessionType: 'Practice' },
+            { SessionNum: 1, SessionType: 'Race' },
+          ],
+          1001
+        )
+      );
+      lifecycle._onTelemetry(makeTelemetry(1));
+      typeSpy.mockClear();
+
+      // A new event whose session 1 is qualifying rather than the race. The
+      // stale session number must not be resolved against the new list.
+      lifecycle._onSession(
+        makeSessionList(
+          [
+            { SessionNum: 0, SessionType: 'Practice' },
+            { SessionNum: 1, SessionType: 'Open Qualify' },
+          ],
+          2002
+        )
+      );
+
+      expect(typeSpy).not.toHaveBeenCalled();
+
+      lifecycle._onTelemetry(makeTelemetry(0));
+      expect(typeSpy).toHaveBeenCalledExactlyOnceWith('Practice');
+    });
+
+    it('stays quiet while the event is the same', () => {
+      const lifecycle = createSessionLifecycle();
+      const typeSpy = vi.fn();
+      lifecycle.onSessionTypeChange(typeSpy);
+
+      const list = [
+        { SessionNum: 0, SessionType: 'Practice' },
+        { SessionNum: 1, SessionType: 'Race' },
+      ];
+      lifecycle._onSession(makeSessionList(list, 1001));
+      lifecycle._onTelemetry(makeTelemetry(0));
+      lifecycle._onSession(makeSessionList(list, 1001));
+      lifecycle._onSession(makeSessionList(list, 1001));
+
+      expect(typeSpy).toHaveBeenCalledExactlyOnceWith('Practice');
+    });
+
+    it('reports the state a late subscriber missed', () => {
+      const lifecycle = createSessionLifecycle();
+
+      lifecycle._onSession(
+        makeSessionList([{ SessionNum: 0, SessionType: 'Race' }], 1001)
+      );
+      lifecycle._onTelemetry(makeDrivingTelemetry(0, { IsOnTrack: true }));
+
+      expect(lifecycle.getCurrentState()).toEqual({
+        sessionType: 'Race',
+        isDriving: true,
+      });
+    });
+
+    it('knows nothing before the SDK has published', () => {
+      expect(createSessionLifecycle().getCurrentState()).toEqual({
+        sessionType: undefined,
+        isDriving: undefined,
+      });
     });
   });
 });

--- a/src/app/sessionLifecycle/sessionLifecycle.ts
+++ b/src/app/sessionLifecycle/sessionLifecycle.ts
@@ -3,6 +3,8 @@ import logger from '../logger';
 
 type Callback = () => void;
 type CarIdxCallback = (carIdx: number) => void;
+type SessionTypeCallback = (sessionType: string) => void;
+type DrivingStateCallback = (isDriving: boolean) => void;
 export interface SessionEnterEvent {
   replay: boolean;
 }
@@ -17,6 +19,20 @@ export interface SessionLifecycle {
   onDriverLeft: (cb: CarIdxCallback) => () => void;
   /** Called when the session number changes (practice -> quali -> race). */
   onSessionNumChange: (cb: Callback) => () => void;
+  /**
+   * Called when the type of the current session resolves or changes, e.g.
+   * 'Practice' -> 'Race'. Unlike onSessionNumChange this also fires for the
+   * first session seen, because entering an event is itself the transition a
+   * consumer cares about. Two consecutive practice sessions do not fire it:
+   * the number changes but the type does not.
+   */
+  onSessionTypeChange: (cb: SessionTypeCallback) => () => void;
+  /**
+   * Called when the player gets in or out of the car. False covers spotting
+   * for a team-mate, spectating, sitting in the garage and replay playback —
+   * anything that is not hands on the wheel.
+   */
+  onDrivingStateChange: (cb: DrivingStateCallback) => () => void;
   /** Called when iRacing disconnects (SDK stops publishing). */
   onDisconnect: (cb: Callback) => () => void;
 
@@ -32,11 +48,16 @@ export function createSessionLifecycle(): SessionLifecycle {
   const driverJoinedCallbacks = new Set<CarIdxCallback>();
   const driverLeftCallbacks = new Set<CarIdxCallback>();
   const sessionNumChangeCallbacks = new Set<Callback>();
+  const sessionTypeChangeCallbacks = new Set<SessionTypeCallback>();
+  const drivingStateChangeCallbacks = new Set<DrivingStateCallback>();
   const disconnectCallbacks = new Set<Callback>();
 
   // Track current state to detect deltas.
   let knownDriverCarIdxs = new Set<number>();
   let lastSessionNum = -1;
+  const sessionTypesByNum = new Map<number, string>();
+  let lastSessionType: string | undefined;
+  let lastIsDriving: boolean | undefined;
 
   function fire<T>(callbacks: Set<(arg: T) => void>, arg: T): void {
     callbacks.forEach((cb) => {
@@ -58,6 +79,38 @@ export function createSessionLifecycle(): SessionLifecycle {
     });
   }
 
+  /**
+   * The session number arrives on the telemetry tick and the types arrive with
+   * session info, in no guaranteed order, so resolution is attempted after
+   * either one moves.
+   */
+  function resolveSessionType(): void {
+    if (lastSessionNum === -1) return;
+    const sessionType = sessionTypesByNum.get(lastSessionNum);
+    if (!sessionType || sessionType === lastSessionType) return;
+    logger.info(
+      `[sessionLifecycle] Session type: ${lastSessionType ?? 'none'} -> ${sessionType}`
+    );
+    lastSessionType = sessionType;
+    fire(sessionTypeChangeCallbacks, sessionType);
+  }
+
+  function resolveDrivingState(telemetry: Telemetry): void {
+    const flag = (key: keyof Telemetry): boolean =>
+      (telemetry[key] as { value?: unknown[] } | undefined)?.value?.[0] ===
+      true;
+
+    // Mirrors the renderer's useDrivingState: in the car counts even when
+    // stationary in the pit box, while the garage and replay playback do not.
+    const inCar =
+      flag('IsOnTrack') || flag('PlayerCarInPitStall') || flag('OnPitRoad');
+    const isDriving = inCar && !flag('IsInGarage') && !flag('IsReplayPlaying');
+
+    if (isDriving === lastIsDriving) return;
+    lastIsDriving = isDriving;
+    fire(drivingStateChangeCallbacks, isDriving);
+  }
+
   return {
     onEnter(cb) {
       enterCallbacks.add(cb);
@@ -74,6 +127,14 @@ export function createSessionLifecycle(): SessionLifecycle {
     onSessionNumChange(cb) {
       sessionNumChangeCallbacks.add(cb);
       return () => sessionNumChangeCallbacks.delete(cb);
+    },
+    onSessionTypeChange(cb) {
+      sessionTypeChangeCallbacks.add(cb);
+      return () => sessionTypeChangeCallbacks.delete(cb);
+    },
+    onDrivingStateChange(cb) {
+      drivingStateChangeCallbacks.add(cb);
+      return () => drivingStateChangeCallbacks.delete(cb);
     },
     onDisconnect(cb) {
       disconnectCallbacks.add(cb);
@@ -94,10 +155,22 @@ export function createSessionLifecycle(): SessionLifecycle {
           fireAll(sessionNumChangeCallbacks);
         }
         lastSessionNum = sessionNum;
+        resolveSessionType();
       }
+      resolveDrivingState(telemetry);
     },
 
     _onSession(session) {
+      // Built before the driver check below: a session published with no
+      // drivers still carries a valid session list, and the type of the
+      // session the player is in does not depend on who else is in it.
+      for (const info of session?.SessionInfo?.Sessions ?? []) {
+        if (info?.SessionNum != null && info.SessionType) {
+          sessionTypesByNum.set(info.SessionNum, info.SessionType);
+        }
+      }
+      resolveSessionType();
+
       const drivers = session?.DriverInfo?.Drivers;
 
       if (!drivers || drivers.length === 0) {
@@ -150,6 +223,9 @@ export function createSessionLifecycle(): SessionLifecycle {
       }
       knownDriverCarIdxs = new Set();
       lastSessionNum = -1;
+      sessionTypesByNum.clear();
+      lastSessionType = undefined;
+      lastIsDriving = undefined;
       fireAll(disconnectCallbacks);
     },
   };

--- a/src/app/sessionLifecycle/sessionLifecycle.ts
+++ b/src/app/sessionLifecycle/sessionLifecycle.ts
@@ -10,6 +10,14 @@ export interface SessionEnterEvent {
 }
 type EnterCallback = (event: SessionEnterEvent) => void;
 
+/** A snapshot of what the lifecycle has resolved so far. */
+export interface SessionLifecycleState {
+  /** Undefined until the current session's type resolves. */
+  sessionType: string | undefined;
+  /** Undefined until the first telemetry frame settles it. */
+  isDriving: boolean | undefined;
+}
+
 export interface SessionLifecycle {
   /** Called when a live or recorded telemetry source begins publishing. */
   onEnter: (cb: EnterCallback) => () => void;
@@ -36,6 +44,18 @@ export interface SessionLifecycle {
   /** Called when iRacing disconnects (SDK stops publishing). */
   onDisconnect: (cb: Callback) => () => void;
 
+  /**
+   * The state the change callbacks above have already reported, for a consumer
+   * that attaches after the SDK has started publishing.
+   *
+   * Those callbacks only carry transitions and never replay, so a subscriber
+   * wired up during startup — after iRacingSDKSetup has begun its loop — misses
+   * everything that resolved before it arrived. Anything that has to act on the
+   * current state rather than merely on changes to it needs to read this once
+   * after subscribing.
+   */
+  getCurrentState: () => SessionLifecycleState;
+
   // Internal — called by iracingSdkBridge on each SDK tick.
   _onEnter: (event: SessionEnterEvent) => void;
   _onTelemetry: (telemetry: Telemetry) => void;
@@ -58,6 +78,7 @@ export function createSessionLifecycle(): SessionLifecycle {
   const sessionTypesByNum = new Map<number, string>();
   let lastSessionType: string | undefined;
   let lastIsDriving: boolean | undefined;
+  let lastSubSessionId: string | undefined;
 
   function fire<T>(callbacks: Set<(arg: T) => void>, arg: T): void {
     callbacks.forEach((cb) => {
@@ -141,6 +162,10 @@ export function createSessionLifecycle(): SessionLifecycle {
       return () => disconnectCallbacks.delete(cb);
     },
 
+    getCurrentState() {
+      return { sessionType: lastSessionType, isDriving: lastIsDriving };
+    },
+
     _onEnter(event) {
       fire(enterCallbacks, event);
     },
@@ -161,6 +186,36 @@ export function createSessionLifecycle(): SessionLifecycle {
     },
 
     _onSession(session) {
+      // Moving between subsessions — open practice into the race event, say —
+      // does not disconnect the SDK, so none of the per-event state below is
+      // otherwise cleared. Two things go wrong when it survives: session
+      // numbers restart at 0 and would collide with the old event's entries,
+      // and a new event whose first session shares the old one's type (a race
+      // event opening with a warmup, which iRacing reports as 'Practice')
+      // would be deduplicated away and never fire.
+      //
+      // The session number is dropped rather than kept because it belongs to
+      // the old event: resolving against it would look the stale number up in
+      // the new event's table and briefly announce whichever session happens
+      // to sit at that index. Resolution waits for the next telemetry tick to
+      // supply the real one, which is the same tick that would have carried a
+      // number change anyway.
+      const subSessionId =
+        session?.WeekendInfo?.SubSessionID != null
+          ? String(session.WeekendInfo.SubSessionID)
+          : undefined;
+      if (subSessionId !== undefined && subSessionId !== lastSubSessionId) {
+        if (lastSubSessionId !== undefined) {
+          logger.info(
+            `[sessionLifecycle] SubSession changed: ${lastSubSessionId} -> ${subSessionId}`
+          );
+          sessionTypesByNum.clear();
+          lastSessionType = undefined;
+          lastSessionNum = -1;
+        }
+        lastSubSessionId = subSessionId;
+      }
+
       // Built before the driver check below: a session published with no
       // drivers still carries a valid session list, and the type of the
       // session the player is in does not depend on who else is in it.
@@ -226,6 +281,7 @@ export function createSessionLifecycle(): SessionLifecycle {
       sessionTypesByNum.clear();
       lastSessionType = undefined;
       lastIsDriving = undefined;
+      lastSubSessionId = undefined;
       fireAll(disconnectCallbacks);
     },
   };

--- a/src/app/storage/appSettings.spec.ts
+++ b/src/app/storage/appSettings.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  getSessionProfileMap,
+  setSessionProfileMap,
+  initialiseSessionProfileMap,
+} from './appSettings';
+import { SESSION_PROFILE_KEYS } from '@irdashies/types';
+
+const mockReadData = vi.hoisted(() => vi.fn());
+const mockWriteData = vi.hoisted(() => vi.fn());
+
+vi.mock('./storage', () => ({
+  readData: mockReadData,
+  writeData: mockWriteData,
+}));
+
+const KEY = 'sessionProfileMap';
+
+describe('session profile map', () => {
+  beforeEach(() => {
+    mockReadData.mockReset();
+    mockWriteData.mockReset();
+  });
+
+  describe('initialiseSessionProfileMap', () => {
+    it('points every session type at the profile in use on a first run', () => {
+      mockReadData.mockReturnValue(undefined);
+
+      const seeded = initialiseSessionProfileMap('race-layout');
+
+      for (const key of SESSION_PROFILE_KEYS) {
+        expect(seeded[key]).toBe('race-layout');
+      }
+      expect(mockWriteData).toHaveBeenCalledWith(KEY, seeded);
+    });
+
+    it('leaves spotting unset, so stepping out of the car changes nothing', () => {
+      mockReadData.mockReturnValue(undefined);
+
+      const seeded = initialiseSessionProfileMap('race-layout');
+
+      expect(seeded.spotting).toBeUndefined();
+    });
+
+    it('does not re-seed once a mapping has been stored', () => {
+      mockReadData.mockReturnValue({ race: 'chosen-by-user' });
+
+      const result = initialiseSessionProfileMap('some-other-profile');
+
+      expect(result).toEqual({ race: 'chosen-by-user' });
+      expect(mockWriteData).not.toHaveBeenCalled();
+    });
+
+    it('respects a map the user has deliberately emptied', () => {
+      // An empty object is a decision — every row set back to "Don't switch" —
+      // and must not be mistaken for "never configured".
+      mockReadData.mockReturnValue({});
+
+      const result = initialiseSessionProfileMap('race-layout');
+
+      expect(result).toEqual({});
+      expect(mockWriteData).not.toHaveBeenCalled();
+    });
+
+    it('seeds a no-op: every session resolves to the active profile', () => {
+      mockReadData.mockReturnValue(undefined);
+
+      const seeded = initialiseSessionProfileMap('current');
+
+      // Nothing can switch while every value is the profile already in use,
+      // which is what makes seeding safe to do without asking.
+      expect(new Set(Object.values(seeded))).toEqual(new Set(['current']));
+    });
+  });
+
+  describe('get and set', () => {
+    it('reads back what was stored', () => {
+      mockReadData.mockReturnValue({ race: 'race-layout' });
+      expect(getSessionProfileMap()).toEqual({ race: 'race-layout' });
+    });
+
+    it('reports an unconfigured map as empty', () => {
+      mockReadData.mockReturnValue(undefined);
+      expect(getSessionProfileMap()).toEqual({});
+    });
+
+    it('persists a map under the settings key', () => {
+      setSessionProfileMap({ practice: 'a', spotting: 'b' });
+      expect(mockWriteData).toHaveBeenCalledWith(KEY, {
+        practice: 'a',
+        spotting: 'b',
+      });
+    });
+  });
+});

--- a/src/app/storage/appSettings.spec.ts
+++ b/src/app/storage/appSettings.spec.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import {
-  getSessionProfileMap,
-  setSessionProfileMap,
-  initialiseSessionProfileMap,
-} from './appSettings';
-import { SESSION_PROFILE_KEYS } from '@irdashies/types';
+import { getSessionProfileMap, setSessionProfileMap } from './appSettings';
 
 const mockReadData = vi.hoisted(() => vi.fn());
 const mockWriteData = vi.hoisted(() => vi.fn());
@@ -22,54 +17,26 @@ describe('session profile map', () => {
     mockWriteData.mockReset();
   });
 
-  describe('initialiseSessionProfileMap', () => {
-    it('points every session type at the profile in use on a first run', () => {
+  /**
+   * Reading must never write. An earlier version seeded every session type with
+   * the profile in use on first run, which is only a no-op while that profile
+   * stays active: pick another by hand without ever opening the feature and the
+   * next session transition drags you back. Nothing here may map a trigger the
+   * user has not mapped themselves.
+   */
+  describe('an install that has never configured the feature', () => {
+    it('maps nothing, so no session transition switches a profile', () => {
       mockReadData.mockReturnValue(undefined);
 
-      const seeded = initialiseSessionProfileMap('race-layout');
-
-      for (const key of SESSION_PROFILE_KEYS) {
-        expect(seeded[key]).toBe('race-layout');
-      }
-      expect(mockWriteData).toHaveBeenCalledWith(KEY, seeded);
+      expect(getSessionProfileMap()).toEqual({});
     });
 
-    it('leaves spotting unset, so stepping out of the car changes nothing', () => {
+    it('does not write anything on being read', () => {
       mockReadData.mockReturnValue(undefined);
 
-      const seeded = initialiseSessionProfileMap('race-layout');
+      getSessionProfileMap();
 
-      expect(seeded.spotting).toBeUndefined();
-    });
-
-    it('does not re-seed once a mapping has been stored', () => {
-      mockReadData.mockReturnValue({ race: 'chosen-by-user' });
-
-      const result = initialiseSessionProfileMap('some-other-profile');
-
-      expect(result).toEqual({ race: 'chosen-by-user' });
       expect(mockWriteData).not.toHaveBeenCalled();
-    });
-
-    it('respects a map the user has deliberately emptied', () => {
-      // An empty object is a decision — every row set back to "Don't switch" —
-      // and must not be mistaken for "never configured".
-      mockReadData.mockReturnValue({});
-
-      const result = initialiseSessionProfileMap('race-layout');
-
-      expect(result).toEqual({});
-      expect(mockWriteData).not.toHaveBeenCalled();
-    });
-
-    it('seeds a no-op: every session resolves to the active profile', () => {
-      mockReadData.mockReturnValue(undefined);
-
-      const seeded = initialiseSessionProfileMap('current');
-
-      // Nothing can switch while every value is the profile already in use,
-      // which is what makes seeding safe to do without asking.
-      expect(new Set(Object.values(seeded))).toEqual(new Set(['current']));
     });
   });
 

--- a/src/app/storage/appSettings.ts
+++ b/src/app/storage/appSettings.ts
@@ -1,4 +1,5 @@
 import type { SessionProfileMap } from '@irdashies/types';
+import { SESSION_PROFILE_KEYS } from '@irdashies/types';
 import { readData, writeData } from './storage';
 
 const CYCLE_PROFILES_KEY = 'cycleProfiles';
@@ -23,7 +24,7 @@ export const setShowProfileBanner = (enabled: boolean): void => {
 
 /**
  * Which profile to switch to for each session type, plus one for spotting.
- * An empty map means the feature is off, which is how it starts.
+ * A key with no profile means "leave the profile alone" for that trigger.
  */
 export const getSessionProfileMap = (): SessionProfileMap => {
   return readData<SessionProfileMap>(SESSION_PROFILE_MAP_KEY) ?? {};
@@ -31,4 +32,34 @@ export const getSessionProfileMap = (): SessionProfileMap => {
 
 export const setSessionProfileMap = (map: SessionProfileMap): void => {
   writeData(SESSION_PROFILE_MAP_KEY, map);
+};
+
+/**
+ * First run only: point every session type at the profile already in use.
+ *
+ * Starting with nothing mapped left the settings page looking inert and made
+ * the feature easy to miss. Seeding it with the current profile shows what the
+ * mapping is for, and is behaviourally a no-op — every session type resolves to
+ * the profile that is already active, so nothing switches until the user
+ * changes a row.
+ *
+ * Spotting is deliberately left unset. It is a state rather than a session
+ * type, and pre-arming it would mean the overlay changes the first time the
+ * player steps out of the car, which nobody asked for.
+ *
+ * "Never configured" is distinguished from "deliberately cleared": only an
+ * absent key seeds. A user who empties every row keeps an empty map.
+ */
+export const initialiseSessionProfileMap = (
+  currentProfileId: string
+): SessionProfileMap => {
+  const stored = readData<SessionProfileMap>(SESSION_PROFILE_MAP_KEY);
+  if (stored !== undefined) return stored;
+
+  const seeded: SessionProfileMap = {};
+  for (const key of SESSION_PROFILE_KEYS) {
+    seeded[key] = currentProfileId;
+  }
+  writeData(SESSION_PROFILE_MAP_KEY, seeded);
+  return seeded;
 };

--- a/src/app/storage/appSettings.ts
+++ b/src/app/storage/appSettings.ts
@@ -1,7 +1,9 @@
+import type { SessionProfileMap } from '@irdashies/types';
 import { readData, writeData } from './storage';
 
 const CYCLE_PROFILES_KEY = 'cycleProfiles';
 const SHOW_PROFILE_BANNER_KEY = 'showProfileBanner';
+const SESSION_PROFILE_MAP_KEY = 'sessionProfileMap';
 
 export const getCycleProfiles = (): boolean => {
   return readData<boolean>(CYCLE_PROFILES_KEY) ?? false;
@@ -17,4 +19,16 @@ export const getShowProfileBanner = (): boolean => {
 
 export const setShowProfileBanner = (enabled: boolean): void => {
   writeData(SHOW_PROFILE_BANNER_KEY, enabled);
+};
+
+/**
+ * Which profile to switch to for each session type, plus one for spotting.
+ * An empty map means the feature is off, which is how it starts.
+ */
+export const getSessionProfileMap = (): SessionProfileMap => {
+  return readData<SessionProfileMap>(SESSION_PROFILE_MAP_KEY) ?? {};
+};
+
+export const setSessionProfileMap = (map: SessionProfileMap): void => {
+  writeData(SESSION_PROFILE_MAP_KEY, map);
 };

--- a/src/app/storage/appSettings.ts
+++ b/src/app/storage/appSettings.ts
@@ -1,5 +1,4 @@
 import type { SessionProfileMap } from '@irdashies/types';
-import { SESSION_PROFILE_KEYS } from '@irdashies/types';
 import { readData, writeData } from './storage';
 
 const CYCLE_PROFILES_KEY = 'cycleProfiles';
@@ -24,7 +23,18 @@ export const setShowProfileBanner = (enabled: boolean): void => {
 
 /**
  * Which profile to switch to for each session type, plus one for spotting.
- * A key with no profile means "leave the profile alone" for that trigger.
+ * A key with no profile means "leave the profile alone" for that trigger, and
+ * an unconfigured install has no key set at all.
+ *
+ * Nothing is seeded here. An earlier version pointed every session type at the
+ * profile in use on first run so the settings page would show what the mapping
+ * was for, described as behaviourally a no-op — and it is, but only while the
+ * seeded profile stays active. Seed profile A, manually switch to B without
+ * ever opening this feature, and the next session transition drags you back to
+ * A: an automatic profile switch for someone who never asked for one, against
+ * this feature's own documented default. Discoverability is a settings-page
+ * problem and is solved there, with rows reading "Don't switch" and a one-click
+ * "Use current profile for all".
  */
 export const getSessionProfileMap = (): SessionProfileMap => {
   return readData<SessionProfileMap>(SESSION_PROFILE_MAP_KEY) ?? {};
@@ -32,34 +42,4 @@ export const getSessionProfileMap = (): SessionProfileMap => {
 
 export const setSessionProfileMap = (map: SessionProfileMap): void => {
   writeData(SESSION_PROFILE_MAP_KEY, map);
-};
-
-/**
- * First run only: point every session type at the profile already in use.
- *
- * Starting with nothing mapped left the settings page looking inert and made
- * the feature easy to miss. Seeding it with the current profile shows what the
- * mapping is for, and is behaviourally a no-op — every session type resolves to
- * the profile that is already active, so nothing switches until the user
- * changes a row.
- *
- * Spotting is deliberately left unset. It is a state rather than a session
- * type, and pre-arming it would mean the overlay changes the first time the
- * player steps out of the car, which nobody asked for.
- *
- * "Never configured" is distinguished from "deliberately cleared": only an
- * absent key seeds. A user who empties every row keeps an empty map.
- */
-export const initialiseSessionProfileMap = (
-  currentProfileId: string
-): SessionProfileMap => {
-  const stored = readData<SessionProfileMap>(SESSION_PROFILE_MAP_KEY);
-  if (stored !== undefined) return stored;
-
-  const seeded: SessionProfileMap = {};
-  for (const key of SESSION_PROFILE_KEYS) {
-    seeded[key] = currentProfileId;
-  }
-  writeData(SESSION_PROFILE_MAP_KEY, seeded);
-  return seeded;
 };

--- a/src/frontend/components/Settings/sections/ProfileSettings.stories.tsx
+++ b/src/frontend/components/Settings/sections/ProfileSettings.stories.tsx
@@ -1,0 +1,72 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { DashboardProvider } from '@irdashies/context';
+import { mockDashboardBridge } from '@irdashies/storybook';
+import type { DashboardBridge, SessionProfileMap } from '@irdashies/types';
+import { ProfileSettings } from './ProfileSettings';
+
+const profiles = [
+  { id: 'default', name: 'Default' },
+  { id: 'quali-clean', name: 'Qualifying' },
+  { id: 'race-full', name: 'Race' },
+  { id: 'spotter-view', name: 'Spotting' },
+].map((profile) => ({
+  ...profile,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  lastModified: '2026-01-01T00:00:00.000Z',
+}));
+
+/**
+ * Holds the mapping in memory so selections stick while the story is open,
+ * the way they do against real storage.
+ */
+const bridgeWithProfiles = (initial: SessionProfileMap): DashboardBridge => {
+  let map: SessionProfileMap = { ...initial };
+  return {
+    ...mockDashboardBridge,
+    listProfiles: () => Promise.resolve(profiles),
+    getSessionProfileMap: () => Promise.resolve(map),
+    setSessionProfileMap: (next: SessionProfileMap) => {
+      map = next;
+      return Promise.resolve();
+    },
+  };
+};
+
+const meta: Meta<typeof ProfileSettings> = {
+  component: ProfileSettings,
+  title: 'components/Settings/ProfileSettings',
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProfileSettings>;
+
+// No TelemetryDecorator here: it supplies its own DashboardProvider bound to
+// the shared mock bridge, and as the innermost decorator that provider would
+// shadow this one — leaving the story with the mock's single profile and no
+// session mapping. This section reads dashboard context only, so its provider
+// is all it needs.
+const withBridge = (map: SessionProfileMap): Story['decorators'] => [
+  (Story) => (
+    <DashboardProvider bridge={bridgeWithProfiles(map)}>
+      <div style={{ height: '100vh', width: '700px', overflowY: 'auto' }}>
+        <Story />
+      </div>
+    </DashboardProvider>
+  ),
+];
+
+/** How the mapping looks before the user has configured anything. */
+export const Default: Story = {
+  decorators: withBridge({}),
+};
+
+/** A configured event: a layout per session, plus one for spotting. */
+export const SessionMappingConfigured: Story = {
+  decorators: withBridge({
+    practice: 'default',
+    openQualify: 'quali-clean',
+    race: 'race-full',
+    spotting: 'spotter-view',
+  }),
+};

--- a/src/frontend/components/Settings/sections/ProfileSettings.tsx
+++ b/src/frontend/components/Settings/sections/ProfileSettings.tsx
@@ -12,6 +12,7 @@ import {
   SPOTTING_TRIGGER_KEY,
   SPOTTING_TRIGGER_LABEL,
 } from '@irdashies/types';
+import logger from '@irdashies/utils/logger';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import {
   CopySimpleIcon,
@@ -25,12 +26,14 @@ const SessionProfileRow = ({
   label,
   profiles,
   value,
+  disabled,
   onChange,
 }: {
   triggerKey: ProfileTriggerKey;
   label: string;
   profiles: DashboardProfile[];
   value: string;
+  disabled: boolean;
   onChange: (triggerKey: ProfileTriggerKey, profileId: string) => void;
 }) => (
   <div className="flex items-center justify-between gap-4">
@@ -43,8 +46,9 @@ const SessionProfileRow = ({
     <select
       id={`session-profile-${triggerKey}`}
       value={value}
+      disabled={disabled}
       onChange={(e) => onChange(triggerKey, e.target.value)}
-      className="bg-slate-900 border border-slate-600 text-white px-3 py-2 rounded text-sm min-w-52"
+      className="bg-slate-900 border border-slate-600 text-white px-3 py-2 rounded text-sm min-w-52 disabled:opacity-50 disabled:cursor-not-allowed"
     >
       <option value="">Don&apos;t switch</option>
       {profiles.map((profile) => (
@@ -74,28 +78,52 @@ export const ProfileSettings = () => {
   const [sessionProfileMap, setSessionProfileMap] = useState<SessionProfileMap>(
     {}
   );
+  // The rows stay disabled until the stored map has arrived. Editing one before
+  // then would build a new map from an empty one and wipe what is on disk.
+  const [sessionProfileMapLoaded, setSessionProfileMapLoaded] = useState(false);
+
+  // Every write sends the whole map, so it must be derived from the newest one
+  // rather than from a render's closure. Two edits in quick succession would
+  // otherwise both build on the same state and the second would drop the
+  // first's selection.
+  const sessionProfileMapRef = useRef<SessionProfileMap>({});
+  // Writes are chained so they reach storage in the order they were made. Two
+  // in flight at once can otherwise be persisted out of order, leaving the
+  // stored map disagreeing with what the page shows.
+  const sessionProfileWrites = useRef<Promise<unknown>>(Promise.resolve());
 
   useEffect(() => {
     bridge.getCycleProfiles?.().then((v) => setCycleProfiles(v ?? false));
     bridge
       .getShowProfileBanner?.()
       .then((v) => setShowProfileBanner(v ?? true));
-    bridge.getSessionProfileMap?.().then((v) => setSessionProfileMap(v ?? {}));
+    bridge.getSessionProfileMap?.().then((v) => {
+      sessionProfileMapRef.current = v ?? {};
+      setSessionProfileMap(v ?? {});
+      setSessionProfileMapLoaded(true);
+    });
   }, [bridge]);
 
-  const handleSessionProfileChange = async (
+  const handleSessionProfileChange = (
     triggerKey: ProfileTriggerKey,
     profileId: string
   ) => {
     // An empty selection drops the key entirely rather than storing a blank,
     // so "no profile" and "profile deleted" stay the same thing on disk.
     const next = Object.fromEntries(
-      Object.entries({ ...sessionProfileMap, [triggerKey]: profileId }).filter(
-        ([, id]) => Boolean(id)
-      )
+      Object.entries({
+        ...sessionProfileMapRef.current,
+        [triggerKey]: profileId,
+      }).filter(([, id]) => Boolean(id))
     ) as SessionProfileMap;
-    await bridge.setSessionProfileMap?.(next);
+
+    sessionProfileMapRef.current = next;
     setSessionProfileMap(next);
+    sessionProfileWrites.current = sessionProfileWrites.current
+      .then(() => bridge.setSessionProfileMap?.(next))
+      .catch((err) => {
+        logger.error('Failed to save the session profile map', err);
+      });
   };
 
   const handleToggleCycleProfiles = async (checked: boolean) => {
@@ -563,6 +591,7 @@ export const ProfileSettings = () => {
                 label={SESSION_PROFILE_LABELS[key]}
                 profiles={profiles}
                 value={sessionProfileMap[key] ?? ''}
+                disabled={!sessionProfileMapLoaded}
                 onChange={handleSessionProfileChange}
               />
             ))}
@@ -574,6 +603,7 @@ export const ProfileSettings = () => {
               label={SPOTTING_TRIGGER_LABEL}
               profiles={profiles}
               value={sessionProfileMap[SPOTTING_TRIGGER_KEY] ?? ''}
+              disabled={!sessionProfileMapLoaded}
               onChange={handleSessionProfileChange}
             />
             <p className="text-sm text-slate-400">

--- a/src/frontend/components/Settings/sections/ProfileSettings.tsx
+++ b/src/frontend/components/Settings/sections/ProfileSettings.tsx
@@ -1,7 +1,17 @@
 import { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useDashboard } from '@irdashies/context';
-import type { DashboardProfile } from '@irdashies/types';
+import type {
+  DashboardProfile,
+  ProfileTriggerKey,
+  SessionProfileMap,
+} from '@irdashies/types';
+import {
+  SESSION_PROFILE_KEYS,
+  SESSION_PROFILE_LABELS,
+  SPOTTING_TRIGGER_KEY,
+  SPOTTING_TRIGGER_LABEL,
+} from '@irdashies/types';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import {
   CopySimpleIcon,
@@ -9,6 +19,42 @@ import {
   CaretDownIcon,
   TrashIcon,
 } from '@phosphor-icons/react';
+
+const SessionProfileRow = ({
+  triggerKey,
+  label,
+  profiles,
+  value,
+  onChange,
+}: {
+  triggerKey: ProfileTriggerKey;
+  label: string;
+  profiles: DashboardProfile[];
+  value: string;
+  onChange: (triggerKey: ProfileTriggerKey, profileId: string) => void;
+}) => (
+  <div className="flex items-center justify-between gap-4">
+    <label
+      htmlFor={`session-profile-${triggerKey}`}
+      className="text-md font-medium text-slate-300"
+    >
+      {label}
+    </label>
+    <select
+      id={`session-profile-${triggerKey}`}
+      value={value}
+      onChange={(e) => onChange(triggerKey, e.target.value)}
+      className="bg-slate-900 border border-slate-600 text-white px-3 py-2 rounded text-sm min-w-52"
+    >
+      <option value="">Don&apos;t switch</option>
+      {profiles.map((profile) => (
+        <option key={profile.id} value={profile.id}>
+          {profile.name}
+        </option>
+      ))}
+    </select>
+  </div>
+);
 
 export const ProfileSettings = () => {
   const {
@@ -25,13 +71,32 @@ export const ProfileSettings = () => {
 
   const [cycleProfiles, setCycleProfiles] = useState(false);
   const [showProfileBanner, setShowProfileBanner] = useState(true);
+  const [sessionProfileMap, setSessionProfileMap] = useState<SessionProfileMap>(
+    {}
+  );
 
   useEffect(() => {
     bridge.getCycleProfiles?.().then((v) => setCycleProfiles(v ?? false));
     bridge
       .getShowProfileBanner?.()
       .then((v) => setShowProfileBanner(v ?? true));
+    bridge.getSessionProfileMap?.().then((v) => setSessionProfileMap(v ?? {}));
   }, [bridge]);
+
+  const handleSessionProfileChange = async (
+    triggerKey: ProfileTriggerKey,
+    profileId: string
+  ) => {
+    // An empty selection drops the key entirely rather than storing a blank,
+    // so "no profile" and "profile deleted" stay the same thing on disk.
+    const next = Object.fromEntries(
+      Object.entries({ ...sessionProfileMap, [triggerKey]: profileId }).filter(
+        ([, id]) => Boolean(id)
+      )
+    ) as SessionProfileMap;
+    await bridge.setSessionProfileMap?.(next);
+    setSessionProfileMap(next);
+  };
 
   const handleToggleCycleProfiles = async (checked: boolean) => {
     await bridge.setCycleProfiles?.(checked);
@@ -472,6 +537,50 @@ export const ProfileSettings = () => {
               />
               <div className="w-11 h-6 bg-slate-700 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-500 rounded-full peer peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
             </label>
+          </div>
+        </div>
+
+        {/* Session mapping */}
+        <div className="bg-slate-800/50 border border-slate-700 rounded-lg p-4 space-y-3">
+          <div>
+            <h3 className="text-lg font-semibold text-white mb-2">
+              Switch Profile By Session
+            </h3>
+            <p className="text-sm text-gray-400 mb-3">
+              Set a profile for each session type and it is applied
+              automatically as the event moves from practice through to the
+              race. A session left on Don&apos;t switch keeps whatever profile
+              you are already on, so to come back to a layout, map that session
+              to it rather than leaving it unset.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            {SESSION_PROFILE_KEYS.map((key) => (
+              <SessionProfileRow
+                key={key}
+                triggerKey={key}
+                label={SESSION_PROFILE_LABELS[key]}
+                profiles={profiles}
+                value={sessionProfileMap[key] ?? ''}
+                onChange={handleSessionProfileChange}
+              />
+            ))}
+          </div>
+
+          <div className="border-t border-slate-700 pt-3 space-y-2">
+            <SessionProfileRow
+              triggerKey={SPOTTING_TRIGGER_KEY}
+              label={SPOTTING_TRIGGER_LABEL}
+              profiles={profiles}
+              value={sessionProfileMap[SPOTTING_TRIGGER_KEY] ?? ''}
+              onChange={handleSessionProfileChange}
+            />
+            <p className="text-sm text-slate-400">
+              Applied while you are in a session but not in the car, whichever
+              session type it is, and handed back as soon as you are driving
+              again.
+            </p>
           </div>
         </div>
 

--- a/src/frontend/components/Settings/sections/ProfileSettings.tsx
+++ b/src/frontend/components/Settings/sections/ProfileSettings.tsx
@@ -21,6 +21,15 @@ import {
   TrashIcon,
 } from '@phosphor-icons/react';
 
+interface SessionProfileRowProps {
+  triggerKey: ProfileTriggerKey;
+  label: string;
+  profiles: DashboardProfile[];
+  value: string;
+  disabled: boolean;
+  onChange: (triggerKey: ProfileTriggerKey, profileId: string) => void;
+}
+
 const SessionProfileRow = ({
   triggerKey,
   label,
@@ -28,14 +37,7 @@ const SessionProfileRow = ({
   value,
   disabled,
   onChange,
-}: {
-  triggerKey: ProfileTriggerKey;
-  label: string;
-  profiles: DashboardProfile[];
-  value: string;
-  disabled: boolean;
-  onChange: (triggerKey: ProfileTriggerKey, profileId: string) => void;
-}) => (
+}: SessionProfileRowProps) => (
   <div className="flex items-center justify-between gap-4">
     <label
       htmlFor={`session-profile-${triggerKey}`}

--- a/src/frontend/components/Settings/sections/ProfileSettings.tsx
+++ b/src/frontend/components/Settings/sections/ProfileSettings.tsx
@@ -106,19 +106,7 @@ export const ProfileSettings = () => {
     });
   }, [bridge]);
 
-  const handleSessionProfileChange = (
-    triggerKey: ProfileTriggerKey,
-    profileId: string
-  ) => {
-    // An empty selection drops the key entirely rather than storing a blank,
-    // so "no profile" and "profile deleted" stay the same thing on disk.
-    const next = Object.fromEntries(
-      Object.entries({
-        ...sessionProfileMapRef.current,
-        [triggerKey]: profileId,
-      }).filter(([, id]) => Boolean(id))
-    ) as SessionProfileMap;
-
+  const persistSessionProfileMap = (next: SessionProfileMap) => {
     sessionProfileMapRef.current = next;
     setSessionProfileMap(next);
     sessionProfileWrites.current = sessionProfileWrites.current
@@ -126,6 +114,44 @@ export const ProfileSettings = () => {
       .catch((err) => {
         logger.error('Failed to save the session profile map', err);
       });
+  };
+
+  const handleSessionProfileChange = (
+    triggerKey: ProfileTriggerKey,
+    profileId: string
+  ) => {
+    // An empty selection drops the key entirely rather than storing a blank,
+    // so "no profile" and "profile deleted" stay the same thing on disk.
+    persistSessionProfileMap(
+      Object.fromEntries(
+        Object.entries({
+          ...sessionProfileMapRef.current,
+          [triggerKey]: profileId,
+        }).filter(([, id]) => Boolean(id))
+      ) as SessionProfileMap
+    );
+  };
+
+  /**
+   * Fills in every session type with the profile in use right now.
+   *
+   * This is what the feature used to do behind the user's back on first run, to
+   * keep the page from looking inert. It is the same convenience offered as a
+   * choice: nothing is mapped until someone presses this, so an install that
+   * never opens the section never switches profiles.
+   *
+   * Spotting is left out on purpose. It is a state rather than a session type,
+   * and filling it in would change the overlay the first time the player steps
+   * out of the car.
+   */
+  const handleUseCurrentProfileForAll = () => {
+    if (!currentProfile) return;
+    persistSessionProfileMap({
+      ...sessionProfileMapRef.current,
+      ...Object.fromEntries(
+        SESSION_PROFILE_KEYS.map((key) => [key, currentProfile.id])
+      ),
+    } as SessionProfileMap);
   };
 
   const handleToggleCycleProfiles = async (checked: boolean) => {
@@ -597,6 +623,17 @@ export const ProfileSettings = () => {
                 onChange={handleSessionProfileChange}
               />
             ))}
+          </div>
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handleUseCurrentProfileForAll}
+              disabled={!sessionProfileMapLoaded || !currentProfile}
+              className="text-sm text-blue-400 hover:text-blue-300 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Use {currentProfile?.name ?? 'current profile'} for all sessions
+            </button>
           </div>
 
           <div className="border-t border-slate-700 pt-3 space-y-2">

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,15 @@ import {
   getSessionLifecycle,
   onBridgeChanged,
 } from './app/bridge/iracingSdk/setup';
-import { getOrCreateDefaultDashboard } from './app/storage/dashboards';
+import {
+  getOrCreateDefaultDashboard,
+  getCurrentProfileId,
+  getProfile,
+  setCurrentProfile,
+} from './app/storage/dashboards';
+import { getSessionProfileMap } from './app/storage/appSettings';
+import { createSessionProfileSwitcher } from './app/services/sessionProfileSwitcher';
+import type { SessionProfileSwitcher } from './app/services/sessionProfileSwitcher';
 import { setupTaskbar, KeybindingManager } from './app';
 import {
   publishDashboardUpdates,
@@ -103,6 +111,7 @@ const channelBus = new ChannelBus({
   deliveryEnabled: !perfRun.enabled || perfRun.channelDelivery === 'on',
 });
 let disconnectLifecycleChannel: (() => void) | undefined;
+let sessionProfileSwitcher: SessionProfileSwitcher | undefined;
 let incidentRuntime: IncidentRuntime | undefined;
 let disposeLapHistoryRuntime: (() => void) | undefined;
 // Resolved per call: a runtime outlives any single SDK bridge, so it must
@@ -226,6 +235,15 @@ app.on('ready', async () => {
     getSessionLifecycle(),
     channelBus
   );
+  // Applies the profile mapped to each session type, and to spotting. Inert
+  // until the user maps at least one, so this changes nothing by default.
+  sessionProfileSwitcher = createSessionProfileSwitcher({
+    lifecycle: getSessionLifecycle(),
+    getMap: getSessionProfileMap,
+    getCurrentProfileId,
+    profileExists: (profileId) => getProfile(profileId) !== null,
+    switchProfile: (profileId) => setCurrentProfile(profileId),
+  });
   await iRacingSDKSetup(overlayManager, channelBus);
 
   // Perform one-time cleanup of old reference laps
@@ -405,6 +423,7 @@ const handleBeforeQuit = createBeforeQuitHandler({
   shutdown: async () => {
     keybindingManager?.stopGamepad();
     disconnectLifecycleChannel?.();
+    sessionProfileSwitcher?.dispose();
     disposeRendererDataSubscriptions?.();
     incidentRuntime?.dispose();
     disposeLapHistoryRuntime?.();

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,10 @@ import {
   getProfile,
   setCurrentProfile,
 } from './app/storage/dashboards';
-import { getSessionProfileMap } from './app/storage/appSettings';
+import {
+  getSessionProfileMap,
+  initialiseSessionProfileMap,
+} from './app/storage/appSettings';
 import { createSessionProfileSwitcher } from './app/services/sessionProfileSwitcher';
 import type { SessionProfileSwitcher } from './app/services/sessionProfileSwitcher';
 import { setupTaskbar, KeybindingManager } from './app';
@@ -235,15 +238,6 @@ app.on('ready', async () => {
     getSessionLifecycle(),
     channelBus
   );
-  // Applies the profile mapped to each session type, and to spotting. Inert
-  // until the user maps at least one, so this changes nothing by default.
-  sessionProfileSwitcher = createSessionProfileSwitcher({
-    lifecycle: getSessionLifecycle(),
-    getMap: getSessionProfileMap,
-    getCurrentProfileId,
-    profileExists: (profileId) => getProfile(profileId) !== null,
-    switchProfile: (profileId) => setCurrentProfile(profileId),
-  });
   await iRacingSDKSetup(overlayManager, channelBus);
 
   // Perform one-time cleanup of old reference laps
@@ -398,6 +392,25 @@ app.on('ready', async () => {
       ? (updatedDashboard) => createPerfDashboard(updatedDashboard, perfRun)
       : undefined
   );
+  // Deliberately after publishDashboardUpdates: switching a profile emits
+  // 'dashboardUpdated', and that listener is what actually applies it to the
+  // windows. Wired any earlier — telemetry starts flowing back at
+  // iRacingSDKSetup — a switch triggered by the session the player is already
+  // in would emit into an EventEmitter with no listener, silently leaving the
+  // stored profile and the visible overlays disagreeing.
+  //
+  // On a first run this points every session type at the profile already in
+  // use, so the settings page shows what the mapping is for. It is a no-op
+  // behaviourally: every type resolves to the active profile until one is
+  // changed.
+  initialiseSessionProfileMap(getCurrentProfileId());
+  sessionProfileSwitcher = createSessionProfileSwitcher({
+    lifecycle: getSessionLifecycle(),
+    getMap: getSessionProfileMap,
+    getCurrentProfileId,
+    profileExists: (profileId) => getProfile(profileId) !== null,
+    switchProfile: (profileId) => setCurrentProfile(profileId),
+  });
   setupKeybindingsBridge(keybindingManager);
 
   await analytics.init(overlayManager.getVersion(), dashboard);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,10 +12,7 @@ import {
   getProfile,
   setCurrentProfile,
 } from './app/storage/dashboards';
-import {
-  getSessionProfileMap,
-  initialiseSessionProfileMap,
-} from './app/storage/appSettings';
+import { getSessionProfileMap } from './app/storage/appSettings';
 import { createSessionProfileSwitcher } from './app/services/sessionProfileSwitcher';
 import type { SessionProfileSwitcher } from './app/services/sessionProfileSwitcher';
 import { setupTaskbar, KeybindingManager } from './app';
@@ -418,11 +415,10 @@ app.on('ready', async () => {
   // in would emit into an EventEmitter with no listener, silently leaving the
   // stored profile and the visible overlays disagreeing.
   //
-  // On a first run this points every session type at the profile already in
-  // use, so the settings page shows what the mapping is for. It is a no-op
-  // behaviourally: every type resolves to the active profile until one is
-  // changed.
-  initialiseSessionProfileMap(getCurrentProfileId());
+  // Arriving this late is also why the switcher seeds itself from the
+  // lifecycle's current state on construction: by now the SDK has been
+  // publishing for a while, and the events it fires are transitions that are
+  // not replayed to a new subscriber.
   sessionProfileSwitcher = createSessionProfileSwitcher({
     lifecycle: getSessionLifecycle(),
     getMap: getSessionProfileMap,

--- a/src/types/dashboardBridge.ts
+++ b/src/types/dashboardBridge.ts
@@ -3,6 +3,7 @@ import type {
   DashboardProfile,
   DriverTagSettings,
 } from './dashboardLayout';
+import type { SessionProfileMap } from './sessionProfiles';
 
 export interface SaveDashboardOptions {
   forceReload?: boolean;
@@ -62,6 +63,8 @@ export interface DashboardBridge {
   setCycleProfiles?: (enabled: boolean) => Promise<void>;
   getShowProfileBanner?: () => Promise<boolean>;
   setShowProfileBanner?: (enabled: boolean) => Promise<void>;
+  getSessionProfileMap?: () => Promise<SessionProfileMap>;
+  setSessionProfileMap?: (map: SessionProfileMap) => Promise<void>;
   listProfiles: () => Promise<DashboardProfile[]>;
   createProfile: (name: string) => Promise<DashboardProfile>;
   cloneProfile: (profileId: string) => Promise<DashboardProfile>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,3 +20,4 @@ export * from './performance';
 export * from './gamepadToken';
 export * from './channels';
 export * from './telemetryInspectorBridge';
+export * from './sessionProfiles';

--- a/src/types/sessionProfiles.ts
+++ b/src/types/sessionProfiles.ts
@@ -1,0 +1,93 @@
+/**
+ * Session types a profile can be bound to, so the app can switch layouts as an
+ * event moves from practice through qualifying to the race.
+ *
+ * This deliberately mirrors the vocabulary of `SessionVisibilitySettings`
+ * rather than reusing it: widget visibility has no Warmup key, and adding one
+ * there would change the settings shape of every widget that has visibility
+ * options.
+ */
+export type SessionProfileKey =
+  | 'practice'
+  | 'timeTrial'
+  | 'openQualify'
+  | 'loneQualify'
+  | 'warmup'
+  | 'race'
+  | 'offlineTesting';
+
+export const SESSION_PROFILE_KEYS: SessionProfileKey[] = [
+  'practice',
+  'timeTrial',
+  'openQualify',
+  'loneQualify',
+  'warmup',
+  'race',
+  'offlineTesting',
+];
+
+/** Display labels for the settings UI, in the order sessions normally run. */
+export const SESSION_PROFILE_LABELS: Record<SessionProfileKey, string> = {
+  practice: 'Practice',
+  timeTrial: 'Time Trial',
+  openQualify: 'Open Qualifying',
+  loneQualify: 'Lone Qualifying',
+  warmup: 'Warmup',
+  race: 'Race',
+  offlineTesting: 'Offline Testing',
+};
+
+/**
+ * `spotting` is not a session type — it is a state that can occur inside any
+ * of them, when the player is in the session but not in the car. It takes
+ * precedence over the session type while it lasts, and hands back as soon as
+ * the player is driving again.
+ */
+export type ProfileTriggerKey = SessionProfileKey | 'spotting';
+
+export const SPOTTING_TRIGGER_KEY = 'spotting' as const;
+
+export const SPOTTING_TRIGGER_LABEL = 'Spotting / watching';
+
+/**
+ * Maps a profile id to each trigger. A key that is absent, or set to an empty
+ * string, means "leave the profile alone" — which is what every key means
+ * until the user configures one.
+ */
+export type SessionProfileMap = Partial<Record<ProfileTriggerKey, string>>;
+
+/**
+ * iRacing reports session types as display strings in `SessionInfo.Sessions[]`.
+ * Only exact known values map; anything unrecognised yields undefined and is
+ * treated as "no opinion", so an unfamiliar session never yanks the user onto
+ * a different layout.
+ *
+ * These are every distinct value seen across 205 recorded sessions: Practice,
+ * Race, Lone Qualify, Offline Testing, Open Qualify, Warmup and Lone Practice.
+ * Two are worth knowing about:
+ *
+ * - A Time Trial reports as 'Lone Practice' (with SessionName 'TIME TRIAL'),
+ *   which is why the Time Trial trigger keys off that string.
+ * - Heat events run several sessions that all report 'Race', separated only by
+ *   SessionSubType (Heat / Consolation / Feature). They therefore share one
+ *   profile, and moving between heats does not re-trigger a switch.
+ */
+const SESSION_TYPE_TO_KEY: Record<string, SessionProfileKey> = {
+  Practice: 'practice',
+  // A Time Trial reports as 'Lone Practice' with SessionName 'TIME TRIAL'.
+  // It gets its own trigger because it is a solo hot-lap session, closer in
+  // use to qualifying than to open practice.
+  'Lone Practice': 'timeTrial',
+  'Open Qualify': 'openQualify',
+  'Lone Qualify': 'loneQualify',
+  Warmup: 'warmup',
+  Race: 'race',
+  'Offline Testing': 'offlineTesting',
+};
+
+export const sessionProfileKeyFor = (
+  sessionType: string | undefined | null
+): SessionProfileKey | undefined => {
+  if (!sessionType) return undefined;
+  return SESSION_TYPE_TO_KEY[sessionType.trim()];
+};


### PR DESCRIPTION
Closes #608.

## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

Layout configuration is global, so running different columns in qualifying and the race means reconfiguring between sessions or switching profiles by hand. The request asks for "a one time setup, and only start and forget to use afterwards".

Read literally, per-session variants of every widget setting would be a config explosion and a migration problem. But **profiles already carry a complete dashboard each**, and switching one already live-reloads the overlays without destroying windows. So this maps a profile to each session type and applies it as the event moves along — which means everything can differ per session, not just columns: widget positions, and which widgets exist at all.

**Nothing changes for an existing install.** A trigger with no profile mapped means "leave the profile alone", and an unrecognised session type gets no opinion rather than a guess.

### Spotting

Spotting gets its own trigger, because it is a *state* rather than a session type — it can happen inside any of them. It outranks the session type while the player is out of the car and hands back the moment they are driving again.

The outbound edge waits 20s, the inbound is immediate. Getting out of the car is not always deliberate — a tow, a quick garage visit, the pause during a driver swap — and throwing the whole layout around on every blip would be worse than switching a little late.

### Where it hooks in

Two derived events are added to `sessionLifecycle`, which already sees both halves of the data and is the single session event source:

- `onSessionTypeChange` resolves `SessionNum` against the session list in **either arrival order** (the number arrives on the telemetry tick, the types with session info) and fires on *type* changes only — so two consecutive practice sessions do not churn the layout.
- `onDrivingStateChange` mirrors the renderer's `useDrivingState`: in the car counts even when stationary in the pit box; the garage and replay playback do not.

The mapping crosses IPC, so it is rebuilt from an allowlist of trigger keys rather than trusted.

### Session types are validated against real data, not guessed

Checked against **205 recorded sessions**. iRacing emitted exactly seven distinct `SessionType` strings and all seven are handled:

| SessionType | Occurrences |
| --- | --- |
| `Practice` | 144 |
| `Race` | 100 |
| `Lone Qualify` | 61 |
| `Offline Testing` | 55 |
| `Open Qualify` | 19 |
| `Warmup` | 4 |
| `Lone Practice` | 2 |

Two findings worth recording, both captured in a comment in `sessionProfiles.ts`:

- **A Time Trial reports as `Lone Practice`** (with `SessionName: TIME TRIAL`), so it has its own trigger rather than silently landing on the practice profile.
- **Heat events run several sessions that all report `Race`**, separated only by `SessionSubType` (Heat / Consolation / Feature). They therefore share one profile, and moving between heats does not re-trigger a switch.

### On switching while driving

Deliberately **not** gated on the player being stationary. Gating would mean never getting the race layout during a race, since qualifying to race fires while you may already be rolling. The switch takes the same near-instant path as a manual profile change (`dashboardBridge.ts`: no destroy/recreate), though widgets that differ between the two profiles still have windows opened or closed — that is inherent to the feature. This was specifically watched for on the rig.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

No such setting exists. Changing layout between sessions means switching profiles by hand, or reconfiguring widgets.

### After
<!-- Screenshot or description of the new behaviour -->

A new **Switch Profile By Session** section under Settings, Profiles, with a row per session type and one for spotting below a divider:

```
Switch Profile By Session

  Practice             [ Default       v ]
  Time Trial           [ Do not switch v ]
  Open Qualifying      [ Qualifying    v ]
  Lone Qualifying      [ Do not switch v ]
  Warmup               [ Do not switch v ]
  Race                 [ Race          v ]
  Offline Testing      [ Do not switch v ]
  ----------------------------------------
  Spotting / watching  [ Spotting      v ]
```

Two Storybook stories cover it: `components/Settings/ProfileSettings` gives `Default` (how it looks before configuration) and `SessionMappingConfigured`.

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

`defaultDashboard.ts` is untouched: this adds no widget and no widget config. The mapping is an app setting alongside `cycleProfiles` and `showProfileBanner`, and it seeds on first run rather than shipping a committed default.

## Validation

- **On the sim rig**, in iRacing, against a packaged build. Two problems were found there and fixed before this PR: the mapping started empty and looked inert (now seeded on first run), and the switcher was constructed before `publishDashboardUpdates` registered the listener that applies a switch — so a switch for the session already in progress emitted into an `EventEmitter` with no listener, silently leaving the stored profile and the visible overlays disagreeing.
- **Session-type strings** validated against 205 real captures, as above. `Warmup` in particular was a guess until it was confirmed verbatim in a recorded session.
- **Tests verified by mutation, not by passing.** 20 deliberate mutations across the switcher and the lifecycle — removing the already-current guard, removing the deleted-profile guard, breaking spotting precedence, removing the dwell and its cancellation, making an unmapped session inherit a default, letting the garage count as driving, firing on every tick instead of on the edge, and so on. Every one was caught by the test that names it. One early mutation was itself a no-op and was rewritten as a real one rather than counted.
- **Storybook** verified in a browser, which caught a fixture bug that jsdom did not: the story's bridge overrides were not reaching the component because `TelemetryDecorator` nests its own `DashboardProvider`.
- `npm test` — 1952 tests across 198 files, all passing.
- `npm run lint` — clean. `npm run build-storybook` — succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic profile switching for supported session types, including Practice, Qualifying, Race, Warmup, Time Trial, and Offline Testing.
  - Added **Switch Profile By Session** settings for configuring session and spotting profile mappings.
  - Profiles now switch when entering or leaving the car, with a brief delay before switching to the spotting profile.
  - Session profile mappings are saved and restored between launches.
  - Unknown or unconfigured session types leave the active profile unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
