### PR TITLE
chore: remove hard-coded telemetry type fallbacks

### DIFF
--- a/src/app/irsdk/native/scripts/generate-var-types.js
+++ b/src/app/irsdk/native/scripts/generate-var-types.js
@@ -1,27 +1,32 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-const path = require("path");
-const fs = require("fs");
+const path = require('path');
+const fs = require('fs');
 
 // Prefer Debug build but fall back to Release if Debug is not built.
-const debugBinary = path.resolve(__dirname, "../build/Debug/irsdk_node.node");
-const releaseBinary = path.resolve(__dirname, "../build/Release/irsdk_node.node");
+const debugBinary = path.resolve(__dirname, '../build/Debug/irsdk_node.node');
+const releaseBinary = path.resolve(
+  __dirname,
+  '../build/Release/irsdk_node.node'
+);
 let nativeBinary = null;
 if (fs.existsSync(debugBinary)) nativeBinary = debugBinary;
 else if (fs.existsSync(releaseBinary)) nativeBinary = releaseBinary;
 else {
-  console.error("Native module not found. Build the native addon (run the build script) and try again.");
+  console.error(
+    'Native module not found. Build the native addon (run the build script) and try again.'
+  );
   process.exit(1);
 }
 const NativeSDK = require(nativeBinary).iRacingSdkNode;
 
-const TARGET_FILE = "_GENERATED_telemetry.ts";
-const OUT_PATH = path.resolve(__dirname, "../../types/", TARGET_FILE);
+const TARGET_FILE = '_GENERATED_telemetry.ts';
+const OUT_PATH = path.resolve(__dirname, '../../types/', TARGET_FILE);
 
 // Ensure the output directory exists (robust when script is run from different CWDs)
 fs.mkdirSync(path.dirname(OUT_PATH), { recursive: true });
 
-console.log("Generating iRacing telemetry variable types.");
-console.log("Make sure the sim is running!");
+console.log('Generating iRacing telemetry variable types.');
+console.log('Make sure the sim is running!');
 
 const sdk = new NativeSDK();
 sdk.startSDK();
@@ -30,28 +35,14 @@ sdk.startSDK();
 sdk.broadcast(10, 1);
 // Wait a max of 5s
 if (!sdk.waitForData(5000)) {
-  process.stderr.write("No data. Make sure the sim is running and try again.");
+  process.stderr.write('No data. Make sure the sim is running and try again.');
   process.exit(1);
 }
 
-const varTypes = [
-  "string",
-  "boolean",
-  "number",
-  "number",
-  "number",
-  "number",
-];
+const varTypes = ['string', 'boolean', 'number', 'number', 'number', 'number'];
 
 // Get all the types
-const types = {
-  // Car-specific fields observed in fuel-test2.irdt (2026.09.10.02).
-  // Keep them available when generating from a car that omits them.
-  dcTractionControlToggle: 1,
-  dcLowFuelAccept: 1,
-  dcDashPage2: 4,
-  ...sdk.__getTelemetryTypes(),
-};
+const types = sdk.__getTelemetryTypes();
 const out = `
 // ! THIS FILE IS AUTO-GENERATED, EDITS WILL BE OVERRIDDEN !
 // ! Make changes to the generate-var-types in @irsk-node/native !
@@ -81,17 +72,20 @@ export interface TelemetryVarList {
   // Manually added entries
   dcPeakBrakeBias: TelemetryVariable<number[]>;
 
-${Object.keys(types).map((varName) => 
-  `  ${varName}: TelemetryVariable<${varTypes[types[varName]]}[]>`
-).join(";\n")};
+${Object.keys(types)
+  .map(
+    (varName) =>
+      `  ${varName}: TelemetryVariable<${varTypes[types[varName]]}[]>`
+  )
+  .join(';\n')};
 }
 `;
 
-fs.writeFile(OUT_PATH, out, "utf-8", (err) => {
+fs.writeFile(OUT_PATH, out, 'utf-8', (err) => {
   if (err) {
-    console.error("There was an error creating the file:", err);
+    console.error('There was an error creating the file:', err);
     return;
   }
-  console.log("Successfully generated types!");
+  console.log('Successfully generated types!');
   process.exit(0);
 });


### PR DESCRIPTION
$## Description\n\nRemove the hard-coded telemetry fallbacks added in PR #732. Telemetry types are sourced exclusively from the live SDK generator, matching the native generation pattern. The generated declarations and optional WeekendInfo.AltAssetTag remain in main.\n\n## Screenshots\n\n### Before\nNot applicable: type-generation maintenance only.\n\n### After\nNot applicable: runtime and UI behavior unchanged.\n\n## Type of Change\n\n- [x] Refactoring (no functional changes)\n\n## Checklist\n\n- [x] I have performed a self-review of my own code\n- [x] I have run targeted lint via the pre-commit hook\n- [x] I have run git diff --check\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Telemetry variable lists now reflect only the variables provided by the SDK, preventing certain car-specific entries from appearing when unsupported.

* **Style**
  * Improved internal script formatting and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->