### PR TITLE
fix: refresh incident count after a session restart

### DIFF
--- a/src/app/processors/SessionBarProcessor.spec.ts
+++ b/src/app/processors/SessionBarProcessor.spec.ts
@@ -3,6 +3,37 @@ import type { Session, Telemetry } from '@irdashies/types';
 import { SessionBarProcessor } from './SessionBarProcessor';
 
 describe('SessionBarProcessor', () => {
+  it('refreshes incidents after a clock rewind and keeps the 5 Hz cadence', () => {
+    const processor = new SessionBarProcessor();
+    processor.init({} as Session);
+    const frame = (time: number, incidents: number): Telemetry =>
+      ({
+        SessionTime: { value: [time] },
+        SessionNum: { value: [2] },
+        PlayerCarTeamIncidentCount: { value: [incidents] },
+      }) as unknown as Telemetry;
+
+    processor.onFrame(frame(600, 4));
+    expect(processor.snapshot().incidents).toBe(4);
+    const version = processor.snapshotVersion();
+    processor.onFrame(frame(600.1, 5));
+    expect(processor.snapshotVersion()).toBe(version);
+
+    processor.onFrame(frame(0, 0));
+    expect(processor.snapshot()).toMatchObject({ sessionNum: 2, incidents: 0 });
+    const restartVersion = processor.snapshotVersion();
+    expect(restartVersion).toBeGreaterThan(version);
+
+    processor.onFrame(frame(0.1, 1));
+    expect(processor.snapshot().incidents).toBe(0);
+    expect(processor.snapshotVersion()).toBe(restartVersion);
+    processor.onFrame(frame(0.2, 1));
+    expect(processor.snapshot().incidents).toBe(1);
+    expect(processor.snapshotVersion()).toBeGreaterThan(restartVersion);
+    processor.onFrame(frame(30, 2));
+    expect(processor.snapshot().incidents).toBe(2);
+  });
+
   it('returns snapshots detached from reusable processor buffers', () => {
     const processor = new SessionBarProcessor();
     processor.init({

--- a/src/app/processors/SessionBarProcessor.ts
+++ b/src/app/processors/SessionBarProcessor.ts
@@ -63,7 +63,10 @@ export class SessionBarProcessor implements TelemetryProcessor<SessionBarSnapsho
     }
     this.lap = currentLap;
     this.lapTop = Math.max(this.lapTop, speed);
-    if (time < this.lastTime || time - this.lastTime < 0.2 - 1e-6) return;
+    // A restart can rewind the clock without changing SessionNum. Let the
+    // current telemetry through immediately, then resume the normal cadence.
+    if (time < this.lastTime) this.lastTime = -Infinity;
+    if (time - this.lastTime < 0.2 - 1e-6) return;
     this.lastTime = time;
     const info = this.session?.SessionInfo?.Sessions?.find(
       (s) => s.SessionNum === sessionNum


### PR DESCRIPTION
## Description

Restarting a session with the same session number can rewind session time and leave the incident count frozen until the clock catches up. Reset the session bar update timer on a clock rewind so the current telemetry is processed immediately, then resume the normal 5 Hz cadence.

Validation: the new regression test reproduces 600s / 4 incidents → 0s / 0 incidents with the same session number and verifies continued updates and throttling. It failed before the fix and passes after it. All 3 SessionBarProcessor tests pass; `npm run lint`, Prettier, and `git diff --check` pass. Not tested in iRacing; the full test suite was not run.

Architecture impact: existing main-process processor only; no new channels, lifecycle events, allocations, or subscriptions. The change only resets the update timer. Normal update cadence remains 5 Hz, verified by the regression test; no performance benchmark was run.

Architecture checklist (unchecked items are not applicable):

- [x] N1 — no new fs.*Sync outside startup
- [x] N2 — no new frontend → src/app/ imports (including type-only)
- [x] N3 — no new cross-widget imports
- [ ] N4 — every new ipcMain handler validates renderer input
- [ ] R2.1/R2.2 — telemetry hooks use rounded variants (or no-round list)
- [ ] R3.1 — new renderer stores participate in centralized reset/lifecycle handling
- [ ] R4.1 — new bridges use defineBridge
- [ ] R6.1 — new storage code is async
- [ ] R7.1 — new widget uses explicit registration/settings/default flow
- [ ] R8.1/R8.2 — settings defaults and migrations updated
- [ ] R10.1 — native code null-checks pointers and bounds-checks indices
- [x] R11.1 — no direct console logging introduced
- [ ] R13.1 — new high-frequency code is wrapped in perfMetrics
- [x] R14.1 — affected processor has regression coverage
- [ ] Storybook story exists for any new visual component
- [x] Architecture impact and performance validation described above

## Screenshots

### Before

With the same session number, telemetry changing from 600 seconds / 4 incidents to 0 seconds / 0 incidents leaves the display at 4 incidents.

### After

The first frame after the rewind updates the count to 0 incidents. Subsequent updates follow the normal cadence. No layout changes.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependency update

## Checklist

- [ ] I have discussed this change in the discord server
- [ ] I have tested this in iRacing (either in an online session or with AI)
- [ ] All tests pass locally via `npm test`
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `npm run lint` and fixed any issues
- [x] I have performed a self-review of my own code
- [ ] I have added/updated Storybook stories for visual changes
- [ ] I have updated the README.md (if applicable)
- [ ] I have updated defaultDashboard.ts if introducing new widgets or configurations (if applicable)
