### PR TITLE
fix: restore blue faster cars alerts in single-class races

### DIFF
--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.spec.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.spec.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@testing-library/react';
+import { useWeekendInfoNumCarClasses } from '@irdashies/context';
+import { FasterCarsFromBehind } from './FasterCarsFromBehind';
+
+vi.mock('@irdashies/context', () => ({
+  useDashboard: () => ({ isDemoMode: false }),
+  useSessionVisibility: () => true,
+  useWeekendInfoNumCarClasses: vi.fn(),
+}));
+
+vi.mock('./hooks/useFasterCarsSettings', () => ({
+  useFasterCarsSettings: () => ({ showName: true }),
+}));
+
+const car = vi.hoisted(() => ({
+  carIdx: 1,
+  name: 'Following Driver',
+  classColor: 0xffffff,
+}));
+
+vi.mock('./hooks/useCarBehind', () => ({
+  useCarBehind: () => [car],
+}));
+
+describe('FasterCarsFromBehind colours', () => {
+  it.each([
+    [1, 0xffffff, 'bg-sky-500'],
+    [1, 0xffda59, 'bg-sky-500'],
+    [undefined, 0xffffff, 'bg-sky-500'],
+    [2, 0xffda59, 'bg-yellow-500'],
+    [2, 0x33ceff, 'bg-blue-500'],
+    [2, 0xffffff, 'bg-stone-500'],
+  ])(
+    'uses %s classes and colour %s to render %s',
+    (classes, color, expected) => {
+      vi.mocked(useWeekendInfoNumCarClasses).mockReturnValue(classes);
+      car.classColor = color;
+
+      render(<FasterCarsFromBehind />);
+
+      const box = screen.getByText('Following Driver').closest('.w-full');
+      expect(box).toHaveClass(expected);
+    }
+  );
+});

--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.stories.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.stories.tsx
@@ -71,6 +71,7 @@ export const Display: Story = {
     distance: -1.0,
     percent: 50,
     classColor: 0xffda59,
+    isMultiClass: true,
   },
   decorators: [TelemetryDecorator('/test-data/1747384033336')],
 };
@@ -84,6 +85,7 @@ export const MultipleDrivers: Story = {
         rating={1420}
         distance={-1.0}
         percent={80}
+        isMultiClass
         classColor={0xffda59} // Yellow/GT3
       />
       <FasterCarsFromBehindDisplay
@@ -92,6 +94,7 @@ export const MultipleDrivers: Story = {
         rating={1250}
         distance={-2.5}
         percent={60}
+        isMultiClass
         classColor={0x33ceff} // Blue/GT4
       />
       <FasterCarsFromBehindDisplay
@@ -100,9 +103,19 @@ export const MultipleDrivers: Story = {
         rating={980}
         distance={-4.2}
         percent={40}
+        isMultiClass
         classColor={0xff5888} // Pink/LMP
       />
     </div>
   ),
   decorators: [TelemetryDecorator('/test-data/1747384033336')],
+};
+
+export const SingleClass: Story = {
+  ...Display,
+  args: {
+    ...Display.args,
+    classColor: 0xffffff,
+    isMultiClass: false,
+  },
 };

--- a/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
+++ b/src/frontend/components/FasterCarsFromBehind/FasterCarsFromBehind.tsx
@@ -1,4 +1,8 @@
-import { useSessionVisibility, useDashboard } from '@irdashies/context';
+import {
+  useSessionVisibility,
+  useDashboard,
+  useWeekendInfoNumCarClasses,
+} from '@irdashies/context';
 import { useCarBehind } from './hooks/useCarBehind';
 import { useFasterCarsSettings } from './hooks/useFasterCarsSettings';
 import { getTailwindStyle } from '@irdashies/utils/colors';
@@ -13,10 +17,13 @@ export interface FasterCarsFromBehindProps {
   distance?: number;
   percent?: number;
   classColor?: number;
+  isMultiClass?: boolean;
 }
 
 export const FasterCarsFromBehind = () => {
   const { isDemoMode } = useDashboard();
+  const numCarClasses = useWeekendInfoNumCarClasses();
+  const isMultiClass = isDemoMode || (numCarClasses ?? 0) > 1;
   const settings = useFasterCarsSettings();
   const carsBehind = useCarBehind({
     distanceThreshold: settings?.distanceThreshold,
@@ -44,7 +51,11 @@ export const FasterCarsFromBehind = () => {
   return (
     <div className={`flex flex-col gap-2 h-full ${containerAlignment}`}>
       {orderedCars.map((car) => (
-        <FasterCarsFromBehindDisplay key={car.carIdx} {...car} />
+        <FasterCarsFromBehindDisplay
+          key={car.carIdx}
+          {...car}
+          isMultiClass={isMultiClass}
+        />
       ))}
     </div>
   );
@@ -57,6 +68,7 @@ export const FasterCarsFromBehindDisplay = ({
   distance,
   percent,
   classColor,
+  isMultiClass = false,
 }: FasterCarsFromBehindProps) => {
   const settings = useFasterCarsSettings();
 
@@ -67,7 +79,11 @@ export const FasterCarsFromBehindDisplay = ({
   const animate = distance && distance > -1.5 ? 'animate-pulse' : '';
   const red = percent || 0;
   const green = 100 - (percent || 0);
-  const background = getTailwindStyle(classColor, undefined, true).classHeader;
+  const background = getTailwindStyle(
+    classColor,
+    undefined,
+    isMultiClass
+  ).classHeader;
 
   name = settings?.removeNumbersFromName ? name.replace(/\d/g, '') : name;
 


### PR DESCRIPTION
## Description

Restore the blue Faster Cars From Behind background in single-class races. The widget previously always requested multiclass colours, so the grey fallback introduced in #706 also affected single-class alerts. Use the session class count to choose the colour mode; demo mode retains its sample class colours.

Validation: 39 focused tests passed via `npm run test -- --run --no-coverage src/frontend/components/FasterCarsFromBehind src/frontend/utils/colors.spec.ts`; `npm run lint` passed. Added regression coverage for single-class, missing session data, and multiclass colours, plus a SingleClass Storybook story. Not tested in iRacing or visually in Storybook.

Architecture impact: widget presentation only, using the existing session selector and a primitive display prop. No new telemetry subscriptions, channels, stores, or configuration.

## Screenshots

### Before

Single-class alerts with an unrecognised class colour display a stone-grey background.

### After

Single-class alerts display sky blue. Multiclass alerts retain their class colours and existing grey fallback. The SingleClass Storybook story provides the reproduction case; screenshots were not captured.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [x] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)

### Architecture Pre-PR Checklist

- [x] N1 — no new fs.*Sync outside startup
- [x] N2 — no new frontend → src/app/ imports (including type-only)
- [x] N3 — no new cross-widget imports
- [x] N4 — every new ipcMain handler validates renderer input (none added)
- [x] R2.1/R2.2 — telemetry hooks use rounded variants or exceptions (none added)
- [x] R3.1 — new session-derived stores participate in reset/lifecycle handling (none added)
- [x] R4.1 — new bridges use defineBridge (none added)
- [x] R6.1 — all new storage code is async (none added)
- [x] R7.1 — new widget follows registration/settings/default flow (none added)
- [x] R8.1/R8.2 — settings defaults and migrations handled (no changes)
- [x] R10.1 — native code null-checks pointers and bounds-checks indices (no changes)
- [x] R11.1 — logging uses project logger and literal levels (none added)
- [x] R13.1 — new high-frequency code wrapped in perfMetrics (none added)
- [x] R14.1 — new processors/selectors have spec coverage (none added)
- [x] Storybook story exists for any new visual component (existing component stories updated)
- [x] PR description includes architecture impact; no new hot path requiring performance measurements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the “Faster Cars From Behind” display to adapt its header styling based on whether the session includes multiple car classes.
  * Added support for consistent class-color presentation in both single-class and multi-class sessions.
  * Added a single-class showcase scenario for clearer visual validation.

* **Tests**
  * Added coverage verifying background colors across supported car-class configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->