### PR TITLE
fix: the Gantry is empty after its window is minimised during a race

### DIFF
--- a/site/src/utils/previewChannelRuntime.ts
+++ b/site/src/utils/previewChannelRuntime.ts
@@ -77,8 +77,8 @@ export function createPreviewChannelRuntime(
     isDestroyed: () => disposed,
     // Always active. Gating this on `document.visibilityState` looks like a
     // free CPU saving but is a trap: a subscription created while the document
-    // reports hidden never fires `notifySubscriberCount`, so ProcessorHost
-    // never activates the processor and the preview stays permanently empty.
+    // reports hidden counts as no visible demand, so ProcessorHost never
+    // activates the processor and the preview stays permanently empty.
     // A document can report hidden while still painting (occluded tab,
     // automation, some embeds). The saving is redundant anyway — browsers
     // already throttle timers and pause rAF for genuinely backgrounded tabs.

--- a/src/app/bridge/channelBridge.spec.ts
+++ b/src/app/bridge/channelBridge.spec.ts
@@ -369,4 +369,91 @@ describe('ChannelBus', () => {
     expect(target.send).toHaveBeenCalledOnce();
     expect(target.send).toHaveBeenCalledWith(CHANNEL_DELIVERY, 'snapshot', 7);
   });
+
+  it('reports the registered count alongside the active count', () => {
+    const { bus } = createBus();
+    const target = createTarget();
+    const counts: [number, number][] = [];
+    bus.onSubscriberCountChanged((channel, activeCount, registeredCount) => {
+      if (channel === 'snapshot') counts.push([activeCount, registeredCount]);
+    });
+
+    bus.subscribe(target, 'snapshot', 10);
+    target.visible = false;
+    bus.rendererBecameHidden(target.id);
+    bus.unsubscribe(target.id, 'snapshot');
+
+    expect(counts).toEqual([
+      [1, 1],
+      [0, 1],
+      [0, 0],
+    ]);
+  });
+
+  it('notifies when a hidden renderer subscribes', () => {
+    const { bus } = createBus();
+    const target = createTarget();
+    const listener = vi.fn();
+    bus.onSubscriberCountChanged(listener);
+
+    // The Gantry is created with `show: false`, so its first subscribe can
+    // land while hidden. Registered demand still changed.
+    target.visible = false;
+    bus.subscribe(target, 'snapshot', 10);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith('snapshot', 0, 1);
+    expect(bus.subscriberCount('snapshot')).toBe(0);
+    expect(bus.registeredSubscriberCount('snapshot')).toBe(1);
+  });
+
+  it('notifies when an inactive subscription is removed', () => {
+    const { bus } = createBus();
+    const first = createTarget(1);
+    const second = createTarget(2);
+    first.visible = false;
+    second.visible = false;
+    bus.subscribe(first, 'snapshot', 10);
+    bus.subscribe(second, 'snapshot', 10);
+    const listener = vi.fn();
+    bus.onSubscriberCountChanged(listener);
+
+    bus.unsubscribe(first.id, 'snapshot');
+    expect(listener).toHaveBeenLastCalledWith('snapshot', 0, 1);
+    expect(bus.registeredSubscriberCount('snapshot')).toBe(1);
+
+    bus.removeRenderer(second.id);
+    expect(listener).toHaveBeenLastCalledWith('snapshot', 0, 0);
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(bus.registeredSubscriberCount('snapshot')).toBe(0);
+  });
+
+  it('delivers the latest snapshot once to a window shown after hidden publishes', () => {
+    const { bus, clock } = createBus();
+    const target = createTarget();
+    bus.subscribe(target, 'snapshot', 10);
+    bus.publish('snapshot', 1);
+
+    target.visible = false;
+    bus.rendererBecameHidden(target.id);
+    clock.advance(100);
+    bus.publish('snapshot', 2);
+    bus.publish('snapshot', 3);
+    expect(target.send).toHaveBeenCalledTimes(1);
+
+    // Stands in for a processor that kept running while the window was hidden
+    // and republishes its current snapshot as soon as demand returns.
+    bus.onSubscriberCountChanged((channel, activeCount) => {
+      if (channel === 'snapshot' && activeCount > 0) bus.publish('snapshot', 3);
+    });
+    target.visible = true;
+    bus.rendererBecameVisible(target.id);
+
+    expect(target.send).toHaveBeenCalledTimes(2);
+    expect(target.send).toHaveBeenLastCalledWith(
+      CHANNEL_DELIVERY,
+      'snapshot',
+      3
+    );
+  });
 });

--- a/src/app/bridge/channelBridge.spec.ts
+++ b/src/app/bridge/channelBridge.spec.ts
@@ -136,16 +136,71 @@ describe('ChannelBus', () => {
   it('suppresses hidden renderers and removes destroyed renderers', () => {
     const { bus } = createBus();
     const target = createTarget();
-    bus.subscribe(target, 'event');
+    bus.subscribe(target, 'snapshot');
 
     target.visible = false;
-    bus.publish('event', { type: 'hidden' });
+    bus.publish('snapshot', { value: 1 });
     expect(target.send).not.toHaveBeenCalled();
 
     target.visible = true;
     target.destroyed = true;
-    bus.publish('event', { type: 'destroyed' });
-    expect(bus.subscriberCount('event')).toBe(0);
+    bus.publish('snapshot', { value: 2 });
+    expect(bus.subscriberCount('snapshot')).toBe(0);
+  });
+
+  it('still delivers events to a hidden renderer', () => {
+    const { bus } = createBus();
+    const target = createTarget();
+    bus.subscribe(target, 'event');
+
+    // A hidden window cannot be re-seeded from a snapshot, so an event
+    // dropped here is lost for good. This is the minimised-Gantry case: the
+    // window stayed subscribed but missed every incident of a race.
+    target.visible = false;
+    bus.publish('event', { type: 'first' });
+    bus.publish('event', { type: 'second' });
+
+    expect(target.send).toHaveBeenCalledTimes(2);
+    expect(target.send).toHaveBeenNthCalledWith(1, CHANNEL_DELIVERY, 'event', {
+      type: 'first',
+    });
+    expect(target.send).toHaveBeenNthCalledWith(2, CHANNEL_DELIVERY, 'event', {
+      type: 'second',
+    });
+    // Hidden or not, an event subscription is still real demand.
+    expect(bus.subscriberCount('event')).toBe(1);
+  });
+
+  it('keeps delivering events across a hide and show cycle', () => {
+    const { bus } = createBus();
+    const target = createTarget();
+    bus.subscribe(target, 'event');
+
+    target.visible = false;
+    bus.rendererBecameHidden(target.id);
+    bus.publish('event', { type: 'whileHidden' });
+
+    target.visible = true;
+    bus.rendererBecameVisible(target.id);
+    bus.publish('event', { type: 'whileVisible' });
+
+    expect(target.send).toHaveBeenCalledTimes(2);
+    expect(target.send).toHaveBeenNthCalledWith(1, CHANNEL_DELIVERY, 'event', {
+      type: 'whileHidden',
+    });
+  });
+
+  it('subscribes an already-hidden renderer to events as active', () => {
+    const { bus } = createBus();
+    const target = createTarget();
+
+    // The Gantry window is created with `show: false`, so its first subscribe
+    // can land before the window is ever shown.
+    target.visible = false;
+    bus.subscribe(target, 'event');
+    bus.publish('event', { type: 'beforeFirstShow' });
+
+    expect(target.send).toHaveBeenCalledOnce();
   });
 
   it('cancels pending delivery on unsubscribe and renderer removal', () => {

--- a/src/app/bridge/channelBridgeIpc.spec.ts
+++ b/src/app/bridge/channelBridgeIpc.spec.ts
@@ -44,6 +44,19 @@ import {
   ChannelBus,
   setupChannelBridge,
 } from './channelBridge';
+import type { CarSpeedsSnapshot } from '@irdashies/types';
+
+/**
+ * Visibility gating only applies to snapshot channels, so the demand-pausing
+ * tests below use a real one. The payload content is irrelevant here — these
+ * tests assert demand accounting.
+ */
+const SNAPSHOT_CHANNEL = 'car-speeds.snapshot';
+const SNAPSHOT_PAYLOAD: CarSpeedsSnapshot = {
+  carSpeeds: [],
+  sessionNum: 0,
+  version: 1,
+};
 
 describe('channel bridge IPC boundary', () => {
   beforeEach(() => {
@@ -65,21 +78,44 @@ describe('channel bridge IPC boundary', () => {
     ).toThrow('Event channels do not accept');
     expect(() => subscribe({ sender }, 123)).toThrow('Invalid channel name');
 
-    subscribe({ sender }, 'session.lifecycle');
-    expect(bus.subscriberCount('session.lifecycle')).toBe(1);
-    expect(bus.registeredSubscriberCount('session.lifecycle')).toBe(1);
+    subscribe({ sender }, SNAPSHOT_CHANNEL);
+    expect(bus.subscriberCount(SNAPSHOT_CHANNEL)).toBe(1);
+    expect(bus.registeredSubscriberCount(SNAPSHOT_CHANNEL)).toBe(1);
 
     windowState.visible = false;
     windowListeners.get('hide')?.();
-    expect(bus.subscriberCount('session.lifecycle')).toBe(0);
-    expect(bus.registeredSubscriberCount('session.lifecycle')).toBe(1);
+    expect(bus.subscriberCount(SNAPSHOT_CHANNEL)).toBe(0);
+    expect(bus.registeredSubscriberCount(SNAPSHOT_CHANNEL)).toBe(1);
 
     windowState.visible = true;
     windowListeners.get('show')?.();
-    expect(bus.subscriberCount('session.lifecycle')).toBe(1);
+    expect(bus.subscriberCount(SNAPSHOT_CHANNEL)).toBe(1);
 
     sender.destroy();
-    expect(bus.subscriberCount('session.lifecycle')).toBe(0);
+    expect(bus.subscriberCount(SNAPSHOT_CHANNEL)).toBe(0);
+    expect(bus.registeredSubscriberCount(SNAPSHOT_CHANNEL)).toBe(0);
+  });
+
+  it('keeps event demand through a hide and show cycle', () => {
+    const bus = new ChannelBus();
+    setupChannelBridge(bus);
+    const subscribe = handlers.get(CHANNEL_SUBSCRIBE);
+    const sender = new FakeSender();
+    if (!subscribe) throw new Error('subscribe handler not installed');
+
+    subscribe({ sender }, 'session.lifecycle');
+    expect(bus.subscriberCount('session.lifecycle')).toBe(1);
+
+    // Event channels are not gated on visibility, so hiding the window must
+    // not drop them. Nothing replays them once they are missed.
+    windowState.visible = false;
+    windowListeners.get('hide')?.();
+    expect(bus.subscriberCount('session.lifecycle')).toBe(1);
+
+    bus.publish('session.lifecycle', { type: 'sessionNumChange' });
+    expect(sender.send).toHaveBeenCalledOnce();
+
+    sender.destroy();
     expect(bus.registeredSubscriberCount('session.lifecycle')).toBe(0);
   });
 
@@ -90,18 +126,18 @@ describe('channel bridge IPC boundary', () => {
     const sender = new FakeSender();
     if (!subscribe) throw new Error('subscribe handler not installed');
 
-    subscribe({ sender }, 'session.lifecycle');
-    expect(bus.subscriberCount('session.lifecycle')).toBe(1);
+    subscribe({ sender }, SNAPSHOT_CHANNEL);
+    expect(bus.subscriberCount(SNAPSHOT_CHANNEL)).toBe(1);
 
     // Platforms that keep reporting the window as visible while minimised rely
     // on the event to drop demand.
     windowListeners.get('minimize')?.();
-    expect(bus.subscriberCount('session.lifecycle')).toBe(0);
-    expect(bus.registeredSubscriberCount('session.lifecycle')).toBe(1);
+    expect(bus.subscriberCount(SNAPSHOT_CHANNEL)).toBe(0);
+    expect(bus.registeredSubscriberCount(SNAPSHOT_CHANNEL)).toBe(1);
 
     // Electron emits `restore`, never `show`, when leaving the minimised state.
     windowListeners.get('restore')?.();
-    expect(bus.subscriberCount('session.lifecycle')).toBe(1);
+    expect(bus.subscriberCount(SNAPSHOT_CHANNEL)).toBe(1);
   });
 
   it('reactivates a subscription that publish() deactivated while minimized', () => {
@@ -111,19 +147,19 @@ describe('channel bridge IPC boundary', () => {
     const sender = new FakeSender();
     if (!subscribe) throw new Error('subscribe handler not installed');
 
-    subscribe({ sender }, 'session.lifecycle');
+    subscribe({ sender }, SNAPSHOT_CHANNEL);
 
     // Platforms that report a minimised window as hidden let publish() drop the
     // subscription on its own — publish() deactivates but never reactivates.
     windowState.visible = false;
-    bus.publish('session.lifecycle', { type: 'sessionNumChange' });
-    expect(bus.subscriberCount('session.lifecycle')).toBe(0);
+    bus.publish(SNAPSHOT_CHANNEL, SNAPSHOT_PAYLOAD);
+    expect(bus.subscriberCount(SNAPSHOT_CHANNEL)).toBe(0);
 
     windowState.visible = true;
     windowListeners.get('restore')?.();
-    expect(bus.subscriberCount('session.lifecycle')).toBe(1);
+    expect(bus.subscriberCount(SNAPSHOT_CHANNEL)).toBe(1);
 
-    bus.publish('session.lifecycle', { type: 'sessionNumChange' });
+    bus.publish(SNAPSHOT_CHANNEL, SNAPSHOT_PAYLOAD);
     expect(sender.send).toHaveBeenCalled();
   });
 });

--- a/src/app/bridge/channelBus.ts
+++ b/src/app/bridge/channelBus.ts
@@ -35,7 +35,15 @@ interface ChannelBusOptions {
   onDeliver?: (rendererId: number, channel: string) => void;
 }
 
-type SubscriberCountListener = (channel: string, count: number) => void;
+/**
+ * `activeCount` is visible demand. `registeredCount` also includes hidden
+ * windows that are still subscribed.
+ */
+type SubscriberCountListener = (
+  channel: string,
+  activeCount: number,
+  registeredCount: number
+) => void;
 
 interface Subscription {
   target: RendererTarget;
@@ -133,14 +141,15 @@ export class ChannelBus {
       definition.kind === 'snapshot' && this.latestSnapshots.has(channel);
     const cachedSnapshotBeforeSubscribe = this.latestSnapshots.get(channel);
     subscribers.set(target.id, subscription);
-    if (active) {
-      this.notifySubscriberCount(channel);
-    } else if (
+    if (
+      !active &&
       definition.kind === 'snapshot' &&
       this.subscriberCount(channel) === 0
     ) {
       this.latestSnapshots.delete(channel);
     }
+    // A hidden subscription still changes the registered count.
+    this.notifySubscriberCount(channel);
 
     if (
       this.deliveryEnabled &&
@@ -384,12 +393,11 @@ export class ChannelBus {
     subscription?.timer?.cancel();
     const removed = subscribers?.delete(rendererId) ?? false;
     if (subscribers?.size === 0) this.subscriptions.delete(channel);
-    if (removed && subscription?.active) {
-      if (this.subscriberCount(channel) === 0) {
-        this.clearCachedSnapshot(channel);
-      }
-      this.notifySubscriberCount(channel);
+    if (!removed) return;
+    if (subscription?.active && this.subscriberCount(channel) === 0) {
+      this.clearCachedSnapshot(channel);
     }
+    this.notifySubscriberCount(channel);
   }
 
   private setSubscriptionActive(
@@ -418,9 +426,10 @@ export class ChannelBus {
   }
 
   private notifySubscriberCount(channel: string): void {
-    const count = this.subscriberCount(channel);
+    const activeCount = this.subscriberCount(channel);
+    const registeredCount = this.registeredSubscriberCount(channel);
     this.subscriberCountListeners.forEach((listener) =>
-      listener(channel, count)
+      listener(channel, activeCount, registeredCount)
     );
   }
 }

--- a/src/app/bridge/channelBus.ts
+++ b/src/app/bridge/channelBus.ts
@@ -58,6 +58,21 @@ const systemSchedule = (callback: () => void, delayMs: number): TimerHandle => {
   return { cancel: () => clearTimeout(timeout) };
 };
 
+/**
+ * Whether a channel stops delivering while its window is hidden.
+ *
+ * Only snapshot channels do. A hidden window has nothing to draw, and it is
+ * re-seeded from `latestSnapshots` when it comes back, so nothing is lost.
+ *
+ * Event channels are never gated. Each publish is a discrete fact — an
+ * incident, a session change — that no later snapshot can reconstruct, so
+ * suppressing one while the window is hidden loses it permanently. A minimised
+ * Gantry used to miss every incident of a race that way. All event channels are
+ * low volume, so delivering to a hidden window costs nothing worth saving.
+ */
+const isVisibilityGated = (definition: ChannelDefinition): boolean =>
+  definition.kind === 'snapshot';
+
 export class ChannelBus {
   private readonly registry: Readonly<Record<string, ChannelDefinition>>;
   private readonly now: () => number;
@@ -99,7 +114,7 @@ export class ChannelBus {
       existing.rateHz = rateHz;
       existing.timer?.cancel();
       existing.timer = undefined;
-      const active = target.isVisible();
+      const active = isVisibilityGated(definition) ? target.isVisible() : true;
       this.setSubscriptionActive(channel, existing, active);
       if (existing.pending !== undefined && active) {
         this.queueDelivery(channel, existing, existing.pending);
@@ -112,7 +127,7 @@ export class ChannelBus {
       subscribers = new Map();
       this.subscriptions.set(channel, subscribers);
     }
-    const active = target.isVisible();
+    const active = isVisibilityGated(definition) ? target.isVisible() : true;
     const subscription: Subscription = { target, rateHz, active };
     const hadCachedSnapshotBeforeSubscribe =
       definition.kind === 'snapshot' && this.latestSnapshots.has(channel);
@@ -168,11 +183,13 @@ export class ChannelBus {
         this.remove(channel, rendererId);
         continue;
       }
-      if (!subscription.target.isVisible()) {
-        this.setSubscriptionActive(channel, subscription, false);
-        continue;
+      if (isVisibilityGated(definition)) {
+        if (!subscription.target.isVisible()) {
+          this.setSubscriptionActive(channel, subscription, false);
+          continue;
+        }
+        if (!subscription.active) continue;
       }
-      if (!subscription.active) continue;
       this.onPublish?.(rendererId, channel);
       this.increment(this.publicationCounts, rendererId, channel);
       this.queueDelivery(channel, subscription, payload);
@@ -183,6 +200,9 @@ export class ChannelBus {
     for (const [channel, subscribers] of this.subscriptions) {
       const subscription = subscribers.get(rendererId);
       if (!subscription) continue;
+      // Event subscriptions stay active while the window is away, so a
+      // minimised window keeps receiving them instead of losing them.
+      if (!isVisibilityGated(this.definition(channel))) continue;
       this.setSubscriptionActive(channel, subscription, false);
     }
   }

--- a/src/app/bridge/defineBridge.spec.ts
+++ b/src/app/bridge/defineBridge.spec.ts
@@ -32,11 +32,16 @@ describe('defineRendererSubscriptionBridge', () => {
     removeHandler.mockClear();
   });
 
-  const setup = () =>
-    defineRendererSubscriptionBridge<'telemetry' | 'sessionData'>({
+  type Key = 'telemetry' | 'sessionData';
+
+  const setup = (
+    onSubscribe?: (sender: Electron.WebContents, key: Key) => void
+  ) =>
+    defineRendererSubscriptionBridge<Key>({
       name: 'legacy-test',
-      isValidKey: (value): value is 'telemetry' | 'sessionData' =>
+      isValidKey: (value): value is Key =>
         value === 'telemetry' || value === 'sessionData',
+      onSubscribe,
     });
 
   it('validates keys and tracks subscriptions by sender identity', () => {
@@ -51,6 +56,24 @@ describe('defineRendererSubscriptionBridge', () => {
 
     expect(bridge.registry.has(7, 'telemetry')).toBe(true);
     expect(bridge.registry.hasAny('telemetry')).toBe(true);
+  });
+
+  it('calls onSubscribe with the sender and key once registered', () => {
+    const onSubscribe = vi.fn((sender: Electron.WebContents, key: Key) =>
+      bridge.registry.has(sender.id, key)
+    );
+    const bridge = setup(onSubscribe);
+    const sender = new FakeSender(13);
+    const subscribe = handlers.get('legacy-test:subscribe');
+
+    expect(() => subscribe?.({ sender }, 'invalid')).toThrow();
+    expect(onSubscribe).not.toHaveBeenCalled();
+
+    subscribe?.({ sender }, 'sessionData');
+
+    expect(onSubscribe).toHaveBeenCalledWith(sender, 'sessionData');
+    // True means the registry already held the subscription when called.
+    expect(onSubscribe).toHaveReturnedWith(true);
   });
 
   it.each(['did-start-loading', 'destroyed'])(

--- a/src/app/bridge/defineBridge.ts
+++ b/src/app/bridge/defineBridge.ts
@@ -62,6 +62,7 @@ export const createSubscriptionBridgeClient = <K extends string>(
 export const defineRendererSubscriptionBridge = <K extends string>(options: {
   name: string;
   isValidKey: (value: unknown) => value is K;
+  onSubscribe?: (sender: Electron.WebContents, key: K) => void;
 }) => {
   const channels = subscriptionChannels(options.name);
   const registry = new RendererSubscriptionRegistry<K>();
@@ -84,6 +85,7 @@ export const defineRendererSubscriptionBridge = <K extends string>(options: {
       event.sender.once('did-start-loading', cleanup);
     }
     registry.subscribe(rendererId, key);
+    options.onSubscribe?.(event.sender, key);
   });
 
   ipcMain.handle(channels.unsubscribe, (event, key: unknown) => {

--- a/src/app/bridge/rendererDataSubscriptions.ts
+++ b/src/app/bridge/rendererDataSubscriptions.ts
@@ -9,8 +9,14 @@ export const isRendererDataStream = (
 ): value is RendererDataStream =>
   value === 'sessionData' || value === 'telemetryInspector';
 
-export const setupRendererDataSubscriptions = () =>
+export const setupRendererDataSubscriptions = (options?: {
+  onSubscribe?: (
+    sender: Electron.WebContents,
+    stream: RendererDataStream
+  ) => void;
+}) =>
   defineRendererSubscriptionBridge<RendererDataStream>({
     name: RENDERER_DATA_SUBSCRIPTION_BRIDGE,
     isValidKey: isRendererDataStream,
+    onSubscribe: options?.onSubscribe,
   });

--- a/src/app/overlayManager.gantry.spec.ts
+++ b/src/app/overlayManager.gantry.spec.ts
@@ -21,6 +21,10 @@ class FakeWebContents {
 
 class FakeBrowserWindow {
   static getAllWindows = vi.fn(() => []);
+  static fromWebContents = vi.fn(
+    (webContents: FakeWebContents) =>
+      createdWindows.find((w) => w.webContents === webContents) ?? null
+  );
   webContents = new FakeWebContents();
   destroyed = false;
   shown = false;
@@ -195,6 +199,91 @@ describe('OverlayManager Gantry window', () => {
       revision: 3,
     });
     expect(subscriptions.has).toHaveBeenCalledWith(42, 'sessionData');
+  });
+
+  it.each(['show', 'restore'])(
+    'resends the latest session on %s to a subscribed window',
+    (eventName) => {
+      const manager = new OverlayManager();
+      const subscriptions = {
+        has: vi.fn(() => false),
+        hasAny: vi.fn(() => false),
+      };
+      manager.setRendererDataSubscriptions(subscriptions);
+      manager.createGantryWindow(dashboard(true));
+      const [window] = gantryWindows();
+      const handler = window.on.mock.calls.find(
+        ([event]) => event === eventName
+      )?.[1] as () => void;
+      window.shown = true;
+
+      // No cached session yet.
+      handler();
+      expect(window.webContents.send).not.toHaveBeenCalled();
+
+      // Cached, but this window is not subscribed.
+      manager.publishMessage('sessionData', { revision: 1 });
+      handler();
+      expect(window.webContents.send).not.toHaveBeenCalled();
+
+      subscriptions.has.mockReturnValue(true);
+      handler();
+      expect(window.webContents.send).toHaveBeenCalledWith('sessionData', {
+        revision: 1,
+      });
+    }
+  );
+
+  it('fires onOverlayReady callbacks as gantry when the page loads', () => {
+    const manager = new OverlayManager();
+    const onReady = vi.fn();
+    manager.onOverlayReady(onReady);
+    manager.createGantryWindow(dashboard(true));
+    const [window] = gantryWindows();
+    const loaded = window.webContents.on.mock.calls.find(
+      ([event]) => event === 'did-finish-load'
+    )?.[1] as () => void;
+
+    loaded();
+    expect(onReady).toHaveBeenCalledWith('gantry');
+
+    onReady.mockClear();
+    window.destroyed = true;
+    loaded();
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  it('seeds the cached session only to a visible subscribed window', () => {
+    const manager = new OverlayManager();
+    const subscriptions = {
+      has: vi.fn(() => true),
+      hasAny: vi.fn(() => false),
+    };
+    manager.setRendererDataSubscriptions(subscriptions);
+    manager.publishMessage('sessionData', { revision: 1 });
+    manager.createGantryWindow(dashboard(true));
+    const [window] = gantryWindows();
+    const sender = window.webContents as unknown as Electron.WebContents;
+
+    // Hidden: nothing is sent.
+    expect(manager.seedSessionData(sender)).toBe(false);
+    expect(window.webContents.send).not.toHaveBeenCalled();
+
+    window.shown = true;
+    expect(manager.seedSessionData(sender)).toBe(true);
+    expect(window.webContents.send).toHaveBeenCalledWith('sessionData', {
+      revision: 1,
+    });
+
+    // Not subscribed: nothing is sent.
+    window.webContents.send.mockClear();
+    subscriptions.has.mockReturnValue(false);
+    expect(manager.seedSessionData(sender)).toBe(false);
+    expect(window.webContents.send).not.toHaveBeenCalled();
+
+    // No owning window.
+    const orphan = new FakeWebContents() as unknown as Electron.WebContents;
+    expect(manager.seedSessionData(orphan)).toBe(false);
   });
 
   it('drops its reference when the renderer crashes so it can be recreated', () => {

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -664,6 +664,17 @@ export class OverlayManager {
     this.latestSessionData = undefined;
   }
 
+  /** Sends the cached session to a visible, subscribed sender window. */
+  public seedSessionData(sender: Electron.WebContents): boolean {
+    const win = BrowserWindow.fromWebContents(sender);
+    if (!win) return false;
+    return refreshSessionDataForVisibleWindow(
+      win,
+      this.rendererDataSubscriptions,
+      this.latestSessionData
+    );
+  }
+
   public hasTelemetryInspectorSubscribers(): boolean {
     return (
       this.rendererDataSubscriptions?.hasAny('telemetryInspector') ?? false
@@ -1014,6 +1025,22 @@ export class OverlayManager {
 
     browserWindow.on('closed', () => {
       this.gantryWindow = undefined;
+    });
+
+    // Electron emits restore, not show, when a minimised window comes back.
+    const resendSessionData = () => {
+      refreshSessionDataForVisibleWindow(
+        browserWindow,
+        this.rendererDataSubscriptions,
+        this.latestSessionData
+      );
+    };
+    browserWindow.on('show', resendSessionData);
+    browserWindow.on('restore', resendSessionData);
+
+    browserWindow.webContents.on('did-finish-load', () => {
+      if (browserWindow.isDestroyed()) return;
+      this.onWindowReadyCallbacks.forEach((cb) => cb('gantry'));
     });
 
     // Without this a renderer crash leaves a live-but-blank BrowserWindow that

--- a/src/app/processors/ProcessorHost.spec.ts
+++ b/src/app/processors/ProcessorHost.spec.ts
@@ -5,7 +5,7 @@ import type {
   SessionLifecycleEvent,
   Telemetry,
 } from '@irdashies/types';
-import { ChannelBus } from '../bridge/channelBridge';
+import { CHANNEL_DELIVERY, ChannelBus } from '../bridge/channelBridge';
 import { createSessionLifecycle } from '../sessionLifecycle';
 import type { TelemetryProcessor } from './TelemetryProcessor';
 import {
@@ -416,5 +416,120 @@ describe('ProcessorHost', () => {
 
     expect(processor.onFrame).toHaveBeenCalledOnce();
     expect(logError).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a processWhileHidden processor fed while its only subscriber is hidden', () => {
+    const bus = new ChannelBus();
+    let visible = true;
+    const renderer = target(16, () => visible);
+    bus.subscribe(renderer, 'lap-times.snapshot');
+    bus.subscribe(renderer, 'track-state.snapshot');
+    const lapTimes = fakeProcessor('lap-times.snapshot', 'event');
+    const trackState = fakeProcessor('track-state.snapshot', 25);
+    const createLapTimes = vi.fn(() => lapTimes);
+    const host = new ProcessorHost({
+      bus,
+      metrics: metrics(),
+      definitions: [
+        {
+          ...definition('lap-times.snapshot', createLapTimes),
+          processWhileHidden: true,
+        },
+        definition('track-state.snapshot', () => trackState),
+      ],
+    });
+    host.onFrame({} as Telemetry);
+
+    visible = false;
+    bus.rendererBecameHidden(renderer.id);
+    host.onFrame({} as Telemetry);
+
+    expect(lapTimes.onFrame).toHaveBeenCalledTimes(2);
+    expect(createLapTimes).toHaveBeenCalledOnce();
+    expect(host.snapshot('lap-times.snapshot')).toBeDefined();
+    // The unflagged processor still follows visible demand.
+    expect(trackState.onFrame).toHaveBeenCalledOnce();
+    expect(host.snapshot('track-state.snapshot')).toBeUndefined();
+  });
+
+  it('seeds a shown window from a processWhileHidden processor without a new frame', () => {
+    vi.useFakeTimers();
+    const bus = new ChannelBus();
+    let visible = true;
+    const renderer = target(17, () => visible);
+    bus.subscribe(renderer, 'lap-times.snapshot');
+    const processor = fakeProcessor('lap-times.snapshot', 'event', (state) => {
+      state.version += 1;
+    });
+    const host = new ProcessorHost({
+      bus,
+      metrics: metrics(),
+      definitions: [
+        {
+          ...definition('lap-times.snapshot', () => processor),
+          processWhileHidden: true,
+        },
+      ],
+    });
+    host.onFrame({} as Telemetry);
+
+    visible = false;
+    bus.rendererBecameHidden(renderer.id);
+    host.onFrame({} as Telemetry);
+    host.onFrame({} as Telemetry);
+    host.onFrame({} as Telemetry);
+    vi.runAllTimers();
+    const deliveriesBeforeShow = renderer.send.mock.calls.length;
+
+    visible = true;
+    bus.rendererBecameVisible(renderer.id);
+
+    expect(processor.onFrame).toHaveBeenCalledTimes(4);
+    expect(renderer.send).toHaveBeenCalledTimes(deliveriesBeforeShow + 1);
+    expect(renderer.send).toHaveBeenLastCalledWith(
+      CHANNEL_DELIVERY,
+      'lap-times.snapshot',
+      { version: 4 }
+    );
+    vi.runAllTimers();
+    expect(renderer.send).toHaveBeenCalledTimes(deliveriesBeforeShow + 1);
+  });
+
+  it('deactivates a processWhileHidden processor when its last registered subscriber leaves', () => {
+    const bus = new ChannelBus();
+    const first = target(18, () => false);
+    const second = target(19, () => false);
+    const processors: FakeProcessor<'lap-times.snapshot'>[] = [];
+    const host = new ProcessorHost({
+      bus,
+      metrics: metrics(),
+      definitions: [
+        {
+          ...definition('lap-times.snapshot', () => {
+            const processor = fakeProcessor('lap-times.snapshot', 'event');
+            processors.push(processor);
+            return processor;
+          }),
+          processWhileHidden: true,
+        },
+      ],
+    });
+    expect(processors).toHaveLength(0);
+
+    // Both windows are hidden from the start, like a Gantry created with
+    // `show: false`. Registered demand alone activates the processor.
+    bus.subscribe(first, 'lap-times.snapshot');
+    bus.subscribe(second, 'lap-times.snapshot');
+    host.onFrame({} as Telemetry);
+    expect(processors).toHaveLength(1);
+    expect(processors[0].onFrame).toHaveBeenCalledOnce();
+
+    bus.removeRenderer(first.id);
+    expect(host.snapshot('lap-times.snapshot')).toBeDefined();
+
+    bus.unsubscribe(second.id, 'lap-times.snapshot');
+    expect(host.snapshot('lap-times.snapshot')).toBeUndefined();
+    expect(first.send).not.toHaveBeenCalled();
+    expect(second.send).not.toHaveBeenCalled();
   });
 });

--- a/src/app/processors/ProcessorHost.ts
+++ b/src/app/processors/ProcessorHost.ts
@@ -74,6 +74,14 @@ export interface ProcessorDefinition<K extends ProcessorChannel> {
   readonly channel: K;
   readonly dependencies?: readonly ProcessorChannel[];
   readonly retainWhenInactive?: boolean;
+  /**
+   * Keep processing frames while every subscribed window is hidden. Demand then
+   * follows registered subscriptions instead of visible ones, so state built up
+   * over a race (such as lap-time history) survives a minimised window. The bus
+   * still gates delivery; the current snapshot is pushed when a window becomes
+   * visible again. Off by default so a hidden window costs nothing.
+   */
+  readonly processWhileHidden?: boolean;
   readonly metricsPrefix: string;
   create(
     context: ProcessorFactoryContext
@@ -122,6 +130,13 @@ const snapshotToken = (snapshot: unknown): unknown => {
   return typeof version === 'number' ? version : snapshot;
 };
 
+const hasDirectDemand = (
+  definition: AnyProcessorDefinition,
+  activeCount: number,
+  registeredCount: number
+): boolean =>
+  definition.processWhileHidden ? registeredCount > 0 : activeCount > 0;
+
 export class ProcessorHost {
   private readonly bus: ChannelBus;
   private readonly metrics: ProcessorMetrics;
@@ -132,6 +147,8 @@ export class ProcessorHost {
   private readonly statesByChannel = new Map<ProcessorChannel, RuntimeState>();
   private readonly directDemand = new Set<ProcessorChannel>();
   private activeDemand = new Set<ProcessorChannel>();
+  /** Last visible subscriber count per channel, to spot a window being shown. */
+  private readonly activeCounts = new Map<ProcessorChannel, number>();
   private readonly reportedFailures = new Set<string>();
   /** Channels whose first publish has already been logged. Debug aid only. */
   private readonly firstPublishLogged = new Set<ProcessorChannel>();
@@ -152,25 +169,37 @@ export class ProcessorHost {
     const definitions = this.sortDefinitions(options.definitions);
     this.states = definitions.map((definition) => ({ definition }));
     for (const state of this.states) {
-      this.statesByChannel.set(state.definition.channel, state);
-      if (this.bus.subscriberCount(state.definition.channel) > 0) {
-        this.directDemand.add(state.definition.channel);
+      const channel = state.definition.channel;
+      this.statesByChannel.set(channel, state);
+      const activeCount = this.bus.subscriberCount(channel);
+      this.activeCounts.set(channel, activeCount);
+      const registeredCount = this.bus.registeredSubscriberCount(channel);
+      if (hasDirectDemand(state.definition, activeCount, registeredCount)) {
+        this.directDemand.add(channel);
       }
     }
 
     this.disconnects.push(
-      this.bus.onSubscriberCountChanged((channel, count) => {
-        if (!this.statesByChannel.has(channel as ProcessorChannel)) return;
-        const processorChannel = channel as ProcessorChannel;
-        const hadDirectDemand = this.directDemand.has(processorChannel);
-        if (count > 0) this.directDemand.add(processorChannel);
-        else this.directDemand.delete(processorChannel);
-        this.reconcileDemand();
-        if (!hadDirectDemand && count > 0) {
+      this.bus.onSubscriberCountChanged(
+        (channel, activeCount, registeredCount) => {
+          const processorChannel = channel as ProcessorChannel;
           const state = this.statesByChannel.get(processorChannel);
-          if (state?.processor) this.publishIfChanged(state, true);
+          if (!state) return;
+          const wasVisible = (this.activeCounts.get(processorChannel) ?? 0) > 0;
+          this.activeCounts.set(processorChannel, activeCount);
+          if (hasDirectDemand(state.definition, activeCount, registeredCount)) {
+            this.directDemand.add(processorChannel);
+          } else {
+            this.directDemand.delete(processorChannel);
+          }
+          this.reconcileDemand();
+          // Seed the first visible window. For a processWhileHidden processor
+          // this is the only way a re-shown window sees what it missed.
+          if (!wasVisible && activeCount > 0 && state.processor) {
+            this.publishIfChanged(state, true);
+          }
         }
-      })
+      )
     );
 
     if (options.lifecycle) {
@@ -257,6 +286,7 @@ export class ProcessorHost {
     this.disconnects.length = 0;
     this.directDemand.clear();
     this.activeDemand.clear();
+    this.activeCounts.clear();
     this.latestSession = undefined;
     this.sourceReplay = undefined;
   }

--- a/src/app/processors/processorRegistry.ts
+++ b/src/app/processors/processorRegistry.ts
@@ -68,6 +68,8 @@ export const createProcessorDefinitions = ({
   }),
   defineProcessor({
     channel: 'lap-times.snapshot',
+    // Gantry's last-lap columns need the history built while it was minimised.
+    processWhileHidden: true,
     metricsPrefix: 'lapTimes',
     create: () => new LapTimesProcessor(),
   }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -217,7 +217,11 @@ app.on('ready', async () => {
   }
 
   setupChannelBridge(channelBus);
-  const rendererDataSubscriptions = setupRendererDataSubscriptions();
+  const rendererDataSubscriptions = setupRendererDataSubscriptions({
+    onSubscribe: (sender, stream) => {
+      if (stream === 'sessionData') overlayManager.seedSessionData(sender);
+    },
+  });
   disposeRendererDataSubscriptions = rendererDataSubscriptions.dispose;
   overlayManager.setRendererDataSubscriptions(
     rendererDataSubscriptions.registry


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

The Gantry sits empty after its window has been minimised for a race. Incidents, standings and the lap graph were all affected, for three separate reasons.

**Event channels were dropped while hidden.** `ChannelBus.publish()` skipped any window that was not visible and threw the payload away. That is fine for snapshot channels, because a hidden window is re-sent the latest snapshot when it comes back. Event channels are never re-sent, so anything dropped is lost for good. In one 32 minute race, 98 incidents were detected and written to disk but only the last 9 reached the list. Three channels are events: `session.lifecycle`, `raceControl.incidents` and `raceControl.sessionId`. All are low volume, so sending them to a hidden window costs almost nothing. They are no longer gated on visibility. Snapshot channels keep the existing behaviour. This also fixes `raceControl.sessionId`. A session change never reached a minimised Gantry, so the incident list was never reloaded for the new session.

**Session data never reached the window.** The drivers list arrives on the legacy `sessionData` stream. It is published only when iRacing changes its session string, and only to visible subscribed windows. On Windows a minimised window reports itself as not visible, so a Gantry minimised for the race never received it, and the standings and lap graph had no field to draw. There was no recovery path either: nothing seeded a renderer when it subscribed, and nothing re-sent the data when the window returned. It is now seeded on subscribe, re-sent on `show` and `restore`, and the window fires the ready callbacks when it loads, so it also picks up the running state when opened mid-session.

**Lap time history stopped recording.** `ProcessorHost` counts visible subscribers as demand, so the lap times processor was destroyed while its only subscriber was hidden. That lost the history behind the Gantry's L-3, L-2 and L-1 columns, which stayed blank for three more laps after a restore. A processor can now opt in to running while its windows are hidden, and it is pushed the current snapshot when one becomes visible. Only `lap-times.snapshot` opts in. Delivery is still gated on visibility, so hidden windows still receive nothing.

Only minimising the window caused this. Closing the Gantry and reopening it reloads everything from disk.

The four event delivery tests were checked by putting the old behaviour back. All four fail with the visibility check restored.

Tested in iRacing by leaving the Gantry hidden for a full race, then restoring it.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

Hidden for the race, then restored. The incident feed held only the last few incidents, the standings list was empty, and the lap graph read "Waiting for the grid".

### After
<!-- Screenshot or description of the new behaviour -->

Incidents, standings and the lap graph all fill in as soon as the window is shown, with the lap delta columns populated straight away.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Updates**
  - Event-based updates continue to be delivered while a renderer or view is hidden, including after hide/show transitions.
  - Snapshot-based updates pause while hidden and resume when visibility is restored.
  - Subscriptions created while hidden remain active and receive future event updates.
  - Selected background processing continues while all subscribed views are hidden.
  - Newly shown or restored views receive the latest available session data without waiting for a new update.
  - Current session data is seeded when a renderer subscribes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->