### PR TITLE
chore: add missing Season 4 SDK field types

### DIFF
--- a/src/app/irsdk/native/scripts/generate-var-types.js
+++ b/src/app/irsdk/native/scripts/generate-var-types.js
@@ -44,7 +44,14 @@ const varTypes = [
 ];
 
 // Get all the types
-const types = sdk.__getTelemetryTypes();
+const types = {
+  // Car-specific fields observed in fuel-test2.irdt (2026.09.10.02).
+  // Keep them available when generating from a car that omits them.
+  dcTractionControlToggle: 1,
+  dcLowFuelAccept: 1,
+  dcDashPage2: 4,
+  ...sdk.__getTelemetryTypes(),
+};
 const out = `
 // ! THIS FILE IS AUTO-GENERATED, EDITS WILL BE OVERRIDDEN !
 // ! Make changes to the generate-var-types in @irsk-node/native !

--- a/src/app/irsdk/types/_GENERATED_telemetry.ts
+++ b/src/app/irsdk/types/_GENERATED_telemetry.ts
@@ -278,6 +278,8 @@ export interface TelemetryVarList {
   dcStarter: TelemetryVariable<boolean[]>;
   dcPitSpeedLimiterToggle: TelemetryVariable<boolean[]>;
   dcHeadlightFlash: TelemetryVariable<boolean[]>;
+  dcTractionControlToggle: TelemetryVariable<boolean[]>;
+  dcLowFuelAccept: TelemetryVariable<boolean[]>;
   dpRFTireChange: TelemetryVariable<number[]>;
   dpLFTireChange: TelemetryVariable<number[]>;
   dpRRTireChange: TelemetryVariable<number[]>;
@@ -287,6 +289,7 @@ export interface TelemetryVarList {
   dpFuelAddKg: TelemetryVariable<number[]>;
   dpFastRepair: TelemetryVariable<number[]>;
   dcDashPage: TelemetryVariable<number[]>;
+  dcDashPage2: TelemetryVariable<number[]>;
   dcBrakeBias: TelemetryVariable<number[]>;
   dcThrottleShape: TelemetryVariable<number[]>;
   dpLFTireColdPress: TelemetryVariable<number[]>;

--- a/src/app/irsdk/types/weekend-info.ts
+++ b/src/app/irsdk/types/weekend-info.ts
@@ -90,6 +90,8 @@ export interface WeekendInfo {
   NumCarClasses: number;
   NumCarTypes: number;
   HeatRacing: number;
+  /** Alternate car ruleset tag (e.g. IMSA); absent in pre-2026 Season 4 data. */
+  AltAssetTag?: string;
   BuildType: string;
   BuildTarget: string;
   BuildVersion: string;


### PR DESCRIPTION
## Description

Add SDK typings for fields observed in `fuel-test2.irdt` (iRacing build `2026.09.10.02`): optional `WeekendInfo.AltAssetTag`, boolean telemetry `dcTractionControlToggle` and `dcLowFuelAccept`, and numeric telemetry `dcDashPage2`. The session tag is new in Season 4; the telemetry fields were also present in the older recording but missing from our types.

Keep the three car-specific telemetry fields in the generator's fallback schema so regeneration from other cars retains them without duplicate declarations. This is type maintenance only; there are no runtime or visual changes.

Validation: TypeScript passed via the first stage of `npm run lint`. The full lint command encountered an existing ambiguous tsconfig root caused by `tmp-data/irsdk-replay-worktree`; all three changed files passed ESLint with an explicit repository tsconfig root. Executed the generator with mocked SDK schemas both omitting and including the fields, confirming correct types and no duplicates. `git diff --check` passed. No live iRacing testing or full test suite run.

Architecture impact: SDK types and generator only (R10.4). No native variables, runtime paths, or architectural boundaries changed; performance measurements are not applicable.

Architecture pre-PR checklist (N/A entries reviewed for this type-only change):

- [x] N1 — no new fs.*Sync outside startup
- [x] N2 — no new frontend → src/app/ imports (including type-only)
- [x] N3 — no new cross-widget imports
- [x] N4 — every new ipcMain handler validates renderer input (N/A)
- [x] R2.1/R2.2 — rounded telemetry hooks or no-round exception (N/A)
- [x] R3.1 — centralized reset/lifecycle for new stores (N/A)
- [x] R4.1 — new bridges use defineBridge (N/A)
- [x] R6.1 — new storage code is async (N/A)
- [x] R7.1 — explicit widget registration (N/A)
- [x] R8.1/R8.2 — settings defaults and tested migrations (N/A)
- [x] R10.1 — native pointer and bounds checks (N/A)
- [x] R11.1 — no new direct console logging
- [x] R13.1 — high-frequency code uses perfMetrics (N/A)
- [x] R14.1 — processor/selector specs (N/A)
- [x] Storybook story for new visual components (N/A)
- [x] Architecture impact and applicable performance results included

## Screenshots

### Before

Not applicable: SDK typings only; the four fields were missing from the type definitions.

### After

Not applicable: the four fields are typed; UI unchanged.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional telemetry data, including traction control toggles, low-fuel acceptance settings, and dashboard page information.
  - Added support for alternate asset tags in weekend information when provided by newer data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->