### PR TITLE
chore: move session timing updater beside its store

### DIFF
--- a/src/frontend/components/DashboardView/DashboardView.tsx
+++ b/src/frontend/components/DashboardView/DashboardView.tsx
@@ -7,7 +7,7 @@ import {
   memo,
   CSSProperties,
 } from 'react';
-import { useDashboard } from '@irdashies/context';
+import { useDashboard, SessionTimingUpdater } from '@irdashies/context';
 import { getWidget } from '../../WidgetIndex';
 import { getWidgetName } from '../../constants/widgetNames';
 import { ResizeIcon, XIcon } from '@phosphor-icons/react';
@@ -16,7 +16,6 @@ import { useDragWidget, useResizeWidget } from '../WidgetContainer';
 import { ResizeHandles } from '../WidgetContainer/ResizeHandle';
 import logger from '@irdashies/utils/logger';
 import { WidgetRuntimeProvider } from '../../widgetRuntime';
-import { SessionTimingUpdater } from '../OverlayContainer/SessionTimingUpdater';
 
 interface WidgetPosition {
   x: number;

--- a/src/frontend/components/OverlayContainer/OverlayContainer.spec.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.spec.tsx
@@ -13,7 +13,7 @@ vi.mock('@irdashies/context', () => ({
   useResetOnDisconnect: vi.fn(),
   usePitLapStoreUpdater: vi.fn(),
   TopSpeedStoreUpdater: vi.fn(),
-  SessionTimingStoreUpdater: vi.fn(),
+  SessionTimingUpdater: vi.fn(() => null),
   TrackTemperatureStoreUpdater: vi.fn(),
   SessionBestLapStoreUpdater: vi.fn(),
   useSectorTimingSnapshot: vi.fn(),

--- a/src/frontend/components/OverlayContainer/OverlayContainer.tsx
+++ b/src/frontend/components/OverlayContainer/OverlayContainer.tsx
@@ -3,6 +3,7 @@ import {
   useDashboard,
   useRunningState,
   useResetOnDisconnect,
+  SessionTimingUpdater,
 } from '@irdashies/context';
 import type { WidgetLayout } from '@irdashies/types';
 import { WidgetContainer } from '../WidgetContainer';
@@ -12,7 +13,6 @@ import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary';
 import { SectorTimingUpdater } from './SectorTimingUpdater';
 import { PushToPassUpdater } from './PushToPassUpdater';
 import { PitLapUpdater } from './PitLapUpdater';
-import { SessionTimingUpdater } from './SessionTimingUpdater';
 import { WidgetRuntimeProvider } from '../../widgetRuntime';
 
 export const OverlayContainer = memo(() => {

--- a/src/frontend/context/SessionTimingStore/SessionTimingStoreUpdater.tsx
+++ b/src/frontend/context/SessionTimingStore/SessionTimingStoreUpdater.tsx
@@ -27,9 +27,8 @@ export const useSessionTimingStoreUpdater = (enabled: boolean) => {
 };
 
 /**
- * Mount once (see OverlayContainer's SessionTimingUpdater) so
- * useSessionLapCount/useTotalRaceValue's leader-car loop + effect run once
- * instead of once per widget that needs them.
+ * Mount once per renderer through SessionTimingUpdater to share one channel
+ * subscription across all widgets that need session timing.
  */
 export const SessionTimingStoreUpdater = ({
   enabled,

--- a/src/frontend/context/SessionTimingStore/SessionTimingUpdater.spec.tsx
+++ b/src/frontend/context/SessionTimingStore/SessionTimingUpdater.spec.tsx
@@ -1,10 +1,14 @@
 import { render } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useDashboard, SessionTimingStoreUpdater } from '@irdashies/context';
+import { useDashboard } from '../DashboardContext/DashboardContext';
+import { SessionTimingStoreUpdater } from './SessionTimingStoreUpdater';
 import { SessionTimingUpdater } from './SessionTimingUpdater';
 
-vi.mock('@irdashies/context', () => ({
+vi.mock('../DashboardContext/DashboardContext', () => ({
   useDashboard: vi.fn(),
+}));
+
+vi.mock('./SessionTimingStoreUpdater', () => ({
   SessionTimingStoreUpdater: vi.fn(() => null),
 }));
 

--- a/src/frontend/context/SessionTimingStore/SessionTimingUpdater.tsx
+++ b/src/frontend/context/SessionTimingStore/SessionTimingUpdater.tsx
@@ -1,4 +1,5 @@
-import { useDashboard, SessionTimingStoreUpdater } from '@irdashies/context';
+import { useDashboard } from '../DashboardContext/DashboardContext';
+import { SessionTimingStoreUpdater } from './SessionTimingStoreUpdater';
 
 const SESSION_TIMING_WIDGET_IDS = new Set(['standings', 'relative', 'infobar']);
 
@@ -12,10 +13,7 @@ export const SessionTimingUpdater = () => {
     (widget) => widget.enabled && SESSION_TIMING_WIDGET_IDS.has(widget.id)
   );
 
-  // Mount conditionally rather than always-mounting with enabled={false}:
-  // useSessionLapCount/useTotalRaceValue run unconditionally once mounted
-  // (React can't skip a hook call from inside), so the only way to actually
-  // avoid the leader-car loop when nothing needs it is to not mount it.
+  // Only mount the channel subscriber when a widget needs session timing.
   if (!enabled) return null;
   return <SessionTimingStoreUpdater enabled={enabled} />;
 };

--- a/src/frontend/context/index.ts
+++ b/src/frontend/context/index.ts
@@ -28,6 +28,7 @@ export * from './CarSpeedStore/TopSpeedStore';
 export * from './CarSpeedStore/TopSpeedStoreUpdater';
 export * from './SessionTimingStore/SessionTimingStore';
 export * from './SessionTimingStore/SessionTimingStoreUpdater';
+export * from './SessionTimingStore/SessionTimingUpdater';
 export * from './TrackTemperatureStore/TrackTemperatureStore';
 export * from './TrackTemperatureStore/TrackTemperatureStoreUpdater';
 export * from './SessionBestLapStore/SessionBestLapStore';


### PR DESCRIPTION
## Description

Follow up on the [architecture cleanup comment in #727](https://github.com/tariknz/irdashies/pull/727#discussion_r3963795414): move `SessionTimingUpdater` and its existing tests into `context/SessionTimingStore`, and import the shared wrapper through `@irdashies/context` in both `DashboardView` and `OverlayContainer`. Refresh stale comments to describe the current channel subscription. Timing behavior is unchanged.

Architecture impact: removes the DashboardView → OverlayContainer timing import (N3/R1.2) and colocates the wrapper with its store (R3.3). No hot-path behavior changes.

Validation: `npm run lint`, Prettier checks on changed files, and `npm run test -- --run --no-coverage src/frontend/context/SessionTimingStore src/frontend/components/OverlayContainer/OverlayContainer.spec.tsx` (4 files, 11 tests passed). No iRacing or Storybook testing; no visual changes.

## Screenshots

<!-- If this PR includes visual changes, please provide before/after screenshots or videos -->

### Before
The dashboard imports the timing wrapper from the OverlayContainer folder. No visual changes.

### After
Both containers import the wrapper from shared context. The displayed timing and widget gating remain unchanged.

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [x] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

<!-- Check all that apply. Put an x in the brackets: [x] -->

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

### Architecture pre-PR checklist

- [x] N1 — no new fs.*Sync outside startup
- [x] N2 — no new frontend → src/app/ imports (including type-only)
- [x] N3 — no new cross-widget imports
- [x] N4 — no new IPC handlers
- [x] R2.1/R2.2 — no telemetry hook changes
- [x] R3.1 — no new session-derived renderer stores
- [x] R4.1 — no new bridges
- [x] R6.1 — no storage changes
- [x] R7.1 — no new widgets
- [x] R8.1/R8.2 — no settings changes
- [x] R10.1 — no native changes
- [x] R11.1 — no logging changes
- [x] R13.1 — no new high-frequency code
- [x] R14.1 — no new processors or selectors; existing timing tests pass
- [x] Storybook story — not applicable; no new visual components
- [x] Architecture impact documented above; performance numbers not applicable to this structural move


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Consolidated session-timing update handling across dashboard and overlay views.
  - Preserved existing conditional mounting and runtime behavior.

- **Documentation**
  - Clarified how session-timing updates are shared across renderer instances and widgets.

- **Tests**
  - Updated test coverage and mocks to reflect the consolidated session-timing update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->