### PR TITLE
feat: keep pit laps out of the lap history graph

### DIFF
--- a/src/frontend/components/LapTimeLog/LapTimeLog.spec.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.spec.tsx
@@ -223,3 +223,82 @@ describe('LapTimeLogDisplay', () => {
     expect(screen.queryByText('LAP 9')).not.toBeInTheDocument();
   });
 });
+
+describe('hiding pitted laps', () => {
+  /**
+   * A practice stint with two stops. The pit laps are far slower, which is what
+   * stretches the chart scale and pulls the average away from the green laps a
+   * driver is actually comparing.
+   */
+  const stint = [
+    { lap: 1, time: 31.6 },
+    { lap: 2, time: 31.2 },
+    { lap: 3, time: 43.2, pitted: true },
+    { lap: 4, time: 38.9, pitted: true },
+    { lap: 5, time: 31.3 },
+    { lap: 6, time: 31.2 },
+  ];
+
+  const renderHistory = (hidePittedLaps: boolean) =>
+    render(
+      <LapTimeLogDisplay
+        settings={mockSettings({
+          showCurrentLap: false,
+          showPredictedLap: false,
+          showLastLap: false,
+          showBestLap: false,
+          history: { enabled: true, count: 10, style: 'list', hidePittedLaps },
+        })}
+        history={stint}
+      />
+    );
+
+  it('shows every lap by default, so nothing changes for an existing setup', () => {
+    renderHistory(false);
+
+    expect(screen.getByText('LAP 3')).toBeInTheDocument();
+    expect(screen.getByText('LAP 4')).toBeInTheDocument();
+    expect(screen.getByText('LAP 6')).toBeInTheDocument();
+  });
+
+  it('leaves out the pit laps when the toggle is on', () => {
+    renderHistory(true);
+
+    expect(screen.queryByText('LAP 3')).not.toBeInTheDocument();
+    expect(screen.queryByText('LAP 4')).not.toBeInTheDocument();
+  });
+
+  it('keeps the green laps either side of a stop', () => {
+    renderHistory(true);
+
+    for (const lap of ['LAP 1', 'LAP 2', 'LAP 5', 'LAP 6']) {
+      expect(screen.getByText(lap)).toBeInTheDocument();
+    }
+  });
+
+  it('still fills the configured number of laps when some are hidden', () => {
+    // Filtering has to happen before the count is applied, or asking for four
+    // laps after two stops silently shows two.
+    render(
+      <LapTimeLogDisplay
+        settings={mockSettings({
+          showCurrentLap: false,
+          showPredictedLap: false,
+          showLastLap: false,
+          showBestLap: false,
+          history: {
+            enabled: true,
+            count: 4,
+            style: 'list',
+            hidePittedLaps: true,
+          },
+        })}
+        history={stint}
+      />
+    );
+
+    for (const lap of ['LAP 1', 'LAP 2', 'LAP 5', 'LAP 6']) {
+      expect(screen.getByText(lap)).toBeInTheDocument();
+    }
+  });
+});

--- a/src/frontend/components/LapTimeLog/LapTimeLog.stories.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.stories.tsx
@@ -15,11 +15,14 @@ const meta: Meta<typeof LapTimeLogDisplay> = {
   parameters: {
     layout: 'centered',
   },
-  decorators: [TelemetryDecorator(), (Story) => (
-    <div style={{ width: '250px' }}>
-      <Story />
-    </div>
-  )],
+  decorators: [
+    TelemetryDecorator(),
+    (Story) => (
+      <div style={{ width: '250px' }}>
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;
@@ -102,11 +105,11 @@ export const NewPersonalBest: Story = {
   args: {
     ...baseArgs,
     current: 4.5, // within 5 seconds
-    lastlap: 91.2, 
+    lastlap: 91.2,
     bestlap: 91.2,
     alltimelap: 91.2, // new personal best
     settings: mockConfig({
-      showAllTimeLap: true,     
+      showAllTimeLap: true,
     }),
   },
 };
@@ -116,7 +119,7 @@ export const NewSessionBest: Story = {
   args: {
     ...baseArgs,
     current: 3.2, // within 5 seconds
-    lastlap: 90.9, 
+    lastlap: 90.9,
     bestlap: 90.9, // new session best
     overall: 90.2,
     settings: mockConfig(),
@@ -211,6 +214,56 @@ export const HistoryChart: Story = {
     ],
     settings: mockConfig({
       history: { enabled: true, count: 10, style: 'chart' },
+    }),
+  },
+};
+
+/**
+ * A practice stint with two stops, shaped like the one a user reported: the pit
+ * laps are ~12s slower, which stretches the y-axis and pulls the average away
+ * from the laps being compared.
+ */
+const pitStintHistory = [
+  { lap: 12, time: 31.2, delta: 0.0 },
+  { lap: 11, time: 31.3, delta: 0.1 },
+  { lap: 10, time: 43.2, delta: 12.0, pitted: true },
+  { lap: 9, time: 38.9, delta: 7.7, pitted: true },
+  { lap: 8, time: 31.4, delta: 0.2 },
+  { lap: 7, time: 31.2, delta: 0.0 },
+  { lap: 6, time: 31.5, delta: 0.3 },
+  { lap: 5, time: 43.6, delta: 12.4, pitted: true },
+  { lap: 4, time: 31.6, delta: 0.4 },
+  { lap: 3, time: 31.3, delta: 0.1 },
+];
+
+export const PittedLapsShown: Story = {
+  name: 'Pit Laps Shown (default)',
+  args: {
+    ...baseArgs,
+    history: pitStintHistory,
+    settings: mockConfig({
+      history: {
+        enabled: true,
+        count: 10,
+        style: 'chart',
+        hidePittedLaps: false,
+      },
+    }),
+  },
+};
+
+export const PittedLapsHidden: Story = {
+  name: 'Pit Laps Hidden',
+  args: {
+    ...baseArgs,
+    history: pitStintHistory,
+    settings: mockConfig({
+      history: {
+        enabled: true,
+        count: 10,
+        style: 'chart',
+        hidePittedLaps: true,
+      },
     }),
   },
 };

--- a/src/frontend/components/LapTimeLog/LapTimeLog.tsx
+++ b/src/frontend/components/LapTimeLog/LapTimeLog.tsx
@@ -101,10 +101,15 @@ export const LapTimeLogDisplay = ({
   // sort laps
   const sortedHistory = useMemo(() => {
     if (!history) return [];
-    return [...history]
+    // Filtered before the slice, so hiding pit laps still shows the configured
+    // number of laps rather than silently shortening the list.
+    const laps = settings.history.hidePittedLaps
+      ? history.filter((entry) => !entry.pitted)
+      : history;
+    return [...laps]
       .sort((a, b) => b.lap - a.lap)
       .slice(0, settings.history.count);
-  }, [history, settings.history.count]);
+  }, [history, settings.history.count, settings.history.hidePittedLaps]);
 
   // predicted lap time
   const predicted =
@@ -227,11 +232,7 @@ export const LapTimeLogDisplay = ({
                         : 'text-zinc-400'
                   }`}
                 >
-                  {formatDelta(
-                    hasPredictedDelta
-                      ? delta
-                      : 0
-                  )}
+                  {formatDelta(hasPredictedDelta ? delta : 0)}
                 </div>
               )}
             </div>

--- a/src/frontend/components/LapTimeLog/demoData.ts
+++ b/src/frontend/components/LapTimeLog/demoData.ts
@@ -4,6 +4,8 @@ export interface LapEntry {
   time: number;
   delta?: number;
   dirty?: boolean;
+  /** The car was in the pit lane or its box during this lap. */
+  pitted?: boolean;
 }
 
 export interface LapTimeLogDemoData {
@@ -21,35 +23,35 @@ export interface LapTimeLogDemoData {
 // Demo data for pitlane helper
 export const getDemoLapTimeLogData = (): LapTimeLogDemoData => {
   return {
-    "current": 84.390,
-    "lastlap": 83.457,
-    "bestlap": 82.301,     
-    "alltimelap": 81.200,  
-    "reference": 83.457,
-    "delta": 0.933,
-    "overall": 82.251,
-    "dirty": false,
-    "history": [
-      { "lap": 1, "time": 82.902, "delta": 0.000 },
-      { "lap": 2, "time": 83.150, "delta": 0.248 },
-      { "lap": 3, "time": 84.254, "delta": 1.104 },
-      { "lap": 4, "time": 82.301, "delta": -1.953 },
-      { "lap": 5, "time": 84.211, "delta": 1.910 },  
-      { "lap": 6, "time": 85.001, "delta": 0.790 },
-      { "lap": 7, "time": 84.999, "delta": -0.002, "dirty": true },
-      { "lap": 8, "time": 84.000, "delta": -0.999, "dirty": true },
-      { "lap": 9, "time": 82.401, "delta": -1.599 }, 
-      { "lap": 10, "time": 83.457, "delta": 1.056 },
-      { "lap": 11, "time": 82.902, "delta": -0.555 },
-      { "lap": 12, "time": 83.150, "delta": 0.248, "dirty": true },
-      { "lap": 13, "time": 84.254, "delta": 1.104 },
-      { "lap": 14, "time": 82.301, "delta": -1.953 },
-      { "lap": 15, "time": 84.211, "delta": 1.910 },
-      { "lap": 16, "time": 85.001, "delta": 0.790, "dirty": true },
-      { "lap": 17, "time": 84.999, "delta": -0.002, "dirty": true },
-      { "lap": 18, "time": 84.000, "delta": -0.999, "dirty": true },
-      { "lap": 19, "time": 82.401, "delta": -1.599 },
-      { "lap": 20, "time": 83.457, "delta": 1.056 }
-    ]
-  }
-}
+    current: 84.39,
+    lastlap: 83.457,
+    bestlap: 82.301,
+    alltimelap: 81.2,
+    reference: 83.457,
+    delta: 0.933,
+    overall: 82.251,
+    dirty: false,
+    history: [
+      { lap: 1, time: 82.902, delta: 0.0 },
+      { lap: 2, time: 83.15, delta: 0.248 },
+      { lap: 3, time: 84.254, delta: 1.104 },
+      { lap: 4, time: 82.301, delta: -1.953 },
+      { lap: 5, time: 84.211, delta: 1.91 },
+      { lap: 6, time: 85.001, delta: 0.79 },
+      { lap: 7, time: 84.999, delta: -0.002, dirty: true },
+      { lap: 8, time: 84.0, delta: -0.999, dirty: true },
+      { lap: 9, time: 82.401, delta: -1.599 },
+      { lap: 10, time: 83.457, delta: 1.056 },
+      { lap: 11, time: 82.902, delta: -0.555 },
+      { lap: 12, time: 83.15, delta: 0.248, dirty: true },
+      { lap: 13, time: 84.254, delta: 1.104 },
+      { lap: 14, time: 82.301, delta: -1.953 },
+      { lap: 15, time: 84.211, delta: 1.91 },
+      { lap: 16, time: 85.001, delta: 0.79, dirty: true },
+      { lap: 17, time: 84.999, delta: -0.002, dirty: true },
+      { lap: 18, time: 84.0, delta: -0.999, dirty: true },
+      { lap: 19, time: 82.401, delta: -1.599 },
+      { lap: 20, time: 83.457, delta: 1.056 },
+    ],
+  };
+};

--- a/src/frontend/components/LapTimeLog/hooks/useLapTimeLog.history.spec.tsx
+++ b/src/frontend/components/LapTimeLog/hooks/useLapTimeLog.history.spec.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { TrackLocation } from '@irdashies/types';
+import type { LapLogSnapshot, LapTimeLogConfig } from '@irdashies/types';
+
+let snapshot: LapLogSnapshot;
+
+vi.mock('@irdashies/context', () => ({
+  useLapLogSnapshot: () => snapshot,
+  useDriverCarIdx: () => 0,
+  useSessionStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      session: {
+        WeekendInfo: { TrackID: 1 },
+        DriverInfo: { Drivers: [{ CarIdx: 0, CarPath: 'testcar' }] },
+      },
+    }),
+  usePersonalBestStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      getPersonalBest: () => undefined,
+      setPersonalBest: () => undefined,
+    }),
+  useGeneralSettings: () => undefined,
+}));
+
+const settings = (
+  overrides: Partial<LapTimeLogConfig['history']> = {}
+): LapTimeLogConfig =>
+  ({
+    background: { opacity: 80 },
+    foreground: { opacity: 70 },
+    scale: 100,
+    alignment: 'top',
+    reverse: false,
+    showCurrentLap: false,
+    showPredictedLap: false,
+    showLastLap: false,
+    showBestLap: false,
+    showAllTimeLap: false,
+    delta: { enabled: false, method: 'bestlap' },
+    history: { enabled: true, count: 20, ...overrides },
+    sessionVisibility: {
+      race: true,
+      loneQualify: true,
+      openQualify: true,
+      practice: true,
+      offlineTesting: true,
+    },
+    showOnlyWhenOnTrack: false,
+  }) as LapTimeLogConfig;
+
+vi.mock('./useLapTimeLogSettings', () => ({
+  useLapTimeLogSettings: () => ({ config: settings() }),
+}));
+
+import { useLapTimeLog } from './useLapTimeLog';
+import { LapTimeLogDisplay } from '../LapTimeLog';
+
+const emptySnapshot: LapLogSnapshot = {
+  lapCompleted: 0,
+  currentLapTime: 30,
+  lastLapTime: 0,
+  bestLapTime: 0,
+  carIdxBestLapTime: [],
+  sessionNum: 0,
+  sessionTime: 0,
+  playerTrackSurface: TrackLocation.OnTrack,
+  incidentCount: 0,
+  lapDistPct: 0.5,
+  deltaToSessionLastLap: 0,
+  deltaToSessionLastLapOk: false,
+  deltaToSessionBestLap: 0,
+  deltaToSessionBestLapOk: false,
+  version: 0,
+};
+
+/**
+ * The retained history feeds the display, and with pitted laps hidden the
+ * display filters it before taking the configured number of laps. So the cap
+ * here is not a display concern that a display-only test can cover: if the hook
+ * has already thrown a clean lap away, no setting can bring it back.
+ *
+ * This drives the real hook through a stint long enough to exercise the cap,
+ * then hands its output to the real display component, because the bug lives in
+ * the seam between the two rather than in either one.
+ */
+describe('lap history retention', () => {
+  /**
+   * One lap in two steps, because the pit latch and the lap recording are
+   * separate effects: the surface has to be seen during the lap for the entry
+   * to be marked when the lap is scored.
+   */
+  const driveLaps = (
+    rerender: () => void,
+    laps: number,
+    isPitLap: (lap: number) => boolean
+  ) => {
+    for (let lap = 1; lap <= laps; lap += 1) {
+      snapshot = {
+        ...snapshot,
+        playerTrackSurface: isPitLap(lap)
+          ? TrackLocation.InPitStall
+          : TrackLocation.OnTrack,
+        lapDistPct: 0.5,
+        version: snapshot.version + 1,
+      };
+      rerender();
+
+      snapshot = {
+        ...snapshot,
+        playerTrackSurface: TrackLocation.OnTrack,
+        lapCompleted: lap,
+        lastLapTime: 90 + lap,
+        lapDistPct: 0.01,
+        version: snapshot.version + 1,
+      };
+      rerender();
+    }
+  };
+
+  it('keeps enough clean laps to fill the display when pit laps are hidden', () => {
+    snapshot = { ...emptySnapshot };
+    const { result, rerender } = renderHook(() => useLapTimeLog());
+
+    // A 40 lap stint stopping every fifth lap: 8 pit laps sit inside the most
+    // recent 40, which under the old cap of 20 left only 16 clean laps for a
+    // display asking for 20.
+    driveLaps(rerender, 40, (lap) => lap % 5 === 0);
+
+    const clean = result.current.history.filter((entry) => !entry.pitted);
+    expect(clean.length).toBeGreaterThanOrEqual(20);
+    expect(
+      result.current.history.filter((entry) => entry.pitted).length
+    ).toBeGreaterThan(0);
+
+    render(
+      <LapTimeLogDisplay
+        {...result.current}
+        settings={settings({ hidePittedLaps: true })}
+      />
+    );
+
+    expect(screen.getAllByText(/^LAP \d+$/)).toHaveLength(20);
+    // Every lap the display shows is a green one, and the newest clean lap
+    // leads: a filter applied after the slice would have shown fewer rows.
+    expect(screen.queryByText('LAP 40')).not.toBeInTheDocument();
+    expect(screen.getByText('LAP 39')).toBeInTheDocument();
+    for (const pitted of [35, 30, 25]) {
+      expect(screen.queryByText(`LAP ${pitted}`)).not.toBeInTheDocument();
+    }
+  });
+});

--- a/src/frontend/components/LapTimeLog/hooks/useLapTimeLog.spec.ts
+++ b/src/frontend/components/LapTimeLog/hooks/useLapTimeLog.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { TrackLocation } from '@irdashies/types';
+import { isPitSurface, isOffTrackSurface } from './useLapTimeLog';
+
+/**
+ * These map `PlayerTrackSurface` onto `TrackLocation`, and getting that mapping
+ * wrong is silent: the value simply never matches and the check quietly does
+ * nothing. That is exactly what happened before — off-track was compared
+ * against a hardcoded 4, which `TrackLocation` cannot produce, so no lap was
+ * ever marked dirty for going off. Every enum member is asserted so a future
+ * edit has to be deliberate.
+ */
+describe('track surface predicates', () => {
+  const everySurface = [
+    TrackLocation.NotInWorld,
+    TrackLocation.OffTrack,
+    TrackLocation.InPitStall,
+    TrackLocation.ApproachingPits,
+    TrackLocation.OnTrack,
+  ];
+
+  describe('isPitSurface', () => {
+    it('is true in the pit box and in the pit lane', () => {
+      expect(isPitSurface(TrackLocation.InPitStall)).toBe(true);
+      expect(isPitSurface(TrackLocation.ApproachingPits)).toBe(true);
+    });
+
+    it('is false everywhere else', () => {
+      expect(isPitSurface(TrackLocation.OnTrack)).toBe(false);
+      expect(isPitSurface(TrackLocation.OffTrack)).toBe(false);
+      expect(isPitSurface(TrackLocation.NotInWorld)).toBe(false);
+    });
+
+    it('matches exactly two of the five surfaces', () => {
+      // Guards against a predicate that is accidentally always true or false.
+      expect(everySurface.filter(isPitSurface)).toEqual([
+        TrackLocation.InPitStall,
+        TrackLocation.ApproachingPits,
+      ]);
+    });
+  });
+
+  describe('isOffTrackSurface', () => {
+    it('is true off track', () => {
+      expect(isOffTrackSurface(TrackLocation.OffTrack)).toBe(true);
+    });
+
+    it('is not true for a value the enum cannot take', () => {
+      // The original bug: 4 is outside TrackLocation, so the comparison could
+      // never succeed and going off never marked a lap dirty.
+      expect(isOffTrackSurface(4)).toBe(false);
+    });
+
+    it('matches exactly one of the five surfaces', () => {
+      expect(everySurface.filter(isOffTrackSurface)).toEqual([
+        TrackLocation.OffTrack,
+      ]);
+    });
+  });
+});

--- a/src/frontend/components/LapTimeLog/hooks/useLapTimeLog.ts
+++ b/src/frontend/components/LapTimeLog/hooks/useLapTimeLog.ts
@@ -30,7 +30,16 @@ export const isPitSurface = (surface: number): boolean =>
 
 export const isOffTrackSurface = (surface: number): boolean =>
   surface === TrackLocation.OffTrack;
-const MAX_HISTORY_ENTRIES = 20;
+/**
+ * The retained history has to outrun the display, not match it. "Number Of Laps
+ * To Show" goes up to 20, and with pitted laps hidden the display filters this
+ * list before taking that many — so a cap of 20 made the setting unsatisfiable
+ * the moment a stop happened: the clean laps that could have filled the gap had
+ * already been dropped here. 60 covers the maximum display count even on short
+ * fuel runs where two laps in three are in-laps or out-laps, and the entries are
+ * five numbers each.
+ */
+const MAX_HISTORY_ENTRIES = 60;
 const FREEZE_TIME = 5;
 
 export const useLapTimeLog = () => {

--- a/src/frontend/components/LapTimeLog/hooks/useLapTimeLog.ts
+++ b/src/frontend/components/LapTimeLog/hooks/useLapTimeLog.ts
@@ -5,10 +5,31 @@ import {
   useSessionStore,
   useDriverCarIdx,
 } from '@irdashies/context';
+import { TrackLocation } from '@irdashies/types';
 import type { LapEntry } from '../demoData';
 import { useLapTimeLogSettings } from './useLapTimeLogSettings';
 
-const TRACK_SURFACE_OFF_TRACK = 4;
+/**
+ * A lap counts as pitted if the car was in the pit lane or its box at any point
+ * during it. That covers the in-lap and the out-lap without special-casing
+ * either: an out-lap starts in the stall, so the surface already reads
+ * InPitStall when it begins.
+ */
+const PIT_SURFACES: readonly number[] = [
+  TrackLocation.InPitStall,
+  TrackLocation.ApproachingPits,
+];
+
+/**
+ * Exported so the mapping onto TrackLocation is testable. It is worth pinning:
+ * this file previously compared the surface against a hardcoded 4, which is not
+ * a value the enum can take, so the off-track check never fired.
+ */
+export const isPitSurface = (surface: number): boolean =>
+  PIT_SURFACES.includes(surface);
+
+export const isOffTrackSurface = (surface: number): boolean =>
+  surface === TrackLocation.OffTrack;
 const MAX_HISTORY_ENTRIES = 20;
 const FREEZE_TIME = 5;
 
@@ -18,11 +39,13 @@ export const useLapTimeLog = () => {
     setHistory([]);
     setSavedDelta(0);
     setIsDirty(false);
+    setIsPitted(false);
     setDisplayTime(undefined);
   };
 
   const resetLapState = () => {
     setIsDirty(false);
+    setIsPitted(false);
     setSavedDelta(0);
   };
 
@@ -46,6 +69,7 @@ export const useLapTimeLog = () => {
   // States
   const [history, setHistory] = useState<LapEntry[]>([]);
   const [isDirty, setIsDirty] = useState<boolean>(false);
+  const [isPitted, setIsPitted] = useState<boolean>(false);
   const [displayTime, setDisplayTime] = useState<number | undefined>(0);
   const [savedDelta, setSavedDelta] = useState<number>(0);
 
@@ -160,12 +184,19 @@ export const useLapTimeLog = () => {
     // 3c. incident/dirty lap logic
     setIsDirty((prev) => {
       if (!prev) {
-        const offTrack = playerTrackSurface === TRACK_SURFACE_OFF_TRACK;
+        // Was TRACK_SURFACE_OFF_TRACK = 4, which is not a value TrackLocation
+        // can take, so this never fired and only the incident half of the
+        // check worked.
+        const offTrack = isOffTrackSurface(playerTrackSurface);
         const incidentOccurred = incidentCount > incidentsAtLapStart.current;
         return offTrack || incidentOccurred;
       }
       return prev;
     });
+
+    // Latched for the lap: the surface reads OnTrack again long before the lap
+    // is scored, so sampling it at the crossing would miss the stop entirely.
+    setIsPitted((prev) => prev || isPitSurface(playerTrackSurface));
   }, [
     currentLapTime,
     liveDelta,
@@ -194,6 +225,7 @@ export const useLapTimeLog = () => {
           ? lastLapTime - referenceAtStartOfLap.current
           : 0,
       dirty: isDirty,
+      pitted: isPitted,
     };
     setHistory((prev) => [newEntry, ...prev].slice(0, MAX_HISTORY_ENTRIES));
     // reset for new lap
@@ -207,6 +239,7 @@ export const useLapTimeLog = () => {
     lapCompleted,
     lastLapTime,
     isDirty,
+    isPitted,
     incidentCount,
     referenceTime,
     history,

--- a/src/frontend/components/Settings/sections/LapTimeLogSettings.tsx
+++ b/src/frontend/components/Settings/sections/LapTimeLogSettings.tsx
@@ -222,6 +222,23 @@ export const LapTimeLogSettings = () => {
                           })
                         }
                       />
+
+                      <SettingToggleRow
+                        title="Hide Pitted Laps"
+                        description="Leave out laps where you pitted. They are much slower than a green lap, so they stretch the chart and pull the average away from your real pace."
+                        enabled={
+                          settings.config.history?.hidePittedLaps ?? false
+                        }
+                        onToggle={(v) =>
+                          handleConfigChange({
+                            ...settings.config,
+                            history: {
+                              ...settings.config.history,
+                              hidePittedLaps: v,
+                            },
+                          })
+                        }
+                      />
                     </SettingsSection>
                   )}
                 </SettingsSection>

--- a/src/types/defaultDashboard.ts
+++ b/src/types/defaultDashboard.ts
@@ -1127,6 +1127,7 @@ export const defaultDashboard: {
           enabled: true,
           count: 10,
           style: 'list',
+          hidePittedLaps: false,
         },
         background: {
           opacity: 80,

--- a/src/types/widgetConfigs.ts
+++ b/src/types/widgetConfigs.ts
@@ -580,6 +580,12 @@ export interface LapTimeLogConfig {
     enabled: boolean;
     count: number;
     style?: 'list' | 'chart';
+    /**
+     * Leave laps that involved a pit stop out of the history. They are far
+     * slower than a green lap, so they stretch the chart scale and drag the
+     * average, which flattens the laps you are actually comparing.
+     */
+    hidePittedLaps?: boolean;
   };
   scale: number;
   alignment: 'top' | 'bottom';


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does including how the changes were tested on iRacing (if applicable) -->

Requested by a user practising ovals: pit laps make the lap history graph hard to read.

A pit lap is ten or more seconds slower than a green one, so it stretches the y-axis and drags the average. The laps you are actually comparing get squashed into a flat band a few pixels tall between the spikes, which is exactly when a tight oval spread matters most.

This adds an optional **Hide Pitted Laps** toggle that leaves those laps out of both the list and the graph.

### Detecting a pit lap

A lap is marked pitted if `PlayerTrackSurface` reads `InPitStall` or `ApproachingPits` at any point during it.

It is **latched for the lap** rather than sampled when the lap is scored — by the time the line is crossed the surface reads `OnTrack` again, so sampling at the crossing would miss every stop.

That also covers the out-lap without special-casing it: an out-lap starts in the box, so the surface already reads `InPitStall` when it begins. Both halves of a stop drop out together, which is what the reported screenshot shows — the spikes come in pairs.

### Filtering happens before the count

Hiding pit laps still shows the configured number of laps. Filtering after the slice would quietly shorten the list — ask for ten laps after two stops and get seven.

Defaults to **off**, so no existing display changes.

### Also fixes a pre-existing bug in the same check

The off-track half of the dirty-lap test compared the surface against a hardcoded `4`:

```ts
const TRACK_SURFACE_OFF_TRACK = 4;
```

`TrackLocation` runs `NotInWorld = -1` to `OnTrack = 3`, so `4` is not a value it can produce and the comparison could never succeed. Only the incident half of the check worked, so going off without picking up an incident left the lap looking clean.

Both surface tests are now small exported predicates with tests over every enum member. The failure mode here is silence rather than an error, which is how this survived — so the mapping is worth pinning.

This is a separate defect from the feature and easy to split out if you would rather it landed on its own.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

Two Storybook stories added on the same ten-lap practice stint with two stops, so the difference is visible without a sim: `widgets/LapTimeLog` → **Pit Laps Shown (default)** and **Pit Laps Hidden**.

### Before
<!-- Screenshot or description of the current behaviour -->

`AVG 0:34.820`. Two spikes dominate the chart; the green laps sit flat along the bottom and the lap-to-lap variation is unreadable.

### After
<!-- Screenshot or description of the new behaviour -->

`AVG 0:31.287`. The average now reflects green-lap pace, the y-axis rescales, and the variation between laps fills the chart.

## Type of Change

<!-- Check the relevant option(s) -->

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [x] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

Not yet tested in iRacing — the pit-surface detection is covered by unit tests and the display by Storybook, but the latch has not been watched through a real stop. Happy to run a practice stint before this merges if you would rather have that first.

## Validation

**Storybook, before and after**, on the same stint: the average moves from `0:34.820` to `0:31.287` and the y-axis rescales, which is the actual complaint being fixed.

**Filter tests, verified by mutation** rather than by passing. Three deliberate breakages, each caught by the test that names it:

| Mutation | Caught by |
| --- | --- |
| Never filter, so the toggle does nothing | "leaves out the pit laps when the toggle is on" |
| Always filter, ignoring the toggle | "shows every lap by default, so nothing changes for an existing setup" |
| Filter after the slice, so the list silently shortens | "still fills the configured number of laps when some are hidden" |

**Surface predicates** are asserted against every member of `TrackLocation`, including an explicit case that `4` is not off-track — the exact value that made the original bug invisible.

`npm test` — 2000 tests across 199 files, all passing. `npm run lint` — clean. `npm run build-storybook` — succeeds.

### One thing worth knowing about the diff

`demoData.ts` shows about 33 lines of change that are **not** mine: the file was not prettier-formatted, and the pre-commit hook normalised it when I touched it. My change to that file is the two-line `pitted` field; the rest is quote and whitespace normalisation. Happy to revert that hunk if you would rather keep it out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Hide Pitted Laps** option to lap history settings.
  - Lap history can now exclude laps involving pit stops while retaining laps around the stop.
  - Added visual examples showing pitted laps displayed or hidden.

- **Bug Fixes**
  - Improved pit-stop and off-track detection for more accurate lap history records.
  - Filtering now occurs before the history display limit is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->