### PR TITLE
fix: times/laps in standings header (obs overlay)

### DIFF
--- a/src/frontend/components/DashboardView/DashboardView.tsx
+++ b/src/frontend/components/DashboardView/DashboardView.tsx
@@ -16,6 +16,7 @@ import { useDragWidget, useResizeWidget } from '../WidgetContainer';
 import { ResizeHandles } from '../WidgetContainer/ResizeHandle';
 import logger from '@irdashies/utils/logger';
 import { WidgetRuntimeProvider } from '../../widgetRuntime';
+import { SessionTimingUpdater } from '../OverlayContainer/SessionTimingUpdater';
 
 interface WidgetPosition {
   x: number;
@@ -357,6 +358,7 @@ export const DashboardView = () => {
       className="w-full h-screen overflow-hidden relative"
       style={{ background: 'transparent' }}
     >
+      <SessionTimingUpdater />
       {enabledWidgets.map((widget) => {
         const position =
           widgetPositions[widget.id] ?? initialPositions[widget.id];


### PR DESCRIPTION
## Description

Fixed display of laps/time to finish for stream overlay (regresion in #667 - commit  e69c9ae).

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
<!-- Screenshot or description of the current behaviour -->

### After
<!-- Screenshot or description of the new behaviour -->

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [x] I have discussed this change in the discord server
- [x] I have tested this in iRacing (either in an online session or with AI)
- [x] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session timing updates to the dashboard view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->