### PR TITLE
feat: show the car's in-car adjustments at a glance

### DIFF
--- a/site/src/shims/logger.ts
+++ b/site/src/shims/logger.ts
@@ -1,0 +1,27 @@
+/**
+ * Browser stub for `src/app/logger`.
+ *
+ * The live preview reuses the app's processors, and those log through the
+ * main-process logger. That module is Node/Electron only: it pulls in
+ * `electron-log/main` -> `electron` (which reads `__dirname` at import time)
+ * and reads `process.env`. Both throw in a browser and take down the whole
+ * preview chunk, so the site swaps the module out for this console logger.
+ *
+ * Wired up in `vite.config.ts` via the `stub-app-logger` plugin.
+ */
+const write =
+  (method: 'log' | 'warn' | 'error') =>
+  (...args: unknown[]) =>
+    console[method](...args);
+
+const logger = {
+  debug: write('log'),
+  info: write('log'),
+  verbose: write('log'),
+  silly: write('log'),
+  log: write('log'),
+  warn: write('warn'),
+  error: write('error'),
+};
+
+export default logger;

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,10 +1,41 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/postcss';
 import path from 'node:path';
 
+const APP_LOGGER = path.resolve(__dirname, '../src/app/logger.ts');
+const LOGGER_STUB = path.resolve(__dirname, 'src/shims/logger.ts');
+
+/**
+ * The preview reuses the app's processors, which log through the Electron
+ * main-process logger. Swap that module for a browser-safe console logger --
+ * see src/shims/logger.ts for why it crashes otherwise.
+ */
+function stubAppLogger(): Plugin {
+  return {
+    name: 'stub-app-logger',
+    enforce: 'pre',
+    async resolveId(source, importer, options) {
+      if (!importer || source === LOGGER_STUB) return null;
+      const resolved = await this.resolve(source, importer, {
+        ...options,
+        skipSelf: true,
+      });
+      if (!resolved) return null;
+      const file = path.resolve(resolved.id.split('?')[0]);
+      return file === APP_LOGGER ? LOGGER_STUB : null;
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [stubAppLogger(), react()],
+  define: {
+    // The preview runs main-process code in the browser, and some of it reads
+    // process.env. The production build already compiles that to `{}`; this
+    // makes the dev server behave the same instead of throwing.
+    'process.env': '{}',
+  },
   server: {
     // Use a dedicated port so the site dev server doesn't clash with the
     // main app's renderer dev server (electron-forge vite plugin on 5173).

--- a/src/app/bridge/dashboard/dashboardBridge.ts
+++ b/src/app/bridge/dashboard/dashboardBridge.ts
@@ -256,6 +256,10 @@ export async function publishDashboardUpdates(
     clearTimeout(hideTimer);
     clearTimeout(settleTimer);
     lastProfileId = profileId;
+    // Autostart lives in the dashboard, so it differs between profiles. Re-apply
+    // it here or the Windows Run entry keeps reflecting the profile the app
+    // started on, while the settings screen shows the one now in use.
+    overlayManager.setupAutoStart();
     const name = getProfile(profileId)?.name ?? '';
     // Banner is cosmetic; the hide/reveal still runs to mask the resize.
     const showBanner = getShowProfileBannerStorage();

--- a/src/app/overlayManager.spec.ts
+++ b/src/app/overlayManager.spec.ts
@@ -55,6 +55,7 @@ vi.mock('electron', () => ({
   app: {
     getVersion: () => '0.0.0',
     disableHardwareAcceleration: vi.fn(),
+    setLoginItemSettings: vi.fn(),
     commandLine: { appendSwitch: vi.fn() },
   },
   BrowserWindow: FakeBrowserWindow,
@@ -74,7 +75,10 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('./storage/storage', () => ({ readData: vi.fn(), writeData: vi.fn() }));
-vi.mock('./storage/dashboards', () => ({ getDashboard: vi.fn() }));
+vi.mock('./storage/dashboards', () => ({
+  getDashboard: vi.fn(),
+  getCurrentProfileId: vi.fn(() => 'default'),
+}));
 vi.mock('./storage/chromiumFlags', () => ({
   getChromiumFlags: vi.fn(() => ({})),
   parseCustomSwitches: vi.fn(() => []),
@@ -92,6 +96,9 @@ vi.mock('./logger', () => ({
 }));
 
 const { OverlayManager } = await import('./overlayManager');
+const { app } = await import('electron');
+const { getDashboard, getCurrentProfileId } =
+  await import('./storage/dashboards');
 
 describe('overlay renderer data visibility recovery', () => {
   it('replays the latest session snapshot when a subscribed window is shown', () => {
@@ -214,5 +221,99 @@ describe('OverlayManager display windows', () => {
     expect(displayWindow.showInactive).toHaveBeenCalledOnce();
     expect(displayWindow.show).not.toHaveBeenCalled();
     expect(displayWindow.focus).not.toHaveBeenCalled();
+  });
+});
+
+describe('settings that are read outside a dashboard update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createdWindows.length = 0;
+  });
+
+  /**
+   * The reported bug: autostart is off in the profile the user is on, on in
+   * 'default'. Reading 'default' at startup re-created the Windows Run entry
+   * every launch, while the settings screen kept showing it as off.
+   */
+  const profiles: Record<string, DashboardLayout> = {
+    default: {
+      widgets: [],
+      generalSettings: {
+        enableAutoStart: true,
+        disableHardwareAcceleration: true,
+      },
+    } as DashboardLayout,
+    GT3: {
+      widgets: [],
+      generalSettings: {
+        enableAutoStart: false,
+        disableHardwareAcceleration: false,
+      },
+    } as DashboardLayout,
+  };
+
+  const onProfile = (profileId: string) => {
+    vi.mocked(getCurrentProfileId).mockReturnValue(profileId);
+    vi.mocked(getDashboard).mockImplementation((id: string) => profiles[id]);
+  };
+
+  it('does not enable autostart from another profile', () => {
+    onProfile('GT3');
+
+    new OverlayManager().setupAutoStart();
+
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: false,
+    });
+  });
+
+  it('enables autostart when the active profile asks for it', () => {
+    onProfile('default');
+
+    new OverlayManager().setupAutoStart();
+
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: true,
+    });
+  });
+
+  it('leaves autostart off when the profile does not mention it', () => {
+    // An absent setting must not opt the user into starting with Windows.
+    vi.mocked(getCurrentProfileId).mockReturnValue('bare');
+    vi.mocked(getDashboard).mockReturnValue({
+      widgets: [],
+      generalSettings: {},
+    } as DashboardLayout);
+
+    new OverlayManager().setupAutoStart();
+
+    expect(app.setLoginItemSettings).toHaveBeenCalledWith({
+      openAtLogin: false,
+    });
+  });
+
+  it('reads the active profile, not the one named default', () => {
+    onProfile('GT3');
+
+    new OverlayManager().setupAutoStart();
+
+    expect(getDashboard).toHaveBeenCalledWith('GT3');
+    expect(getDashboard).not.toHaveBeenCalledWith('default');
+  });
+
+  it('takes hardware acceleration from the active profile too', () => {
+    onProfile('GT3');
+
+    new OverlayManager().setupHardwareAcceleration();
+
+    expect(app.disableHardwareAcceleration).not.toHaveBeenCalled();
+  });
+
+  it('disables hardware acceleration when the active profile asks for it', () => {
+    onProfile('default');
+
+    new OverlayManager().setupHardwareAcceleration();
+
+    expect(app.disableHardwareAcceleration).toHaveBeenCalled();
   });
 });

--- a/src/app/overlayManager.ts
+++ b/src/app/overlayManager.ts
@@ -9,7 +9,16 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { Notification } from 'electron';
 import { readData, writeData } from './storage/storage';
-import { getDashboard } from './storage/dashboards';
+import { getDashboard, getCurrentProfileId } from './storage/dashboards';
+
+/**
+ * Settings read outside a dashboard update must come from the profile the user
+ * is actually on. Reading 'default' meant a setting toggled in any other
+ * profile was shown as changed in the UI while the app kept acting on the
+ * default profile's value - and for autostart that meant re-creating the
+ * Windows Run entry on every launch after the user had turned it off.
+ */
+const activeDashboard = () => getDashboard(getCurrentProfileId());
 import { getChromiumFlags, parseCustomSwitches } from './storage/chromiumFlags';
 import {
   markCorrectedBounds,
@@ -859,7 +868,7 @@ export class OverlayManager {
    * Must be called before the app is ready.
    */
   public setupHardwareAcceleration(): void {
-    const dashboard = getDashboard('default');
+    const dashboard = activeDashboard();
     if (dashboard?.generalSettings?.disableHardwareAcceleration) {
       app.disableHardwareAcceleration();
     }
@@ -915,14 +924,14 @@ export class OverlayManager {
   }
 
   public setupAutoStart(): void {
-    const dashboard = getDashboard('default');
+    const dashboard = activeDashboard();
     app.setLoginItemSettings({
       openAtLogin: dashboard?.generalSettings?.enableAutoStart ?? false,
     });
   }
 
   private shouldCloseToTray(): boolean {
-    const dashboard = getDashboard('default');
+    const dashboard = activeDashboard();
     return dashboard?.generalSettings?.closeToTray ?? true;
   }
 

--- a/src/app/processors/CarSystemsProcessor.spec.ts
+++ b/src/app/processors/CarSystemsProcessor.spec.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CarSystemsProcessor } from './CarSystemsProcessor';
+import type { Session, Telemetry } from '@irdashies/types';
+
+/**
+ * Frames are built the way the SDK publishes them: a variable that the car does
+ * not expose is absent from the frame entirely, not present-and-null.
+ */
+const frame = (
+  values: Record<string, number | boolean | undefined>,
+  { inCar = true }: { inCar?: boolean } = {}
+): Telemetry => {
+  const out: Record<string, { value: unknown[] }> = {
+    SessionNum: { value: [0] },
+    IsOnTrack: { value: [inCar] },
+  };
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) continue;
+    out[key] = { value: [value] };
+  }
+  return out as unknown as Telemetry;
+};
+
+const start = () => {
+  const processor = new CarSystemsProcessor();
+  processor.init({} as Session);
+  processor.onLifecycle({ type: 'enter', replay: false });
+  return processor;
+};
+
+const byKey = (processor: CarSystemsProcessor, key: string) =>
+  processor.snapshot().adjustments.find((a) => a.key === key);
+
+describe('CarSystemsProcessor', () => {
+  let processor: CarSystemsProcessor;
+
+  beforeEach(() => {
+    processor = start();
+  });
+
+  describe('discovery', () => {
+    it('reports only the adjustments the car actually exposes', () => {
+      // A Formula Vee exposes brake bias and nothing else.
+      processor.onFrame(frame({ dcBrakeBias: 48 }));
+
+      expect(processor.snapshot().adjustments.map((a) => a.label)).toEqual([
+        'Brake Bias',
+      ]);
+    });
+
+    it('reports the fuller set a GT3 car exposes', () => {
+      processor.onFrame(
+        frame({
+          dcBrakeBias: 54.5,
+          dcABS: 2,
+          dcTractionControl: 3,
+          dcThrottleShape: 1,
+        })
+      );
+
+      expect(processor.snapshot().adjustments.map((a) => a.label)).toEqual([
+        'Brake Bias',
+        'ABS',
+        'TC',
+        'Throttle Shape',
+      ]);
+    });
+
+    it('ignores momentary controls that are not settings', () => {
+      // dcTractionControlToggle reads false continuously on cars whose traction
+      // control is plainly on, so it is not an on/off state and must not appear.
+      processor.onFrame(
+        frame({
+          dcBrakeBias: 50,
+          dcTractionControl: 4,
+          dcTractionControlToggle: false,
+          dcStarter: false,
+          dcPitSpeedLimiterToggle: false,
+          dcHeadlightFlash: false,
+        })
+      );
+
+      expect(processor.snapshot().adjustments.map((a) => a.key)).toEqual([
+        'dcBrakeBias',
+        'dcTractionControl',
+      ]);
+    });
+
+    it('takes the Clio brake bias variable when that is the one published', () => {
+      processor.onFrame(frame({ dcPeakBrakeBias: 61 }));
+
+      const rows = processor.snapshot().adjustments;
+      expect(rows).toHaveLength(1);
+      expect(rows[0].label).toBe('Brake Bias');
+      expect(rows[0].value).toBe(61);
+    });
+
+    it('does not discover anything from an out-of-car frame', () => {
+      // Spectating publishes a reduced set, so nothing seen out of the car can
+      // be trusted to describe it. The frame carries real adjustments here on
+      // purpose: discovery must be refused because of where it came from, not
+      // because there was nothing in it.
+      processor.onFrame(frame({ dcBrakeBias: 50, dcABS: 2 }, { inCar: false }));
+
+      expect(processor.snapshot().discovered).toBe(false);
+      expect(processor.snapshot().adjustments).toEqual([]);
+    });
+
+    it('picks up a variable that starts publishing a frame later', () => {
+      processor.onFrame(frame({ dcBrakeBias: 50 }));
+      processor.onFrame(frame({ dcBrakeBias: 50, dcABS: 3 }));
+
+      expect(processor.snapshot().adjustments.map((a) => a.key)).toEqual([
+        'dcBrakeBias',
+        'dcABS',
+      ]);
+    });
+
+    it('keeps a row whose variable stops appearing in later in-car frames', () => {
+      processor.onFrame(frame({ dcBrakeBias: 50, dcABS: 3 }));
+      // Still in the car, but ABS is missing from this frame. Dropping the row
+      // would make the table flicker as rows come and go.
+      processor.onFrame(frame({ dcBrakeBias: 50 }));
+
+      expect(processor.snapshot().adjustments.map((a) => a.key)).toEqual([
+        'dcBrakeBias',
+        'dcABS',
+      ]);
+    });
+
+    it('excludes a momentary control even when it reports a number', () => {
+      // dcDashPage is a page index, not a setting to read back. Excluding it
+      // has to be a decision about what belongs, not a side effect of the
+      // boolean controls happening to fail a numeric check.
+      processor.onFrame(
+        frame({ dcBrakeBias: 50, dcDashPage: 2, dcDashPage2: 1 })
+      );
+
+      expect(processor.snapshot().adjustments.map((a) => a.key)).toEqual([
+        'dcBrakeBias',
+      ]);
+    });
+  });
+
+  describe('leaving the car', () => {
+    it('keeps the last known values rather than emptying the table', () => {
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+      processor.onFrame(frame({ dcStarter: false }, { inCar: false }));
+
+      const rows = processor.snapshot().adjustments;
+      expect(rows.map((a) => a.key)).toEqual(['dcBrakeBias', 'dcABS']);
+      expect(byKey(processor, 'dcABS')?.value).toBe(2);
+    });
+  });
+
+  describe('off detection', () => {
+    it('marks a zero as off on an unsigned scale', () => {
+      // A BMW M2 Racing sits at 0 for both when the driver switches them off.
+      processor.onFrame(frame({ dcABS: 0, dcTractionControl: 0 }));
+
+      expect(byKey(processor, 'dcABS')?.isOff).toBe(true);
+      expect(byKey(processor, 'dcTractionControl')?.isOff).toBe(true);
+    });
+
+    it('does not mark a non-zero setting as off', () => {
+      processor.onFrame(frame({ dcABS: 1, dcTractionControl: 3 }));
+
+      expect(byKey(processor, 'dcABS')?.isOff).toBe(false);
+      expect(byKey(processor, 'dcTractionControl')?.isOff).toBe(false);
+    });
+
+    it('does not treat zero as off once the scale is known to be signed', () => {
+      // The BMW M Hybrid V8 reports ABS between -5 and -3, so zero on that
+      // scale is an ordinary setting rather than the system being off.
+      processor.onFrame(frame({ dcABS: -5 }));
+      processor.onFrame(frame({ dcABS: 0 }));
+
+      expect(byKey(processor, 'dcABS')?.isOff).toBe(false);
+    });
+
+    it('judges the scale of each variable independently', () => {
+      processor.onFrame(frame({ dcABS: -3, dcTractionControl: 2 }));
+      processor.onFrame(frame({ dcABS: 0, dcTractionControl: 0 }));
+
+      expect(byKey(processor, 'dcABS')?.isOff).toBe(false);
+      expect(byKey(processor, 'dcTractionControl')?.isOff).toBe(true);
+    });
+  });
+
+  describe('publishing', () => {
+    it('does not bump the version when nothing changed', () => {
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+      const version = processor.snapshot().version;
+
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+
+      expect(processor.snapshot().version).toBe(version);
+    });
+
+    it('bumps the version when the driver turns a dial', () => {
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+      const version = processor.snapshot().version;
+
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 3 }));
+
+      expect(processor.snapshot().version).toBeGreaterThan(version);
+      expect(byKey(processor, 'dcABS')?.value).toBe(3);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('records nothing during a replay', () => {
+      const replaying = new CarSystemsProcessor();
+      replaying.init({} as Session);
+      replaying.onLifecycle({ type: 'enter', replay: true });
+
+      replaying.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+
+      expect(replaying.snapshot().adjustments).toEqual([]);
+      expect(replaying.snapshot().discovered).toBe(false);
+    });
+
+    it('forgets the car when the session changes', () => {
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+
+      processor.onLifecycle({ type: 'sessionNumChange' });
+
+      expect(processor.snapshot().adjustments).toEqual([]);
+      expect(processor.snapshot().discovered).toBe(false);
+    });
+
+    it('forgets the car on disconnect, so the next one starts clean', () => {
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+
+      processor.onLifecycle({ type: 'disconnect' });
+
+      expect(processor.snapshot().discovered).toBe(false);
+    });
+  });
+});

--- a/src/app/processors/CarSystemsProcessor.spec.ts
+++ b/src/app/processors/CarSystemsProcessor.spec.ts
@@ -58,10 +58,12 @@ describe('CarSystemsProcessor', () => {
         })
       );
 
+      // The snapshot carries the full label; the widget renders the short form
+      // from the shared catalogue, so this is the settings-facing name.
       expect(processor.snapshot().adjustments.map((a) => a.label)).toEqual([
         'Brake Bias',
         'ABS',
-        'TC',
+        'Traction Control',
         'Throttle Shape',
       ]);
     });

--- a/src/app/processors/CarSystemsProcessor.spec.ts
+++ b/src/app/processors/CarSystemsProcessor.spec.ts
@@ -211,6 +211,55 @@ describe('CarSystemsProcessor', () => {
     });
   });
 
+  describe('staying on screen', () => {
+    /**
+     * ProcessorHost calls init() on every session update, and iRacing
+     * republishes session data every second or two. Resetting there wiped the
+     * discovered set and the values, so the table blinked empty until the next
+     * frame refilled it - reported from a PEC qualifying session where it
+     * flickered every second or two.
+     */
+    it('survives the repeated init that a session update triggers', () => {
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+      const before = processor.snapshot().adjustments;
+
+      processor.init({} as Session);
+      processor.init({} as Session);
+
+      expect(processor.snapshot().adjustments).toEqual(before);
+      expect(processor.snapshot().discovered).toBe(true);
+    });
+
+    it('does not republish when a session update arrives', () => {
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+      const version = processor.snapshot().version;
+
+      processor.init({} as Session);
+
+      // A version bump makes every subscriber re-render for no change.
+      expect(processor.snapshot().version).toBe(version);
+    });
+
+    it('keeps its values on a frame that omits SessionNum', () => {
+      processor.onFrame(frame({ dcBrakeBias: 54, dcABS: 2 }));
+
+      // No SessionNum, and out of the car so nothing re-discovers within the
+      // same frame. That is when a spurious reset is actually visible: the
+      // table empties and stays empty. An in-car frame hides the damage by
+      // repopulating immediately, which is why this one is deliberately not.
+      const noSessionNum = {
+        IsOnTrack: { value: [false] },
+      } as unknown as Telemetry;
+      processor.onFrame(noSessionNum);
+
+      expect(processor.snapshot().adjustments.map((a) => a.key)).toEqual([
+        'dcBrakeBias',
+        'dcABS',
+      ]);
+      expect(processor.snapshot().discovered).toBe(true);
+    });
+  });
+
   describe('lifecycle', () => {
     it('records nothing during a replay', () => {
       const replaying = new CarSystemsProcessor();

--- a/src/app/processors/CarSystemsProcessor.spec.ts
+++ b/src/app/processors/CarSystemsProcessor.spec.ts
@@ -88,6 +88,48 @@ describe('CarSystemsProcessor', () => {
       ]);
     });
 
+    /**
+     * Values taken from a recorded Dallara IR18 session at Monza: the car
+     * publishes no ABS or traction control at all, and its two hybrid dials sat
+     * at DeployLevel 1.0 / RegenLevel 0.7 — matching the Hybrid block in the
+     * session info for that stint.
+     */
+    it('reports the hybrid dials an IR18 exposes, and no assists it lacks', () => {
+      processor.onFrame(
+        frame({
+          dcBrakeBias: 46.814,
+          dcMGUKDeployFixed: 1,
+          dcMGUKRegenGain: 0.7,
+        })
+      );
+
+      expect(processor.snapshot().adjustments.map((a) => a.label)).toEqual([
+        'Brake Bias',
+        'Deploy Level',
+        'Regen Level',
+      ]);
+      expect(byKey(processor, 'dcMGUKRegenGain')?.value).toBe(0.7);
+      expect(byKey(processor, 'dcMGUKRegenGain')?.isOff).toBe(false);
+    });
+
+    /**
+     * Non-hybrid cars do not publish these keys at all — checked against
+     * recorded Mustang GT3, Ligier JSP320 and Oulton sessions — so discovery
+     * leaves the rows out rather than showing every GT3 driver a dead column.
+     */
+    it('gives a non-hybrid car no hybrid rows', () => {
+      processor.onFrame(frame({ dcBrakeBias: 54.5, dcABS: 2 }));
+
+      expect(byKey(processor, 'dcMGUKDeployFixed')).toBeUndefined();
+      expect(byKey(processor, 'dcMGUKRegenGain')).toBeUndefined();
+    });
+
+    it('marks a regen dial wound fully off as off', () => {
+      processor.onFrame(frame({ dcMGUKRegenGain: 0 }));
+
+      expect(byKey(processor, 'dcMGUKRegenGain')?.isOff).toBe(true);
+    });
+
     it('takes the Clio brake bias variable when that is the one published', () => {
       processor.onFrame(frame({ dcPeakBrakeBias: 61 }));
 

--- a/src/app/processors/CarSystemsProcessor.ts
+++ b/src/app/processors/CarSystemsProcessor.ts
@@ -1,0 +1,171 @@
+import type {
+  CarSystemAdjustment,
+  CarSystemsSnapshot,
+  Session,
+  SessionLifecycleEvent,
+  Telemetry,
+} from '@irdashies/types';
+import { CAR_SYSTEM_ADJUSTMENTS } from '@irdashies/types';
+import type { TelemetryProcessor } from './TelemetryProcessor';
+
+const number = (frame: Telemetry, key: string): number | undefined => {
+  const value = (frame as Record<string, { value?: unknown[] } | undefined>)[
+    key
+  ]?.value?.[0];
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+};
+
+const boolean = (frame: Telemetry, key: keyof Telemetry): boolean =>
+  (frame[key] as { value?: unknown[] } | undefined)?.value?.[0] === true;
+
+/**
+ * Publishes the player car's adjustable systems.
+ *
+ * Two things drive the design, both established from recorded sessions rather
+ * than assumed:
+ *
+ * **The set is per-car and is only visible from inside the car.** A Formula Vee
+ * exposes brake bias alone; a GTP car exposes a dozen. Out of the car iRacing
+ * publishes a reduced set — sessions captured while spectating carry only
+ * dcStarter — so an out-of-car frame cannot be used to conclude that a car
+ * lacks ABS. The discovered set is therefore latched on the first in-car frame
+ * and kept, so the display does not empty out when the player hops out, spectates
+ * or watches a replay.
+ *
+ * **Scales differ and some are signed.** Most run 0..n with 0 meaning off, but
+ * the BMW M Hybrid V8 reports ABS between -5 and -3. A negative value anywhere
+ * in a session proves the scale has a negative side, on which 0 is an ordinary
+ * setting rather than off. That is tracked per variable.
+ */
+export class CarSystemsProcessor implements TelemetryProcessor<CarSystemsSnapshot> {
+  readonly channel = 'car-systems.snapshot';
+  // Adjustments move when a dial is turned. Sampling faster buys nothing and
+  // the snapshot only republishes when a value actually changes.
+  readonly tickRateHz = 10;
+
+  private enabled = true;
+  /** Variables seen on an in-car frame, in CAR_SYSTEM_ADJUSTMENTS order. */
+  private discoveredKeys: string[] = [];
+  /** Variables observed negative at any point: their scale is signed. */
+  private readonly signedKeys = new Set<string>();
+  private readonly latest: CarSystemsSnapshot & {
+    adjustments: CarSystemAdjustment[];
+  } = {
+    adjustments: [],
+    discovered: false,
+    sessionNum: null,
+    version: 0,
+  };
+
+  // The adjustment set is discovered from telemetry, not from session info.
+  init(session: Session): void {
+    void session;
+    this.reset(null);
+  }
+
+  onFrame(frame: Telemetry): void {
+    if (!this.enabled) return;
+
+    const sessionNum = number(frame, 'SessionNum') ?? null;
+    if (
+      this.latest.sessionNum !== null &&
+      sessionNum !== this.latest.sessionNum
+    ) {
+      this.reset(sessionNum);
+    } else if (this.latest.sessionNum === null) {
+      this.latest.sessionNum = sessionNum;
+    }
+
+    // Being in the car is what makes the full set visible. The pit box counts;
+    // the garage and replay playback do not, matching useDrivingState.
+    const inCar =
+      (boolean(frame, 'IsOnTrack') ||
+        boolean(frame, 'PlayerCarInPitStall') ||
+        boolean(frame, 'OnPitRoad')) &&
+      !boolean(frame, 'IsInGarage') &&
+      !boolean(frame, 'IsReplayPlaying');
+
+    if (inCar) {
+      const present = CAR_SYSTEM_ADJUSTMENTS.filter(
+        ({ key }) => number(frame, key) !== undefined
+      ).map(({ key }) => key);
+      // Union rather than replacement: a car can publish a variable a frame
+      // later than the rest, and losing a row mid-session reads as a fault.
+      for (const key of present) {
+        if (!this.discoveredKeys.includes(key)) this.discoveredKeys.push(key);
+      }
+      if (present.length > 0) this.latest.discovered = true;
+    }
+
+    if (!this.latest.discovered) return;
+
+    const next: CarSystemAdjustment[] = [];
+    for (const definition of CAR_SYSTEM_ADJUSTMENTS) {
+      if (!this.discoveredKeys.includes(definition.key)) continue;
+      const value = number(frame, definition.key);
+      if (value === undefined) {
+        // Out of the car the value stops being published. Keep the last known
+        // reading rather than dropping the row.
+        const previous = this.latest.adjustments.find(
+          (a) => a.key === definition.key
+        );
+        if (previous) next.push(previous);
+        continue;
+      }
+      if (value < 0) this.signedKeys.add(definition.key);
+      next.push({
+        key: definition.key,
+        label: definition.label,
+        value,
+        isOff: value === 0 && !this.signedKeys.has(definition.key),
+        precision: definition.precision,
+        unit: definition.unit,
+      });
+    }
+
+    if (this.changed(next)) {
+      this.latest.adjustments = next;
+      this.latest.version += 1;
+    }
+  }
+
+  private changed(next: CarSystemAdjustment[]): boolean {
+    const current = this.latest.adjustments;
+    if (current.length !== next.length) return true;
+    for (let i = 0; i < next.length; i += 1) {
+      const a = current[i];
+      const b = next[i];
+      if (a.key !== b.key || a.value !== b.value || a.isOff !== b.isOff) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private reset(sessionNum: number | null): void {
+    this.discoveredKeys = [];
+    this.signedKeys.clear();
+    this.latest.adjustments = [];
+    this.latest.discovered = false;
+    this.latest.sessionNum = sessionNum;
+    this.latest.version += 1;
+  }
+
+  onLifecycle(event: SessionLifecycleEvent): void {
+    if (event.type === 'enter') {
+      // Scrubbing a replay replays old adjustment values, and the discovered
+      // set would latch from whatever car the replay is following rather than
+      // the player's. Neither is useful, so recording stops during one.
+      this.enabled = !event.replay;
+      if (event.replay) this.reset(null);
+    } else {
+      this.reset(null);
+    }
+  }
+
+  snapshot(): CarSystemsSnapshot {
+    return this.latest;
+  }
+}

--- a/src/app/processors/CarSystemsProcessor.ts
+++ b/src/app/processors/CarSystemsProcessor.ts
@@ -60,22 +60,35 @@ export class CarSystemsProcessor implements TelemetryProcessor<CarSystemsSnapsho
   };
 
   // The adjustment set is discovered from telemetry, not from session info.
+  /**
+   * Deliberately does nothing. ProcessorHost calls this on every session
+   * update, not once at startup, and iRacing republishes session data every
+   * second or two - so resetting here wiped the discovered set and the values
+   * constantly, and the table blinked empty until the next frame refilled it.
+   * Clearing state belongs in onLifecycle, which fires on the events that
+   * actually invalidate it.
+   */
   init(session: Session): void {
     void session;
-    this.reset(null);
   }
 
   onFrame(frame: Telemetry): void {
     if (!this.enabled) return;
 
-    const sessionNum = number(frame, 'SessionNum') ?? null;
-    if (
-      this.latest.sessionNum !== null &&
-      sessionNum !== this.latest.sessionNum
-    ) {
-      this.reset(sessionNum);
-    } else if (this.latest.sessionNum === null) {
-      this.latest.sessionNum = sessionNum;
+    // A frame that omits SessionNum says nothing about which session this is,
+    // so it must not be read as a change. Treating the absent value as null and
+    // comparing it against the stored one reset the whole table on any frame
+    // that happened to arrive without it.
+    const sessionNum = number(frame, 'SessionNum');
+    if (sessionNum !== undefined) {
+      if (
+        this.latest.sessionNum !== null &&
+        sessionNum !== this.latest.sessionNum
+      ) {
+        this.reset(sessionNum);
+      } else if (this.latest.sessionNum === null) {
+        this.latest.sessionNum = sessionNum;
+      }
     }
 
     // Being in the car is what makes the full set visible. The pit box counts;

--- a/src/app/processors/processorRegistry.ts
+++ b/src/app/processors/processorRegistry.ts
@@ -19,6 +19,7 @@ import { ReferenceLapProcessor } from './ReferenceLapProcessor';
 import { RelativeGapProcessor } from './RelativeGapProcessor';
 import { SectorTimingProcessor } from './SectorTimingProcessor';
 import { SessionBarProcessor } from './SessionBarProcessor';
+import { CarSystemsProcessor } from './CarSystemsProcessor';
 import { SessionTimingProcessor } from './SessionTimingProcessor';
 import { StandingsProcessor } from './StandingsProcessor';
 import { TrackStateProcessor } from './TrackStateProcessor';
@@ -126,6 +127,11 @@ export const createProcessorDefinitions = ({
     channel: 'session-bar.snapshot',
     metricsPrefix: 'sessionBar',
     create: () => new SessionBarProcessor(),
+  }),
+  defineProcessor({
+    channel: 'car-systems.snapshot',
+    metricsPrefix: 'carSystems',
+    create: () => new CarSystemsProcessor(),
   }),
   defineProcessor({
     channel: 'driver-controls.snapshot',

--- a/src/frontend/WidgetIndex.tsx
+++ b/src/frontend/WidgetIndex.tsx
@@ -20,6 +20,7 @@ import { InformationBar } from './components/InformationBar/InformationBar';
 import { SlowCarAhead } from './components/SlowCarAhead/SlowCarAhead';
 import { SectorDelta } from './components/SectorDelta/SectorDelta';
 import { DeltaSpeed } from './components/DeltaSpeed/DeltaSpeed';
+import { CarSystems } from './components/CarSystems/CarSystems';
 import { HeartRate } from './components/HeartRate/HeartRate';
 import { CornerNameOverlay } from './components/CornerNameOverlay';
 import { Battle } from './components/Battle/Battle';
@@ -79,6 +80,7 @@ export const WIDGET_MAP: Record<keyof WidgetConfigMap, ElementType> = {
   slowcarahead: SlowCarAhead,
   sectordelta: SectorDelta,
   deltaspeed: DeltaSpeed,
+  carsystems: CarSystems,
   heartrate: HeartRate,
   cornername: CornerNameOverlay,
   battle: Battle,

--- a/src/frontend/components/CarSystems/CarSystems.stories.tsx
+++ b/src/frontend/components/CarSystems/CarSystems.stories.tsx
@@ -1,0 +1,151 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  ChannelSnapshotDecorator,
+  TelemetryDecoratorWithConfig,
+} from '@irdashies/storybook';
+import type { CarSystemAdjustment, CarSystemsSnapshot } from '@irdashies/types';
+import { CarSystems } from './CarSystems';
+
+const adjustment = (
+  key: string,
+  label: string,
+  value: number,
+  extra: Partial<CarSystemAdjustment> = {}
+): CarSystemAdjustment => ({
+  key,
+  label,
+  value,
+  isOff: false,
+  precision: 0,
+  ...extra,
+});
+
+const brakeBias = (value: number) =>
+  adjustment('dcBrakeBias', 'Brake Bias', value, {
+    precision: 1,
+    unit: '%',
+  });
+
+const snapshot = (adjustments: CarSystemAdjustment[]): CarSystemsSnapshot => ({
+  adjustments,
+  discovered: true,
+  sessionNum: 0,
+  version: 1,
+});
+
+const ROWS = [
+  'dcBrakeBias',
+  'dcABS',
+  'dcTractionControl',
+  'dcTractionControl2',
+  'dcThrottleShape',
+];
+
+const story = (
+  systems: CarSystemsSnapshot,
+  config: Record<string, unknown> = {}
+) => ({
+  decorators: [
+    TelemetryDecoratorWithConfig('/test-data/1747384033336', {
+      carsystems: { rows: ROWS, showUnsupportedRows: true, ...config },
+    }),
+    ChannelSnapshotDecorator({ 'car-systems.snapshot': systems }),
+    // The widget is full-width by design and takes its size from its overlay
+    // window, so the story supplies one rather than letting it span the page.
+    (Story: React.ComponentType) => (
+      <div style={{ width: 220 }}>
+        <Story />
+      </div>
+    ),
+  ],
+});
+
+const meta: Meta<typeof CarSystems> = {
+  component: CarSystems,
+  title: 'widgets/CarSystems',
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CarSystems>;
+
+/** A GT3 car: every configured row is supported. */
+export const Gt3: Story = {
+  ...story(
+    snapshot([
+      brakeBias(54.5),
+      adjustment('dcABS', 'ABS', 2),
+      adjustment('dcTractionControl', 'TC', 3),
+      adjustment('dcTractionControl2', 'TC2', 5),
+      adjustment('dcThrottleShape', 'Throttle Shape', 1),
+    ])
+  ),
+};
+
+/**
+ * A Formula Vee exposes brake bias alone. The other rows are kept so the table
+ * does not change shape between cars.
+ */
+export const BrakeBiasOnly: Story = {
+  ...story(snapshot([brakeBias(48)])),
+};
+
+/** The same car with the blank rows turned off. */
+export const SupportedRowsOnly: Story = {
+  ...story(snapshot([brakeBias(48)]), { showUnsupportedRows: false }),
+};
+
+/** ABS and TC switched off: subdued, and distinguishable from a blank row. */
+export const AssistsOff: Story = {
+  ...story(
+    snapshot([
+      brakeBias(52),
+      adjustment('dcABS', 'ABS', 0, { isOff: true }),
+      adjustment('dcTractionControl', 'TC', 0, { isOff: true }),
+    ])
+  ),
+};
+
+/**
+ * A signed scale. The BMW M Hybrid V8 reports ABS between -5 and -3, so a zero
+ * there is an ordinary setting and must not read as off.
+ */
+export const SignedScale: Story = {
+  ...story(
+    snapshot([
+      brakeBias(51.5),
+      adjustment('dcABS', 'ABS', 0),
+      adjustment('dcTractionControl', 'TC', 4),
+    ])
+  ),
+};
+
+/** Every adjustment a heavily configurable car might expose. */
+export const AllRows: Story = {
+  ...story(
+    snapshot([
+      brakeBias(53.5),
+      adjustment('dcABS', 'ABS', 4),
+      adjustment('dcTractionControl', 'TC', 6),
+      adjustment('dcTractionControl2', 'TC2', 2),
+      adjustment('dcThrottleShape', 'Throttle Shape', 3),
+      adjustment('dcEnginePower', 'Engine Power', 5),
+      adjustment('dcFuelMixture', 'Fuel Mixture', 2),
+      adjustment('dcAntiRollFront', 'ARB Front', 4),
+      adjustment('dcAntiRollRear', 'ARB Rear', 3),
+    ]),
+    {
+      rows: [
+        'dcBrakeBias',
+        'dcABS',
+        'dcTractionControl',
+        'dcTractionControl2',
+        'dcThrottleShape',
+        'dcEnginePower',
+        'dcFuelMixture',
+        'dcAntiRollFront',
+        'dcAntiRollRear',
+      ],
+    }
+  ),
+};

--- a/src/frontend/components/CarSystems/CarSystems.stories.tsx
+++ b/src/frontend/components/CarSystems/CarSystems.stories.tsx
@@ -52,8 +52,9 @@ const story = (
     ChannelSnapshotDecorator({ 'car-systems.snapshot': systems }),
     // The widget is full-width by design and takes its size from its overlay
     // window, so the story supplies one rather than letting it span the page.
+    // Wide enough for a strip of columns rather than the old stacked table.
     (Story: React.ComponentType) => (
-      <div style={{ width: 220 }}>
+      <div style={{ width: 420 }}>
         <Story />
       </div>
     ),

--- a/src/frontend/components/CarSystems/CarSystems.stories.tsx
+++ b/src/frontend/components/CarSystems/CarSystems.stories.tsx
@@ -91,6 +91,31 @@ export const BrakeBiasOnly: Story = {
   ...story(snapshot([brakeBias(48)])),
 };
 
+/**
+ * A Dallara IR18, with the values from a recorded Monza stint. It publishes no
+ * ABS or traction control at all, so those columns sit blank, and its two
+ * hybrid dials take their own rows. The energy those dials govern is not here:
+ * it swings the full 0..100% within a lap and belongs in a gauge.
+ */
+export const Ir18Hybrid: Story = {
+  ...story(
+    snapshot([
+      brakeBias(46.8),
+      adjustment('dcMGUKDeployFixed', 'Deploy Level', 1, { precision: 1 }),
+      adjustment('dcMGUKRegenGain', 'Regen Level', 0.7, { precision: 1 }),
+    ]),
+    {
+      rows: [
+        'dcBrakeBias',
+        'dcABS',
+        'dcTractionControl',
+        'dcMGUKDeployFixed',
+        'dcMGUKRegenGain',
+      ],
+    }
+  ),
+};
+
 /** The same car with the blank rows turned off. */
 export const SupportedRowsOnly: Story = {
   ...story(snapshot([brakeBias(48)]), { showUnsupportedRows: false }),

--- a/src/frontend/components/CarSystems/CarSystems.tsx
+++ b/src/frontend/components/CarSystems/CarSystems.tsx
@@ -35,8 +35,12 @@ export const SystemColumn = memo(
     // zero, or a blank for a system the car does not have.
     const subdued = unsupported || adjustment.isOff;
 
+    // flex-auto rather than flex-1: equal-width columns size to the widest
+    // possible content, so a percentage like 53.5% got the same room as a
+    // single digit and crowded its neighbours. Sizing from content lets the
+    // brake bias column take the width it actually needs.
     return (
-      <div className="flex flex-1 min-w-0 flex-col items-center gap-0.5">
+      <div className="flex flex-auto min-w-0 flex-col items-center gap-0.5">
         {/* px-1 rather than the Pitlane Helper's px-2: its chips are standalone
             status pills, these are packed side by side, and the wider padding
             truncated a three-letter label once the column count got high. */}
@@ -51,7 +55,7 @@ export const SystemColumn = memo(
             same balance the Pitlane Helper strikes between its big readouts
             and their small captions. */}
         <div
-          className={`${isCompact ? 'text-base' : 'text-[1.35em] py-0.5'} text-center font-semibold tabular-nums whitespace-nowrap leading-none ${
+          className={`${isCompact ? 'text-base' : 'text-[1.35em] py-0.5'} px-2 text-center font-semibold tabular-nums whitespace-nowrap leading-none ${
             subdued ? 'text-white/40' : 'text-white'
           }`}
         >

--- a/src/frontend/components/CarSystems/CarSystems.tsx
+++ b/src/frontend/components/CarSystems/CarSystems.tsx
@@ -1,0 +1,123 @@
+import { memo, useMemo } from 'react';
+import {
+  useCarSystemsSnapshot,
+  useDrivingState,
+  useSessionVisibility,
+  useGeneralSettings,
+} from '@irdashies/context';
+import {
+  CAR_SYSTEM_ADJUSTMENTS,
+  carSystemRowKey,
+  type CarSystemAdjustment,
+} from '@irdashies/types';
+import { useCarSystemsSettings } from './hooks/useCarSystemsSettings';
+
+/** Placeholder for a row the current car does not have. */
+const BLANK = '--';
+
+const formatValue = (adjustment: CarSystemAdjustment): string => {
+  const value = adjustment.value.toFixed(adjustment.precision);
+  return adjustment.unit ? `${value}${adjustment.unit}` : value;
+};
+
+interface SystemRowProps {
+  label: string;
+  adjustment?: CarSystemAdjustment;
+  isCompact: boolean;
+  rowIndex: number;
+}
+
+export const SystemRow = memo(
+  ({ label, adjustment, isCompact, rowIndex }: SystemRowProps) => {
+    const unsupported = adjustment === undefined;
+    // Off and unsupported are different states that happen to look alike: one
+    // is a system the driver switched off, the other a system the car does not
+    // have. Both are subdued, and the value distinguishes them.
+    const subdued = unsupported || adjustment.isOff;
+
+    return (
+      <tr
+        className={rowIndex % 2 === 0 ? 'bg-slate-800/70' : 'bg-slate-900/70'}
+      >
+        <td
+          className={`${isCompact ? '' : 'py-0.5'} px-2 whitespace-nowrap ${
+            subdued ? 'text-white/40' : 'text-white/80'
+          }`}
+        >
+          {label}
+        </td>
+        <td
+          className={`${isCompact ? '' : 'py-0.5'} px-2 text-right tabular-nums whitespace-nowrap ${
+            subdued ? 'text-white/40' : 'text-white'
+          }`}
+        >
+          {unsupported ? BLANK : formatValue(adjustment)}
+        </td>
+      </tr>
+    );
+  }
+);
+SystemRow.displayName = 'SystemRow';
+
+export const CarSystems = () => {
+  const settings = useCarSystemsSettings();
+  const generalSettings = useGeneralSettings();
+  const snapshot = useCarSystemsSnapshot();
+  const { isDriving } = useDrivingState();
+  const isSessionVisible = useSessionVisibility(settings?.sessionVisibility);
+
+  const isCompact =
+    generalSettings?.compactMode === 'compact' ||
+    generalSettings?.compactMode === 'ultra';
+
+  // Keyed by display row, so the Clio's dcPeakBrakeBias fills the brake bias
+  // row rather than going unmatched.
+  const byRow = useMemo(() => {
+    const map = new Map<string, CarSystemAdjustment>();
+    for (const adjustment of snapshot?.adjustments ?? []) {
+      map.set(carSystemRowKey(adjustment.key), adjustment);
+    }
+    return map;
+  }, [snapshot?.adjustments]);
+
+  const rows = useMemo(() => {
+    const configured = settings?.rows ?? [];
+    return configured
+      .map((key) => {
+        const definition = CAR_SYSTEM_ADJUSTMENTS.find((d) => d.key === key);
+        if (!definition) return undefined;
+        return { key, label: definition.label, adjustment: byRow.get(key) };
+      })
+      .filter((row): row is NonNullable<typeof row> => row !== undefined)
+      .filter(
+        (row) => settings?.showUnsupportedRows || row.adjustment !== undefined
+      );
+  }, [settings?.rows, settings?.showUnsupportedRows, byRow]);
+
+  if (!isSessionVisible) return <></>;
+  if (settings?.showOnlyWhenOnTrack && !isDriving) return <></>;
+  if (rows.length === 0) return <></>;
+
+  return (
+    <div
+      className={`w-full bg-slate-800/(--bg-opacity) rounded-sm ${isCompact ? '' : 'p-2'} overflow-hidden`}
+      style={{
+        ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
+      }}
+    >
+      <table className="w-full table-auto text-sm border-separate border-spacing-y-0.5">
+        <tbody>
+          {rows.map((row, index) => (
+            <SystemRow
+              key={row.key}
+              label={row.label}
+              adjustment={row.adjustment}
+              isCompact={isCompact}
+              rowIndex={index}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/frontend/components/CarSystems/CarSystems.tsx
+++ b/src/frontend/components/CarSystems/CarSystems.tsx
@@ -12,7 +12,7 @@ import {
 } from '@irdashies/types';
 import { useCarSystemsSettings } from './hooks/useCarSystemsSettings';
 
-/** Placeholder for a row the current car does not have. */
+/** Shown for a column the current car does not have. */
 const BLANK = '--';
 
 const formatValue = (adjustment: CarSystemAdjustment): string => {
@@ -20,44 +20,48 @@ const formatValue = (adjustment: CarSystemAdjustment): string => {
   return adjustment.unit ? `${value}${adjustment.unit}` : value;
 };
 
-interface SystemRowProps {
-  label: string;
+interface SystemColumnProps {
+  short: string;
+  chip: string;
   adjustment?: CarSystemAdjustment;
   isCompact: boolean;
-  rowIndex: number;
 }
 
-export const SystemRow = memo(
-  ({ label, adjustment, isCompact, rowIndex }: SystemRowProps) => {
+export const SystemColumn = memo(
+  ({ short, chip, adjustment, isCompact }: SystemColumnProps) => {
     const unsupported = adjustment === undefined;
-    // Off and unsupported are different states that happen to look alike: one
-    // is a system the driver switched off, the other a system the car does not
-    // have. Both are subdued, and the value distinguishes them.
+    // Off and unsupported look alike on purpose - both are "nothing to read
+    // here" - and the value below tells them apart: a number the driver set to
+    // zero, or a blank for a system the car does not have.
     const subdued = unsupported || adjustment.isOff;
 
     return (
-      <tr
-        className={rowIndex % 2 === 0 ? 'bg-slate-800/70' : 'bg-slate-900/70'}
-      >
-        <td
-          className={`${isCompact ? '' : 'py-0.5'} px-2 whitespace-nowrap ${
-            subdued ? 'text-white/40' : 'text-white/80'
+      <div className="flex flex-1 min-w-0 flex-col items-center gap-0.5">
+        {/* px-1 rather than the Pitlane Helper's px-2: its chips are standalone
+            status pills, these are packed side by side, and the wider padding
+            truncated a three-letter label once the column count got high. */}
+        <div
+          className={`w-full text-center text-xs font-bold py-1 px-1 rounded truncate ${
+            subdued ? 'bg-slate-600/60 text-white/60' : `${chip} text-white`
           }`}
         >
-          {label}
-        </td>
-        <td
-          className={`${isCompact ? '' : 'py-0.5'} px-2 text-right tabular-nums whitespace-nowrap ${
+          {short}
+        </div>
+        {/* The value carries the glance, so it outweighs its own label - the
+            same balance the Pitlane Helper strikes between its big readouts
+            and their small captions. */}
+        <div
+          className={`${isCompact ? 'text-base' : 'text-[1.35em] py-0.5'} text-center font-semibold tabular-nums whitespace-nowrap leading-none ${
             subdued ? 'text-white/40' : 'text-white'
           }`}
         >
           {unsupported ? BLANK : formatValue(adjustment)}
-        </td>
-      </tr>
+        </div>
+      </div>
     );
   }
 );
-SystemRow.displayName = 'SystemRow';
+SystemColumn.displayName = 'SystemColumn';
 
 export const CarSystems = () => {
   const settings = useCarSystemsSettings();
@@ -70,9 +74,9 @@ export const CarSystems = () => {
     generalSettings?.compactMode === 'compact' ||
     generalSettings?.compactMode === 'ultra';
 
-  // Keyed by display row, so the Clio's dcPeakBrakeBias fills the brake bias
-  // row rather than going unmatched.
-  const byRow = useMemo(() => {
+  // Keyed by display column, so the Clio's dcPeakBrakeBias fills the brake bias
+  // column rather than going unmatched.
+  const byColumn = useMemo(() => {
     const map = new Map<string, CarSystemAdjustment>();
     for (const adjustment of snapshot?.adjustments ?? []) {
       map.set(carSystemRowKey(adjustment.key), adjustment);
@@ -80,44 +84,50 @@ export const CarSystems = () => {
     return map;
   }, [snapshot?.adjustments]);
 
-  const rows = useMemo(() => {
+  const columns = useMemo(() => {
     const configured = settings?.rows ?? [];
     return configured
       .map((key) => {
         const definition = CAR_SYSTEM_ADJUSTMENTS.find((d) => d.key === key);
         if (!definition) return undefined;
-        return { key, label: definition.label, adjustment: byRow.get(key) };
+        return {
+          key,
+          short: definition.short,
+          chip: definition.chip,
+          adjustment: byColumn.get(key),
+        };
       })
-      .filter((row): row is NonNullable<typeof row> => row !== undefined)
       .filter(
-        (row) => settings?.showUnsupportedRows || row.adjustment !== undefined
+        (column): column is NonNullable<typeof column> => column !== undefined
+      )
+      .filter(
+        (column) =>
+          settings?.showUnsupportedRows || column.adjustment !== undefined
       );
-  }, [settings?.rows, settings?.showUnsupportedRows, byRow]);
+  }, [settings?.rows, settings?.showUnsupportedRows, byColumn]);
 
   if (!isSessionVisible) return <></>;
   if (settings?.showOnlyWhenOnTrack && !isDriving) return <></>;
-  if (rows.length === 0) return <></>;
+  if (columns.length === 0) return <></>;
 
   return (
     <div
-      className={`w-full bg-slate-800/(--bg-opacity) rounded-sm ${isCompact ? '' : 'p-2'} overflow-hidden`}
+      className={`w-full bg-slate-800/(--bg-opacity) rounded text-white font-medium ${isCompact ? 'p-1' : 'p-2'}`}
       style={{
         ['--bg-opacity' as string]: `${settings?.background?.opacity ?? 80}%`,
       }}
     >
-      <table className="w-full table-auto text-sm border-separate border-spacing-y-0.5">
-        <tbody>
-          {rows.map((row, index) => (
-            <SystemRow
-              key={row.key}
-              label={row.label}
-              adjustment={row.adjustment}
-              isCompact={isCompact}
-              rowIndex={index}
-            />
-          ))}
-        </tbody>
-      </table>
+      <div className={`flex w-full ${isCompact ? 'gap-1' : 'gap-2'}`}>
+        {columns.map((column) => (
+          <SystemColumn
+            key={column.key}
+            short={column.short}
+            chip={column.chip}
+            adjustment={column.adjustment}
+            isCompact={isCompact}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/frontend/components/CarSystems/hooks/useCarSystemsSettings.tsx
+++ b/src/frontend/components/CarSystems/hooks/useCarSystemsSettings.tsx
@@ -1,0 +1,36 @@
+import { useDashboard } from '@irdashies/context';
+import {
+  DEFAULT_CAR_SYSTEM_ROWS,
+  type CarSystemsConfig,
+} from '@irdashies/types';
+
+const FALLBACK: CarSystemsConfig = {
+  rows: [...DEFAULT_CAR_SYSTEM_ROWS],
+  showUnsupportedRows: true,
+  background: { opacity: 80 },
+  sessionVisibility: {
+    race: true,
+    loneQualify: true,
+    openQualify: true,
+    practice: true,
+    offlineTesting: true,
+  },
+  showOnlyWhenOnTrack: false,
+};
+
+export const useCarSystemsSettings = (): CarSystemsConfig => {
+  const { currentDashboard } = useDashboard();
+
+  const settings = currentDashboard?.widgets.find(
+    (widget) => widget.id === 'carsystems'
+  )?.config;
+
+  if (settings && typeof settings === 'object' && 'rows' in settings) {
+    const config = settings as unknown as CarSystemsConfig;
+    // A config saved before a row was added to the catalogue simply omits it,
+    // so the stored list is used as-is rather than merged with the defaults.
+    return { ...FALLBACK, ...config };
+  }
+
+  return FALLBACK;
+};

--- a/src/frontend/components/CarSystems/widgetRuntimeDefinition.ts
+++ b/src/frontend/components/CarSystems/widgetRuntimeDefinition.ts
@@ -1,0 +1,9 @@
+import type { WidgetRuntimeDefinition } from '../../widgetRuntime';
+
+export default {
+  id: 'carsystems',
+  sessionData: false,
+  // track-state carries the driving state the widget uses to hide itself.
+  channels: ['car-systems.snapshot', 'track-state.snapshot'],
+  ratePreset: 'static',
+} satisfies WidgetRuntimeDefinition;

--- a/src/frontend/components/CarSystems/widgetRuntimeDefinition.ts
+++ b/src/frontend/components/CarSystems/widgetRuntimeDefinition.ts
@@ -2,7 +2,11 @@ import type { WidgetRuntimeDefinition } from '../../widgetRuntime';
 
 export default {
   id: 'carsystems',
-  sessionData: false,
+  // The widget's session-visibility settings resolve the current session type
+  // through SessionStore, which RendererDataProviders only mounts when a widget
+  // in the window asks for session data. Without this the practice/qualifying/
+  // race toggles silently do nothing in a window holding only this widget.
+  sessionData: true,
   // track-state carries the driving state the widget uses to hide itself.
   channels: ['car-systems.snapshot', 'track-state.snapshot'],
   ratePreset: 'static',

--- a/src/frontend/components/RendererDataProviders/RendererDataProviders.spec.tsx
+++ b/src/frontend/components/RendererDataProviders/RendererDataProviders.spec.tsx
@@ -74,4 +74,16 @@ describe('RendererDataProviders', () => {
     ).not.toBeInTheDocument();
     expect(screen.getByTestId('session-provider')).toBeInTheDocument();
   });
+
+  // Car Systems reads only its own snapshot channel, so nothing about its data
+  // needs suggests session data. Its session-visibility settings need it all
+  // the same, and a window holding just this widget is the normal standalone
+  // overlay case where no other widget can mount the provider for it.
+  it('keeps session data for a Car Systems only renderer', () => {
+    dashboard.widgets = [{ id: 'carsystems', enabled: true, layout }];
+
+    render(<RendererDataProviders />);
+
+    expect(screen.getByTestId('session-provider')).toBeInTheDocument();
+  });
 });

--- a/src/frontend/components/Settings/SettingsLoader.tsx
+++ b/src/frontend/components/Settings/SettingsLoader.tsx
@@ -28,6 +28,7 @@ import { useDashboard } from '@irdashies/context';
 import { SlowCarAheadSettings } from './sections/SlowCarAheadSettings';
 import { SectorDeltaSettings } from './sections/SectorDeltaSettings';
 import { DeltaSpeedSettings } from './sections/DeltaSpeedSettings';
+import { CarSystemsSettings } from './sections/CarSystemsSettings';
 import { HeartRateSettings } from './sections/HeartRateSettings';
 import { CornerNameSettings } from './sections/CornerNameSettings';
 import { BattleSettings } from './sections/BattleSettings';
@@ -98,6 +99,8 @@ export const SettingsLoader = ({ previewMode }: SettingsLoaderProps = {}) => {
       return <SectorDeltaSettings />;
     case 'deltaspeed':
       return <DeltaSpeedSettings />;
+    case 'carsystems':
+      return <CarSystemsSettings />;
     case 'heartrate':
       return <HeartRateSettings />;
     case 'cornername':

--- a/src/frontend/components/Settings/menuItems.ts
+++ b/src/frontend/components/Settings/menuItems.ts
@@ -70,6 +70,12 @@ export const widgetItems: MenuItem[] = [
     widgetType: 'cornername',
   },
   {
+    to: '/settings/carsystems',
+    path: '/carsystems',
+    label: 'Car Systems',
+    widgetType: 'carsystems',
+  },
+  {
     to: '/settings/deltaspeed',
     path: '/deltaspeed',
     label: 'Delta Speed',

--- a/src/frontend/components/Settings/sections/CarSystemsSettings.tsx
+++ b/src/frontend/components/Settings/sections/CarSystemsSettings.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect } from 'react';
+import { BaseSettingsSection } from '../components/BaseSettingsSection';
+import {
+  CAR_SYSTEM_ADJUSTMENTS,
+  CarSystemsWidgetSettings,
+  SettingsTabType,
+  getWidgetDefaultConfig,
+} from '@irdashies/types';
+import { useDashboard } from '@irdashies/context';
+import { TabButton } from '../components/TabButton';
+import { SessionVisibility } from '../components/SessionVisibility';
+import { SettingsSection } from '../components/SettingSection';
+import { SettingToggleRow } from '../components/SettingToggleRow';
+import { SettingDivider } from '../components/SettingDivider';
+import { SettingSliderRow } from '../components/SettingSliderRow';
+
+const SETTING_ID = 'carsystems';
+
+const defaultConfig = getWidgetDefaultConfig('carsystems');
+
+/**
+ * Rows offered in settings. `dcPeakBrakeBias` is excluded because it shares the
+ * brake bias row — offering both would let a user enable the same row twice.
+ */
+const SELECTABLE_ROWS = CAR_SYSTEM_ADJUSTMENTS.filter(
+  (adjustment) => adjustment.key !== 'dcPeakBrakeBias'
+);
+
+export const CarSystemsSettings = () => {
+  const { currentDashboard } = useDashboard();
+
+  const savedSettings = currentDashboard?.widgets.find(
+    (w) => w.id === SETTING_ID
+  ) as CarSystemsWidgetSettings | undefined;
+
+  const [settings, setSettings] = useState<CarSystemsWidgetSettings>({
+    id: SETTING_ID,
+    enabled: savedSettings?.enabled ?? false,
+    config:
+      (savedSettings?.config as CarSystemsWidgetSettings['config']) ??
+      defaultConfig,
+  });
+
+  // Same guarded set-during-render sync as the other widget settings sections:
+  // useState only reads its initialiser once, so mounting before the dashboard
+  // has loaded would otherwise persist defaults over the saved config on the
+  // next edit.
+  const [prevSaved, setPrevSaved] = useState(savedSettings);
+  if (JSON.stringify(savedSettings) !== JSON.stringify(prevSaved)) {
+    setPrevSaved(savedSettings);
+    if (savedSettings) {
+      setSettings({
+        id: SETTING_ID,
+        enabled: savedSettings.enabled ?? false,
+        config:
+          (savedSettings.config as CarSystemsWidgetSettings['config']) ??
+          defaultConfig,
+      });
+    }
+  }
+
+  const [activeTab, setActiveTab] = useState<SettingsTabType>(
+    () =>
+      (localStorage.getItem('carSystemsTab') as SettingsTabType) || 'options'
+  );
+
+  useEffect(() => {
+    localStorage.setItem('carSystemsTab', activeTab);
+  }, [activeTab]);
+
+  if (!currentDashboard) return <>Loading...</>;
+
+  const rows = settings.config.rows ?? [];
+
+  /**
+   * Rows keep catalogue order rather than the order they were toggled on, so
+   * the table reads the same however the user arrived at their selection.
+   */
+  const toggleRow = (
+    key: string,
+    enabled: boolean,
+    handleConfigChange: (change: Partial<typeof settings.config>) => void
+  ) => {
+    const next = enabled
+      ? SELECTABLE_ROWS.filter(
+          (adjustment) =>
+            adjustment.key === key || rows.includes(adjustment.key)
+        ).map((adjustment) => adjustment.key)
+      : rows.filter((row) => row !== key);
+    handleConfigChange({ rows: next });
+  };
+
+  return (
+    <BaseSettingsSection
+      title="Car Systems"
+      description="Brake bias, ABS, traction control and the other adjustments your car exposes."
+      settings={settings as CarSystemsWidgetSettings}
+      onSettingsChange={(s) => setSettings(s as CarSystemsWidgetSettings)}
+      widgetId={SETTING_ID}
+    >
+      {(handleConfigChange) => (
+        <div className="space-y-4">
+          <div className="flex border-b border-slate-700/50">
+            <TabButton
+              id="options"
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+            >
+              Options
+            </TabButton>
+            <TabButton
+              id="visibility"
+              activeTab={activeTab}
+              setActiveTab={setActiveTab}
+            >
+              Visibility
+            </TabButton>
+          </div>
+
+          <div>
+            {activeTab === 'options' && (
+              <>
+                <SettingsSection title="Display">
+                  <SettingSliderRow
+                    title="Background Opacity"
+                    description="Opacity of the widget background."
+                    value={settings.config.background?.opacity ?? 80}
+                    units="%"
+                    min={0}
+                    max={100}
+                    step={5}
+                    onChange={(v) =>
+                      handleConfigChange({ background: { opacity: v } })
+                    }
+                  />
+                  <SettingToggleRow
+                    title="Keep rows the car does not have"
+                    description="Shows a blank row so each adjustment keeps the same position between cars. Turn off to show only what the current car exposes."
+                    enabled={settings.config.showUnsupportedRows ?? true}
+                    onToggle={(v) =>
+                      handleConfigChange({ showUnsupportedRows: v })
+                    }
+                  />
+                </SettingsSection>
+
+                <SettingsSection title="Rows">
+                  {SELECTABLE_ROWS.map((adjustment) => (
+                    <SettingToggleRow
+                      key={adjustment.key}
+                      title={adjustment.label}
+                      enabled={rows.includes(adjustment.key)}
+                      onToggle={(v) =>
+                        toggleRow(adjustment.key, v, handleConfigChange)
+                      }
+                    />
+                  ))}
+                </SettingsSection>
+              </>
+            )}
+
+            {activeTab === 'visibility' && (
+              <SettingsSection title="Session Visibility">
+                <SessionVisibility
+                  sessionVisibility={settings.config.sessionVisibility}
+                  handleConfigChange={handleConfigChange}
+                />
+
+                <SettingDivider />
+
+                <SettingToggleRow
+                  title="Show only when on track"
+                  description="If enabled, widget will only be shown when driving."
+                  enabled={settings.config.showOnlyWhenOnTrack}
+                  onToggle={(v) =>
+                    handleConfigChange({ showOnlyWhenOnTrack: v })
+                  }
+                />
+              </SettingsSection>
+            )}
+          </div>
+        </div>
+      )}
+    </BaseSettingsSection>
+  );
+};

--- a/src/frontend/constants/widgetNames.ts
+++ b/src/frontend/constants/widgetNames.ts
@@ -27,6 +27,7 @@ export const WIDGET_NAMES: Record<WidgetId, string> = {
   slowcarahead: 'Slow Car Ahead',
   sectordelta: 'Sector Delta',
   deltaspeed: 'Delta Speed',
+  carsystems: 'Car Systems',
   heartrate: 'Heart Rate',
   cornername: 'Corner Names',
   battle: 'Battle',

--- a/src/frontend/context/ChannelStore/index.ts
+++ b/src/frontend/context/ChannelStore/index.ts
@@ -13,5 +13,6 @@ export * from './useStandingsSnapshot';
 export * from './useCarSpeedsSnapshot';
 export * from './useBlindSpotSnapshot';
 export * from './useDriverControlsSnapshot';
+export * from './useCarSystemsSnapshot';
 export * from './useTrackStateSnapshot';
 export * from './useSessionLifecycle';

--- a/src/frontend/context/ChannelStore/useCarSystemsSnapshot.ts
+++ b/src/frontend/context/ChannelStore/useCarSystemsSnapshot.ts
@@ -1,0 +1,5 @@
+import type { ChannelBridge } from '@irdashies/types';
+import { useChannelSnapshot } from './useChannelSnapshot';
+
+export const useCarSystemsSnapshot = (enabled = true, bridge?: ChannelBridge) =>
+  useChannelSnapshot('car-systems.snapshot', undefined, bridge, enabled);

--- a/src/frontend/widgetRuntime.spec.tsx
+++ b/src/frontend/widgetRuntime.spec.tsx
@@ -8,6 +8,7 @@ import {
   useWidgetChannelRate,
   WidgetRuntimeProvider,
 } from './widgetRuntime';
+import type { WidgetRuntimeDefinition } from './widgetRuntime';
 
 const widget = (id: string, type?: string): DashboardWidget => ({
   id,
@@ -163,5 +164,48 @@ describe('widget runtime metadata', () => {
     );
 
     expect(result.current).toBe(5);
+  });
+
+  /**
+   * useSessionVisibility resolves the session type through SessionStore, which
+   * RendererDataProviders only mounts when some widget in the window declares
+   * sessionData. The hook returns true when the type is undefined, so a widget
+   * that reads it without asking for session data fails open: its visibility
+   * toggles silently do nothing in a window holding only that widget, and the
+   * bug hides whenever another widget in the same dashboard happens to request
+   * session data. Asserted for every widget rather than one, because nothing
+   * about writing a new widget makes the dependency visible.
+   */
+  it('gives every session-visibility consumer the session data it needs', () => {
+    const sources = import.meta.glob('./components/**/*.{ts,tsx}', {
+      eager: true,
+      query: '?raw',
+      import: 'default',
+    }) as Record<string, string>;
+    const definitionsByDir = new Map<string, WidgetRuntimeDefinition>();
+    for (const [path, module] of Object.entries(
+      import.meta.glob<{ default: WidgetRuntimeDefinition }>(
+        './components/*/widgetRuntimeDefinition.ts',
+        { eager: true }
+      )
+    )) {
+      definitionsByDir.set(path.split('/')[2], module.default);
+    }
+
+    const offenders: string[] = [];
+    for (const [path, source] of Object.entries(sources)) {
+      if (path.includes('.spec.') || path.includes('.stories.')) continue;
+      if (!/\buseSessionVisibility\s*\(/.test(source)) continue;
+      const dir = path.split('/')[2];
+      const definition = definitionsByDir.get(dir);
+      if (!definition) continue;
+      if (definition.sessionData !== true) offenders.push(dir);
+    }
+
+    // Guards the guard: a glob that stopped matching would pass vacuously.
+    expect(
+      Object.keys(sources).some((path) => path.includes('/BlindSpotMonitor/'))
+    ).toBe(true);
+    expect(offenders).toEqual([]);
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,22 @@ const safeErrorDetails = (error: unknown) => {
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) app.quit();
 
-updateElectronApp();
+// Only the official build auto-updates.
+//
+// Side-by-side betas are built with a different app identity (name and
+// productName become irdashies-beta) so they install alongside the real app.
+// The update feed only ever publishes the official app, so a beta that checks
+// it is offered a release built for a *different* application, downloads it in
+// the background, and Squirrel applies it on the next launch — after which the
+// beta no longer starts. The version number is not the problem and bumping it
+// would not help; the identity mismatch is.
+if (app.getName() === 'irdashies') {
+  updateElectronApp();
+} else {
+  log.info(
+    `[update] Auto-update disabled for non-official build "${app.getName()}"`
+  );
+}
 
 const overlayManager = new OverlayManager();
 const analytics = new Analytics();

--- a/src/runtimeBoundaryReplay.spec.ts
+++ b/src/runtimeBoundaryReplay.spec.ts
@@ -34,6 +34,7 @@ type SnapshotChannelName = Exclude<
 const SNAPSHOT_CHANNELS = [
   'blind-spot.snapshot',
   'car-speeds.snapshot',
+  'car-systems.snapshot',
   'driver-controls.snapshot',
   'fuel.projection',
   'lap-times.snapshot',

--- a/src/types/carSystems.ts
+++ b/src/types/carSystems.ts
@@ -14,34 +14,139 @@
  * an on/off state would misreport every car that has it.
  */
 export interface CarSystemDefinition {
-  /** Telemetry variable name, e.g. 'dcABS'. Stable identity for the row. */
+  /** Telemetry variable name, e.g. 'dcABS'. Stable identity for the column. */
   key: string;
-  /** Display label. */
+  /** Full label, used in settings. */
   label: string;
+  /** Abbreviation for the column header, where space is tight. */
+  short: string;
   /** Decimal places the value is meaningful to. */
   precision: number;
   /** Appended on display. */
   unit?: string;
+  /**
+   * Tailwind background class for the column header chip, in the Pitlane
+   * Helper's idiom: a solid colour behind small bold caps.
+   *
+   * Colours carry meaning where the app already has one. Amber is fuel because
+   * FuelCalculator is amber throughout. Yellow is deliberately unused: it means
+   * caution and off-track elsewhere (Flag, Battle), and a fuel column that
+   * looked like a warning would be actively misleading. Red is braking, which
+   * is why brake bias takes it.
+   */
+  chip: string;
 }
 
 export const CAR_SYSTEM_ADJUSTMENTS: readonly CarSystemDefinition[] = [
-  { key: 'dcBrakeBias', label: 'Brake Bias', precision: 1, unit: '%' },
+  {
+    key: 'dcBrakeBias',
+    label: 'Brake Bias',
+    short: 'BB',
+    precision: 1,
+    unit: '%',
+    chip: 'bg-red-600',
+  },
   // The Renault Clio reports its bias here instead. The two never coexist, so
-  // they share a row and whichever the car publishes fills it.
-  { key: 'dcPeakBrakeBias', label: 'Brake Bias', precision: 1, unit: '%' },
-  { key: 'dcABS', label: 'ABS', precision: 0 },
-  { key: 'dcTractionControl', label: 'TC', precision: 0 },
-  { key: 'dcTractionControl2', label: 'TC2', precision: 0 },
-  { key: 'dcThrottleShape', label: 'Throttle Shape', precision: 0 },
-  { key: 'dcEnginePower', label: 'Engine Power', precision: 0 },
-  { key: 'dcFuelMixture', label: 'Fuel Mixture', precision: 0 },
-  { key: 'dcAntiRollFront', label: 'ARB Front', precision: 0 },
-  { key: 'dcAntiRollRear', label: 'ARB Rear', precision: 0 },
-  { key: 'dcDiffEntry', label: 'Diff Entry', precision: 0 },
-  { key: 'dcDiffMiddle', label: 'Diff Mid', precision: 0 },
-  { key: 'dcDiffExit', label: 'Diff Exit', precision: 0 },
-  { key: 'dcWeightJackerLeft', label: 'Jacker L', precision: 0 },
-  { key: 'dcWeightJackerRight', label: 'Jacker R', precision: 0 },
+  // they share a column and whichever the car publishes fills it.
+  {
+    key: 'dcPeakBrakeBias',
+    label: 'Brake Bias',
+    short: 'BB',
+    precision: 1,
+    unit: '%',
+    chip: 'bg-red-600',
+  },
+  {
+    key: 'dcABS',
+    label: 'ABS',
+    short: 'ABS',
+    precision: 0,
+    chip: 'bg-green-600',
+  },
+  {
+    key: 'dcTractionControl',
+    label: 'Traction Control',
+    short: 'TC',
+    precision: 0,
+    chip: 'bg-blue-700',
+  },
+  {
+    key: 'dcTractionControl2',
+    label: 'Traction Control 2',
+    short: 'TC2',
+    precision: 0,
+    chip: 'bg-sky-600',
+  },
+  {
+    key: 'dcThrottleShape',
+    label: 'Throttle Shape',
+    short: 'THR',
+    precision: 0,
+    chip: 'bg-purple-600',
+  },
+  {
+    key: 'dcEnginePower',
+    label: 'Engine Power',
+    short: 'PWR',
+    precision: 0,
+    chip: 'bg-violet-700',
+  },
+  {
+    key: 'dcFuelMixture',
+    label: 'Fuel Mixture',
+    short: 'FUEL',
+    precision: 0,
+    chip: 'bg-amber-600',
+  },
+  {
+    key: 'dcAntiRollFront',
+    label: 'ARB Front',
+    short: 'ARBF',
+    precision: 0,
+    chip: 'bg-teal-600',
+  },
+  {
+    key: 'dcAntiRollRear',
+    label: 'ARB Rear',
+    short: 'ARBR',
+    precision: 0,
+    chip: 'bg-teal-700',
+  },
+  {
+    key: 'dcDiffEntry',
+    label: 'Diff Entry',
+    short: 'DIFE',
+    precision: 0,
+    chip: 'bg-indigo-600',
+  },
+  {
+    key: 'dcDiffMiddle',
+    label: 'Diff Mid',
+    short: 'DIFM',
+    precision: 0,
+    chip: 'bg-indigo-700',
+  },
+  {
+    key: 'dcDiffExit',
+    label: 'Diff Exit',
+    short: 'DIFX',
+    precision: 0,
+    chip: 'bg-indigo-800',
+  },
+  {
+    key: 'dcWeightJackerLeft',
+    label: 'Jacker L',
+    short: 'JKL',
+    precision: 0,
+    chip: 'bg-stone-600',
+  },
+  {
+    key: 'dcWeightJackerRight',
+    label: 'Jacker R',
+    short: 'JKR',
+    precision: 0,
+    chip: 'bg-stone-700',
+  },
 ];
 
 /**

--- a/src/types/carSystems.ts
+++ b/src/types/carSystems.ts
@@ -1,0 +1,64 @@
+/**
+ * The driver-adjustable systems the overlay knows how to display.
+ *
+ * Shared rather than owned by the processor because the widget renders a fixed
+ * set of rows and blanks the ones the current car does not have — so it needs
+ * the labels for adjustments that are absent from the snapshot.
+ *
+ * Only settings belong here: things a driver turns a dial to change and then
+ * wants to read back. Momentary controls are deliberately excluded — dcStarter,
+ * dcHeadlightFlash, dcTearOffVisor, the wiper controls, dcDashPage and
+ * dcPitSpeedLimiterToggle are button presses rather than state. So is
+ * dcTractionControlToggle, despite the name: recorded sessions show it reading
+ * false continuously while traction control is set to 1..5, so treating it as
+ * an on/off state would misreport every car that has it.
+ */
+export interface CarSystemDefinition {
+  /** Telemetry variable name, e.g. 'dcABS'. Stable identity for the row. */
+  key: string;
+  /** Display label. */
+  label: string;
+  /** Decimal places the value is meaningful to. */
+  precision: number;
+  /** Appended on display. */
+  unit?: string;
+}
+
+export const CAR_SYSTEM_ADJUSTMENTS: readonly CarSystemDefinition[] = [
+  { key: 'dcBrakeBias', label: 'Brake Bias', precision: 1, unit: '%' },
+  // The Renault Clio reports its bias here instead. The two never coexist, so
+  // they share a row and whichever the car publishes fills it.
+  { key: 'dcPeakBrakeBias', label: 'Brake Bias', precision: 1, unit: '%' },
+  { key: 'dcABS', label: 'ABS', precision: 0 },
+  { key: 'dcTractionControl', label: 'TC', precision: 0 },
+  { key: 'dcTractionControl2', label: 'TC2', precision: 0 },
+  { key: 'dcThrottleShape', label: 'Throttle Shape', precision: 0 },
+  { key: 'dcEnginePower', label: 'Engine Power', precision: 0 },
+  { key: 'dcFuelMixture', label: 'Fuel Mixture', precision: 0 },
+  { key: 'dcAntiRollFront', label: 'ARB Front', precision: 0 },
+  { key: 'dcAntiRollRear', label: 'ARB Rear', precision: 0 },
+  { key: 'dcDiffEntry', label: 'Diff Entry', precision: 0 },
+  { key: 'dcDiffMiddle', label: 'Diff Mid', precision: 0 },
+  { key: 'dcDiffExit', label: 'Diff Exit', precision: 0 },
+  { key: 'dcWeightJackerLeft', label: 'Jacker L', precision: 0 },
+  { key: 'dcWeightJackerRight', label: 'Jacker R', precision: 0 },
+];
+
+/**
+ * Rows shown by default: the adjustments most cars with any assists expose.
+ * Everything else is available in settings but off, so a GT3 driver is not
+ * given a column of empty differential rows.
+ *
+ * `dcPeakBrakeBias` is not listed because it shares the brake bias row.
+ */
+export const DEFAULT_CAR_SYSTEM_ROWS: readonly string[] = [
+  'dcBrakeBias',
+  'dcABS',
+  'dcTractionControl',
+  'dcTractionControl2',
+  'dcThrottleShape',
+];
+
+/** The row a telemetry key is displayed in; brake bias has two sources. */
+export const carSystemRowKey = (key: string): string =>
+  key === 'dcPeakBrakeBias' ? 'dcBrakeBias' : key;

--- a/src/types/carSystems.ts
+++ b/src/types/carSystems.ts
@@ -133,6 +133,31 @@ export const CAR_SYSTEM_ADJUSTMENTS: readonly CarSystemDefinition[] = [
     precision: 0,
     chip: 'bg-indigo-800',
   },
+  // Hybrid deployment, on the cars that have it. Only the two dials appear
+  // here: the driver sets a deploy level and a regen level and reads them back,
+  // which is exactly what this widget is for. The energy those dials govern —
+  // EnergyERSBatteryPct and friends — is a live readout that swings the full
+  // 0..100% inside a single lap, and belongs in a gauge rather than in a table
+  // of dial positions.
+  //
+  // Levels are fractional 0..1, matching the Hybrid: DeployLevel / RegenLevel
+  // pair in session info, so they are shown to one decimal as the setup screen
+  // does. Recorded sessions have not yet caught a driver moving either dial, so
+  // the step size is unconfirmed; one decimal reads correctly either way.
+  {
+    key: 'dcMGUKDeployFixed',
+    label: 'Deploy Level',
+    short: 'DEP',
+    precision: 1,
+    chip: 'bg-orange-600',
+  },
+  {
+    key: 'dcMGUKRegenGain',
+    label: 'Regen Level',
+    short: 'REGEN',
+    precision: 1,
+    chip: 'bg-emerald-600',
+  },
   {
     key: 'dcWeightJackerLeft',
     label: 'Jacker L',

--- a/src/types/channels/channel.ts
+++ b/src/types/channels/channel.ts
@@ -11,6 +11,7 @@ export type SessionLifecycleEvent =
 export interface ChannelPayloads {
   'blind-spot.snapshot': BlindSpotSnapshot;
   'car-speeds.snapshot': CarSpeedsSnapshot;
+  'car-systems.snapshot': CarSystemsSnapshot;
   'driver-controls.snapshot': DriverControlsSnapshot;
   'fuel.projection': FuelProjectionSnapshot;
   'lap-times.snapshot': LapTimesSnapshot;
@@ -64,6 +65,46 @@ export interface BlindSpotSnapshot {
   carLeftRight: number;
   carIdxLapDistPct: readonly number[];
   isOnTrack: boolean;
+  version: number;
+}
+
+/**
+ * One driver-adjustable system, as the car actually reports it.
+ *
+ * `value` is the raw number from the SDK. Scales differ per car and are not
+ * normalised: most run 0..n where 0 is off, but some are signed — the BMW M
+ * Hybrid V8 reports ABS between -5 and -3 in recorded sessions — so a value of
+ * 0 only means "off" on a scale that has no negative side. `isOff` carries
+ * that judgement so consumers do not each re-derive it.
+ */
+export interface CarSystemAdjustment {
+  /** Telemetry variable name, e.g. 'dcABS'. Stable identity for the row. */
+  key: string;
+  /** Display label, e.g. 'ABS'. */
+  label: string;
+  value: number;
+  /** True only when the car's scale is unsigned and the value is 0. */
+  isOff: boolean;
+  /** Decimal places this value is meaningful to. Brake bias needs one. */
+  precision: number;
+  /** Appended on display, e.g. '%' for brake bias. */
+  unit?: string;
+}
+
+/**
+ * Driver-adjustable systems for the player's car: brake bias, ABS, traction
+ * control and similar.
+ *
+ * The set is discovered rather than fixed, because it varies by car — from
+ * brake bias alone on a Formula Vee to a dozen entries on a GTP car — and the
+ * generated telemetry types carry only the variables one recorded session
+ * happened to expose.
+ */
+export interface CarSystemsSnapshot {
+  adjustments: readonly CarSystemAdjustment[];
+  /** False before any in-car frame has been seen, when the set is unknown. */
+  discovered: boolean;
+  sessionNum: number | null;
   version: number;
 }
 
@@ -378,6 +419,13 @@ export const channelRegistry = {
     kind: 'snapshot',
     defaultRateHz: 25,
     maxRateHz: 25,
+  },
+  // Adjustments change when the driver turns a dial, not per frame, so this
+  // publishes on change and is capped low deliberately.
+  'car-systems.snapshot': {
+    kind: 'snapshot',
+    defaultRateHz: 2,
+    maxRateHz: 10,
   },
   // Publishes on version change, roughly 0.6 times a second in a 60-car field.
   // The rate cap only bounds the worst case; it is not a sampling rate.

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1368,6 +1368,35 @@ export const defaultDashboard: {
       },
     },
     {
+      id: 'carsystems',
+      enabled: false,
+      layout: {
+        x: 6,
+        y: 620,
+        width: 200,
+        height: 160,
+      },
+      config: {
+        rows: [
+          'dcBrakeBias',
+          'dcABS',
+          'dcTractionControl',
+          'dcTractionControl2',
+          'dcThrottleShape',
+        ],
+        showUnsupportedRows: true,
+        background: { opacity: 80 },
+        showOnlyWhenOnTrack: false,
+        sessionVisibility: {
+          race: true,
+          loneQualify: true,
+          openQualify: true,
+          practice: true,
+          offlineTesting: true,
+        },
+      },
+    },
+    {
       id: 'deltaspeed',
       enabled: false,
       layout: {

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1373,8 +1373,11 @@ export const defaultDashboard: {
       layout: {
         x: 6,
         y: 620,
-        width: 200,
-        height: 160,
+        // Wide and short: the systems read left to right as columns, so the
+        // default slot is shaped for a strip rather than the tall table this
+        // widget used to be.
+        width: 380,
+        height: 70,
       },
       config: {
         rows: [

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,3 +20,4 @@ export * from './performance';
 export * from './gamepadToken';
 export * from './channels';
 export * from './telemetryInspectorBridge';
+export * from './carSystems';

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -640,6 +640,22 @@ export interface SectorDeltaConfig {
   alwaysScroll?: boolean;
 }
 
+/**
+ * In-car systems readout.
+ *
+ * `rows` is an explicit ordered list of telemetry keys rather than a set of
+ * booleans, so the rows keep a fixed screen position and a car that lacks one
+ * shows a blank in place rather than shifting everything up.
+ */
+export interface CarSystemsConfig {
+  rows: string[];
+  /** Blank rows for adjustments the current car does not have. */
+  showUnsupportedRows: boolean;
+  background: { opacity: number };
+  sessionVisibility: SessionVisibilitySettings;
+  showOnlyWhenOnTrack: boolean;
+}
+
 export interface DeltaSpeedConfig {
   background: { opacity: number };
   /**
@@ -779,6 +795,7 @@ export interface WidgetConfigMap {
   slowcarahead: SlowCarAheadConfig;
   sectordelta: SectorDeltaConfig;
   deltaspeed: DeltaSpeedConfig;
+  carsystems: CarSystemsConfig;
   heartrate: HeartRateConfig;
   cornername: CornerNameOverlayConfig;
   battle: BattleConfig;
@@ -883,6 +900,7 @@ export type InformationBarWidgetSettings =
 export type SlowCarAheadWidgetSettings = BaseWidgetSettings<SlowCarAheadConfig>;
 export type SectorDeltaWidgetSettings = BaseWidgetSettings<SectorDeltaConfig>;
 export type DeltaSpeedWidgetSettings = BaseWidgetSettings<DeltaSpeedConfig>;
+export type CarSystemsWidgetSettings = BaseWidgetSettings<CarSystemsConfig>;
 export type HeartRateWidgetSettings = BaseWidgetSettings<HeartRateConfig>;
 export type CornerNameWidgetSettings =
   BaseWidgetSettings<CornerNameOverlayConfig>;


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

Brake bias, ABS, traction control and the other settings you change from the wheel had no readout. Brake bias appeared in the session bar; nothing else was surfaced anywhere.

This adds a **Car Systems** widget: one column per adjustment, a coloured chip carrying the abbreviation, the value beneath it. Styled after the Pitlane Helper — same slate panel, same solid status-chip idiom.

### The set of adjustments is discovered, not hardcoded

It varies enormously by car. Checked against **326 recorded sessions**: a Formula Vee exposes brake bias and nothing else, a Porsche 963 GTP exposes a dozen. So the widget shows what the car actually publishes and blanks the rest.

That check also turned up variables **missing from the generated telemetry types** — `dcTractionControl2`, `dcEnginePower`, `dcAntiRollRear`, `dcTractionControlToggle`. `_GENERATED_telemetry.ts` reflects whichever session generated it, so it could not be used as the vocabulary.

### Three findings from that data that shaped the implementation

**Discovery only works from inside the car.** Out of it iRacing publishes a reduced set — sessions captured while spectating carry only `dcStarter` — so an out-of-car frame cannot be used to conclude a car lacks ABS. The set is latched on the first in-car frame and kept, and values persist when the driver hops out rather than the table emptying.

**`dcTractionControlToggle` is a momentary button, not an on/off state.** It reads `false` continuously on cars whose traction control is plainly set to 1..5. Treating it as state would have misreported every car that has it, so it is excluded along with the other momentary controls (`dcStarter`, `dcHeadlightFlash`, the wipers, `dcDashPage`, `dcPitSpeedLimiterToggle`).

**Zero means off, but not on every car.** Most scales run 0..n, and a BMW M2 Racing sits at 0 with the assists switched off. Some are centred on zero instead — the weight jacker runs -20..20, the GTP brake dials -5..5 — where zero is an ordinary setting. Those are declared signed, and zero stops counting as off for them alone.

### A channel does not always carry the same control

This is the part that took real telemetry to settle. iRacing publishes a fixed set of `dc*` variables and each car wires its own dials to whichever ones fit, so the channel name is not a reliable name for the control.

Six cars were driven for this, each sweeping one adjustment at a time with a pause between, and photographed at the end. Matching every channel's final in-car value against the photograph named them all at once — **seven of seven on each of the Cadillac, the Porsche and the W13**, which is not a coincidence any other assignment survives.

| Car | In-car label | Channel |
| --- | --- | --- |
| Cadillac V-Series.R GTP | Brake bias migration | `dcABS` |
| Cadillac V-Series.R GTP | Brake bias target | `dcBrakeMisc` |
| Cadillac / Porsche 963 | TC Slip / TC Gain | `dcTractionControl` / `2` |
| Mercedes W13 | Brake migration (BMIG) | `dcPeakBrakeBias` |
| Mercedes W13 | HISPD diff | `dcDiffExit` |
| Renault Clio | Rear brake valve | `dcPeakBrakeBias` |
| Dallara IR18 | Engine map (MAP) | `dcFuelMixture` |

So rows are renamed per car, keyed on `CarPath`, with the catalogue name as the default:

- The table is **sparse by design**. A car with no entry gets the catalogue name, which is right for the overwhelming majority — new iRacing content is named sensibly on release instead of blank, and only genuine deviations need listing.
- **Only the two names change.** The telemetry key stays the row's identity, so a saved row selection survives a change of car. The chip colour deliberately stays put too: the widget trades on a column holding its position and its look between cars, and a colour that moved on a car change would cost more than the tidier taxonomy gains.
- Resolved **at render from session info**, not in the processor. The processor discovers the adjustment *set* from telemetry because iRacing only publishes it in-car, but which car that is was already in session info — and giving the processor a car identity would mean resetting on a car change, which is the blink 0fcff051 fixed. The lookup sits inside the store selector, so the widget does not re-render on every session update.

**`dcABS` is not ABS everywhere.** GTP cars have no ABS to adjust and wire that channel to brake bias migration. GT3 cars do have ABS and publish it positive with no `dcBrakeMisc` alongside — checked against BMW M4 GT3, Ferrari 296 GT3 and Porsche 911 GT3 R captures — so the name is right there and wrong on the prototypes.

### A wrong number this turned up

`dcPeakBrakeBias` was folded into the brake bias column on the theory that the two never coexisted. **They do.** The W13 publishes a live 52% bias *and* this channel reading 3, so the fold overwrote the real bias and displayed a migration setting as a percentage. @L061N's TCR screenshot shows the same shape independently — "Brake pressure bias" and "Rear brake valve" as two separate rows on one screen.

The fold is gone and the row stands on its own. It is a rear brake valve on the Clio and the TCR, brake migration on the W13, and a brake bias on neither.

### Five adjustments the sweeps turned up

`dcBrakeMisc` (brake bias target), `dcBrakeBiasFine`, `dcEngineBraking`, `dcMGUKDeployMode` and `dcPowerSteering` had no rows. All are off by default. Both bias trims are declared signed — they are centred on zero and the W13 publishes its target sitting at 0 for a whole session, so the "saw a negative once" rule never fires and a neutral setting would report as switched off.

### Presentation

- Off and unsupported both drop the chip to grey; the value tells them apart — a number the driver set to zero, or `--` for a system the car does not have.
- **Two independent filters**, because a car lacking a system and a driver switching one off are different facts. With both off, a GR86 strip collapses to brake bias and ABS: TC2 and throttle shape because the car has neither, traction control because it is switched off.
- Colours carry meaning where the app already has one. Amber is fuel because `FuelCalculator` is amber throughout. Yellow is deliberately unused: it means caution and off-track in `Flag` and `Battle`, and a fuel column that looked like a warning would be actively misleading. Red is braking.
- Columns are configurable and keep a fixed order, so a column does not move position between cars.

Ships `enabled: false` like every other widget.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

No such widget. Brake bias was available as a session-bar item; ABS, traction control and throttle shape were not surfaced anywhere.

### After
<!-- Screenshot or description of the new behaviour -->

In a Toyota GR86, on track:
<img width="874" height="124" alt="CarSystemsDisplay" src="https://github.com/user-attachments/assets/3b36f06a-57fc-44e2-ab11-e9b9d35b2577" />

Three behaviours visible in that one frame, all on live telemetry:

- **TC reads 0 and is greyed** — the driver has traction control switched off.
- **TC2 and THR are blank** — the GR86 does not expose `dcTractionControl2` or `dcThrottleShape`, which matches what that car publishes in the recorded sessions.
- **Brake bias and ABS are live**, in their own colours.

Both of those can now be hidden independently; the `LiveReadingsOnly` story shows the same car with each filter off.

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [x] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

## Validation

**In iRacing**, six cars driven specifically for this: Dallara P217, Cadillac V-Series.R GTP, Porsche 963 GTP, Dallara IR18 (Daytona, for the weight jacker), Mercedes W13 and Renault Clio. Each swept one adjustment at a time with the in-car screen photographed at the end, which is what produced the naming table above. Earlier confirmation of the live widget was in a Toyota GR86.

**Checked against 326 recorded sessions** rather than assumed — the per-car variation, the reduced out-of-car set, the momentary-toggle behaviour and the signed scales all come from that data.

**Two catalogue guesses confirmed by sweeping.** The weight jacker really does run **-20..20 in 41 steps** — visible only on an oval, since a road-course setup locks it to 0, which is why the earlier Monza capture showed nothing. The hybrid dials step in tenths (deploy 0.1..1, regen 0.5..1), so `precision: 1` is exactly right rather than merely safe.

**One claim checked and not adopted.** The rear brake valve was reported as being on both Caterhams as well. The Caterham Academy does not publish the channel at all — four captures carry nothing but `dcDashPage` — so only the Clio and the TCR are named in the code, with that finding written into the comment so it is not re-added on the same say-so.

**Tooling.** `npm run irsdk:inspect` answers questions about a tape, not about the car in it, so a capture recorded to settle which control a channel carries could not be read back. `tools/telemetry-replay/car-systems-report.ts` prints `CarPath` and, per channel, min / max / step count / whether it ever moved / whether it went negative. It reports every `dc*` variable in the tape rather than only the catalogue's, so a channel nobody thought to look for still shows up. Run against the curated ten-minute AI race:

```
channel            min  max  steps  moved  signed
dcABS              3    3    1      NO     -
dcBrakeBias        51   51   1      NO     -
dcTractionControl  3    3    1      NO     -
```

Every channel `moved: NO` across 36,000 in-car frames. Ten minutes of racing establishes presence and sign and proves nothing about ranges, because nobody touched a dial — which is why the six cars above were swept deliberately rather than driven.

**Processor tests verified by mutation rather than by passing.** Nine deliberate breakages; the first pass had **three survivors**, which were real gaps in the tests rather than in the code:

| Mutation | First pass | After |
| --- | --- | --- |
| Discover from out-of-car frames | survived — the test used a variable that is not tracked, so it passed either way | caught |
| Replace the discovered set instead of merging | survived — no case covered a variable *disappearing* | caught |
| Include a momentary control | survived — exclusion came from the numeric type check, not the list | caught |
| Zero always off, ignoring signed scales | caught | caught |
| Nothing ever off | caught | caught |
| Drop rows when a value stops publishing | caught | caught |
| Publish on every frame | caught | caught |
| Keep recording during a replay | caught | caught |
| Skip the session-change reset | caught | caught |

The brake-bias collision fix was checked the same way: reinstating the fold fails the new test, restoring it passes.

**Storybook**, nine stories, including the W13's full brake family — coarse bias, fine trim, target and migration, the four columns that used to be two — and the crowded nine-column case. Two layout defects were found by rendering that last one rather than by reading the code: chip padding truncated a three-letter label, and `ARB F` / `ARB R` both truncated to `AR...`, indistinguishable, so the short labels carry no spaces.

`npm test` — 2749 tests across 240 files, all passing. `npm run lint` — clean. `npm run build-storybook` — succeeds.

### Known gap

Narrowed considerably, and what remains is named rather than guessed at.

- **BMW M Hybrid V8** is the one override in the table that is reasoned rather than read. Its capture has the GTP signature exactly — `dcABS` negative with a `dcBrakeMisc` alongside, which no GT3 car publishes — but its in-car screen was never photographed. Flagged as provisional in the source.
- **Enum adjustments read as numbers.** `dcMGUKDeployMode` is a mode the W13 names in words ("Build"); the TCR's throttle map is likewise named ("Digressive"). Telemetry carries only the position, so the number is shown as published. Whether `0` is an off mode or an ordinary one is also unknown, so it may grey out incorrectly.
- **`dcPowerSteering`** is named from the channel. The P217 is the one car of the six whose screen was not photographed.

All unconfirmed rows are off by default and blank when a car does not publish them, so the failure mode stays a blank column rather than a wrong number.

### Out of scope, but found here

`SessionBarProcessor.ts` substitutes `dcPeakBrakeBias` for the Clio, so the session bar shows that car's rear brake valve labelled as brake bias — the same wrong assumption this PR removes, in shipped code. Left alone deliberately rather than dragging Standings and SessionBar into a naming change; worth its own PR.
