### PR TITLE
fix: the website goes blank when the live preview loads

### DIFF
--- a/site/src/shims/logger.ts
+++ b/site/src/shims/logger.ts
@@ -1,0 +1,27 @@
+/**
+ * Browser stub for `src/app/logger`.
+ *
+ * The live preview reuses the app's processors, and those log through the
+ * main-process logger. That module is Node/Electron only: it pulls in
+ * `electron-log/main` -> `electron` (which reads `__dirname` at import time)
+ * and reads `process.env`. Both throw in a browser and take down the whole
+ * preview chunk, so the site swaps the module out for this console logger.
+ *
+ * Wired up in `vite.config.ts` via the `stub-app-logger` plugin.
+ */
+const write =
+  (method: 'log' | 'warn' | 'error') =>
+  (...args: unknown[]) =>
+    console[method](...args);
+
+const logger = {
+  debug: write('log'),
+  info: write('log'),
+  verbose: write('log'),
+  silly: write('log'),
+  log: write('log'),
+  warn: write('warn'),
+  error: write('error'),
+};
+
+export default logger;

--- a/site/vite.config.ts
+++ b/site/vite.config.ts
@@ -1,10 +1,41 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/postcss';
 import path from 'node:path';
 
+const APP_LOGGER = path.resolve(__dirname, '../src/app/logger.ts');
+const LOGGER_STUB = path.resolve(__dirname, 'src/shims/logger.ts');
+
+/**
+ * The preview reuses the app's processors, which log through the Electron
+ * main-process logger. Swap that module for a browser-safe console logger --
+ * see src/shims/logger.ts for why it crashes otherwise.
+ */
+function stubAppLogger(): Plugin {
+  return {
+    name: 'stub-app-logger',
+    enforce: 'pre',
+    async resolveId(source, importer, options) {
+      if (!importer || source === LOGGER_STUB) return null;
+      const resolved = await this.resolve(source, importer, {
+        ...options,
+        skipSelf: true,
+      });
+      if (!resolved) return null;
+      const file = path.resolve(resolved.id.split('?')[0]);
+      return file === APP_LOGGER ? LOGGER_STUB : null;
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [stubAppLogger(), react()],
+  define: {
+    // The preview runs main-process code in the browser, and some of it reads
+    // process.env. The production build already compiles that to `{}`; this
+    // makes the dev server behave the same instead of throwing.
+    'process.env': '{}',
+  },
   server: {
     // Use a dedicated port so the site dev server doesn't clash with the
     // main app's renderer dev server (electron-forge vite plugin on 5173).


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

The site rendered and then went blank. The console showed `Uncaught ReferenceError: __dirname is not defined` in the `LivePreview` chunk, and on the dev server `Uncaught ReferenceError: process is not defined` at `src/app/logger.ts:15`.

**Cause.** The live preview reuses the app's real processors, so it imports main-process code:

```
site/src/utils/previewChannelRuntime.ts
  -> src/app/processors/ProcessorHost.ts   (line 11: import logger from '../logger')
    -> src/app/logger.ts                   (line 1:  import logger from 'electron-log/main')
      -> electron
```

The `electron` package runs Node-only code at import time to locate the Electron binary, using `__dirname`. Browsers have no `__dirname`, so the module threw while the chunk was still evaluating. `LivePreview` is lazy-loaded inside a `Suspense` with no error boundary, so React had nowhere to put the error and unmounted the root — the page rendered, then disappeared.

`src/app/logger.ts` and `ProcessorHost.ts` also read `process.env`. The production build survived that because the bundler compiles `process.env` to `{}`; the dev server does not, which is why dev failed at a different line than production.

**Fix.** Two changes, both scoped to the site build. The Electron app is untouched and still logs to disk via `electron-log`.

- A `stub-app-logger` Vite plugin resolves `src/app/logger.ts` to a small console logger (`site/src/shims/logger.ts`). This drops `electron-log`, `electron` and `node:path` from the browser graph entirely. A plugin rather than an alias because the importers use relative specifiers (`'../logger'`), which `resolve.alias` cannot target.
- `define: { 'process.env': '{}' }`, because `ProcessorHost.ts:16` genuinely belongs in the preview and cannot be stubbed away. This makes the dev server behave like the production build.

**Testing.** No iRacing session involved — this is a website build issue.

- Headless browser (Edge, DOM dump plus console capture) against both the dev server and the built site: root renders, the preview chunk loads, widgets are present, zero console errors on both.
- Controls, so that "no errors" means something: a page that throws `ReferenceError` was caught by the same capture harness; and a second dev server with only the `define` removed reproduced `process is not defined`, confirming which change does the work.
- `__dirname` occurrences in the built JS: 5 before, 0 after. The `electron` and `electron-log` module bodies are gone from the bundle.
- `npm test` (200 files, 1944 tests) and `npm run lint` both pass.

**Not addressed here.** `LivePreview` still has no error boundary around it in `site/src/App.tsx`, which is why one module throw could blank the whole page. Worth a follow-up, but out of scope for this fix.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

The site renders briefly, then goes completely blank. `#root` is empty. Console:

```
Uncaught ReferenceError: __dirname is not defined
    at LivePreview-Br04OV-2.js:1:20774645
```

### After
<!-- Screenshot or description of the new behaviour -->

The site renders and stays. The live preview section loads with its widgets and the console is clean. Verified by headless DOM dump on both the dev server and the production build:

```
port 5174 (dev) : rootEmpty=0 stuckLoader=0 widgets=3 consoleErrors=0
port 4174 (prod): rootEmpty=0 stuckLoader=0 widgets=3 consoleErrors=0
```

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site preview compatibility by safely handling application logging in the browser.
  * Prevented preview issues caused by unavailable environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->