### PR TITLE
fix: overlays hide behind the sim and the settings window

### DIFF
--- a/src/app/overlayManager.spec.ts
+++ b/src/app/overlayManager.spec.ts
@@ -159,9 +159,45 @@ describe('OverlayManager display windows', () => {
 
       expect(createdWindows).toHaveLength(1);
       expect(createdWindows[0].options.alwaysOnTop).toBe(overlayAlwaysOnTop);
-      expect(createdWindows[0].setAlwaysOnTop).not.toHaveBeenCalled();
     }
   );
+
+  it('puts an always-on-top overlay in the same band as the settings window', () => {
+    // The constructor flag alone is not enough. toggleLockOverlays raises the
+    // settings window to 'screen-saver' 2 during edit mode so it sits above the
+    // overlays, which only works if the overlays are at 'screen-saver' 1. With
+    // the level left off, the settings window and a fullscreen sim both end up
+    // above the overlays instead, and the widgets vanish.
+    const manager = new OverlayManager();
+
+    manager.createOverlays(
+      {
+        widgets: [],
+        generalSettings: { overlayAlwaysOnTop: true },
+      } as DashboardLayout,
+      { createSettingsWindow: false }
+    );
+
+    expect(createdWindows[0].setAlwaysOnTop).toHaveBeenCalledWith(
+      true,
+      'screen-saver',
+      1
+    );
+  });
+
+  it('leaves the level alone when the user has turned always-on-top off', () => {
+    const manager = new OverlayManager();
+
+    manager.createOverlays(
+      {
+        widgets: [],
+        generalSettings: { overlayAlwaysOnTop: false },
+      } as DashboardLayout,
+      { createSettingsWindow: false }
+    );
+
+    expect(createdWindows[0].setAlwaysOnTop).not.toHaveBeenCalled();
+  });
 
   it('shows a ready display overlay without activating it', () => {
     const manager = new OverlayManager();

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -273,6 +273,19 @@ export class OverlayManager {
       visibleOnFullScreen: true,
     });
 
+    // The overlays and the settings window use a deliberate two-level scheme:
+    // overlays at 'screen-saver' 1, and the settings window raised to
+    // 'screen-saver' 2 during edit mode so it sits above them (see
+    // toggleLockOverlays). The constructor's `alwaysOnTop` flag alone puts the
+    // window in a lower band than either, so the settings window — and a
+    // fullscreen sim — end up above the overlays instead of below.
+    //
+    // Guarded on the setting so it still honours the user's choice, which is
+    // what the constructor flag above was changed to do.
+    if (this.overlayAlwaysOnTop) {
+      browserWindow.setAlwaysOnTop(true, 'screen-saver', 1);
+    }
+
     if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {
       browserWindow.loadURL(MAIN_WINDOW_VITE_DEV_SERVER_URL);
     } else {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

Since #716, overlays disappear behind the sim and behind the settings window. On my rig, every time:

- Enter edit mode (F6), click and hold a widget: **every widget vanishes**. The drag still works — the widget moves where you put it, you just cannot see anything.
- On release they do not come back. The next F6 does nothing; a second F6 puts you back *into* edit mode; only a third leaves edit mode with the widgets visible.
- Click into the simulator: **all widgets disappear**.
- Select irDashies from the taskbar: the **settings window comes back without the widgets**.

That last symptom is the one that identifies the cause.

### What is actually going on

The overlays and the settings window use a deliberate two-level window band, and `toggleLockOverlays` says so in a comment:

```ts
// Raise settings window to layer 2 during edit mode so it appears above
// overlay windows (layer 1); revert to normal layering when not editing.
this.currentSettingsWindow.setAlwaysOnTop(true, 'screen-saver', 2);
```

That only works if the overlays are actually on layer 1. #716 removed the call that put them there:

```diff
-    if (this.overlayAlwaysOnTop) {
-      browserWindow.setAlwaysOnTop(true, 'screen-saver', 1);
-    }
```

and left only the constructor flag, which has no level:

```ts
alwaysOnTop: this.overlayAlwaysOnTop,
```

A plain `alwaysOnTop` window sits in a lower band than a `screen-saver` one. So the settings window still climbs to layer 2 while the overlays no longer climb to layer 1 — the settings window now outranks them outright, and so does a fullscreen sim. "Taskbar brings back the settings screen but not the widgets" is exactly what that looks like.

Worth noting: this call was itself the fix from #286 ("remove hack to force on top"), which replaced a `setInterval` that re-asserted always-on-top every five seconds. Removing it brought back the problem that interval had existed to paper over.

### The change

Restore the call, guarded on the setting so #716's actual intent — honour the user's choice rather than forcing always-on-top — is preserved:

```ts
if (this.overlayAlwaysOnTop) {
  browserWindow.setAlwaysOnTop(true, 'screen-saver', 1);
}
```

Three lines. The constructor flag from #716 stays exactly as it is.

### A test had to change, and I want to flag it rather than bury it

#716 added:

```ts
expect(createdWindows[0].setAlwaysOnTop).not.toHaveBeenCalled();
```

That assertion codifies the regression, so it could not stay. It is replaced by two tests that pin the actual contract:

- always-on-top on: `setAlwaysOnTop(true, 'screen-saver', 1)` is called, with a comment explaining why the level matters and what breaks without it.
- always-on-top off: `setAlwaysOnTop` is not called at all, so the user's choice is still honoured.

The `alwaysOnTop=%s` constructor test from #716 is kept unchanged apart from dropping that one line.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

Widgets vanish on click-and-hold in edit mode and do not return; clicking into the sim hides them all; the taskbar restores the settings window without them.

### After
<!-- Screenshot or description of the new behaviour -->

Widgets stay visible while dragging in edit mode, survive clicking into the sim, and come back with the app from the taskbar.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [x] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

No Storybook story: this is main-process window layering, which Storybook cannot exercise.

## Validation

**Isolated with a control build before writing any code.** I first suspected a widget I was working on locally. To check, I built the current `main` with that widget removed entirely and ran the same steps on the rig — every symptom reproduced on a build containing none of my code. That ruled my work out and pointed at this window.

**Confirmed fixed in iRacing**, Toyota GR86 at Virginia, practice. Same steps as the reproduction above: widgets now stay visible through a drag, survive clicking into the sim, and return with the app from the taskbar.

**Unit tests, verified by mutation** rather than by passing. Four deliberate breakages, each caught by the test that names it:

| Mutation | Caught |
| --- | --- |
| Revert to the post-#716 state (no call at all) | yes |
| Use level 2 instead of level 1 | yes |
| Drop the level argument, `setAlwaysOnTop(true)` | yes |
| Ignore the user's setting and always call it | yes |

`npm test` — 1914 tests across 196 files, all passing. `npm run lint` — clean.

**One caveat, stated because it is load-bearing:** I have verified the behaviour empirically on Windows, but not that Electron's `level` argument is documented to affect Windows z-ordering the way this code assumes. The evidence for the diagnosis is the codebase's own stated intent, the history of #286, and the symptoms matching the layering exactly — plus the fix working on the rig. If a maintainer knows a more precise mechanism, I would rather the comment said that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Overlay windows configured to stay on top now maintain the intended stacking order, appearing above regular windows while remaining below the settings window during edit mode.

- **Bug Fixes**
  - The “always on top” overlay setting is now applied consistently when creating overlay windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->