### PR TITLE
fix: use validated race distance for fuel calculations

### DIFF
--- a/src/app/processors/FuelProjectionProcessor.spec.ts
+++ b/src/app/processors/FuelProjectionProcessor.spec.ts
@@ -61,6 +61,43 @@ describe('FuelProjectionProcessor', () => {
     expect(lapCompleted).toHaveBeenCalledOnce();
   });
 
+  it('uses each heat lap limit after qualifying and race transitions', () => {
+    const processor = new FuelProjectionProcessor();
+    processor.init({
+      SessionInfo: {
+        Sessions: [
+          { SessionNum: 0, SessionType: 'Lone Qualify', SessionLaps: 2 },
+          { SessionNum: 1, SessionType: 'Race', SessionLaps: 8 },
+          { SessionNum: 2, SessionType: 'Race', SessionLaps: 20 },
+        ],
+      },
+    } as unknown as Session);
+
+    for (const [sessionNum, totalLaps] of [
+      [0, 0],
+      [1, 8],
+      [2, 20],
+    ]) {
+      if (sessionNum > 0) processor.onLifecycle({ type: 'sessionNumChange' });
+      processor.onFrame(
+        frame({
+          SessionNum: sessionNum,
+          SessionState: 4,
+          SessionTimeRemain: 604800,
+          SessionLapsRemain: 32767,
+          Lap: 3,
+          LapDistPct: 0.25,
+        })
+      );
+      expect(processor.snapshot()).toMatchObject({
+        sessionNum,
+        calculatedTotalRaceLaps: totalLaps,
+        estimatedLapsRemaining: totalLaps > 0 ? totalLaps - 2.25 : 0,
+        hasValidRaceEstimate: totalLaps > 0,
+      });
+    }
+  });
+
   it('resets volatile state on disconnect', () => {
     const processor = new FuelProjectionProcessor();
     processor.onFrame(

--- a/src/app/processors/FuelProjectionProcessor.ts
+++ b/src/app/processors/FuelProjectionProcessor.ts
@@ -362,7 +362,14 @@ export class FuelProjectionProcessor implements TelemetryProcessor<FuelProjectio
           leaderLap + leaderDistance - (playerLap + playerDistance);
         if (distanceBehind > 0) totalRaceLaps -= Math.floor(distanceBehind);
       }
-      return { ...emptyProjection, totalRaceLaps };
+      const playerProgress =
+        Math.max(0, playerLap - 1) + Math.max(0, value(frame, 'LapDistPct'));
+      return {
+        totalRaceLaps,
+        lapsRemaining: Math.max(0, totalRaceLaps - playerProgress),
+        hasValidEstimate: configuredLaps > 0,
+        isFixedLapRace,
+      };
     }
     if (leaderLapTime < 10 || playerLapTime < 10) return emptyProjection;
 

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.spec.tsx
@@ -103,43 +103,86 @@ describe('useFuelCalculation channel parity', () => {
     expect(result.current?.currentLap).toBe(3);
   });
 
-  it('uses the validated timed-race remaining distance without reconstructing it', async () => {
-    window.channelBridge = {
-      subscribe: <K extends ChannelName>(
-        _channel: K,
-        callback: (payload: ChannelPayloads[K]) => void
-      ) => {
-        callback({
-          ...projection,
-          currentLap: 8,
-          lapDistPct: 0.8,
-          sessionLaps: 'unlimited',
-          sessionLapsRemain: 32767,
-          calculatedTotalRaceLaps: 20.1,
-          estimatedLapsRemaining: 9.2,
-          hasValidRaceEstimate: true,
-          isFixedLapRace: false,
-        } as ChannelPayloads[K]);
-        return () => undefined;
-      },
-    };
+  it.each([32767, 30])(
+    'uses the validated timed-race distance with raw remaining laps %s',
+    async (rawLaps) => {
+      window.channelBridge = {
+        subscribe: <K extends ChannelName>(
+          _channel: K,
+          callback: (payload: ChannelPayloads[K]) => void
+        ) => {
+          callback({
+            ...projection,
+            currentLap: 8,
+            lapDistPct: 0.8,
+            sessionLaps: 'unlimited',
+            sessionNum: 2,
+            sessionLapsRemain: rawLaps,
+            calculatedTotalRaceLaps: 20.1,
+            estimatedLapsRemaining: 9.2,
+            hasValidRaceEstimate: true,
+            isFixedLapRace: false,
+          } as ChannelPayloads[K]);
+          return () => undefined;
+        },
+      };
 
-    const { result } = renderHook(() =>
-      useFuelCalculation(defaultFuelCalculatorSettings.safetyMargin, {
-        ...defaultFuelCalculatorSettings,
-        enableStorage: false,
-        enableLogging: false,
-      })
-    );
+      const { result } = renderHook(() =>
+        useFuelCalculation(defaultFuelCalculatorSettings.safetyMargin, {
+          ...defaultFuelCalculatorSettings,
+          enableStorage: false,
+          enableLogging: false,
+        })
+      );
 
-    await waitFor(() => expect(result.current).not.toBeNull());
-    expect(result.current?.lapsRemaining).toBe(9.2);
-    expect(result.current?.lapsRemaining).not.toBeCloseTo(12.2);
-    expect(result.current?.fuelToFinish).toBeCloseTo(
-      9.2 * (result.current?.avgLaps ?? 0) +
-        (defaultFuelCalculatorSettings.safetyMargin + 0.25) * 1.3
-    );
-  });
+      await waitFor(() => expect(result.current).not.toBeNull());
+      expect(result.current?.lapsRemaining).toBe(9.2);
+      expect(result.current?.lapsRemaining).not.toBeCloseTo(12.2);
+      expect(result.current?.fuelToFinish).toBeCloseTo(
+        9.2 * (result.current?.avgLaps ?? 0) +
+          (defaultFuelCalculatorSettings.safetyMargin + 0.25) * 1.3
+      );
+    }
+  );
+
+  it.each([32767, 30])(
+    'uses the active heat distance instead of raw remaining laps (%s)',
+    async (rawLaps) => {
+      window.channelBridge = {
+        subscribe: <K extends ChannelName>(
+          _channel: K,
+          callback: (payload: ChannelPayloads[K]) => void
+        ) => {
+          callback({
+            ...projection,
+            sessionNum: 2,
+            currentLap: 3,
+            lapDistPct: 0.25,
+            sessionLaps: 8,
+            sessionLapsRemain: rawLaps,
+            sessionTimeRemain: 604800,
+            calculatedTotalRaceLaps: 8,
+            estimatedLapsRemaining: 5.75,
+            hasValidRaceEstimate: true,
+            isFixedLapRace: true,
+          } as ChannelPayloads[K]);
+          return () => undefined;
+        },
+      };
+      const { result } = renderHook(() =>
+        useFuelCalculation(0.3, {
+          ...defaultFuelCalculatorSettings,
+          enableStorage: false,
+          enableLogging: false,
+        })
+      );
+      await waitFor(() => expect(result.current?.totalLaps).toBe(8));
+      expect(result.current?.lapsRemaining).toBe(5.75);
+      expect(result.current?.fuelToFinish).toBeCloseTo(
+        5.75 * (result.current?.avgLaps ?? 0) + (0.3 + 0.25) * 1.3
+      );
+    }
+  );
 
   it('accepts a validated zero-lap timed-race estimate', async () => {
     window.channelBridge = {

--- a/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
+++ b/src/frontend/components/FuelCalculator/useFuelCalculation.tsx
@@ -603,6 +603,12 @@ export function useFuelCalculation(
           `[FuelCalculator] ${isCheckeredFlag(sessionFlags) ? 'Checkered' : 'White'} flag - final lap, remaining: ${lapsRemaining.toFixed(2)}`
         );
       }
+    } else if (isRace && hasValidRaceEstimate && calculatedTotalRaceLaps > 0) {
+      // Use the active session's race distance for both lap-limited and timed
+      // heats. Raw remaining-lap telemetry can disagree with the heat limit.
+      totalLaps = Math.ceil(calculatedTotalRaceLaps);
+      lapsRemaining = estimatedLapsRemaining;
+      lapsRemainingRefuel = lapsRemaining;
     } else if (sessionLapsRemain === TIMED_RACE_LAPS_REMAINING) {
       // Use centralized useTotalRaceLaps hook for timed race calculations
       if (hasValidRaceEstimate && calculatedTotalRaceLaps > 0) {


### PR DESCRIPTION
## Description

Use the active race's validated remaining distance when calculating fuel, regardless of whether raw `SessionLapsRemain` equals the unlimited sentinel. Previously, a timed heat with any other raw value bypassed the timed estimate. Lap-limited races now also publish a validated remaining distance from their active session limit and player progress.

Validation:
- 73 focused fuel tests passed, including timed races with sentinel and finite raw lap counts, plus qualifying-to-multiple-race transitions.
- `npm run lint` passed; `git diff --check` passed.
- `ai-race-10min.irdt`: fuel-state baseline matched across 36,000 frames. Overall curated validation failed on an identical relative-gap mismatch reproduced on the unchanged base commit.
- `fuel-test.irdt`: compared current and base fuel processors across all 186,896 frames (about 52 minutes, including qualifying and a 35-minute timed race). All processor snapshots matched; no invalid validated distance estimates. This tape did not exercise the changed renderer distance-selection path.
- Not tested live in iRacing; the reported timed heat issue still needs live confirmation. The full unit suite was not run.

Architecture impact: existing main-process fuel processor and its renderer consumer only; no channel contract, storage, lifecycle, or subscription changes. Added scalar arithmetic in the existing processing path; no performance benchmark was run.

## Screenshots

No layout changes; behavior examples from regression tests are provided below.

### Before
A timed race with a validated 9.2 laps remaining and raw remaining laps of 30 uses the raw count plus current-lap distance for fuel requirements.

### After
The same timed race uses the validated 9.2 laps remaining for fuel requirements. An 8-lap heat at lap 3, 25% complete, uses 5.75 laps remaining even if raw telemetry reports 30.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

### Architecture Pre-PR Checklist

- [x] N1 — no new synchronous filesystem I/O
- [x] N2 — no frontend imports from app
- [x] N3 — no cross-widget imports
- [x] N4 — no new IPC handlers
- [x] R2.1/R2.2 — no telemetry subscription changes
- [x] R3.1 — no new renderer stores
- [x] R4.1 — no new bridges
- [x] R6.1 — no storage changes
- [x] R7.1 — no new widgets
- [x] R8.1/R8.2 — no settings changes
- [x] R10.1 — no native changes
- [x] R11.1 — no logging changes
- [x] R13.1 — no new high-frequency processing path
- [x] R14.1 — regression tests added to existing processor and hook suites
- [x] Storybook — no new visual component; not applicable
- [ ] Performance numbers — not measured; scope described above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved fuel calculations for lap-limited races by using the correct race distance and estimated laps remaining.
  - Fixed lap-progress reporting so remaining laps are calculated accurately and never shown as negative.
  - Preserved existing timed-race fuel estimates while improving consistency across qualifying, heat, and race sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->