### PR TITLE
fix: incident replay switches to the right car but the wrong camera

### DIFF
--- a/src/app/bridge/raceControlBridge.spec.ts
+++ b/src/app/bridge/raceControlBridge.spec.ts
@@ -40,6 +40,8 @@ const { setupRaceControlBridge, resolveCameraGroupNum } =
   await import('./raceControlBridge');
 const { loadIncidents, clearIncidents, pruneOldSessions } =
   await import('../storage/incidentStorage');
+const { getCurrentBridge, onBridgeChanged } =
+  await import('./iracingSdk/setup');
 
 const savedThresholds = {
   slowSpeedThreshold: 21,
@@ -72,11 +74,10 @@ const createRuntime = () => {
   return { runtime, changeSessionId: () => sessionIdChanged('2') };
 };
 
-describe('resolveCameraGroupNum', () => {
-  const sessionWithGroups = (
-    groups: { GroupNum: number; GroupName: string }[]
-  ) => ({ CameraInfo: { Groups: groups } }) as unknown as Session;
+const sessionWithGroups = (groups: { GroupNum: number; GroupName: string }[]) =>
+  ({ CameraInfo: { Groups: groups } }) as unknown as Session;
 
+describe('resolveCameraGroupNum', () => {
   const session = sessionWithGroups([
     { GroupNum: 12, GroupName: 'Chase' },
     { GroupNum: 13, GroupName: 'Far Chase' },
@@ -248,5 +249,69 @@ describe('setupRaceControlBridge', () => {
     expect(handlers.get('raceControl:clearIncidents')?.({})).toBeUndefined();
     expect(loadIncidents).not.toHaveBeenCalled();
     expect(clearIncidents).not.toHaveBeenCalled();
+  });
+});
+
+describe('camera group across a bridge change', () => {
+  /**
+   * A fake SDK bridge. onSessionData is captured rather than invoked, so a test
+   * can decide whether the new bridge has published a session yet.
+   */
+  const createBridge = () => {
+    let publishSession: ((session: Session) => void) | undefined;
+    return {
+      bridge: {
+        onSessionData: vi.fn((cb: (session: Session) => void) => {
+          publishSession = cb;
+          return () => undefined;
+        }),
+        onTelemetry: vi.fn(() => () => undefined),
+        changeCameraNumber: vi.fn(),
+        triggerReplaySessionSearch: vi.fn(),
+      },
+      publishSession: (session: Session) => publishSession?.(session),
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers.clear();
+    dashboardListeners.clear();
+  });
+
+  it('does not carry a camera group across a bridge swap', () => {
+    // Camera group numbers are session-specific. After the bridge is replaced -
+    // toggling demo mode, or the SDK reconnecting - the old session must not be
+    // used to resolve them, or the wrong camera is selected.
+    const { runtime } = createRuntime();
+    const first = createBridge();
+    vi.mocked(getCurrentBridge).mockReturnValue(
+      first.bridge as unknown as ReturnType<typeof getCurrentBridge>
+    );
+
+    setupRaceControlBridge(
+      runtime,
+      dashboardWith({ incidentCameraGroup: 'Far Chase' })
+    );
+    first.publishSession(
+      sessionWithGroups([{ GroupNum: 13, GroupName: 'Far Chase' }])
+    );
+
+    // The first bridge resolves the group normally.
+    handlers.get('raceControl:focusDriver')?.({}, '7');
+    expect(first.bridge.changeCameraNumber).toHaveBeenCalledWith('7', 13, 0);
+
+    // Swap the bridge and re-wire, without the new one publishing a session.
+    const second = createBridge();
+    vi.mocked(getCurrentBridge).mockReturnValue(
+      second.bridge as unknown as ReturnType<typeof getCurrentBridge>
+    );
+    const rewire = vi.mocked(onBridgeChanged).mock.calls[0]?.[0] as () => void;
+    rewire();
+
+    handlers.get('raceControl:focusDriver')?.({}, '7');
+
+    // Group 0 means "leave the camera alone", which is the safe fallback.
+    expect(second.bridge.changeCameraNumber).toHaveBeenCalledWith('7', 0, 0);
   });
 });

--- a/src/app/bridge/raceControlBridge.spec.ts
+++ b/src/app/bridge/raceControlBridge.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DashboardLayout } from '@irdashies/types';
 import type { IncidentRuntimeHandle } from './raceControlBridge';
+import type { Session } from '@irdashies/types';
 
 const handlers = new Map<string, (...args: unknown[]) => unknown>();
 const dashboardListeners = new Set<(dashboard: DashboardLayout) => void>();
@@ -35,7 +36,8 @@ vi.mock('../logger', () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
-const { setupRaceControlBridge } = await import('./raceControlBridge');
+const { setupRaceControlBridge, resolveCameraGroupNum } =
+  await import('./raceControlBridge');
 const { loadIncidents, clearIncidents, pruneOldSessions } =
   await import('../storage/incidentStorage');
 
@@ -69,6 +71,48 @@ const createRuntime = () => {
   };
   return { runtime, changeSessionId: () => sessionIdChanged('2') };
 };
+
+describe('resolveCameraGroupNum', () => {
+  const sessionWithGroups = (
+    groups: { GroupNum: number; GroupName: string }[]
+  ) => ({ CameraInfo: { Groups: groups } }) as unknown as Session;
+
+  const session = sessionWithGroups([
+    { GroupNum: 12, GroupName: 'Chase' },
+    { GroupNum: 13, GroupName: 'Far Chase' },
+    { GroupNum: 18, GroupName: 'TV1' },
+  ]);
+
+  it('resolves a group name to its session-specific number', () => {
+    expect(resolveCameraGroupNum(session, 'Far Chase')).toBe(13);
+    expect(resolveCameraGroupNum(session, 'TV1')).toBe(18);
+  });
+
+  it('matches case and surrounding whitespace loosely', () => {
+    expect(resolveCameraGroupNum(session, '  far chase ')).toBe(13);
+  });
+
+  it('returns 0 when the group is absent, so the camera is left alone', () => {
+    // 0 is iRacing's "leave the camera group unchanged", not group index 0.
+    expect(resolveCameraGroupNum(session, 'Helicopter')).toBe(0);
+  });
+
+  it('returns 0 when there is no session or no camera info yet', () => {
+    expect(resolveCameraGroupNum(undefined, 'Far Chase')).toBe(0);
+    expect(resolveCameraGroupNum({} as Session, 'Far Chase')).toBe(0);
+  });
+
+  it('returns 0 for an empty or missing group name', () => {
+    expect(resolveCameraGroupNum(session, '')).toBe(0);
+    expect(resolveCameraGroupNum(session, '   ')).toBe(0);
+    expect(resolveCameraGroupNum(session, undefined)).toBe(0);
+  });
+
+  it('rejects a non-positive group number rather than passing it through', () => {
+    const broken = sessionWithGroups([{ GroupNum: 0, GroupName: 'Far Chase' }]);
+    expect(resolveCameraGroupNum(broken, 'Far Chase')).toBe(0);
+  });
+});
 
 describe('setupRaceControlBridge', () => {
   beforeEach(() => {

--- a/src/app/bridge/raceControlBridge.ts
+++ b/src/app/bridge/raceControlBridge.ts
@@ -168,6 +168,13 @@ export const setupRaceControlBridge = (
     unsubscribeSession?.();
     unsubscribeTelemetry?.();
 
+    // The cached session belongs to the bridge being replaced. Its camera group
+    // numbers are session-specific, so keeping it across a swap - toggling demo
+    // mode, or the SDK reconnecting - would resolve a group name against the
+    // previous session until the new bridge publishes. Clearing it falls back
+    // to group 0, which leaves the camera alone.
+    latestSession = undefined;
+
     const bridge = getCurrentBridge();
     if (!bridge) return;
 

--- a/src/app/bridge/raceControlBridge.ts
+++ b/src/app/bridge/raceControlBridge.ts
@@ -11,6 +11,7 @@ import {
   INCIDENT_THRESHOLD_BOUNDS,
   type IncidentThresholds,
 } from '../../types/raceControl';
+import { DEFAULT_INCIDENT_CAMERA_GROUP } from '../../types/widgetConfigs';
 import logger from '../logger';
 
 /** Small interface over IncidentRuntime — keeps this bridge decoupled from
@@ -81,11 +82,37 @@ const isValidReplayIncident = (
 const isValidReplaySeconds = (value: unknown): value is number =>
   isFiniteNumber(value) && value >= 0 && value <= 300;
 
+/**
+ * iRacing camera groups are numbered from 1, and `CameraSwitchNum` treats
+ * group 0 as "leave the camera group alone" — which is why passing 0 switched
+ * the car but kept whatever camera was already selected. Resolve the
+ * configured group by name against the session's own list, and fall back to 0
+ * (unchanged) when the track or car does not offer it.
+ */
+export const resolveCameraGroupNum = (
+  session: Session | undefined,
+  groupName: string | undefined
+): number => {
+  if (!groupName) return 0;
+  const wanted = groupName.trim().toLowerCase();
+  if (!wanted) return 0;
+  const groups = session?.CameraInfo?.Groups;
+  if (!Array.isArray(groups)) return 0;
+  const match = groups.find(
+    (group) => group?.GroupName?.trim().toLowerCase() === wanted
+  );
+  return isFiniteNumber(match?.GroupNum) && match.GroupNum > 0
+    ? match.GroupNum
+    : 0;
+};
+
 export const setupRaceControlBridge = (
   runtime: IncidentRuntimeHandle,
   initialDashboard?: DashboardLayout
 ) => {
   let retention: 'all' | 5 | 10 | 20 = 'all';
+  let cameraGroupName: string = DEFAULT_INCIDENT_CAMERA_GROUP;
+  let latestSession: Session | undefined;
 
   const applyRetention = (value: 'all' | 5 | 10 | 20) => {
     retention = value;
@@ -123,6 +150,11 @@ export const setupRaceControlBridge = (
     if (isValidRetention(config.sessionRetention)) {
       applyRetention(config.sessionRetention);
     }
+    cameraGroupName =
+      typeof config.incidentCameraGroup === 'string' &&
+      config.incidentCameraGroup.trim()
+        ? config.incidentCameraGroup
+        : DEFAULT_INCIDENT_CAMERA_GROUP;
   };
 
   applyDashboard(initialDashboard);
@@ -140,8 +172,11 @@ export const setupRaceControlBridge = (
     if (!bridge) return;
 
     unsubscribeSession =
-      bridge.onSessionData((session) => runtime.onSession(session)) ??
-      undefined;
+      bridge.onSessionData((session) => {
+        // Kept so the incident buttons can resolve a camera group by name.
+        latestSession = session;
+        runtime.onSession(session);
+      }) ?? undefined;
     unsubscribeTelemetry =
       bridge.onTelemetry((telemetry) => runtime.onFrame(telemetry)) ??
       undefined;
@@ -196,8 +231,11 @@ export const setupRaceControlBridge = (
     }
     const bridge = getCurrentBridge();
     if (!bridge) return;
-    logger.info(`[RaceControl] focusDriver #${carNumber}`);
-    bridge.changeCameraNumber(carNumber, 0, 0);
+    const groupNum = resolveCameraGroupNum(latestSession, cameraGroupName);
+    logger.info(
+      `[RaceControl] focusDriver #${carNumber} cameraGroup=${cameraGroupName} num=${groupNum}`
+    );
+    bridge.changeCameraNumber(carNumber, groupNum, 0);
   });
 
   ipcMain.handle(
@@ -222,10 +260,11 @@ export const setupRaceControlBridge = (
         0,
         Math.round((incident.sessionTime - seconds) * 1000)
       );
+      const groupNum = resolveCameraGroupNum(latestSession, cameraGroupName);
       logger.info(
-        `[RaceControl] replayIncident car=${incident.carIdx ?? 'unknown'} (${incident.driverName ?? 'unknown'} #${incident.carNumber}) type=${incident.type ?? 'unknown'} sessionTime=${incident.sessionTime.toFixed(2)} sessionNum=${incident.sessionNum} offset=-${seconds}s targetTimeMs=${targetTimeMs}`
+        `[RaceControl] replayIncident car=${incident.carIdx ?? 'unknown'} (${incident.driverName ?? 'unknown'} #${incident.carNumber}) type=${incident.type ?? 'unknown'} sessionTime=${incident.sessionTime.toFixed(2)} sessionNum=${incident.sessionNum} offset=-${seconds}s targetTimeMs=${targetTimeMs} cameraGroup=${cameraGroupName} num=${groupNum}`
       );
-      bridge.changeCameraNumber(incident.carNumber, 0, 0);
+      bridge.changeCameraNumber(incident.carNumber, groupNum, 0);
       bridge.triggerReplaySessionSearch(incident.sessionNum, targetTimeMs);
     }
   );

--- a/src/frontend/components/Settings/components/SettingSelectRow.tsx
+++ b/src/frontend/components/Settings/components/SettingSelectRow.tsx
@@ -23,6 +23,9 @@ export function SettingSelectRow<T extends string>({
       </div>
 
       <select
+        // The visible <h4> is not tied to the control, so without this a
+        // screen reader announces an unnamed combobox.
+        aria-label={title}
         className="bg-slate-700 text-white rounded-md px-2 py-1"
         value={value}
         onChange={(e) => onChange(e.target.value as T)}

--- a/src/frontend/components/Settings/sections/GantrySettings.spec.tsx
+++ b/src/frontend/components/Settings/sections/GantrySettings.spec.tsx
@@ -1,8 +1,19 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { DashboardLayout, LapGraphConfig } from '@irdashies/types';
+import type {
+  CameraGroup,
+  DashboardLayout,
+  LapGraphConfig,
+} from '@irdashies/types';
 import { deepMergeConfig, getWidgetDefaultConfig } from '@irdashies/types';
 import { GantrySettings } from './GantrySettings';
+
+/** Camera groups as the session publishes them; Cameras is unused by these tests. */
+const cameraGroup = (GroupNum: number, GroupName: string): CameraGroup => ({
+  GroupNum,
+  GroupName,
+  Cameras: [],
+});
 
 // GantrySettings is memo()'d and takes no props, so a plain rerender() would be
 // skipped. Back the mocked context with a real external store instead, which is
@@ -12,8 +23,9 @@ const mocks = vi.hoisted(() => {
   const listeners = new Set<() => void>();
   return {
     listeners,
-    cameraGroups: undefined as
-      { GroupNum: number; GroupName: string }[] | undefined,
+    // The shared type, so a change to the session contract fails here at
+    // compile time rather than drifting silently.
+    cameraGroups: undefined as CameraGroup[] | undefined,
     onDashboardUpdated: vi.fn(),
     getDashboard: () => dashboard,
     setDashboard: (next: DashboardLayout | undefined) => {
@@ -114,9 +126,9 @@ describe('GantrySettings incident camera', () => {
 
   it("offers the session's own camera groups once they arrive", () => {
     mocks.cameraGroups = [
-      { GroupNum: 12, GroupName: 'Chase' },
-      { GroupNum: 13, GroupName: 'Far Chase' },
-      { GroupNum: 18, GroupName: 'TV1' },
+      cameraGroup(12, 'Chase'),
+      cameraGroup(13, 'Far Chase'),
+      cameraGroup(18, 'TV1'),
     ];
     mocks.setDashboard(dashboardWith('all'));
     render(<GantrySettings />);
@@ -126,7 +138,7 @@ describe('GantrySettings incident camera', () => {
   });
 
   it('keeps a saved group that this track does not offer', () => {
-    mocks.cameraGroups = [{ GroupNum: 12, GroupName: 'Chase' }];
+    mocks.cameraGroups = [cameraGroup(12, 'Chase')];
     mocks.setDashboard(
       dashboardFor(gantryConfig({ incidentCameraGroup: 'Blimp' }))
     );
@@ -138,10 +150,7 @@ describe('GantrySettings incident camera', () => {
   });
 
   it('writes the chosen group', () => {
-    mocks.cameraGroups = [
-      { GroupNum: 13, GroupName: 'Far Chase' },
-      { GroupNum: 18, GroupName: 'TV1' },
-    ];
+    mocks.cameraGroups = [cameraGroup(13, 'Far Chase'), cameraGroup(18, 'TV1')];
     mocks.setDashboard(dashboardWith('all'));
     render(<GantrySettings />);
 

--- a/src/frontend/components/Settings/sections/GantrySettings.spec.tsx
+++ b/src/frontend/components/Settings/sections/GantrySettings.spec.tsx
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => {
   const listeners = new Set<() => void>();
   return {
     listeners,
+    cameraGroups: undefined as
+      { GroupNum: number; GroupName: string }[] | undefined,
     onDashboardUpdated: vi.fn(),
     getDashboard: () => dashboard,
     setDashboard: (next: DashboardLayout | undefined) => {
@@ -32,6 +34,7 @@ vi.mock('@irdashies/context', async () => {
       onDashboardUpdated: mocks.onDashboardUpdated,
     }),
     useTrackStateSelector: () => 1,
+    useSessionCameraGroups: () => mocks.cameraGroups,
   };
 });
 
@@ -77,9 +80,76 @@ const savedLapGraph = (): LapGraphConfig => {
   return (config as { lapGraph: LapGraphConfig }).lapGraph;
 };
 
-// The only saved value rendered on the default "Options" tab.
-const retentionValue = () =>
-  (screen.getByRole('combobox', { name: '' }) as HTMLSelectElement).value;
+const selectValue = (name: string) =>
+  (screen.getByRole('combobox', { name }) as HTMLSelectElement).value;
+
+const retentionValue = () => selectValue('Keep Sessions');
+
+const cameraSelect = () =>
+  screen.getByRole('combobox', {
+    name: 'Incident Camera',
+  }) as HTMLSelectElement;
+
+const savedGantryConfig = () => {
+  const dashboard = mocks.onDashboardUpdated.mock.calls.at(-1)?.[0] as
+    DashboardLayout | undefined;
+  return dashboard?.widgets.find((w) => w.id === 'gantry')?.config as Record<
+    string,
+    unknown
+  >;
+};
+
+describe('GantrySettings incident camera', () => {
+  beforeEach(() => {
+    mocks.onDashboardUpdated.mockClear();
+    mocks.cameraGroups = undefined;
+  });
+
+  it('falls back to Far Chase before a session has loaded', () => {
+    mocks.setDashboard(dashboardWith('all'));
+    render(<GantrySettings />);
+
+    expect(cameraSelect().value).toBe('Far Chase');
+  });
+
+  it("offers the session's own camera groups once they arrive", () => {
+    mocks.cameraGroups = [
+      { GroupNum: 12, GroupName: 'Chase' },
+      { GroupNum: 13, GroupName: 'Far Chase' },
+      { GroupNum: 18, GroupName: 'TV1' },
+    ];
+    mocks.setDashboard(dashboardWith('all'));
+    render(<GantrySettings />);
+
+    const labels = [...cameraSelect().options].map((o) => o.value);
+    expect(labels).toEqual(['Chase', 'Far Chase', 'TV1']);
+  });
+
+  it('keeps a saved group that this track does not offer', () => {
+    mocks.cameraGroups = [{ GroupNum: 12, GroupName: 'Chase' }];
+    mocks.setDashboard(
+      dashboardFor(gantryConfig({ incidentCameraGroup: 'Blimp' }))
+    );
+    render(<GantrySettings />);
+
+    // Dropping it would silently rewrite the user's choice on one track.
+    expect([...cameraSelect().options].map((o) => o.value)).toContain('Blimp');
+    expect(cameraSelect().value).toBe('Blimp');
+  });
+
+  it('writes the chosen group', () => {
+    mocks.cameraGroups = [
+      { GroupNum: 13, GroupName: 'Far Chase' },
+      { GroupNum: 18, GroupName: 'TV1' },
+    ];
+    mocks.setDashboard(dashboardWith('all'));
+    render(<GantrySettings />);
+
+    fireEvent.change(cameraSelect(), { target: { value: 'TV1' } });
+
+    expect(savedGantryConfig().incidentCameraGroup).toBe('TV1');
+  });
+});
 
 describe('GantrySettings', () => {
   beforeEach(() => {

--- a/src/frontend/components/Settings/sections/GantrySettings.tsx
+++ b/src/frontend/components/Settings/sections/GantrySettings.tsx
@@ -8,10 +8,15 @@ import {
   SettingsTabType,
   INCIDENT_THRESHOLD_BOUNDS,
   LAP_GRAPH_LAP_WINDOW_BOUNDS,
+  DEFAULT_INCIDENT_CAMERA_GROUP,
   getWidgetDefaultConfig,
 } from '@irdashies/types';
-import { useDashboard, useTrackStateSelector } from '@irdashies/context';
-import type { TrackStateSnapshot } from '@irdashies/types';
+import {
+  useDashboard,
+  useSessionCameraGroups,
+  useTrackStateSelector,
+} from '@irdashies/context';
+import type { CameraGroup, TrackStateSnapshot } from '@irdashies/types';
 import { TabButton } from '../components/TabButton';
 import { SettingsSection } from '../components/SettingSection';
 import { SettingActionButton } from '../components/SettingActionButton';
@@ -148,6 +153,26 @@ const retentionOptions = [
 const toSessionRetention = (value: string): SessionRetention =>
   value === 'all' ? 'all' : (Number(value) as SessionRetention);
 
+/**
+ * Camera groups come from the live session, so the list is empty until a
+ * session loads. The saved value is always offered so the current choice is
+ * never silently dropped from the dropdown.
+ */
+const cameraGroupOptions = (
+  groups: CameraGroup[] | undefined,
+  selected: string
+) => {
+  const names = (groups ?? [])
+    .map((group) => group?.GroupName?.trim())
+    .filter((name): name is string => !!name);
+  const unique = [
+    ...new Set([DEFAULT_INCIDENT_CAMERA_GROUP, selected, ...names]),
+  ]
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+  return unique.map((name) => ({ label: name, value: name }));
+};
+
 interface YAxisModeOption {
   value: LapGraphYAxisMode;
   label: string;
@@ -218,6 +243,7 @@ export const GantrySettings = memo(() => {
     () => (localStorage.getItem('gantryTab') as SettingsTabType) || 'options'
   );
   const [showDisabledHint, setShowDisabledHint] = useState(false);
+  const cameraGroups = useSessionCameraGroups();
 
   useEffect(() => {
     localStorage.setItem('gantryTab', activeTab);
@@ -234,6 +260,8 @@ export const GantrySettings = memo(() => {
   // A config saved before the lap graph settings existed has no block until the
   // migrator runs on the next dashboard load.
   const lapGraph = config.lapGraph ?? defaultConfig.lapGraph;
+  const cameraGroup =
+    config.incidentCameraGroup ?? DEFAULT_INCIDENT_CAMERA_GROUP;
 
   return (
     <BaseSettingsSection
@@ -341,6 +369,16 @@ export const GantrySettings = memo(() => {
                     ))}
                   </div>
                 </div>
+
+                <SettingSelectRow
+                  title="Incident Camera"
+                  description="Which iRacing camera the incident replay buttons switch to. The list comes from the current session, so it fills in once you are on track. Falls back to the camera already selected when a track does not offer this group."
+                  value={cameraGroup}
+                  options={cameraGroupOptions(cameraGroups, cameraGroup)}
+                  onChange={(v) =>
+                    handleConfigChange({ incidentCameraGroup: v })
+                  }
+                />
 
                 <SettingSelectRow
                   title="Keep Sessions"

--- a/src/frontend/context/SessionStore/SessionStore.tsx
+++ b/src/frontend/context/SessionStore/SessionStore.tsx
@@ -1,4 +1,5 @@
 import type {
+  CameraGroup,
   Session,
   SessionQualifyPosition,
   SessionResults,
@@ -135,6 +136,18 @@ export const useSessionQualifyPositions = (sessionNum: number | undefined) =>
       state.session?.SessionInfo?.Sessions?.find(
         (s) => s.SessionNum === sessionNum
       )?.QualifyPositions,
+    arrayShallowCompare
+  );
+
+/**
+ * Camera groups this track and car offer, e.g. "Far Chase", "TV1". Group
+ * numbers are session-specific, so anything that stores a camera choice must
+ * store the name and resolve the number against this list.
+ */
+export const useSessionCameraGroups = () =>
+  useStoreWithEqualityFn(
+    useSessionStore,
+    (state): CameraGroup[] | undefined => state.session?.CameraInfo?.Groups,
     arrayShallowCompare
   );
 

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1,5 +1,6 @@
 import type { GeneralSettingsType } from './dashboardLayout';
 import type { TypedDashboardWidget, WidgetConfigMap } from './widgetConfigs';
+import { DEFAULT_INCIDENT_CAMERA_GROUP } from './widgetConfigs';
 
 export const defaultDashboard: {
   widgets: TypedDashboardWidget[];
@@ -1465,6 +1466,7 @@ export const defaultDashboard: {
         pitEntryDurationSeconds: 0.6,
         cooldownSeconds: 5,
         sessionRetention: 'all',
+        incidentCameraGroup: DEFAULT_INCIDENT_CAMERA_GROUP,
         lapGraph: {
           yAxisMode: 'trace',
           lapWindow: 75,

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -6,6 +6,7 @@ import type {
   Driver as SdkDriver,
   CarSetupInfo,
 } from '../app/irsdk/types';
+import type { CameraInfo, CameraGroup } from '../app/irsdk/types/camera-info';
 import type { Sector } from '../app/irsdk/types/split-info';
 
 export type Session = SessionData;
@@ -15,3 +16,4 @@ export type { SessionQualifyPosition };
 export type Driver = SdkDriver;
 export type { CarSetupInfo };
 export type { Sector };
+export type { CameraInfo, CameraGroup };

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -730,9 +730,18 @@ export interface GantryConfig {
   cooldownSeconds: number;
   // Persistence
   sessionRetention: SessionRetention;
+  /**
+   * iRacing camera group the incident replay buttons switch to, by name.
+   * Names differ per track and content, so this is matched against the
+   * session's own CameraInfo groups and ignored when it is not present.
+   */
+  incidentCameraGroup: string;
   // Lap Graph tab
   lapGraph: LapGraphConfig;
 }
+
+/** Chase camera far enough back to show what happened around the car. */
+export const DEFAULT_INCIDENT_CAMERA_GROUP = 'Far Chase';
 
 export type GantryWidgetSettings = BaseWidgetSettings<GantryConfig>;
 


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

The incident replay buttons switched to the right car but kept whatever camera was already selected, so you often could not see the incident.

The bridge passed camera group `0`. iRacing numbers camera groups from 1 and treats 0 as "leave the camera group alone". `focusDriver` had the same problem.

Group numbers change from session to session, so the setting stores the group name and looks up the number from the session's own camera list when you click. If the track does not have that group, the camera is left alone, same as today.

Adds a Gantry setting for the camera group, filled from the current session and defaulting to Far Chase. Before a session loads the list only shows the default, because camera groups come from the session. A saved group that the current track does not offer stays in the list rather than being replaced.

Also adds `aria-label` to `SettingSelectRow`. The dropdown had no name for screen readers. This covers every select in Settings, not just the new one.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

Clicking an incident replay button switched to the correct car but stayed on the current camera, for example TV Scenic.

### After
<!-- Screenshot or description of the new behaviour -->

<img width="824" height="96" alt="image" src="https://github.com/user-attachments/assets/2087bb85-9be6-4482-b8a8-ceec6a43067e" />

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Incident Camera** setting to choose which camera group is used for incident focus and replay.
  * Camera options now reflect the active session, are alphabetically organized, and include the default **Far Chase** option.
  * Incident camera selection is saved and applied automatically when available.
  * If the selected camera group is unavailable, incident actions leave the camera unchanged.

* **Accessibility**
  * Improved accessibility for settings dropdowns by providing descriptive labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->