### PR TITLE
feat: tell lap graph lines apart, and plot position for the whole race

### DIFF
--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.spec.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.spec.tsx
@@ -2,11 +2,19 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LapGraphCanvas } from './LapGraphCanvas';
 import type { LapGraphSeries } from './LapGraphCanvas';
+import { identityForGridSlot } from './lapGraphPalette';
 
 interface FakeContext {
   strokes: number;
   clears: number;
   fills: number;
+  /** Dash array passed to the most recent `setLineDash` call before a stroke. */
+  lastDash: readonly number[];
+  /** One entry per `stroke()` call, the dash in effect at that point. */
+  dashPerStroke: (readonly number[])[];
+  lastWidth: number;
+  /** One entry per `stroke()` call, the lineWidth in effect at that point. */
+  widthPerStroke: number[];
 }
 
 const contexts = new Map<string, FakeContext>();
@@ -21,8 +29,13 @@ const createFakeContext = (record: FakeContext) =>
     moveTo: vi.fn(),
     lineTo: vi.fn(),
     arc: vi.fn(),
+    setLineDash: vi.fn((segments: number[]) => {
+      record.lastDash = segments;
+    }),
     stroke: vi.fn(() => {
       record.strokes++;
+      record.dashPerStroke.push(record.lastDash);
+      record.widthPerStroke.push(record.lastWidth);
     }),
     fill: vi.fn(() => {
       record.fills++;
@@ -32,7 +45,12 @@ const createFakeContext = (record: FakeContext) =>
     globalAlpha: 1,
     strokeStyle: '',
     fillStyle: '',
-    lineWidth: 1,
+    set lineWidth(value: number) {
+      record.lastWidth = value;
+    },
+    get lineWidth() {
+      return record.lastWidth;
+    },
     lineJoin: 'round',
     lineCap: 'round',
   }) as unknown as CanvasRenderingContext2D;
@@ -40,12 +58,13 @@ const createFakeContext = (record: FakeContext) =>
 const PLOT_WIDTH = 800;
 const PLOT_HEIGHT = 400;
 
+/** Grid slot = carIdx + 1, so carIdx 0-9 are solid and 10-19 are dashed. */
 const field: LapGraphSeries[] = Array.from({ length: 60 }, (_, carIdx) => ({
   carIdx,
   carNumber: String(carIdx + 1),
   displayName: `Driver ${carIdx + 1}`,
   isPlayer: carIdx === 3,
-  color: '#22c55e',
+  ...identityForGridSlot(carIdx + 1),
   points: Array.from({ length: 200 }, (_, i) => ({
     lap: i + 1,
     value: carIdx * 0.5 + i * 0.05,
@@ -93,7 +112,15 @@ beforeEach(() => {
       const key = this.getAttribute('data-testid') ?? 'unknown';
       let record = contexts.get(key);
       if (!record) {
-        record = { strokes: 0, clears: 0, fills: 0 };
+        record = {
+          strokes: 0,
+          clears: 0,
+          fills: 0,
+          lastDash: [],
+          dashPerStroke: [],
+          lastWidth: 1,
+          widthPerStroke: [],
+        };
         contexts.set(key, record);
       }
       const held = this as HTMLCanvasElement & {
@@ -193,6 +220,59 @@ describe('LapGraphCanvas', () => {
     renderChart();
 
     await waitFor(() => expect(contextFor('lap-graph-brush').strokes).toBe(60));
+  });
+
+  it('sets a non-empty dash before stroking a dashed series on the base canvas', async () => {
+    renderChart();
+
+    await waitFor(() => expect(contextFor('lap-graph-base').strokes).toBe(60));
+
+    const base = contextFor('lap-graph-base');
+    // Slots 1-10 and 41-50 are solid; the other 40 carry a pattern. Counting
+    // both sides catches a dash leaking onto a solid car, which a `some()`
+    // check would pass straight over.
+    const solid = base.dashPerStroke.filter((dash) => dash.length === 0);
+    expect(solid).toHaveLength(20);
+    expect(base.dashPerStroke).toHaveLength(60);
+  });
+
+  it('keeps the crosshair solid after hovering a dashed line', async () => {
+    renderChart();
+    await waitFor(() => expect(contextFor('lap-graph-base').strokes).toBe(60));
+
+    const plot = screen.getByLabelText('Lap graph plot');
+    const overlay = contextFor('lap-graph-overlay');
+
+    // Sweep the pointer so it crosses lines carrying a dash pattern. Canvas
+    // dash state persists on the context between strokes, so a crosshair that
+    // does not set its own dash inherits whichever line was hovered last.
+    for (let i = 0; i < 20; i++) {
+      fireEvent.pointerMove(plot, {
+        clientX: 20 + i * 25,
+        clientY: 40 + (i % 7) * 30,
+      });
+    }
+
+    // The crosshair is the only overlay stroke drawn at width 1; a focused
+    // line is always width 3. Every one of them must be solid.
+    const crosshairDashes = overlay.dashPerStroke.filter(
+      (_dash, index) => overlay.widthPerStroke[index] === 1
+    );
+    expect(crosshairDashes.length).toBeGreaterThan(0);
+    // Proves the sweep actually crossed dashed lines, so a leak had something
+    // to leak. Without it this test would pass on an all-solid field.
+    expect(overlay.dashPerStroke.some((dash) => dash.length > 0)).toBe(true);
+    expect(crosshairDashes.every((dash) => dash.length === 0)).toBe(true);
+  });
+
+  it('always forces solid on the brush strip, regardless of series pattern', async () => {
+    renderChart();
+
+    await waitFor(() => expect(contextFor('lap-graph-brush').strokes).toBe(60));
+
+    const brush = contextFor('lap-graph-brush');
+    expect(brush.dashPerStroke.length).toBe(60);
+    expect(brush.dashPerStroke.every((dash) => dash.length === 0)).toBe(true);
   });
 
   it('keeps the caption and controls in the DOM rather than the canvas', async () => {

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.stories.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.stories.tsx
@@ -2,8 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useMemo, useState } from 'react';
 import { LapGraphCanvas } from './LapGraphCanvas';
 import type { LapGraphMode, LapGraphSeries, LapPoint } from './LapGraphCanvas';
-
-const CLASS_COLORS = ['#22c55e', '#38bdf8', '#f472b6', '#fbbf24'];
+import { identityForGridSlot } from './lapGraphPalette';
 
 /** Deterministic noise, so a story looks the same on every reload. */
 const seededRandom = (seed: number) => {
@@ -66,13 +65,14 @@ const buildPoints = (
   return points;
 };
 
+/** Grid slot = carIdx + 1, so a 60-car field shows solid, dashed and dotted. */
 const buildField = (options: FieldOptions): LapGraphSeries[] =>
   Array.from({ length: options.cars }, (_, carIdx) => ({
     carIdx,
     carNumber: String(carIdx + 1),
     displayName: `Driver ${String(carIdx + 1).padStart(2, '0')}`,
     isPlayer: carIdx === 3,
-    color: CLASS_COLORS[carIdx % CLASS_COLORS.length],
+    ...identityForGridSlot(carIdx + 1),
     points: buildPoints(carIdx, options),
   }));
 

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphCanvas.tsx
@@ -45,6 +45,7 @@ import {
   type PreparedSeries,
 } from './useLapGraphSeries';
 import { anchorInsideBounds } from '../Tooltip/tooltipPosition';
+import { scaleDash } from './lapGraphPalette';
 
 export type {
   LapGraphMode,
@@ -106,14 +107,34 @@ const prepareCanvas = (
   if (!ctx) return null;
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, width, height);
+  // The context is reused between draws, and neither setTransform nor
+  // clearRect resets these. Without the reset a dash or cap set by the last
+  // draw leaks into the next one.
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+  ctx.setLineDash([]);
   return { ctx, width, height };
 };
 
+interface StrokeOverride {
+  color: string;
+  width: number;
+  alpha: number;
+  /** Unscaled identity dash pattern. `[]` forces solid, e.g. the brush strip. */
+  dash: readonly number[];
+}
+
+/**
+ * Canvas dash state persists on the context between `stroke()` calls, so
+ * every stroke — base series, hover overlay restroke, brush override — sets
+ * its own dash immediately before drawing. None may rely on what the
+ * previous stroke left behind.
+ */
 const strokeSeries = (
   target: CanvasTarget,
   prepared: PreparedSeries,
   geometry: LapGraphGeometry,
-  override?: { color: string; width: number; alpha: number }
+  override?: StrokeOverride
 ) => {
   const points = prepared.points;
   if (points.length === 0) return;
@@ -122,6 +143,7 @@ const strokeSeries = (
   ctx.globalAlpha = style.alpha;
   ctx.strokeStyle = style.color;
   ctx.lineWidth = style.width;
+  ctx.setLineDash(scaleDash(style.dash, style.width));
   ctx.beginPath();
   for (let i = 0; i < points.length; i++) {
     const x = lapToX(points[i].lap, geometry.window, width);
@@ -141,11 +163,8 @@ const strokeSeries = (
 const drawAllSeries = (
   target: CanvasTarget,
   geometry: LapGraphGeometry,
-  override?: { color: string; width: number; alpha: number }
+  override?: StrokeOverride
 ) => {
-  const { ctx } = target;
-  ctx.lineJoin = 'round';
-  ctx.lineCap = 'round';
   for (const prepared of geometry.ordered) {
     strokeSeries(target, prepared, geometry, override);
   }
@@ -338,6 +357,9 @@ export const LapGraphCanvas = memo(
         color: accentRef.current,
         width: 1,
         alpha: BRUSH_ALPHA,
+        // Always solid: at 1px in a ~40px overview, a dash pattern across
+        // dozens of overlapping laps is noise, not identity.
+        dash: [],
       });
     }, [brushGeometry, brushSize.width, brushSize.height]);
 
@@ -401,6 +423,7 @@ export const LapGraphCanvas = memo(
       ctx.globalAlpha = 0.5;
       ctx.strokeStyle = accentRef.current;
       ctx.lineWidth = 1;
+      ctx.setLineDash([]);
       ctx.beginPath();
       ctx.moveTo(crosshairX, 0);
       ctx.lineTo(crosshairX, size.height);
@@ -416,6 +439,8 @@ export const LapGraphCanvas = memo(
         color: brightenColor(hovered.source.color),
         width: 3,
         alpha: 1,
+        // Focus keeps the driver's own pattern — only colour and width change.
+        dash: hovered.source.dash,
       });
 
       const markerY = valueToY(

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphView.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphView.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useDriverStandings } from '@irdashies/domain/standings/useDriverStandings';
+import { useQualifyingGrid } from '@irdashies/domain/standings/useQualifyingGrid';
 import {
   classReferenceLap,
   gapToClassLeader,
@@ -23,11 +24,19 @@ import {
 } from '../../../shared/DriverName/DriverName';
 import { LapGraphCanvas } from './LapGraphCanvas';
 import type { LapGraphSeries } from './LapGraphCanvas';
-import { LapGraphDriverList } from './LapGraphDriverList';
-import type { DriverListEntry } from './LapGraphDriverList';
+import { LapGraphDriverList } from './components/LapGraphDriverList/LapGraphDriverList';
+import type { DriverListEntry } from './components/LapGraphDriverList/LapGraphDriverList';
 import { Tooltip } from '../Tooltip/Tooltip';
 import { useGantrySettings } from '../../hooks/useGantrySettings';
 import { autoPinCarIdxs } from './lapGraphAutoPin';
+import { identityForGridSlot } from './lapGraphPalette';
+
+/**
+ * Fallback grid slot for a carIdx `useQualifyingGrid` somehow has no entry
+ * for. Unreachable in practice: the map is built from this exact class's
+ * carIdx list, which always covers every member below.
+ */
+const FALLBACK_GRID_SLOT = 1;
 
 interface Props {
   /** Driver picked in the tab bar's Follow control, if any. */
@@ -200,15 +209,10 @@ export const LapGraphView = memo(
       return best;
     }, [activeClass]);
 
-    const classColor = useMemo(
-      () =>
-        getTailwindStyle(
-          activeClass?.color ?? 0x94a3b8,
-          undefined,
-          isMultiClass
-        ).canvasFill,
-      [activeClass, isMultiClass]
-    );
+    // Numeric class colour for LapGraphDriverList's car-number chip. The
+    // list resolves it through getTailwindStyle itself, the same shared
+    // helper the canvas class-selector buttons below use.
+    const classColorValue = activeClass?.color ?? 0x94a3b8;
 
     // Player, class leader, and the cars either side of the player. Reduced to a
     // string first so a position reshuffle that does not change the set never
@@ -259,6 +263,14 @@ export const LapGraphView = memo(
       // eslint-disable-next-line @eslint-react/exhaustive-deps
       [membersKey]
     );
+
+    // carIdx never changes for a driver mid-race, so this only moves when the
+    // class roster itself changes, not on every standings tick.
+    const classCarIdxs = useMemo(
+      () => members.map((member) => member.carIdx),
+      [members]
+    );
+    const qualifyingGrid = useQualifyingGrid(classCarIdxs);
 
     // Hold the snapshot at an identity that only moves when `version` moves. A
     // resend, or resubscribing after a tab switch, delivers an equal snapshot as
@@ -311,18 +323,22 @@ export const LapGraphView = memo(
         }
         if (points.length === 0) continue;
 
+        const identity = identityForGridSlot(
+          qualifyingGrid.get(member.carIdx) ?? FALLBACK_GRID_SLOT
+        );
         series.push({
           carIdx: member.carIdx,
           carNumber: member.carNumber,
           displayName: member.displayName,
           isPlayer: member.isPlayer,
-          color: classColor,
+          color: identity.color,
+          dash: identity.dash,
           points,
         });
       }
 
       return { series, reference };
-    }, [history, mode, members, leaderCarIdx, classColor]);
+    }, [history, mode, members, leaderCarIdx, qualifyingGrid]);
 
     const axisCaption = useMemo(
       () => axisCaptionFor(mode, built.reference),
@@ -354,6 +370,7 @@ export const LapGraphView = memo(
           isPlayer: member.isPlayer,
           position: positions.get(member.carIdx),
           hasLine: drawn.has(member.carIdx),
+          gridSlot: qualifyingGrid.get(member.carIdx) ?? FALLBACK_GRID_SLOT,
         }))
         .sort(
           (a, b) =>
@@ -362,7 +379,7 @@ export const LapGraphView = memo(
         );
       // Deliberately keyed on the positions signature, not the list identity.
       // eslint-disable-next-line @eslint-react/exhaustive-deps
-    }, [members, built.series, positionsKey]);
+    }, [members, built.series, positionsKey, qualifyingGrid]);
 
     const emptyMessage = useMemo(() => {
       if (sessionType && sessionType !== 'Race') {
@@ -483,7 +500,8 @@ export const LapGraphView = memo(
           </div>
           <LapGraphDriverList
             drivers={roster}
-            classColor={classColor}
+            classColorValue={classColorValue}
+            isMultiClass={isMultiClass}
             shownCarIdxs={pinnedCarIdxs}
             focusedCarIdx={focusedCarIdx}
             onToggle={togglePin}

--- a/src/frontend/components/Gantry/components/LapGraph/LapGraphView.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/LapGraphView.tsx
@@ -4,7 +4,7 @@ import { useQualifyingGrid } from '@irdashies/domain/standings/useQualifyingGrid
 import {
   classReferenceLap,
   gapToClassLeader,
-  positionByLap,
+  positionsByLap,
   raceTrace,
   readCrossings,
   traceAnchor,
@@ -298,17 +298,28 @@ export const LapGraphView = memo(
         ? traceAnchor(leaderCrossings, reference.seconds)
         : undefined;
 
-      const series: LapGraphSeries[] = [];
+      // Read every car once: position mode ranks the whole class against
+      // itself, so it needs the field before it can place any single car.
+      const crossingsByCar = new Map<number, LapCrossing[]>();
       for (const member of members) {
-        const crossings: LapCrossing[] =
+        const crossings =
           member.carIdx === leaderCarIdx
             ? leaderCrossings
             : readCrossings(history, member.carIdx);
-        if (crossings.length === 0) continue;
+        if (crossings.length > 0) crossingsByCar.set(member.carIdx, crossings);
+      }
+
+      const positionPoints =
+        mode === 'position' ? positionsByLap(crossingsByCar) : undefined;
+
+      const series: LapGraphSeries[] = [];
+      for (const member of members) {
+        const crossings = crossingsByCar.get(member.carIdx);
+        if (!crossings) continue;
 
         let points: LapPoint[];
         if (mode === 'position') {
-          points = positionByLap(crossings);
+          points = positionPoints?.get(member.carIdx) ?? [];
         } else if (mode === 'gap') {
           points = gapToClassLeader(crossings, leaderCrossings);
         } else if (reference && anchor) {

--- a/src/frontend/components/Gantry/components/LapGraph/components/LapGraphDriverList/LapGraphDriverList.spec.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/components/LapGraphDriverList/LapGraphDriverList.spec.tsx
@@ -2,6 +2,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { LapGraphDriverList } from './LapGraphDriverList';
 import type { DriverListEntry } from './LapGraphDriverList';
+import {
+  identityForGridSlot,
+  swatchDashArrayForGridSlot,
+} from '../../lapGraphPalette';
 
 const drivers: DriverListEntry[] = [
   {
@@ -11,6 +15,7 @@ const drivers: DriverListEntry[] = [
     position: 1,
     isPlayer: false,
     hasLine: true,
+    gridSlot: 1,
   },
   {
     carIdx: 2,
@@ -19,6 +24,7 @@ const drivers: DriverListEntry[] = [
     position: 2,
     isPlayer: true,
     hasLine: true,
+    gridSlot: 2,
   },
   {
     carIdx: 3,
@@ -27,6 +33,7 @@ const drivers: DriverListEntry[] = [
     position: 3,
     isPlayer: false,
     hasLine: false,
+    gridSlot: 3,
   },
 ];
 
@@ -38,7 +45,8 @@ const renderList = (
   render(
     <LapGraphDriverList
       drivers={drivers}
-      classColor="#22c55e"
+      classColorValue={0x22c55e}
+      isMultiClass={false}
       shownCarIdxs={[1]}
       focusedCarIdx={null}
       onToggle={onToggle}
@@ -127,5 +135,65 @@ describe('LapGraphDriverList', () => {
     fireEvent.click(row);
 
     expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('shows the class colour on the car-number chip in multi-class', () => {
+    // 16767577 is iRacing's class-1 (yellow) colour decimal.
+    renderList({ classColorValue: 16767577, isMultiClass: true });
+
+    const chip = screen.getByText('#11').parentElement;
+    expect(chip?.className).toContain('bg-yellow-800');
+  });
+
+  it("renders the swatch colour and dash pattern for the driver's grid slot", () => {
+    const solidIdentity = identityForGridSlot(1);
+    const dashedIdentity = identityForGridSlot(11);
+    const roster: DriverListEntry[] = [
+      {
+        carIdx: 10,
+        carNumber: '5',
+        displayName: 'Solid Driver',
+        position: 1,
+        isPlayer: false,
+        hasLine: true,
+        gridSlot: 1,
+      },
+      {
+        carIdx: 11,
+        carNumber: '6',
+        displayName: 'Dashed Driver',
+        position: 2,
+        isPlayer: false,
+        hasLine: true,
+        gridSlot: 11,
+      },
+    ];
+    renderList({ drivers: roster, shownCarIdxs: [10, 11] });
+
+    const solidLine = screen
+      .getByTitle(/Hide Solid Driver/)
+      .querySelector('line');
+    const dashedLine = screen
+      .getByTitle(/Hide Dashed Driver/)
+      .querySelector('line');
+
+    expect(solidLine).toHaveAttribute('stroke', solidIdentity.color);
+    expect(solidLine).not.toHaveAttribute('stroke-dasharray');
+    expect(dashedLine).toHaveAttribute('stroke', dashedIdentity.color);
+    expect(dashedLine).toHaveAttribute(
+      'stroke-dasharray',
+      swatchDashArrayForGridSlot(11)
+    );
+  });
+
+  it('gives player styling precedence over focused and drawn styling', () => {
+    // Hamilton (carIdx 2) is the player. Focus him and leave him unpinned to
+    // exercise every lower-precedence branch at once.
+    renderList({ focusedCarIdx: 2, shownCarIdxs: [] });
+
+    const playerRow = screen.getByTitle(/always drawn/);
+    expect(playerRow.className).toContain('bg-yellow-500/20');
+    expect(playerRow.className).toContain('text-amber-300');
+    expect(playerRow.className).not.toContain('bg-sky-500/20');
   });
 });

--- a/src/frontend/components/Gantry/components/LapGraph/components/LapGraphDriverList/LapGraphDriverList.stories.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/components/LapGraphDriverList/LapGraphDriverList.stories.tsx
@@ -23,7 +23,9 @@ interface DriverListArgs {
   /** Drivers at the back of the list still on their opening lap. */
   withoutLines: number;
   playerIndex: number;
-  classColor: string;
+  /** Numeric class colour, shared by every line in the chart. */
+  classColorValue: number;
+  isMultiClass: boolean;
   shownCarIdxs: number[];
   focusedCarIdx: number | null;
 }
@@ -40,10 +42,17 @@ const buildRoster = ({
     position: index + 1,
     isPlayer: index === playerIndex,
     hasLine: index < driverCount - withoutLines,
+    // Sequential grid slots walk through every identity pattern once the
+    // roster passes 10 (dashed), 20 (dotted) and 30 (dash-dot) drivers.
+    gridSlot: index + 1,
   }));
 
+interface HarnessProps {
+  args: DriverListArgs;
+}
+
 /** Toggling and hovering are callbacks, so the story owns that state. */
-const Harness = (args: DriverListArgs) => {
+const Harness = ({ args }: HarnessProps) => {
   const drivers = useMemo(() => buildRoster(args), [args]);
   const [shown, setShown] = useState<readonly number[]>(args.shownCarIdxs);
   const [hovered, setHovered] = useState<number | null>(args.focusedCarIdx);
@@ -55,7 +64,8 @@ const Harness = (args: DriverListArgs) => {
       </div>
       <LapGraphDriverList
         drivers={drivers}
-        classColor={args.classColor}
+        classColorValue={args.classColorValue}
+        isMultiClass={args.isMultiClass}
         shownCarIdxs={shown}
         focusedCarIdx={hovered}
         onToggle={(carIdx) =>
@@ -79,14 +89,23 @@ const meta: Meta = {
     driverCount: SURNAMES.length,
     withoutLines: 2,
     playerIndex: 3,
-    classColor: '#22c55e',
+    // 16767577 is iRacing's class-1 (yellow) colour decimal.
+    classColorValue: 16767577,
+    isMultiClass: false,
     shownCarIdxs: [0, 1],
     focusedCarIdx: null,
   },
   argTypes: {
-    classColor: {
-      control: 'color',
-      description: 'Class colour, shared by every line in the chart.',
+    classColorValue: {
+      control: 'number',
+      description:
+        'Numeric class colour, shared by every line in the chart. Only visible on the car-number chip when isMultiClass is true.',
+      table: { category: 'Props' },
+    },
+    isMultiClass: {
+      control: 'boolean',
+      description:
+        'Whether the session has more than one car class, which puts the class colour on the car-number chip.',
       table: { category: 'Props' },
     },
     shownCarIdxs: {
@@ -117,7 +136,7 @@ const meta: Meta = {
   },
   // Remounted on an arg change so the pin state re-seeds from the control.
   render: (args) => (
-    <Harness key={JSON.stringify(args)} {...(args as DriverListArgs)} />
+    <Harness key={JSON.stringify(args)} args={args as DriverListArgs} />
   ),
 };
 export default meta;
@@ -127,4 +146,23 @@ export const Field: Story = {};
 
 export const WaitingForTheGrid: Story = {
   args: { driverCount: 0, shownCarIdxs: [] },
+};
+
+export const MultiClass: Story = {
+  args: {
+    isMultiClass: true,
+    // 3395327 is iRacing's class-2 (blue) colour decimal.
+    classColorValue: 3395327,
+  },
+};
+
+export const IdentityPatterns: Story = {
+  args: {
+    // 34 grid slots shows all four patterns in one roster: solid (1-10),
+    // dashed (11-20), dotted (21-30) and into dash-dot (31-34).
+    driverCount: 34,
+    withoutLines: 0,
+    playerIndex: 0,
+    shownCarIdxs: Array.from({ length: 34 }, (_, index) => index),
+  },
 };

--- a/src/frontend/components/Gantry/components/LapGraph/components/LapGraphDriverList/LapGraphDriverList.tsx
+++ b/src/frontend/components/Gantry/components/LapGraph/components/LapGraphDriverList/LapGraphDriverList.tsx
@@ -1,5 +1,9 @@
-import { memo } from 'react';
-import { brightenColor } from './useLapGraphSeries';
+import { memo, useMemo } from 'react';
+import { getTailwindStyle } from '@irdashies/utils/colors';
+import {
+  identityForGridSlot,
+  swatchDashArrayForGridSlot,
+} from '../../lapGraphPalette';
 
 export interface DriverListEntry {
   carIdx: number;
@@ -11,13 +15,17 @@ export interface DriverListEntry {
   isPlayer: boolean;
   /** False until the car has completed a lap the chart can draw. */
   hasLine: boolean;
+  /** Qualifying grid slot driving the line's colour/pattern identity. */
+  gridSlot: number;
 }
 
 export interface LapGraphDriverListProps {
   /** Drivers in the selected class, leader first. */
   drivers: readonly DriverListEntry[];
-  /** Class colour, shared by every line in the chart. */
-  classColor: string;
+  /** Numeric class colour, shared by every line in the chart. */
+  classColorValue: number;
+  /** Whether the session currently has more than one car class. */
+  isMultiClass: boolean;
   /** Cars currently drawn at full strength. */
   shownCarIdxs: readonly number[];
   /** The one line drawn brightest, from the Follow control or list hover. */
@@ -29,20 +37,30 @@ export interface LapGraphDriverListProps {
 /**
  * The class roster down the side of the chart, in running order. Clicking a
  * name draws that car's line; hovering one lifts it above the field.
+ *
+ * Row styling replicates Standings' DriverInfoRow/cell classes directly —
+ * Rule N3 forbids importing from another widget folder, so this is a
+ * deliberate copy, same as Battle.tsx does for the same cells.
  */
 export const LapGraphDriverList = memo(
   ({
     drivers,
-    classColor,
+    classColorValue,
+    isMultiClass,
     shownCarIdxs,
     focusedCarIdx,
     onToggle,
     onHover,
   }: LapGraphDriverListProps) => {
     const shown = new Set(shownCarIdxs);
+    // Match CarNumberCell: class-colour chip via the same shared helper.
+    const tailwindStyles = useMemo(
+      () => getTailwindStyle(classColorValue, undefined, isMultiClass),
+      [classColorValue, isMultiClass]
+    );
 
     return (
-      <div className="w-[24ch] max-w-[40%] shrink-0 flex flex-col min-h-0 border-l border-slate-700/50 pl-2">
+      <div className="w-[24ch] max-w-[40%] shrink-0 flex flex-col min-h-0 border-l border-slate-700/50 pl-2 text-sm">
         <div className="shrink-0 pb-1 text-slate-500 font-bold uppercase tracking-wider">
           Drivers
         </div>
@@ -57,6 +75,23 @@ export const LapGraphDriverList = memo(
             // The player's line is always drawn, so toggling it would change
             // nothing on screen while latching the auto-pin set off.
             const canToggle = entry.hasLine && !entry.isPlayer;
+            const identity = identityForGridSlot(entry.gridSlot);
+            const swatchDashArray = swatchDashArrayForGridSlot(entry.gridSlot);
+
+            // One mutually-exclusive chain, highest precedence first, so two
+            // same-specificity utilities never fight over stylesheet order.
+            // No `hover:` variants: pointing at a row focuses it, so the
+            // focused branch is already what the pointer sees.
+            const rowStateClasses = entry.isPlayer
+              ? 'bg-yellow-500/20 text-amber-300'
+              : !entry.hasLine
+                ? 'odd:bg-slate-800/70 even:bg-slate-900/70 text-slate-600'
+                : isFocused
+                  ? 'bg-sky-500/20 text-white'
+                  : isShown
+                    ? 'odd:bg-slate-800/70 even:bg-slate-900/70 text-slate-100'
+                    : 'odd:bg-slate-800/70 even:bg-slate-900/70 text-slate-500';
+
             return (
               <button
                 key={entry.carIdx}
@@ -83,37 +118,42 @@ export const LapGraphDriverList = memo(
                 className={[
                   'flex items-center gap-1.5 w-full px-1 py-0.5 rounded-sm text-left',
                   'focus:outline-none focus:ring-1 focus:ring-sky-400',
-                  !entry.hasLine
-                    ? 'text-slate-600'
-                    : isFocused
-                      ? 'bg-sky-500/20 text-white'
-                      : isShown
-                        ? 'text-slate-200 hover:bg-slate-700/40'
-                        : 'text-slate-500 hover:bg-slate-800/70',
-                  entry.isPlayer ? 'text-amber-300' : '',
+                  rowStateClasses,
+                  // Kept out of the chain above: cursor is not a colour
+                  // utility, so it has no ordering conflict to resolve.
                   canToggle ? 'cursor-pointer' : 'cursor-default',
-                ]
-                  .filter(Boolean)
-                  .join(' ')}
+                ].join(' ')}
               >
                 <span className="w-5 shrink-0 text-right tabular-nums text-slate-500">
                   {entry.position ?? '-'}
                 </span>
                 <span
-                  className="w-1.5 h-3 shrink-0 rounded-xs border border-slate-600"
-                  style={{
-                    backgroundColor: isShown
-                      ? isFocused
-                        ? brightenColor(classColor)
-                        : classColor
-                      : 'transparent',
-                  }}
-                />
-                <span className="w-[4ch] shrink-0 tabular-nums">
-                  #{entry.carNumber}
+                  className={`${tailwindStyles.driverIcon} border-l-4 text-white text-right px-1 whitespace-nowrap`}
+                >
+                  <span className="inline-block min-w-[4ch]">
+                    #{entry.carNumber}
+                  </span>
                 </span>
-                <span className="flex-1 min-w-0 truncate">
-                  {entry.displayName}
+                <svg
+                  width="14"
+                  height="10"
+                  viewBox="0 0 14 10"
+                  aria-hidden="true"
+                  className="shrink-0"
+                >
+                  <line
+                    x1={1}
+                    y1={5}
+                    x2={13}
+                    y2={5}
+                    stroke={identity.color}
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeDasharray={swatchDashArray}
+                  />
+                </svg>
+                <span className="flex-1 min-w-0">
+                  <span className="block truncate">{entry.displayName}</span>
                 </span>
               </button>
             );

--- a/src/frontend/components/Gantry/components/LapGraph/lapGraphPalette.spec.ts
+++ b/src/frontend/components/Gantry/components/LapGraph/lapGraphPalette.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  IDENTITY_COLORS,
+  identityForGridSlot,
+  scaleDash,
+  swatchDashArrayForGridSlot,
+} from './lapGraphPalette';
+
+describe('IDENTITY_COLORS', () => {
+  it('has exactly ten colours, in ramp order', () => {
+    expect(IDENTITY_COLORS).toEqual([
+      '#199e70',
+      '#9085e9',
+      '#e66767',
+      '#c026d3',
+      '#008300',
+      '#0891b2',
+      '#c98500',
+      '#d55181',
+      '#3987e5',
+      '#d95926',
+    ]);
+  });
+
+  it('holds ten distinct colours', () => {
+    expect(new Set(IDENTITY_COLORS).size).toBe(10);
+  });
+});
+
+/**
+ * The ramp values live in the assertion above and nowhere else. Everything
+ * below indexes into it, so a re-step only has to touch one place.
+ */
+const FIRST = IDENTITY_COLORS[0];
+const LAST = IDENTITY_COLORS[9];
+
+describe('identityForGridSlot', () => {
+  it('gives positions 1-10 solid lines in ramp order', () => {
+    expect(identityForGridSlot(1)).toEqual({
+      color: FIRST,
+      dash: [],
+    });
+    expect(identityForGridSlot(10)).toEqual({
+      color: LAST,
+      dash: [],
+    });
+  });
+
+  it('gives positions 11-20 the dashed pattern, colours repeating', () => {
+    expect(identityForGridSlot(11)).toEqual({
+      color: FIRST,
+      dash: [7, 4],
+    });
+    expect(identityForGridSlot(20)).toEqual({
+      color: LAST,
+      dash: [7, 4],
+    });
+  });
+
+  it('gives positions 21-30 the dotted pattern', () => {
+    expect(identityForGridSlot(21)).toEqual({
+      color: FIRST,
+      dash: [2, 3],
+    });
+    expect(identityForGridSlot(30)).toEqual({
+      color: LAST,
+      dash: [2, 3],
+    });
+  });
+
+  it('gives positions 31-40 the dash-dot pattern', () => {
+    expect(identityForGridSlot(31)).toEqual({
+      color: FIRST,
+      dash: [7, 3, 2, 3],
+    });
+    expect(identityForGridSlot(40)).toEqual({
+      color: LAST,
+      dash: [7, 3, 2, 3],
+    });
+  });
+
+  it('wraps every 40 slots, colliding slot 41 with slot 1', () => {
+    expect(identityForGridSlot(41)).toEqual(identityForGridSlot(1));
+    expect(identityForGridSlot(52)).toEqual(identityForGridSlot(12));
+  });
+});
+
+describe('scaleDash', () => {
+  it('leaves solid alone', () => {
+    expect(scaleDash([], 3)).toEqual([]);
+  });
+
+  it('multiplies every entry by the line width', () => {
+    expect(scaleDash([7, 4], 2)).toEqual([14, 8]);
+    expect(scaleDash([2, 3], 3)).toEqual([6, 9]);
+    expect(scaleDash([7, 3, 2, 3], 3)).toEqual([21, 9, 6, 9]);
+  });
+
+  it('does not mutate the source array', () => {
+    const dash = [7, 4];
+    scaleDash(dash, 5);
+    expect(dash).toEqual([7, 4]);
+  });
+});
+
+describe('swatchDashArrayForGridSlot', () => {
+  it('omits the attribute for solid', () => {
+    expect(swatchDashArrayForGridSlot(1)).toBeUndefined();
+  });
+
+  it('uses the swatch-tuned values for each pattern', () => {
+    expect(swatchDashArrayForGridSlot(11)).toBe('4 2');
+    expect(swatchDashArrayForGridSlot(21)).toBe('1.5 2');
+    expect(swatchDashArrayForGridSlot(31)).toBe('4 1.5 1 1.5');
+  });
+
+  it('wraps in step with identityForGridSlot', () => {
+    expect(swatchDashArrayForGridSlot(41)).toBe(swatchDashArrayForGridSlot(1));
+  });
+});

--- a/src/frontend/components/Gantry/components/LapGraph/lapGraphPalette.ts
+++ b/src/frontend/components/Gantry/components/LapGraph/lapGraphPalette.ts
@@ -1,0 +1,106 @@
+/**
+ * Per-driver line identity: colour + dash pattern, keyed off qualifying grid
+ * slot (1-based). Fixed for the whole race — carIdx and qualifying position
+ * never change mid-session, so a driver's identity never does either.
+ *
+ * identityIndex = slot - 1
+ * colorIndex    = identityIndex % 10
+ * patternIndex  = floor(identityIndex / 10) % 4
+ *
+ * 10 colours x 4 patterns = 40 unique identities, then the ramp repeats.
+ * Slot 41 collides with slot 1. Deliberate: cars that deep in the field are
+ * drawn at context (faint background) strength anyway, and the readout and
+ * driver list always resolve identity from carIdx, never from colour alone.
+ */
+
+/**
+ * Qualifying positions 1-10, solid.
+ *
+ * Stepped for the dark plot surface (#0f172a) and ordered so that adjacent
+ * grid slots sit as far apart as possible, which is what a reader actually
+ * compares. Verified with the dataviz palette validator on the adjacent
+ * pairlist (the one that applies to line charts): worst adjacent deltaE 13.2
+ * under deuteranopia, 19.3 under normal vision, every check passing.
+ *
+ * Do not re-order or re-shade by eye. The previous ramp was a smooth hue
+ * sweep, which put emerald next to teal at deltaE 5.2 (normal vision) and
+ * fuchsia next to violet at 0.4 (protanopia) — indistinguishable in practice.
+ * Re-run the validator before changing any value here.
+ *
+ * Ten colours cannot all be mutually distinguishable: under an all-pairs test
+ * only three clear the floors, on any surface. Identity therefore also rests
+ * on the dash pattern, the driver-list swatch, and the hover readout, which
+ * name the car directly.
+ */
+export const IDENTITY_COLORS: readonly string[] = [
+  '#199e70', // 1 aqua
+  '#9085e9', // 2 violet
+  '#e66767', // 3 red
+  '#c026d3', // 4 fuchsia
+  '#008300', // 5 green
+  '#0891b2', // 6 cyan
+  '#c98500', // 7 gold
+  '#d55181', // 8 magenta
+  '#3987e5', // 9 blue
+  '#d95926', // 10 orange
+];
+
+/** Base canvas dash arrays at lineWidth 1 (CSS px), in ramp order. */
+const BASE_CANVAS_DASH: readonly (readonly number[])[] = [
+  [], // solid: positions 1-10
+  [7, 4], // dashed: positions 11-20
+  [2, 3], // dotted: positions 21-30
+  [7, 3, 2, 3], // dash-dot: positions 31-40
+];
+
+/**
+ * `stroke-dasharray` values for the driver-list legend swatch. Tuned smaller
+ * than the canvas dash table above: the swatch is ~14px wide and needs its
+ * own numbers to read as a pattern rather than a line with a stray gap.
+ * `undefined` for solid omits the attribute entirely.
+ */
+const SWATCH_DASH_ARRAYS: readonly (string | undefined)[] = [
+  undefined,
+  '4 2',
+  '1.5 2',
+  '4 1.5 1 1.5',
+];
+
+export interface LineIdentity {
+  color: string;
+  /** Unscaled base dash pattern, at lineWidth 1. Scale with `scaleDash`. */
+  dash: readonly number[];
+}
+
+/**
+ * Slots are 1-based. Anything lower (or non-finite) would index the ramps
+ * negatively and hand back `undefined`, which reaches the canvas as a crash
+ * rather than a wrong colour, so clamp rather than trust the caller.
+ */
+const identityIndexForGridSlot = (slot: number): number =>
+  Number.isFinite(slot) ? Math.max(0, Math.floor(slot) - 1) : 0;
+
+const patternIndexForGridSlot = (slot: number): number =>
+  Math.floor(identityIndexForGridSlot(slot) / IDENTITY_COLORS.length) %
+  BASE_CANVAS_DASH.length;
+
+/** Colour + base dash pattern for a 1-based qualifying grid slot. */
+export const identityForGridSlot = (slot: number): LineIdentity => ({
+  color:
+    IDENTITY_COLORS[identityIndexForGridSlot(slot) % IDENTITY_COLORS.length],
+  dash: BASE_CANVAS_DASH[patternIndexForGridSlot(slot)],
+});
+
+/**
+ * Scales a base dash pattern to a stroke width, so dash and gap length stay
+ * proportional to the line rather than shrinking into a blob at width 1 or
+ * blowing out at width 3. Solid (`[]`) is unaffected either way.
+ */
+export const scaleDash = (
+  dash: readonly number[],
+  lineWidth: number
+): number[] => dash.map((segment) => segment * lineWidth);
+
+/** `stroke-dasharray` for the driver-list legend swatch at a grid slot. */
+export const swatchDashArrayForGridSlot = (slot: number): string | undefined =>
+  SWATCH_DASH_ARRAYS[patternIndexForGridSlot(slot)];

--- a/src/frontend/components/Gantry/components/LapGraph/useLapGraphSeries.spec.ts
+++ b/src/frontend/components/Gantry/components/LapGraph/useLapGraphSeries.spec.ts
@@ -33,6 +33,7 @@ const makeSeries = (
   displayName: `Driver ${carIdx}`,
   isPlayer: false,
   color: '#22c55e',
+  dash: [],
   points,
   ...overrides,
 });
@@ -238,18 +239,27 @@ describe('emphasis tiers', () => {
   });
 
   it('gives each tier a distinct weight', () => {
-    expect(strokeStyleFor('context', '#22c55e')).toEqual({
+    expect(strokeStyleFor('context', '#22c55e', [7, 4])).toEqual({
       color: '#22c55e',
       width: 1,
       alpha: CONTEXT_ALPHA,
+      dash: [7, 4],
     });
-    expect(strokeStyleFor('pinned', '#22c55e').width).toBe(2);
-    expect(strokeStyleFor('focus', '#22c55e').width).toBe(3);
+    expect(strokeStyleFor('pinned', '#22c55e', [7, 4]).width).toBe(2);
+    expect(strokeStyleFor('focus', '#22c55e', [7, 4]).width).toBe(3);
   });
 
   it('brightens only the focus tier', () => {
-    expect(strokeStyleFor('focus', '#22c55e').color).not.toBe('#22c55e');
-    expect(strokeStyleFor('pinned', '#22c55e').color).toBe('#22c55e');
+    expect(strokeStyleFor('focus', '#22c55e', []).color).not.toBe('#22c55e');
+    expect(strokeStyleFor('pinned', '#22c55e', []).color).toBe('#22c55e');
+  });
+
+  it('keeps the identity dash pattern at every tier, including focus', () => {
+    const dash = [7, 4];
+
+    expect(strokeStyleFor('context', '#22c55e', dash).dash).toBe(dash);
+    expect(strokeStyleFor('pinned', '#22c55e', dash).dash).toBe(dash);
+    expect(strokeStyleFor('focus', '#22c55e', dash).dash).toBe(dash);
   });
 });
 

--- a/src/frontend/components/Gantry/components/LapGraph/useLapGraphSeries.ts
+++ b/src/frontend/components/Gantry/components/LapGraph/useLapGraphSeries.ts
@@ -24,8 +24,10 @@ export interface LapGraphSeries {
   /** Already formatted for display. Do not reformat. */
   displayName: string;
   isPlayer: boolean;
-  /** CSS colour string, already resolved from the car class. */
+  /** CSS colour string, resolved from the driver's qualifying grid identity. */
   color: string;
+  /** Unscaled identity dash pattern, at lineWidth 1. See `lapGraphPalette`. */
+  dash: readonly number[];
   points: readonly LapPoint[];
 }
 
@@ -36,6 +38,8 @@ export interface StrokeStyle {
   color: string;
   width: number;
   alpha: number;
+  /** Unscaled identity dash pattern. Scale with `scaleDash` before drawing. */
+  dash: readonly number[];
 }
 
 export interface PreparedSeries {
@@ -237,16 +241,22 @@ export const brightenColor = (color: string, amount = 0.4): string => {
 
 export const CONTEXT_ALPHA = 0.15;
 
-/** The three emphasis tiers from the plan, as concrete stroke settings. */
+/**
+ * The three emphasis tiers from the plan, as concrete stroke settings. The
+ * dash pattern is the driver's fixed identity and is never flattened by
+ * tier — a focused line keeps its shape, only brighter and wider, so it
+ * never comes to look like a different driver's regular line.
+ */
 export const strokeStyleFor = (
   tier: EmphasisTier,
-  color: string
+  color: string,
+  dash: readonly number[]
 ): StrokeStyle => {
   if (tier === 'focus') {
-    return { color: brightenColor(color), width: 3, alpha: 1 };
+    return { color: brightenColor(color), width: 3, alpha: 1, dash };
   }
-  if (tier === 'pinned') return { color, width: 2, alpha: 1 };
-  return { color, width: 1, alpha: CONTEXT_ALPHA };
+  if (tier === 'pinned') return { color, width: 2, alpha: 1, dash };
+  return { color, width: 1, alpha: CONTEXT_ALPHA, dash };
 };
 
 /**
@@ -315,7 +325,7 @@ export const prepareLapGraph = ({
     prepared.push({
       source: entry,
       tier,
-      stroke: strokeStyleFor(tier, entry.color),
+      stroke: strokeStyleFor(tier, entry.color, entry.dash),
       points,
     });
   }

--- a/src/frontend/domain/lapHistory/lapSeries.spec.ts
+++ b/src/frontend/domain/lapHistory/lapSeries.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   traceAnchor,
   gapToClassLeader,
-  positionByLap,
+  positionsByLap,
   raceTrace,
   traceOrigin,
 } from './lapSeries';
@@ -176,34 +176,120 @@ describe('gapToClassLeader', () => {
   });
 });
 
-describe('positionByLap', () => {
-  it('maps laps to in-class positions', () => {
-    const points = positionByLap([
-      crossing(1, 100, { classPosition: 4 }),
-      crossing(2, 190, { classPosition: 3 }),
-      crossing(3, 280, { classPosition: 3 }),
-      crossing(4, 370, { classPosition: 1 }),
-    ]);
+describe('positionsByLap', () => {
+  const field = (
+    cars: Record<number, [lap: number, sessionTime: number][]>
+  ): Map<number, LapCrossing[]> =>
+    new Map(
+      Object.entries(cars).map(([carIdx, laps]) => [
+        Number(carIdx),
+        laps.map(([lap, sessionTime]) => crossing(lap, sessionTime)),
+      ])
+    );
 
-    expect(points).toEqual([
-      { lap: 1, value: 4 },
-      { lap: 2, value: 3 },
-      { lap: 3, value: 3 },
-      { lap: 4, value: 1 },
+  it('ranks each lap by who crossed the line first', () => {
+    const points = positionsByLap(
+      field({
+        7: [
+          [1, 100],
+          [2, 200],
+        ],
+        8: [
+          [1, 90],
+          [2, 210],
+        ],
+      })
+    );
+
+    // Car 8 led lap 1 and lost the place on lap 2.
+    expect(points.get(8)).toEqual([
+      { lap: 1, value: 1 },
+      { lap: 2, value: 2 },
+    ]);
+    expect(points.get(7)).toEqual([
+      { lap: 1, value: 2 },
+      { lap: 2, value: 1 },
     ]);
   });
 
-  it('skips crossings with an unknown position', () => {
-    const points = positionByLap([
-      crossing(1, 100, { classPosition: 0 }),
-      crossing(2, 190, { classPosition: 2 }),
+  it('ignores classPosition entirely', () => {
+    // The regression this exists for: iRacing left classPosition at 0 for 81%
+    // of crossings in a real race, which silently truncated the chart.
+    const crossings = new Map<number, LapCrossing[]>([
+      [1, [crossing(5, 500, { classPosition: 0 })]],
+      [2, [crossing(5, 400, { classPosition: 0 })]],
     ]);
 
-    expect(points).toEqual([{ lap: 2, value: 2 }]);
+    expect(positionsByLap(crossings).get(2)).toEqual([{ lap: 5, value: 1 }]);
+    expect(positionsByLap(crossings).get(1)).toEqual([{ lap: 5, value: 2 }]);
   });
 
-  it('returns nothing without crossings', () => {
-    expect(positionByLap([])).toEqual([]);
+  it('places a lapped car behind cars that finished the lap earlier', () => {
+    const points = positionsByLap(
+      field({
+        1: [[3, 300]],
+        2: [[3, 900]],
+      })
+    );
+
+    expect(points.get(2)).toEqual([{ lap: 3, value: 2 }]);
+  });
+
+  it('gives a car no point for a lap it never completed', () => {
+    const points = positionsByLap(
+      field({
+        1: [
+          [1, 100],
+          [2, 200],
+        ],
+        2: [[1, 110]],
+      })
+    );
+
+    expect(points.get(2)).toEqual([{ lap: 1, value: 2 }]);
+    expect(points.get(1)).toHaveLength(2);
+  });
+
+  it('keeps the first crossing when a lap is recorded twice', () => {
+    // A tow or reset re-baselines the car and can record the lap again.
+    const points = positionsByLap(
+      new Map<number, LapCrossing[]>([
+        [1, [crossing(2, 250), crossing(2, 800)]],
+        [2, [crossing(2, 400)]],
+      ])
+    );
+
+    expect(points.get(1)).toEqual([{ lap: 2, value: 1 }]);
+  });
+
+  it('skips crossings with no usable session time', () => {
+    const points = positionsByLap(
+      new Map<number, LapCrossing[]>([
+        [1, [crossing(1, 0)]],
+        [2, [crossing(1, 120)]],
+      ])
+    );
+
+    expect(points.has(1)).toBe(false);
+    expect(points.get(2)).toEqual([{ lap: 1, value: 1 }]);
+  });
+
+  it('returns points in lap order', () => {
+    const points = positionsByLap(
+      field({
+        1: [
+          [3, 300],
+          [1, 100],
+          [2, 200],
+        ],
+      })
+    );
+
+    expect(points.get(1)?.map((p) => p.lap)).toEqual([1, 2, 3]);
+  });
+
+  it('handles an empty field', () => {
+    expect(positionsByLap(new Map()).size).toBe(0);
   });
 });
 

--- a/src/frontend/domain/lapHistory/lapSeries.ts
+++ b/src/frontend/domain/lapHistory/lapSeries.ts
@@ -97,16 +97,61 @@ export const gapToClassLeader = (
   return points;
 };
 
-/** In-class position at each recorded lap. */
-export const positionByLap = (
-  crossings: readonly LapCrossing[]
-): LapPoint[] => {
-  const points: LapPoint[] = [];
+/**
+ * Position at the end of each lap for a whole field, derived from the order
+ * cars crossed the line rather than from `classPosition`.
+ *
+ * `CarIdxClassPosition` cannot be trusted: iRacing leaves it at 0 for most
+ * crossings — 81% of them in a measured 20-lap race, and every crossing after
+ * lap 6 — which truncated the chart at the last lap it happened to populate.
+ * `lap` and `sessionTime` are always recorded, so rank on those instead.
+ *
+ * Ranking by crossing time is exact, lapped cars included: if another car
+ * completed the same lap earlier it is ahead, whether it is on this lap or
+ * several ahead. Cars that never completed a lap simply have no point for it.
+ *
+ * Pass one class's crossings to get class position; pass the field to get
+ * overall position.
+ */
+export const positionsByLap = (
+  crossingsByCar: ReadonlyMap<number, readonly LapCrossing[]>
+): Map<number, LapPoint[]> => {
+  // lap -> [carIdx, earliest sessionTime on that lap]
+  const byLap = new Map<number, { carIdx: number; sessionTime: number }[]>();
 
-  for (const crossing of crossings) {
-    // The processor records 0 when the position was unknown at the crossing.
-    if (crossing.classPosition <= 0) continue;
-    points.push({ lap: crossing.lap, value: crossing.classPosition });
+  for (const [carIdx, crossings] of crossingsByCar) {
+    const earliest = new Map<number, number>();
+    for (const crossing of crossings) {
+      if (!(crossing.sessionTime > 0)) continue;
+      const seen = earliest.get(crossing.lap);
+      // A lap can be recorded twice (a tow or reset re-baselines the car).
+      // The first crossing is the one that decides track order.
+      if (seen === undefined || crossing.sessionTime < seen) {
+        earliest.set(crossing.lap, crossing.sessionTime);
+      }
+    }
+    for (const [lap, sessionTime] of earliest) {
+      const entries = byLap.get(lap);
+      if (entries) entries.push({ carIdx, sessionTime });
+      else byLap.set(lap, [{ carIdx, sessionTime }]);
+    }
+  }
+
+  const points = new Map<number, LapPoint[]>();
+  for (const [lap, entries] of byLap) {
+    entries.sort((a, b) => a.sessionTime - b.sessionTime);
+    entries.forEach((entry, index) => {
+      const existing = points.get(entry.carIdx);
+      const point = { lap, value: index + 1 };
+      if (existing) existing.push(point);
+      else points.set(entry.carIdx, [point]);
+    });
+  }
+
+  // The map is filled lap-group by lap-group, so each car's points arrive out
+  // of order. Everything downstream assumes lap-ordered points.
+  for (const carPoints of points.values()) {
+    carPoints.sort((a, b) => a.lap - b.lap);
   }
 
   return points;

--- a/src/frontend/domain/standings/index.ts
+++ b/src/frontend/domain/standings/index.ts
@@ -6,5 +6,6 @@ export * from './useDriverRelatives';
 export * from './useHighlightColor';
 export * from './useInformationBarSettings';
 export * from './useRadioActiveCarIdxs';
+export * from './useQualifyingGrid';
 export * from './useRelativeSettings';
 export * from './useStandingsSettings';

--- a/src/frontend/domain/standings/useDriverStandings.tsx
+++ b/src/frontend/domain/standings/useDriverStandings.tsx
@@ -4,8 +4,6 @@ import {
   useSessionFastestLaps,
   useSessionIsOfficial,
   useSessionPositions,
-  useSessionQualifyingResults,
-  useSessionQualifyPositions,
   useSessionType,
   useStandingsSnapshot,
   useLapTimeHistory,
@@ -25,8 +23,8 @@ import type { StandingsWidgetSettings } from '@irdashies/types';
 import { useDriverLivePositions } from './useDriverLivePositions';
 import { useStandingsSettings } from './useStandingsSettings';
 import { useRadioActiveCarIdxs } from './useRadioActiveCarIdxs';
+import { useQualifyingResults } from './useQualifyingGrid';
 import { TrackLocation } from '@irdashies/types';
-import type { SessionResults } from '@irdashies/types';
 
 const EMPTY_NUMBERS: number[] = [];
 const EMPTY_BOOLEANS: boolean[] = [];
@@ -66,34 +64,10 @@ export const useDriverStandings = (
   // Use focus car index which handles spectator mode (uses CamCarIdx when spectating)
   const standingsSnapshot = useStandingsSnapshot();
   const driverCarIdx = standingsSnapshot?.focusCarIdx ?? undefined;
-  const qualifyingResultsRaw = useSessionQualifyingResults();
   const sessionNum = standingsSnapshot?.sessionNum ?? undefined;
   const sessionType = useSessionType(sessionNum);
   const positions = useSessionPositions(sessionNum);
-  const sessionQualifyPositions = useSessionQualifyPositions(sessionNum);
-
-  // In heat race format QualifyResultsInfo.Results is null; fall back to the
-  // race session's QualifyPositions which holds the actual starting grid order.
-  const qualifyingResults: SessionResults[] | undefined =
-    qualifyingResultsRaw?.length
-      ? qualifyingResultsRaw
-      : sessionQualifyPositions?.map((q) => ({
-          Position: q.Position + 1,
-          ClassPosition: q.ClassPosition,
-          CarIdx: q.CarIdx,
-          Lap: q.FastestLap,
-          Time: q.FastestTime,
-          FastestLap: q.FastestLap,
-          FastestTime: q.FastestTime,
-          LastTime: -1,
-          LapsLed: 0,
-          LapsComplete: 0,
-          JokerLapsComplete: 0,
-          LapsDriven: 0,
-          Incidents: 0,
-          ReasonOutId: 0,
-          ReasonOutStr: 'Running',
-        }));
+  const qualifyingResults = useQualifyingResults();
   const standingsSettings = useStandingsSettings();
   const useLivePositionStandings = standingsSettings?.useLivePosition ?? false;
   const customClassOrdering = standingsSettings?.customClassOrdering ?? false;

--- a/src/frontend/domain/standings/useQualifyingGrid.spec.ts
+++ b/src/frontend/domain/standings/useQualifyingGrid.spec.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  normalizeQualifyingResults,
+  qualifyingGridSlots,
+} from './useQualifyingGrid';
+import type { SessionQualifyPosition, SessionResults } from '@irdashies/types';
+
+vi.mock('@irdashies/context', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@irdashies/context')>();
+  return {
+    ...actual,
+    useStandingsSnapshot: vi.fn(),
+    useSessionQualifyingResults: vi.fn(),
+    useSessionQualifyPositions: vi.fn(),
+  };
+});
+
+const {
+  useStandingsSnapshot,
+  useSessionQualifyingResults,
+  useSessionQualifyPositions,
+} = await import('@irdashies/context');
+const { useQualifyingGrid, useQualifyingResults } =
+  await import('./useQualifyingGrid');
+
+const qualifyResult = (
+  carIdx: number,
+  classPosition: number,
+  overrides: Partial<SessionResults> = {}
+): SessionResults => ({
+  Position: classPosition + 1,
+  ClassPosition: classPosition,
+  CarIdx: carIdx,
+  Lap: 1,
+  Time: 90,
+  FastestLap: 1,
+  FastestTime: 90,
+  LastTime: 90,
+  LapsLed: 0,
+  LapsComplete: 1,
+  JokerLapsComplete: 0,
+  LapsDriven: 1,
+  Incidents: 0,
+  ReasonOutId: 0,
+  ReasonOutStr: 'Running',
+  ...overrides,
+});
+
+const qualifyPosition = (
+  carIdx: number,
+  classPosition: number
+): SessionQualifyPosition => ({
+  Position: classPosition + 1,
+  ClassPosition: classPosition,
+  CarIdx: carIdx,
+  FastestLap: 1,
+  FastestTime: 90,
+});
+
+describe('normalizeQualifyingResults', () => {
+  it('uses the qualifying results as-is when present', () => {
+    const raw = [qualifyResult(0, 0), qualifyResult(1, 1)];
+
+    expect(normalizeQualifyingResults(raw, undefined)).toBe(raw);
+  });
+
+  it('falls back to QualifyPositions for a heat race, mapping shapes across', () => {
+    const positions = [qualifyPosition(4, 2)];
+
+    const result = normalizeQualifyingResults([], positions);
+
+    expect(result).toEqual([
+      {
+        Position: 4,
+        ClassPosition: 2,
+        CarIdx: 4,
+        Lap: 1,
+        Time: 90,
+        FastestLap: 1,
+        FastestTime: 90,
+        LastTime: -1,
+        LapsLed: 0,
+        LapsComplete: 0,
+        JokerLapsComplete: 0,
+        LapsDriven: 0,
+        Incidents: 0,
+        ReasonOutId: 0,
+        ReasonOutStr: 'Running',
+      },
+    ]);
+  });
+
+  it('falls back when raw results is undefined, not just empty', () => {
+    const positions = [qualifyPosition(0, 0)];
+
+    expect(normalizeQualifyingResults(undefined, positions)).toEqual([
+      expect.objectContaining({ CarIdx: 0, ClassPosition: 0 }),
+    ]);
+  });
+
+  it('returns undefined when there is no qualifying data at all', () => {
+    expect(normalizeQualifyingResults(undefined, undefined)).toBeUndefined();
+    expect(normalizeQualifyingResults([], undefined)).toBeUndefined();
+  });
+});
+
+describe('qualifyingGridSlots', () => {
+  it('assigns ClassPosition + 1 for every driver with a result', () => {
+    const results = [
+      qualifyResult(10, 0),
+      qualifyResult(11, 1),
+      qualifyResult(12, 2),
+    ];
+
+    const slots = qualifyingGridSlots(results, [10, 11, 12]);
+
+    expect(slots.get(10)).toBe(1);
+    expect(slots.get(11)).toBe(2);
+    expect(slots.get(12)).toBe(3);
+  });
+
+  it('places cars missing from qualifying data past the qualified field, by carIdx', () => {
+    const results = [qualifyResult(5, 0), qualifyResult(9, 1)];
+
+    const slots = qualifyingGridSlots(results, [5, 9, 7, 3]);
+
+    expect(slots.get(5)).toBe(1);
+    expect(slots.get(9)).toBe(2);
+    // Highest qualified slot is 2, so unqualified cars start at 3 + carIdx.
+    expect(slots.get(3)).toBe(6);
+    expect(slots.get(7)).toBe(10);
+  });
+
+  it('keeps every slot unchanged when another car leaves the roster', () => {
+    const results = [qualifyResult(5, 0)];
+    const full = qualifyingGridSlots(results, [5, 3, 9, 14]);
+
+    // Car 9 retires and drops out of the standings list.
+    const reduced = qualifyingGridSlots(results, [5, 3, 14]);
+
+    for (const carIdx of [5, 3, 14]) {
+      expect(reduced.get(carIdx)).toBe(full.get(carIdx));
+    }
+  });
+
+  it('keeps unqualified slots unchanged when the whole roster shrinks', () => {
+    const full = qualifyingGridSlots(undefined, [2, 5, 9, 14]);
+    const reduced = qualifyingGridSlots(undefined, [2, 9, 14]);
+
+    // The bug this guards: ranking unqualified cars against the current
+    // roster shifted 9 and 14 down a slot when 5 disappeared, restyling
+    // their lines mid-race.
+    expect(reduced.get(9)).toBe(full.get(9));
+    expect(reduced.get(14)).toBe(full.get(14));
+  });
+
+  it('assigns distinct slots from carIdx alone when there is no qualifying data whatsoever', () => {
+    const slots = qualifyingGridSlots(undefined, [40, 2, 17]);
+
+    expect(slots.get(2)).toBe(3);
+    expect(slots.get(17)).toBe(18);
+    expect(slots.get(40)).toBe(41);
+    expect(new Set(slots.values()).size).toBe(3);
+  });
+
+  it('handles partial data: some cars in results, some entirely absent', () => {
+    const results = [qualifyResult(1, 4)]; // ClassPosition 4 -> slot 5
+
+    const slots = qualifyingGridSlots(results, [1, 2, 3]);
+
+    expect(slots.get(1)).toBe(5);
+    // Unqualified cars sit past the highest known slot, at 6 + carIdx.
+    expect(slots.get(2)).toBe(8);
+    expect(slots.get(3)).toBe(9);
+  });
+
+  it.each([
+    ['NaN', Number.NaN],
+    ['negative', -1],
+    ['null', null as unknown as number],
+  ])('treats a %s ClassPosition as no result', (_label, classPosition) => {
+    const results = [qualifyResult(1, 0, { ClassPosition: classPosition })];
+
+    const slots = qualifyingGridSlots(results, [1]);
+
+    // Falls through to the unqualified branch (0 + 1 + carIdx), rather than
+    // indexing the palette negatively or inheriting the pole sitter's slot.
+    expect(slots.get(1)).toBe(2);
+  });
+
+  it('is deterministic across repeated calls with the same inputs', () => {
+    const results = [qualifyResult(3, 1)];
+    const carIdxs = [3, 8, 1];
+
+    const first = qualifyingGridSlots(results, carIdxs);
+    const second = qualifyingGridSlots(results, carIdxs);
+
+    expect([...first.entries()]).toEqual([...second.entries()]);
+  });
+});
+
+describe('useQualifyingResults', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useStandingsSnapshot).mockReturnValue({
+      sessionNum: 0,
+    } as ReturnType<typeof useStandingsSnapshot>);
+  });
+
+  it('stays referentially stable across re-renders when inputs are unchanged', () => {
+    const raw = [qualifyResult(0, 0)];
+    vi.mocked(useSessionQualifyingResults).mockReturnValue(raw);
+    vi.mocked(useSessionQualifyPositions).mockReturnValue(undefined);
+
+    const { result, rerender } = renderHook(() => useQualifyingResults());
+    const first = result.current;
+    rerender();
+
+    expect(result.current).toBe(first);
+  });
+
+  it('rebuilds when the heat-race fallback source changes', () => {
+    vi.mocked(useSessionQualifyingResults).mockReturnValue(undefined);
+    vi.mocked(useSessionQualifyPositions).mockReturnValue([
+      qualifyPosition(0, 0),
+    ]);
+
+    const { result, rerender } = renderHook(() => useQualifyingResults());
+    const first = result.current;
+
+    vi.mocked(useSessionQualifyPositions).mockReturnValue([
+      qualifyPosition(0, 0),
+      qualifyPosition(1, 1),
+    ]);
+    rerender();
+
+    expect(result.current).not.toBe(first);
+    expect(result.current).toHaveLength(2);
+  });
+});
+
+describe('useQualifyingGrid', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useStandingsSnapshot).mockReturnValue({
+      sessionNum: 0,
+    } as ReturnType<typeof useStandingsSnapshot>);
+    vi.mocked(useSessionQualifyingResults).mockReturnValue([
+      qualifyResult(2, 0),
+      qualifyResult(5, 1),
+    ]);
+    vi.mocked(useSessionQualifyPositions).mockReturnValue(undefined);
+  });
+
+  it('stays referentially stable when the same carIdx list is passed as a new array', () => {
+    const { result, rerender } = renderHook(
+      ({ carIdxs }) => useQualifyingGrid(carIdxs),
+      { initialProps: { carIdxs: [2, 5] } }
+    );
+    const first = result.current;
+
+    // A fresh array with the same content, as a caller like LapGraphView does.
+    rerender({ carIdxs: [2, 5] });
+
+    expect(result.current).toBe(first);
+  });
+
+  it('recomputes when the carIdx set actually changes', () => {
+    const { result, rerender } = renderHook(
+      ({ carIdxs }) => useQualifyingGrid(carIdxs),
+      { initialProps: { carIdxs: [2, 5] } }
+    );
+
+    rerender({ carIdxs: [2, 5, 9] });
+
+    // Qualified slots top out at 2, so car 9 lands at 3 + 9.
+    expect(result.current.get(9)).toBe(12);
+  });
+});

--- a/src/frontend/domain/standings/useQualifyingGrid.ts
+++ b/src/frontend/domain/standings/useQualifyingGrid.ts
@@ -1,0 +1,118 @@
+import { useMemo } from 'react';
+import {
+  useSessionQualifyingResults,
+  useSessionQualifyPositions,
+  useStandingsSnapshot,
+} from '@irdashies/context';
+import type { SessionQualifyPosition, SessionResults } from '@irdashies/types';
+
+/**
+ * Normalises qualifying results the same way for every consumer.
+ *
+ * In heat race formats `QualifyResultsInfo.Results` is null; the race
+ * session's `QualifyPositions` then holds the real starting grid order
+ * instead, so this falls back to mapping that shape onto `SessionResults`.
+ */
+export const normalizeQualifyingResults = (
+  raw: SessionResults[] | undefined,
+  qualifyPositions: SessionQualifyPosition[] | undefined
+): SessionResults[] | undefined => {
+  if (raw?.length) return raw;
+  return qualifyPositions?.map((q) => ({
+    Position: q.Position + 1,
+    ClassPosition: q.ClassPosition,
+    CarIdx: q.CarIdx,
+    Lap: q.FastestLap,
+    Time: q.FastestTime,
+    FastestLap: q.FastestLap,
+    FastestTime: q.FastestTime,
+    LastTime: -1,
+    LapsLed: 0,
+    LapsComplete: 0,
+    JokerLapsComplete: 0,
+    LapsDriven: 0,
+    Incidents: 0,
+    ReasonOutId: 0,
+    ReasonOutStr: 'Running',
+  }));
+};
+
+/**
+ * Qualifying results, with the heat-race `QualifyPositions` fallback applied.
+ *
+ * Memoised on the two source arrays: the fallback branch used to allocate a
+ * brand-new array on every render, and that array fed the big
+ * `standingsWithGain` memo in `useDriverStandings` as a dependency — so heat
+ * races rebuilt the whole standings tree on every render for no reason. This
+ * keeps the identity stable when neither source array has actually changed.
+ */
+export const useQualifyingResults = (): SessionResults[] | undefined => {
+  const standingsSnapshot = useStandingsSnapshot();
+  const sessionNum = standingsSnapshot?.sessionNum ?? undefined;
+  const raw = useSessionQualifyingResults();
+  const qualifyPositions = useSessionQualifyPositions(sessionNum);
+
+  return useMemo(
+    () => normalizeQualifyingResults(raw, qualifyPositions),
+    [raw, qualifyPositions]
+  );
+};
+
+/**
+ * carIdx -> 1-based qualifying grid slot, for one class's roster.
+ *
+ * A driver with a qualifying result gets `ClassPosition + 1` — the same
+ * convention `augmentStandingsWithPositionChange` in `createStandings.ts`
+ * already uses.
+ *
+ * A driver with no result (no qualifying data at all, or just missing from
+ * it) is placed past the qualified field by their carIdx. Both halves depend
+ * only on session data and the car's own index, never on who else is in
+ * `carIdxs` — a driver retiring must not restyle everyone else's line
+ * mid-race, which is exactly what ranking the unqualified cars against the
+ * current roster would do.
+ */
+export const qualifyingGridSlots = (
+  results: SessionResults[] | undefined,
+  carIdxs: readonly number[]
+): ReadonlyMap<number, number> => {
+  const qualifiedSlotByCarIdx = new Map<number, number>();
+  let highestQualifiedSlot = 0;
+
+  for (const result of results ?? []) {
+    // Rejects null and non-integers too: `isFinite(null)` is true, which
+    // would silently hand that car the pole sitter's identity.
+    if (!Number.isInteger(result.ClassPosition) || result.ClassPosition < 0) {
+      continue;
+    }
+    const slot = result.ClassPosition + 1;
+    qualifiedSlotByCarIdx.set(result.CarIdx, slot);
+    if (slot > highestQualifiedSlot) highestQualifiedSlot = slot;
+  }
+
+  const slots = new Map<number, number>();
+  for (const carIdx of carIdxs) {
+    slots.set(
+      carIdx,
+      qualifiedSlotByCarIdx.get(carIdx) ?? highestQualifiedSlot + 1 + carIdx
+    );
+  }
+
+  return slots;
+};
+
+/** `qualifyingGridSlots`, held stable across renders for the same class roster. */
+export const useQualifyingGrid = (
+  carIdxs: readonly number[]
+): ReadonlyMap<number, number> => {
+  const results = useQualifyingResults();
+  const carIdxsKey = carIdxs.join(',');
+
+  return useMemo(
+    () => qualifyingGridSlots(results, carIdxs),
+    // Deliberately keyed on the carIdx signature, not list identity — callers
+    // commonly pass a freshly derived array every render.
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+    [results, carIdxsKey]
+  );
+};


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

Two fixes for the Gantry lap graph.

**Line colours.** Every car in a class was drawn in the same colour, so you could not tell one line from another. Each driver now gets a colour and dash pattern based on their qualifying position, fixed for the whole race. Ten colours across four dash patterns cover 40 cars.

The colours were checked with a palette validator instead of picked by eye. Cars that qualified near each other get the furthest apart colours, and the set holds up for red-green colour blindness. Colour on its own cannot separate ten lines, so the dash pattern, the driver list swatch and the hover readout all help identify a car.

**Position chart.** It stopped part way through a race. It read `classPosition` from each lap crossing, but iRacing leaves `CarIdxClassPosition` at 0 most of the time. In a recorded 20 lap race it was 0 on 81% of crossings, and on every crossing after lap 6.

Positions now come from the order cars crossed the line on each lap. Lap number and session time are always recorded, and crossing order is correct for lapped cars too. Replayed against the same race file, the chart went from 6 laps and 23 cars to 21 laps and 24 cars. Drivers with no usable position could not be selected in the driver list before, and now can.

**Driver list.** Restyled to match the main standings list, and moved into its own component folder. Each row shows a swatch of that driver's line.

**Qualifying results.** Moved into a shared `useQualifyingGrid` selector. The heat race fallback used to build a new array on every render, which rebuilt the whole standings tree each time. Standings and Relative get that fix as well.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

All lines in a class drawn in one colour. In Position mode the chart ended at lap 6 of a 20 lap race, with several drivers greyed out in the driver list.

### After
<!-- Screenshot or description of the new behaviour -->

<img width="1385" height="793" alt="Screenshot 2026-09-05 215939" src="https://github.com/user-attachments/assets/bef18394-8299-4164-a5e2-87d99fae6b67" />

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
